### PR TITLE
`al`: Implement `PlayerHolder` and some utility functions

### DIFF
--- a/lib/al/player/PlayerHolder.h
+++ b/lib/al/player/PlayerHolder.h
@@ -8,9 +8,24 @@ class LiveActor;
 class PlayerHolder {
 public:
     PlayerHolder(int);
-    LiveActor* getPlayer(int);
-    int* getPlayerNum() const;
-    int* getBufferSize() const;
-    void registerPlayer(LiveActor*, PadRumbleKeeper*);
+    void clear();
+    void registerPlayer(LiveActor* actor, PadRumbleKeeper* rumble_keeper);
+    LiveActor* getPlayer(int index) const;
+    LiveActor* tryGetPlayer(int index) const;
+    int getPlayerNum() const;
+    int getBufferSize() const;
+    bool isFull() const;
+    bool isExistPadRumbleKeeper(int index) const;
+    PadRumbleKeeper* getPadRumbleKeeper(int index) const;
+
+private:
+    struct Player {
+        LiveActor* mActor = nullptr;
+        PadRumbleKeeper* mPadRumbleKeeper = nullptr;
+    };
+
+    Player* mPlayers = nullptr;
+    int mBufferSize = 0;
+    int mPlayerNum = 0;
 };
 }  // namespace al

--- a/lib/al/util/OtherUtil.h
+++ b/lib/al/util/OtherUtil.h
@@ -34,10 +34,6 @@ class PlacementInfo;
 
 // from Starlight's header files. TODO clean this up, and include them in the proper places
 
-PlayerActorHakoniwa* getPlayerActor(al::LiveActor const*, int);
-
-PlayerActorHakoniwa* tryGetPlayerActor(al::PlayerHolder const*, int);
-
 sead::Heap* getCurrentHeap();
 
 al::Projection* getProjection(al::IUseCamera const*, int);

--- a/lib/al/util/PlayerUtil.h
+++ b/lib/al/util/PlayerUtil.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+class PlayerHolder;
+
+int getPlayerNumMax(const PlayerHolder* holder);
+int getAlivePlayerNum(const PlayerHolder* holder);
+LiveActor* getPlayerActor(const PlayerHolder* holder, int index);
+const sead::Vector3f& getPlayerPos(const PlayerHolder* holder, int index);
+LiveActor* tryGetPlayerActor(const PlayerHolder* holder, int index);
+bool isPlayerDead(const PlayerHolder* holder, int index);
+bool isPlayerAreaTarget(const PlayerHolder* holder, int index);
+LiveActor* tryFindAlivePlayerActorFirst(const PlayerHolder* holder);
+LiveActor* findAlivePlayerActorFirst(const PlayerHolder* holder);
+}  // namespace al

--- a/src/al/player/CMakeLists.txt
+++ b/src/al/player/CMakeLists.txt
@@ -3,6 +3,7 @@ target_sources(odyssey PRIVATE
     PlayerActorHakoniwa.cpp
     PlayerConst.cpp
     PlayerCostumeInfo.cpp
+    PlayerHolder.cpp
     PlayerModelHolder.cpp
     PlayerPainPartsKeeper.cpp
     PlayerTrigger.cpp

--- a/src/al/player/PlayerHolder.cpp
+++ b/src/al/player/PlayerHolder.cpp
@@ -1,0 +1,60 @@
+#include "al/player/PlayerHolder.h"
+
+namespace al {
+
+PlayerHolder::PlayerHolder(int count) {
+    mPlayers = nullptr;
+    mPlayerNum = 0;
+    mBufferSize = count;
+
+    mPlayers = new Player[count];
+    clear();
+}
+
+void PlayerHolder::clear() {
+    for (int i = 0; i < mBufferSize; i++) {
+        mPlayers[i].mActor = nullptr;
+        mPlayers[i].mPadRumbleKeeper = nullptr;
+    }
+}
+
+void PlayerHolder::registerPlayer(LiveActor* actor, PadRumbleKeeper* rumble_keeper) {
+    mPlayers[mPlayerNum].mActor = actor;
+    mPlayers[mPlayerNum].mPadRumbleKeeper = rumble_keeper;
+    mPlayerNum++;
+}
+
+LiveActor* PlayerHolder::getPlayer(int index) const {
+    return mPlayers[index].mActor;
+}
+
+LiveActor* PlayerHolder::tryGetPlayer(int index) const {
+    if (mBufferSize <= index) {
+        return nullptr;
+    } else if (mPlayerNum <= index) {
+        return nullptr;
+    }
+
+    return mPlayers[index].mActor;
+}
+
+int PlayerHolder::getPlayerNum() const {
+    return mPlayerNum;
+}
+
+int PlayerHolder::getBufferSize() const {
+    return mBufferSize;
+}
+
+bool PlayerHolder::isFull() const {
+    return mBufferSize <= mPlayerNum;
+}
+
+bool PlayerHolder::isExistPadRumbleKeeper(int index) const {
+    return mPlayers[index].mPadRumbleKeeper != nullptr;
+}
+
+PadRumbleKeeper* PlayerHolder::getPadRumbleKeeper(int index) const {
+    return mPlayers[index].mPadRumbleKeeper;
+}
+}  // namespace al

--- a/src/al/util/CMakeLists.txt
+++ b/src/al/util/CMakeLists.txt
@@ -6,6 +6,7 @@ target_sources(odyssey PRIVATE
     NerveUtil.cpp
     OtherUtil.cpp
     PlacementUtil.cpp
+    PlayerUtil.cpp
     RandomUtil.cpp
     StringUtil.cpp
 )

--- a/src/al/util/PlayerUtil.cpp
+++ b/src/al/util/PlayerUtil.cpp
@@ -1,0 +1,75 @@
+#include "al/util/PlayerUtil.h"
+
+#include "al/player/PlayerHolder.h"
+#include "al/util/LiveActorUtil.h"
+#include "al/util/OtherUtil.h"
+
+namespace al {
+
+int getPlayerNumMax(const PlayerHolder* holder) {
+    return holder->getPlayerNum();
+}
+
+int getAlivePlayerNum(const PlayerHolder* holder) {
+    int player_num = holder->getPlayerNum();
+    int alive_players = 0;
+
+    for (int i = 0; i < player_num; i++) {
+        LiveActor* player = holder->tryGetPlayer(i);
+        if (isAlive(player)) {
+            alive_players++;
+        }
+    }
+
+    return alive_players;
+}
+
+LiveActor* getPlayerActor(const PlayerHolder* holder, int index) {
+    return holder->tryGetPlayer(index);
+}
+
+const sead::Vector3f& getPlayerPos(const PlayerHolder* holder, int index) {
+    LiveActor* player = holder->tryGetPlayer(index);
+    return getTrans(player);
+}
+
+LiveActor* tryGetPlayerActor(const PlayerHolder* holder, int index) {
+    return holder->tryGetPlayer(index);
+}
+
+bool isPlayerDead(const PlayerHolder* holder, int index) {
+    LiveActor* player = holder->tryGetPlayer(index);
+    return isDead(player);
+}
+
+bool isPlayerAreaTarget(const PlayerHolder* holder, int index) {
+    LiveActor* player = holder->tryGetPlayer(index);
+    return isAreaTarget(player);
+}
+
+LiveActor* tryFindAlivePlayerActorFirst(const PlayerHolder* holder) {
+    u32 player_num = holder->getPlayerNum();
+
+    for (u32 i = 0; i < player_num; i++) {
+        LiveActor* player = holder->tryGetPlayer(i);
+        if (!isDead(player)) {
+            return player;
+        }
+    }
+
+    return nullptr;
+}
+
+LiveActor* findAlivePlayerActorFirst(const PlayerHolder* holder) {
+    u32 player_num = holder->getPlayerNum();
+
+    for (u32 i = 0; i < player_num; i++) {
+        LiveActor* player = holder->tryGetPlayer(i);
+        if (!isDead(player)) {
+            return player;
+        }
+    }
+
+    return nullptr;
+}
+}  // namespace al


### PR DESCRIPTION
Some notes:
* I couldn't find a `sead` data structure which matches the ordering of the class members in `PlayerHolder` (pointer, size, count).
* ~~I tried implementing `al::getAlivePlayerNum()` with a for loop, but the ordering of two `MOV W##, WZR` instructions would never be right. If I did it with a do-while (which I did in this PR), the ordering matches.~~
* ~~`al::getPlayerPos()` is odd. The game's function uses two `BL`s in a row, but no matter what I do, I always get `BL`, `LDP`, and then `B`. If I remove the return statement, the function would then contain the two `BL`s, but the epilogue would no longer be correct.~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monsterdruide1/odysseydecomp/10)
<!-- Reviewable:end -->
