### PR TITLE
Add OdysseyHeaders publishing workflow

### DIFF
--- a/.github/scripts/copy-headers.sh
+++ b/.github/scripts/copy-headers.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# bash boilerplate
+set -euo pipefail # strict mode
+readonly SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+function l { # Log a message to the terminal.
+    echo
+    echo -e "[$SCRIPT_NAME] ${1:-}"
+}
+
+# Delete everything within the headers repo to get a fresh start
+rm -r $DESTINATION_PATH/*
+
+# Copy libraries
+mkdir $DESTINATION_PATH/NintendoSDK $DESTINATION_PATH/agl $DESTINATION_PATH/al $DESTINATION_PATH/eui $DESTINATION_PATH/sead
+cp -r ./lib/NintendoSDK/include/* $DESTINATION_PATH/NintendoSDK
+cp -r ./lib/aarch64 $DESTINATION_PATH/
+cp -r ./lib/agl/include/* $DESTINATION_PATH/agl
+cp -r ./lib/al/include/* $DESTINATION_PATH/al
+cp -r ./lib/eui/include/* $DESTINATION_PATH/eui
+cp -r ./lib/sead/include/* $DESTINATION_PATH/sead
+
+# Copy headers of game
+mkdir $DESTINATION_PATH/game
+rsync -a --prune-empty-dirs --include '*/' --include '*.h' --exclude '*' src/ $DESTINATION_PATH/game
+
+# Make all contents of every class public
+grep -rli 'private:' * | xargs -i@ sed -i 's/private:/public:/g' @
+grep -rli 'protected:' * | xargs -i@ sed -i 's/protected:/public:/g' @

--- a/.github/scripts/push-headers.sh
+++ b/.github/scripts/push-headers.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# bash boilerplate
+readonly SCRIPT_NAME="$(basename "$0")"
+readonly SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+function l { # Log a message to the terminal.
+    echo
+    echo -e "[$SCRIPT_NAME] ${1:-}"
+}
+
+# move to the root the OdysseyHeaders repo
+cd "./OdysseyHeaders"
+echo "Open root of OdysseyHeaders repo"
+
+git add -A .
+git config user.name $COMMIT_AUTHOR_NAME
+git config user.email $COMMIT_AUTHOR_MAIL
+git commit -am "$COMMIT_MESSAGE"
+git push -f -u origin $HEADER_BRANCH
+
+echo "Updated headers successfully pushed to OdysseyHeaders repo"

--- a/.github/workflows/clean-headers.yml
+++ b/.github/workflows/clean-headers.yml
@@ -1,0 +1,34 @@
+# heavily inspired by https://www.paigeniedringhaus.com/blog/copy-files-from-one-repo-to-another-automatically-with-git-hub-actions
+
+name: Clean/Delete branches when removed from Decomp/PRs closed
+
+on:
+  delete:
+  pull_request_target:
+    types: [closed]
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  copy_headers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out OdysseyHeaders project
+      uses: actions/checkout@v3
+      with:
+        repository: MonsterDruide1/OdysseyHeaders
+        path: ./OdysseyHeaders
+        token: ${{ secrets.HEADERS_TOKEN }}
+    - name: Create proper branch name (for PRs, in Headers repo)
+      run: |
+        if [[ $GITHUB_EVENT_NAME == 'pull_request_target' ]]
+        then
+          echo "HEADER_BRANCH=pr-`expr match "$GITHUB_REF_NAME" '.*\(^[0-9]*\)/'`" >> "$GITHUB_ENV"
+        else
+          echo "HEADER_BRANCH=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+        fi
+    - name: Delete branch from OdysseyHeaders
+      run: |
+        cd OdysseyHeaders
+        git push -d origin $HEADER_BRANCH

--- a/.github/workflows/copy-headers.yml
+++ b/.github/workflows/copy-headers.yml
@@ -1,0 +1,55 @@
+# heavily inspired by https://www.paigeniedringhaus.com/blog/copy-files-from-one-repo-to-another-automatically-with-git-hub-actions
+
+name: Copy headers to separate repo
+
+on:
+  push:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  copy_headers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out OdysseyDecomp project
+      uses: actions/checkout@v3
+      with:
+        submodules: recursive
+    - name: Check out branch if in PR
+      if: ${{ github.event_name == 'pull_request_target' }}
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        submodules: recursive
+    - name: Check out OdysseyHeaders project
+      uses: actions/checkout@v3
+      with:
+        repository: MonsterDruide1/OdysseyHeaders
+        path: ./OdysseyHeaders
+        token: ${{ secrets.HEADERS_TOKEN }}
+    - name: Create proper branch name (for PRs, in Headers repo)
+      run: |
+        if [[ $GITHUB_EVENT_NAME == 'pull_request_target' ]]
+        then
+          echo "HEADER_BRANCH=pr-`expr match "$GITHUB_REF_NAME" '.*\(^[0-9]*\)/'`" >> "$GITHUB_ENV"
+        else
+          echo "HEADER_BRANCH=$GITHUB_REF_NAME" >> "$GITHUB_ENV"
+        fi
+    - name: Move to correct branch of OdysseyHeaders and reset history
+      run: |
+        cd OdysseyHeaders
+        git checkout $HEADER_BRANCH 2>/dev/null || git checkout -b $HEADER_BRANCH
+        git reset --hard origin/master
+    - name: Copy files
+      run: bash ./.github/scripts/copy-headers.sh
+      env:
+        DESTINATION_PATH: ./OdysseyHeaders
+    - name: Push to OdysseyHeaders repo
+      run: bash ./.github/scripts/push-headers.sh
+      env:
+        COMMIT_AUTHOR_NAME: ${{ github.event.commits[0].author.name }}
+        COMMIT_AUTHOR_MAIL: ${{ github.event.commits[0].author.email }}
+        COMMIT_MESSAGE: ${{ github.event.commits[0].message }}


### PR DESCRIPTION
This PR adds another workflow, which will be responsible for automatically pushing to the [OdysseyHeaders](https://github.com/MonsterDruide1/OdysseyHeaders) repo.

It will push `master` to `master`, branches on the main repo to their respective name, and PRs to `pr-#` (`#`=PR-number), and automatically clean up deleted branches/closed PRs.
=> this PR will end up on `headers-repo` and `pr-21`.

Some testing on a separate repo has shown that files that are not referenced by the git history will not be cloned with the repository, so after deleting their respective branches, PR/branch files will not take up any more space on the headers repo in the long term.

Please note that this workflow will always only do a single commit on top of the `master` branch, squashing all changes (if multiple commits are done on a branch/PR).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/21)
<!-- Reviewable:end -->
