### PR TITLE
`al/player`: Correct `getPortNo()` and `getViewMtx()` positions in PlayerActorBase

### DIFF
--- a/lib/al/player/PlayerActorBase.h
+++ b/lib/al/player/PlayerActorBase.h
@@ -11,6 +11,8 @@ public:
 
     virtual void init(const al::ActorInitInfo&) override;
     virtual void initPlayer(const al::ActorInitInfo&, const PlayerInitInfo&);
+    virtual unsigned int getPortNo() const;
+    virtual void* getViewMtx() const;          // NOTE: unknown return type
     virtual void* getPlayerCollision() const;  // NOTE: unknown return type
     virtual al::PlayerHackKeeper* getPlayerHackKeeper() const override;
     virtual bool isEnableDemo();
@@ -34,8 +36,6 @@ public:
     virtual bool isDamageStopDemo() const;  // NOTE: unknown return type
     virtual void* getPlayerPuppet();        // NOTE: unknown return type
     virtual void* getPlayerInfo() const;    // NOTE: unknown return type
-    virtual unsigned int getPortNo() const;
-    virtual void* getViewMtx() const;  // NOTE: unknown return type
     virtual void movement() override;
     virtual bool checkDeathArea();
     virtual void sendCollisionMsg();


### PR DESCRIPTION
I think these are in the wrong position.

![image](https://user-images.githubusercontent.com/11504941/148626445-266977d2-3915-4dc7-80ac-04c7b3d2448e.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monsterdruide1/odysseydecomp/7)
<!-- Reviewable:end -->
