### PR TITLE
Add workflow for progress

### DIFF
--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -1,0 +1,51 @@
+name: progress
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish_progress:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out project
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Set up dependencies
+      run: sudo apt install -y ninja-build cmake ccache clang curl libncurses5
+    - name: Set up python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+    - name: Set up python package dependencies
+      run: pip install toml colorama cxxfilt
+    - name: Set up cache for clang
+      uses: actions/cache@v3
+      with:
+        key: clang391-401
+        path: |
+          toolchain/clang-3.9.1
+          toolchain/clang-4.0.1
+    - name: Run simplified setup
+      run: tools/setup.py --project
+    - name: Build project
+      run: tools/build.py
+    - name: Upload progress state
+      run: |
+        full_ansi="$(tools/common/progress.py)"
+        full=`echo $full_ansi | sed -e 's/\x1b\[[0-9;]*m//g'`
+        echo $full
+        MATCHING=`echo $full | sed -n "s/^.*matching\s(\([0-9]\+\.[0-9]\+\)%.*$/\1/p"`
+        MINOR=`echo $full | sed -n "s/^.*non-matching (minor issues)\s(\([0-9]\+\.[0-9]\+\)%.*$/\1/p"`
+        MAJOR=`echo $full | sed -n "s/^.*non-matching (major issues)\s(\([0-9]\+\.[0-9]\+\)%.*$/\1/p"`
+        var=`curl "https://monsterdruide.one/OdysseyDecomp/save_progress.php?matching=$MATCHING&minor=$MINOR&major=$MAJOR&pw=$PROGRESS_PASS"`
+        if [[ "$var" == "OK" ]]; then
+          exit 0
+        else
+          echo $var;
+          exit 1
+        fi
+      env:
+        PROGRESS_PASS: ${{ secrets.PROGRESS_PASS }}

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# OdysseyDecomp
+# OdysseyDecomp ![Decompiled Status](https://img.shields.io/badge/dynamic/json?url=https://monsterdruide.one/OdysseyDecomp/progress.json&query=$.matching&suffix=%&label=decompiled&color=blue)
 Decompilation of all Super Mario Odyssey versions, from 1.0.0 to 1.3.0.
 
 # Building

--- a/tools/setup.py
+++ b/tools/setup.py
@@ -77,10 +77,13 @@ def main():
                         help="Path to the original NSO (1.0, compressed or not)", nargs="?")
     parser.add_argument("--cmake_backend", type=str,
                         help="CMake backend to use (Ninja, Unix Makefiles, etc.)", nargs="?", default="Ninja")
+    parser.add_argument("--project-only", action="store_true",
+                        help="Disable viking and original NSO setup")
     args = parser.parse_args()
-
-    setup.install_viking()
-    prepare_executable(args.original_nso)
+    
+    if not args.project_only:
+        setup.install_viking()
+        prepare_executable(args.original_nso)
     setup.set_up_compiler("3.9.1")
     setup.set_up_compiler("4.0.1")
     create_build_dir(Version.VER_100, args.cmake_backend)


### PR DESCRIPTION
Adding a GitHub workflow that only triggers on `master` (and currently this branch for testing), that publishes the progress to a simple `php` script.

PHP:
```php
<?php
$myfile = fopen("progress.json", "w") or die("Unable to open file!");
$pw = $_GET["pw"];
if (strcmp($pw, "[...]") !== 0) {
	die("Wrong password!");
}
$matching = $_GET["matching"];
$minor = $_GET["minor"];
$major = $_GET["major"];
$txt = <<<JSON
{
    "matching": $matching,
    "non_matching_minor": $minor,
    "non_matching_major": $major
}

JSON;
fwrite($myfile, $txt);
fclose($myfile);
echo "OK";
?>
```

Publishing the [progress.json](https://monsterdruide.one/OdysseyDecomp/progress.json), which can then be used to render a shield.io-Badge.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/15)
<!-- Reviewable:end -->
