### PR TITLE
`.gitignore`: Fix build folder for non-default CLion toolchains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ bin/
 .vscode/
 .cache/
 .DS_Store
+/cmake-build-*
 
 # IDA
 *.id0
@@ -46,4 +47,3 @@ perf.data.old
 tools/check
 tools/listsym
 tools/decompme
-/cmake-build-debug


### PR DESCRIPTION
Changes `/cmake-build-debug` to `/cmake-build-*` as using a toolchain without changing the build folder will cause the new folder to not be caught by the `.gitignore`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/monsterdruide1/odysseydecomp/13)
<!-- Reviewable:end -->
