### PR TITLE
lots of AreaObj.* functions

### DIFF
--- a/lib/al/include/Library/Area/AreaInitInfo.h
+++ b/lib/al/include/Library/Area/AreaInitInfo.h
@@ -7,21 +7,21 @@ class PlacementInfo;
 class StageSwitchDirector;
 class SceneObjHolder;
 
-class AreaInitInfo : public al::PlacementInfo {
-private:
-    al::StageSwitchDirector* mStageSwitchDirector;
-    al::SceneObjHolder* mSceneObjHolder;
-
+class AreaInitInfo : public PlacementInfo {
 public:
     AreaInitInfo(){};
-    AreaInitInfo(const al::PlacementInfo& placementInfo,
-                 al::StageSwitchDirector* stageSwitchDirector, al::SceneObjHolder* sceneObjHolder);
-    AreaInitInfo(const al::PlacementInfo& placementInfo, const al::AreaInitInfo& initInfo);
+    AreaInitInfo(const PlacementInfo& placementInfo, StageSwitchDirector* stageSwitchDirector,
+                 SceneObjHolder* sceneObjHolder);
+    AreaInitInfo(const PlacementInfo& placementInfo, const AreaInitInfo& initInfo);
 
-    void set(const al::PlacementInfo& placementInfo, al::StageSwitchDirector* stageSwitchDirector,
-             al::SceneObjHolder* sceneObjHolder);
+    void set(const PlacementInfo& placementInfo, StageSwitchDirector* stageSwitchDirector,
+             SceneObjHolder* sceneObjHolder);
 
-    al::StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; }
-    al::SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
+    StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; }
+    SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
+
+private:
+    StageSwitchDirector* mStageSwitchDirector;
+    SceneObjHolder* mSceneObjHolder;
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaInitInfo.h
+++ b/lib/al/include/Library/Area/AreaInitInfo.h
@@ -3,13 +3,12 @@
 #include "Library/Placement/PlacementInfo.h"
 
 namespace al {
-class PlacementInfo;
 class StageSwitchDirector;
 class SceneObjHolder;
 
 class AreaInitInfo : public PlacementInfo {
 public:
-    AreaInitInfo(){};
+    AreaInitInfo();
     AreaInitInfo(const PlacementInfo& placementInfo, StageSwitchDirector* stageSwitchDirector,
                  SceneObjHolder* sceneObjHolder);
     AreaInitInfo(const PlacementInfo& placementInfo, const AreaInitInfo& initInfo);

--- a/lib/al/include/Library/Area/AreaInitInfo.h
+++ b/lib/al/include/Library/Area/AreaInitInfo.h
@@ -3,26 +3,25 @@
 #include "Library/Placement/PlacementInfo.h"
 
 namespace al {
+class PlacementInfo;
 class StageSwitchDirector;
 class SceneObjHolder;
 
-class AreaInitInfo {
-public:
-    AreaInitInfo();
-    AreaInitInfo(const PlacementInfo& placementInfo, StageSwitchDirector* stageSwitchDirector,
-                 SceneObjHolder* sceneObjHolder);
-    AreaInitInfo(const PlacementInfo& placementInfo, const AreaInitInfo& initInfo);
-
-    void set(const PlacementInfo& placementInfo, StageSwitchDirector* stageSwitchDirector,
-             SceneObjHolder* sceneObjHolder);
-
-    const PlacementInfo& getPlacementInfo() const { return mPlacementInfo; }
-    StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; }
-    SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
-
+class AreaInitInfo : public al::PlacementInfo {
 private:
-    PlacementInfo mPlacementInfo;
-    StageSwitchDirector* mStageSwitchDirector;
-    SceneObjHolder* mSceneObjHolder;
+    al::StageSwitchDirector* mStageSwitchDirector;
+    al::SceneObjHolder* mSceneObjHolder;
+
+public:
+    AreaInitInfo(){};
+    AreaInitInfo(const al::PlacementInfo& placementInfo,
+                 al::StageSwitchDirector* stageSwitchDirector, al::SceneObjHolder* sceneObjHolder);
+    AreaInitInfo(const al::PlacementInfo& placementInfo, const al::AreaInitInfo& initInfo);
+
+    void set(const al::PlacementInfo& placementInfo, al::StageSwitchDirector* stageSwitchDirector,
+             al::SceneObjHolder* sceneObjHolder);
+
+    al::StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; }
+    al::SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObj.h
+++ b/lib/al/include/Library/Area/AreaObj.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <math/seadMatrix.h>
+
 #include "Library/HostIO/HioNode.h"
 #include "Library/Scene/IUseSceneObjHolder.h"
 #include "Library/Stage/IUseStageSwitch.h"

--- a/lib/al/include/Library/Area/AreaObj.h
+++ b/lib/al/include/Library/Area/AreaObj.h
@@ -22,7 +22,7 @@ public:
     void initStageSwitchKeeper() override;
     virtual void init(const AreaInitInfo& initInfo);
     virtual bool isInVolume(const sead::Vector3f& position) const;
-    virtual bool isInVolumeOffset(const sead::Vector3f&, f32 offset) const;
+    virtual bool isInVolumeOffset(const sead::Vector3f& position, f32 offset) const;
     SceneObjHolder* getSceneObjHolder() const override;
     void validate();
     void invalidate();

--- a/lib/al/include/Library/Area/AreaObj.h
+++ b/lib/al/include/Library/Area/AreaObj.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <math/seadMatrix.h>
-#include "al/include/Library/HostIO/HioNode.h"
-#include "al/include/Library/Scene/IUseSceneObjHolder.h"
-#include "al/include/Library/Stage/IUseStageSwitch.h"
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/IUseSceneObjHolder.h"
+#include "Library/Stage/IUseStageSwitch.h"
 
 namespace al {
 class AreaInitInfo;
@@ -14,16 +14,6 @@ class SceneObjHolder;
 class StageSwitchKeeper;
 
 class AreaObj : public IUseStageSwitch, public IUseSceneObjHolder, public HioNode {
-private:
-    const char* mName;
-    AreaShape* mAreaShape = nullptr;
-    StageSwitchKeeper* mStageSwitchKeeper = nullptr;
-    SceneObjHolder* mSceneObjHolder = nullptr;
-    sead::Matrix34f mMatrixTR = sead::Matrix34f::ident;
-    PlacementInfo* mPlacementInfo = nullptr;
-    s32 mPriority = -1;
-    bool isValid = true;
-
 public:
     AreaObj(const char* name);
     const char* getName() const override;
@@ -37,6 +27,16 @@ public:
     void invalidate();
 
     s32 getPriority() { return mPriority; };
+
+private:
+    const char* mName;
+    AreaShape* mAreaShape = nullptr;
+    StageSwitchKeeper* mStageSwitchKeeper = nullptr;
+    SceneObjHolder* mSceneObjHolder = nullptr;
+    sead::Matrix34f mMatrixTR = sead::Matrix34f::ident;
+    PlacementInfo* mPlacementInfo = nullptr;
+    s32 mPriority = -1;
+    bool isValid = true;
 };
 
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObj.h
+++ b/lib/al/include/Library/Area/AreaObj.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include "al/include/Library/HostIO/HioNode.h"
+#include "al/include/Library/Scene/IUseSceneObjHolder.h"
+#include "al/include/Library/Stage/IUseStageSwitch.h"
+
+namespace al {
+class AreaInitInfo;
+class AreaObjGroup;
+class AreaShape;
+class PlacementInfo;
+class SceneObjHolder;
+class StageSwitchKeeper;
+
+class AreaObj : public IUseStageSwitch, public IUseSceneObjHolder, public HioNode {
+private:
+    const char* mName;
+    AreaShape* mAreaShape = nullptr;
+    StageSwitchKeeper* mStageSwitchKeeper = nullptr;
+    SceneObjHolder* mSceneObjHolder = nullptr;
+    sead::Matrix34f mMatrixTR = sead::Matrix34f::ident;
+    PlacementInfo* mPlacementInfo = nullptr;
+    s32 mPriority = -1;
+    bool isValid = true;
+
+public:
+    AreaObj(const char* name);
+    const char* getName() const override;
+    StageSwitchKeeper* getStageSwitchKeeper() const override;
+    void initStageSwitchKeeper() override;
+    virtual void init(const AreaInitInfo& initInfo);
+    virtual bool isInVolume(const sead::Vector3f& position) const;
+    virtual bool isInVolumeOffset(const sead::Vector3f&, f32 offset) const;
+    SceneObjHolder* getSceneObjHolder() const override;
+    void validate();
+    void invalidate();
+
+    s32 getPriority() { return mPriority; };
+};
+
+}  // namespace al

--- a/lib/al/include/Library/Area/AreaObjDirector.h
+++ b/lib/al/include/Library/Area/AreaObjDirector.h
@@ -2,6 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+
 #include "Library/Area/AreaObjGroup.h"
 
 namespace al {

--- a/lib/al/include/Library/Area/AreaObjDirector.h
+++ b/lib/al/include/Library/Area/AreaObjDirector.h
@@ -2,7 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
-#include "al/include/Library/Area/AreaObjGroup.h"
+#include "Library/Area/AreaObjGroup.h"
 
 namespace al {
 class AreaObjFactory;

--- a/lib/al/include/Library/Area/AreaObjDirector.h
+++ b/lib/al/include/Library/Area/AreaObjDirector.h
@@ -2,6 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+#include "al/include/Library/Area/AreaObjGroup.h"
 
 namespace al {
 class AreaObjFactory;
@@ -17,19 +18,35 @@ public:
     void endInit();
     void update();
     void placement(const AreaInitInfo& initInfo);
-    void placement(const AreaInitInfo& initInfo, s32);
+    void placement(const AreaInitInfo* initInfo, s32 initInfoCount);
     void createAreaObjGroup(const AreaInitInfo& initInfo);
-    void createAreaObjGroupBuffer(const AreaInitInfo& initInfo);
+    void createAreaObjGroupBuffer();
     void placementAreaObj(const AreaInitInfo& initInfo);
-    AreaObjGroup* getAreaObjGroup(const char* name);
-    bool isExistAreaGroup(const char* name);
+    AreaObjGroup* getAreaObjGroup(const char* name) const;
+    bool isExistAreaGroup(const char* name) const;
     AreaObj* getInVolumeAreaObj(const char* name, const sead::Vector3f& position);
-    AreaObjMtxConnecterHolder* getMtxConnecterHolder();
+    AreaObjMtxConnecterHolder* getMtxConnecterHolder() const;
 
 private:
-    AreaObjFactory* mFactory;
-    AreaObjMtxConnecterHolder* mMtxConnecterHolder;
-    AreaObjGroup** mAreaGroups;
-    u32 mAreaGroupCount;
+    const AreaObjFactory* mFactory = nullptr;
+    AreaObjMtxConnecterHolder* mMtxConnecterHolder = nullptr;
+    AreaObjGroup** mAreaGroups = nullptr;
+    u32 mAreaGroupCount = 0;
+
+    AreaObjGroup* _getAreaObjGroup(const char* name) const {
+        s32 lower = 0;
+        s32 upper = mAreaGroupCount;
+        while (lower < upper) {
+            s32 i = (lower + upper) / 2;
+            s32 equalString = strcmp(name, mAreaGroups[i]->getName());
+            if (equalString == 0) {
+                return mAreaGroups[i];
+            } else if (equalString > 0) {
+                lower = i + 1;
+            } else
+                upper = i;
+        }
+        return nullptr;
+    }
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObjDirector.h
+++ b/lib/al/include/Library/Area/AreaObjDirector.h
@@ -33,21 +33,5 @@ private:
     AreaObjMtxConnecterHolder* mMtxConnecterHolder = nullptr;
     AreaObjGroup** mAreaGroups = nullptr;
     u32 mAreaGroupCount = 0;
-
-    AreaObjGroup* _getAreaObjGroup(const char* name) const {
-        s32 lower = 0;
-        s32 upper = mAreaGroupCount;
-        while (lower < upper) {
-            s32 i = (lower + upper) / 2;
-            s32 equalString = strcmp(name, mAreaGroups[i]->getName());
-            if (equalString == 0) {
-                return mAreaGroups[i];
-            } else if (equalString > 0) {
-                lower = i + 1;
-            } else
-                upper = i;
-        }
-        return nullptr;
-    }
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObjFactory.h
+++ b/lib/al/include/Library/Area/AreaObjFactory.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "al/include/Library/Factory/Factory.h"
+
+namespace al {
+
+class AreaObj;
+
+using AreaObjCreatorFunction = AreaObj* (*)(const char*);
+
+struct AreaGroupInfo {
+    const char* name;
+    s32 size;
+};
+
+class AreaObjFactory : public Factory<AreaObjCreatorFunction> {
+private:
+    AreaGroupInfo* mAreaGroupInfo = nullptr;
+    s32 mNumBuffers = 0;
+
+public:
+    AreaObjFactory(const char* factoryName);
+    s32 tryFindAddBufferSize(const char* bufferName) const;
+
+    AreaGroupInfo* getAreaGroupInfo() const { return mAreaGroupInfo; };
+    s32 getAreaGroupCount() const { return mNumBuffers; };
+
+    template <s32 N>
+    void setAreaGroupInfo(AreaGroupInfo (&areaInfo)[N]) {
+        mNumBuffers = N;
+        mAreaGroupInfo = areaInfo;
+    }
+};
+
+}  // namespace al

--- a/lib/al/include/Library/Area/AreaObjFactory.h
+++ b/lib/al/include/Library/Area/AreaObjFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Factory/Factory.h"
+#include "Library/Factory/Factory.h"
 
 namespace al {
 
@@ -14,10 +14,6 @@ struct AreaGroupInfo {
 };
 
 class AreaObjFactory : public Factory<AreaObjCreatorFunction> {
-private:
-    AreaGroupInfo* mAreaGroupInfo = nullptr;
-    s32 mNumBuffers = 0;
-
 public:
     AreaObjFactory(const char* factoryName);
     s32 tryFindAddBufferSize(const char* bufferName) const;
@@ -30,6 +26,10 @@ public:
         mNumBuffers = N;
         mAreaGroupInfo = areaInfo;
     }
+
+private:
+    AreaGroupInfo* mAreaGroupInfo = nullptr;
+    s32 mNumBuffers = 0;
 };
 
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObjGroup.h
+++ b/lib/al/include/Library/Area/AreaObjGroup.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class AreaObj;
+
+class AreaObjGroup {
+private:
+    const char* mGroupName;
+    al::AreaObj** mBuffer = nullptr;
+    s32 mCount = 0;
+    s32 mCapacity;
+
+public:
+    AreaObjGroup(const char* groupName, const int capacity);
+    void createBuffer();
+    void createBuffer(const s32 capacity);
+    al::AreaObj* getAreaObj(const s32 index) const;
+    al::AreaObj* getInVolumeAreaObj(const sead::Vector3f& position) const;
+    void incrementCount();
+    void registerAreaObj(al::AreaObj* newAreaObj);
+
+    const char* getName() const { return mGroupName; };
+};
+}  // namespace al

--- a/lib/al/include/Library/Area/AreaObjGroup.h
+++ b/lib/al/include/Library/Area/AreaObjGroup.h
@@ -6,21 +6,21 @@ namespace al {
 class AreaObj;
 
 class AreaObjGroup {
-private:
-    const char* mGroupName;
-    al::AreaObj** mBuffer = nullptr;
-    s32 mCount = 0;
-    s32 mCapacity;
-
 public:
     AreaObjGroup(const char* groupName, const int capacity);
     void createBuffer();
     void createBuffer(const s32 capacity);
-    al::AreaObj* getAreaObj(const s32 index) const;
-    al::AreaObj* getInVolumeAreaObj(const sead::Vector3f& position) const;
+    AreaObj* getAreaObj(const s32 index) const;
+    AreaObj* getInVolumeAreaObj(const sead::Vector3f& position) const;
     void incrementCount();
-    void registerAreaObj(al::AreaObj* newAreaObj);
+    void registerAreaObj(AreaObj* newAreaObj);
 
     const char* getName() const { return mGroupName; };
+
+private:
+    const char* mGroupName;
+    AreaObj** mBuffer = nullptr;
+    s32 mCount = 0;
+    s32 mCapacity;
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/AreaObjMtxConnecter.h
+++ b/lib/al/include/Library/Area/AreaObjMtxConnecter.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include "al/include/Library/Placement/PlacementInfo.h"
+
+namespace al {
+class AreaObj;
+class MtxConnector;
+class PlacementInfo;
+class ValidatorBase;
+
+class AreaObjMtxConnecter {
+private:
+    AreaObj* mAreaObj;
+    sead::Matrix34f mMatrix;
+    MtxConnector* mMtxConnector = nullptr;
+    PlacementInfo mPlacementInfo;
+    ValidatorBase* mValidatorBase = nullptr;
+
+public:
+    AreaObjMtxConnecter(AreaObj* areaObj, const PlacementInfo& placementInfo);
+    bool trySetParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
+                         const ValidatorBase* validatorBase);
+    bool trySyncParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
+                          const ValidatorBase* validatorBase);
+    void update();
+};
+
+class AreaObjMtxConnecterHolder {
+private:
+    MtxConnector** mMtxConnectors;
+    s32 mNumConnectors = 0;
+    s32 mCapacity;
+
+public:
+    AreaObjMtxConnecterHolder(s32 capacity);
+    void registerParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
+                           const ValidatorBase* validatorBase);
+    void registerSyncParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
+                               const ValidatorBase* validatorBase);
+    s32 tryAddArea(AreaObj* areaObj, const PlacementInfo& placementInfo);
+    void update();
+};
+
+}  // namespace al

--- a/lib/al/include/Library/Area/AreaObjMtxConnecter.h
+++ b/lib/al/include/Library/Area/AreaObjMtxConnecter.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <math/seadMatrix.h>
+
 #include "Library/Placement/PlacementInfo.h"
 
 namespace al {

--- a/lib/al/include/Library/Area/AreaObjMtxConnecter.h
+++ b/lib/al/include/Library/Area/AreaObjMtxConnecter.h
@@ -38,7 +38,7 @@ public:
     void update();
 
 private:
-    MtxConnector** mMtxConnectors;
+    AreaObjMtxConnecter** mMtxConnectors;
     s32 mNumConnectors = 0;
     s32 mCapacity;
 };

--- a/lib/al/include/Library/Area/AreaObjMtxConnecter.h
+++ b/lib/al/include/Library/Area/AreaObjMtxConnecter.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <math/seadMatrix.h>
-#include "al/include/Library/Placement/PlacementInfo.h"
+#include "Library/Placement/PlacementInfo.h"
 
 namespace al {
 class AreaObj;
@@ -10,13 +10,6 @@ class PlacementInfo;
 class ValidatorBase;
 
 class AreaObjMtxConnecter {
-private:
-    AreaObj* mAreaObj;
-    sead::Matrix34f mMatrix;
-    MtxConnector* mMtxConnector = nullptr;
-    PlacementInfo mPlacementInfo;
-    ValidatorBase* mValidatorBase = nullptr;
-
 public:
     AreaObjMtxConnecter(AreaObj* areaObj, const PlacementInfo& placementInfo);
     bool trySetParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
@@ -24,14 +17,16 @@ public:
     bool trySyncParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
                           const ValidatorBase* validatorBase);
     void update();
+
+private:
+    AreaObj* mAreaObj;
+    sead::Matrix34f mMatrix;
+    MtxConnector* mMtxConnector = nullptr;
+    PlacementInfo mPlacementInfo;
+    ValidatorBase* mValidatorBase = nullptr;
 };
 
 class AreaObjMtxConnecterHolder {
-private:
-    MtxConnector** mMtxConnectors;
-    s32 mNumConnectors = 0;
-    s32 mCapacity;
-
 public:
     AreaObjMtxConnecterHolder(s32 capacity);
     void registerParentMtx(const sead::Matrix34f* parentMtx, const PlacementInfo& placementInfo,
@@ -40,6 +35,11 @@ public:
                                const ValidatorBase* validatorBase);
     s32 tryAddArea(AreaObj* areaObj, const PlacementInfo& placementInfo);
     void update();
+
+private:
+    MtxConnector** mMtxConnectors;
+    s32 mNumConnectors = 0;
+    s32 mCapacity;
 };
 
 }  // namespace al

--- a/lib/al/include/Library/Area/TrafficArea.h
+++ b/lib/al/include/Library/Area/TrafficArea.h
@@ -1,17 +1,19 @@
-#include "al/include/Library/Area/AreaObj.h"
+#pragma once
+
+#include "Library/Area/AreaObj.h"
 
 namespace al {
 class TrafficArea : public AreaObj {
-private:
-    bool mCarFull = false;
-    bool mNpcFull = false;
-    bool mNpcUnavailable = false;
-    char mUnkChar = '\0';
-
 public:
     TrafficArea(const char* name);
 
     bool tryPermitEnterCar();
     bool tryPermitEnterNpc();
+
+private:
+    bool mCarFull = false;
+    bool mNpcFull = false;
+    bool mNpcUnavailable = false;
+    char mUnkChar = '\0';
 };
 }  // namespace al

--- a/lib/al/include/Library/Area/TrafficArea.h
+++ b/lib/al/include/Library/Area/TrafficArea.h
@@ -1,0 +1,17 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+class TrafficArea : public AreaObj {
+private:
+    bool mCarFull = false;
+    bool mNpcFull = false;
+    bool mNpcUnavailable = false;
+    char mUnkChar = '\0';
+
+public:
+    TrafficArea(const char* name);
+
+    bool tryPermitEnterCar();
+    bool tryPermitEnterNpc();
+};
+}  // namespace al

--- a/lib/al/include/Library/Area/TrafficArea.h
+++ b/lib/al/include/Library/Area/TrafficArea.h
@@ -14,6 +14,6 @@ private:
     bool mCarFull = false;
     bool mNpcFull = false;
     bool mNpcUnavailable = false;
-    char mUnkChar = '\0';
+    bool mCarUnavailable = false;
 };
 }  // namespace al

--- a/lib/al/include/Library/Factory/Factory.h
+++ b/lib/al/include/Library/Factory/Factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+
 #include "Library/Base/String.h"
 
 namespace al {

--- a/lib/al/include/Library/Factory/Factory.h
+++ b/lib/al/include/Library/Factory/Factory.h
@@ -32,7 +32,7 @@ public:
 
     s32 getNumFactoryEntries() const { return mNumFactoryEntries; }
 
-    s32 getEntryIndex(const char* entryName, T* creationPtr) const {
+    s32 getEntryIndex(T* creationPtr, const char* entryName) const {
         const char* name = convertName(entryName);
         s32 nFactoryEntries = mNumFactoryEntries;
         const NameToCreator<T>* entries = mFactoryEntries;

--- a/lib/al/include/Library/Factory/Factory.h
+++ b/lib/al/include/Library/Factory/Factory.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
-#include "al/include/Library/Base/String.h"
+#include "Library/Base/String.h"
 
 namespace al {
 template <typename T>

--- a/lib/al/include/Library/Factory/Factory.h
+++ b/lib/al/include/Library/Factory/Factory.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include "al/include/Library/Base/String.h"
 
 namespace al {
 template <typename T>
@@ -27,6 +28,21 @@ public:
     }
 
     virtual const char* convertName(const char* name) const { return name; }
+
+    s32 getNumFactoryEntries() const { return mNumFactoryEntries; }
+
+    s32 getEntryIndex(const char* entryName, T* creationPtr) const {
+        const char* name = convertName(entryName);
+        s32 nFactoryEntries = mNumFactoryEntries;
+        const NameToCreator<T>* entries = mFactoryEntries;
+        for (s32 i = 0; i < nFactoryEntries; i++) {
+            if (isEqualString(name, entries[i].mName)) {
+                *creationPtr = entries[i].mCreationFunction;
+                return i;
+            }
+        }
+        return -1;
+    }
 
 private:
     const char* mFactoryName;

--- a/lib/al/include/Library/LiveActor/ActorInitInfo.h
+++ b/lib/al/include/Library/LiveActor/ActorInitInfo.h
@@ -76,6 +76,8 @@ public:
     void initNoViewId(const PlacementInfo*, const ActorInitInfo&);
 
     const PlacementInfo& getPlacementInfo() const { return *mPlacementInfo; }
+    StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; };
+    SceneObjHolder* getActorSceneObjHolder() const { return mActorSceneInfo.mSceneObjHolder; };
 
 private:
     LiveActorGroup* mKitDrawingGroup;

--- a/lib/al/include/Library/Placement/PlacementFunction.h
+++ b/lib/al/include/Library/Placement/PlacementFunction.h
@@ -239,17 +239,18 @@ bool tryGetDisplayScale(sead::Vector3f* scale, const ActorInitInfo& initInfo);
 }  // namespace al
 
 class alPlacementFunction {
-    s32 getCameraId(const al::ActorInitInfo& initInfo);
-    void getLinkGroupId(al::PlacementId* groupId, const al::ActorInitInfo& initInfo,
-                        const char* linkName);
-    bool isEnableLinkGroupId(const al::ActorInitInfo& initInfo, const char* linkName);
-    bool isEnableGroupClipping(const al::ActorInitInfo& initInfo);
-    void getClippingGroupId(al::PlacementId* groupId, const al::ActorInitInfo& initInfo);
-    void createClippingViewId(const al::PlacementInfo& placementInfo);
-    void getClippingViewId(al::PlacementId* viewId, const al::PlacementInfo& placementInfo);
-    void getClippingViewId(al::PlacementId* viewId, const al::ActorInitInfo& initInfo);
-    void getModelName(const char** modelName, const al::ActorInitInfo& initInfo);
-    void getModelName(const char** modelName, const al::PlacementInfo& placementInfo);
-    bool tryGetModelName(const char** modelName, const al::PlacementInfo& placementInfo);
-    bool tryGetModelName(const char** modelName, const al::ActorInitInfo& initInfo);
+public:
+    static s32 getCameraId(const al::ActorInitInfo& initInfo);
+    static void getLinkGroupId(al::PlacementId* groupId, const al::ActorInitInfo& initInfo,
+                               const char* linkName);
+    static bool isEnableLinkGroupId(const al::ActorInitInfo& initInfo, const char* linkName);
+    static bool isEnableGroupClipping(const al::ActorInitInfo& initInfo);
+    static void getClippingGroupId(al::PlacementId* groupId, const al::ActorInitInfo& initInfo);
+    static void createClippingViewId(const al::PlacementInfo& placementInfo);
+    static void getClippingViewId(al::PlacementId* viewId, const al::PlacementInfo& placementInfo);
+    static void getClippingViewId(al::PlacementId* viewId, const al::ActorInitInfo& initInfo);
+    static void getModelName(const char** modelName, const al::ActorInitInfo& initInfo);
+    static void getModelName(const char** modelName, const al::PlacementInfo& placementInfo);
+    static bool tryGetModelName(const char** modelName, const al::PlacementInfo& placementInfo);
+    static bool tryGetModelName(const char** modelName, const al::ActorInitInfo& initInfo);
 };

--- a/lib/al/include/Library/Play/Area/CameraStartParamArea.h
+++ b/lib/al/include/Library/Play/Area/CameraStartParamArea.h
@@ -1,18 +1,20 @@
-#include "al/include/Library/Area/AreaObj.h"
+#pragma once
+
+#include "Library/Area/AreaObj.h"
 
 namespace al {
-class CameraStartParamArea : public al::AreaObj {
+class CameraStartParamArea : public AreaObj {
+public:
+    CameraStartParamArea(const char* name);
+
+    void init(const AreaInitInfo& areaInitInfo) override;
+
+    void appear();
+    void kill();
+
 private:
     bool mIsAlive = true;
     f32* mAngleH = nullptr;
     f32* mAngleV = nullptr;
-
-public:
-    CameraStartParamArea(const char* name);
-
-    void init(const al::AreaInitInfo& areaInitInfo) override;
-
-    void appear();
-    void kill();
 };
 }  // namespace al

--- a/lib/al/include/Library/Play/Area/CameraStartParamArea.h
+++ b/lib/al/include/Library/Play/Area/CameraStartParamArea.h
@@ -1,0 +1,18 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+class CameraStartParamArea : public al::AreaObj {
+private:
+    bool mIsAlive = true;
+    f32* mAngleH = nullptr;
+    f32* mAngleV = nullptr;
+
+public:
+    CameraStartParamArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+
+    void appear();
+    void kill();
+};
+}  // namespace al

--- a/lib/al/include/Library/Play/Area/SeBarrierArea.h
+++ b/lib/al/include/Library/Play/Area/SeBarrierArea.h
@@ -1,0 +1,14 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+class SeBarrierArea : public AreaObj {
+private:
+    sead::Vector3f mTrans = {0.0, 0.0, 0.0};
+    bool mHasData = false;
+
+public:
+    SeBarrierArea(const char* name);
+
+    void init(const AreaInitInfo& areaInitInfo) override;
+};
+}  // namespace al

--- a/lib/al/include/Library/Play/Area/SeBarrierArea.h
+++ b/lib/al/include/Library/Play/Area/SeBarrierArea.h
@@ -1,14 +1,16 @@
-#include "al/include/Library/Area/AreaObj.h"
+#pragma once
+
+#include "Library/Area/AreaObj.h"
 
 namespace al {
 class SeBarrierArea : public AreaObj {
-private:
-    sead::Vector3f mTrans = {0.0, 0.0, 0.0};
-    bool mHasData = false;
-
 public:
     SeBarrierArea(const char* name);
 
     void init(const AreaInitInfo& areaInitInfo) override;
+
+private:
+    sead::Vector3f mTrans = {0.0, 0.0, 0.0};
+    bool mHasData = false;
 };
 }  // namespace al

--- a/lib/al/include/Library/Play/Area/SePlayArea.h
+++ b/lib/al/include/Library/Play/Area/SePlayArea.h
@@ -1,13 +1,15 @@
-#include "al/include/Library/Area/AreaObj.h"
+#pragma once
+
+#include "Library/Area/AreaObj.h"
 
 namespace al {
 class SePlayArea : public AreaObj {
-private:
-    char* mSePlayName = nullptr;
-
 public:
     SePlayArea(const char* name);
 
     void init(const AreaInitInfo& areaInitInfo) override;
+
+private:
+    char* mSePlayName = nullptr;
 };
 }  // namespace al

--- a/lib/al/include/Library/Play/Area/SePlayArea.h
+++ b/lib/al/include/Library/Play/Area/SePlayArea.h
@@ -1,0 +1,13 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+class SePlayArea : public AreaObj {
+private:
+    char* mSePlayName = nullptr;
+
+public:
+    SePlayArea(const char* name);
+
+    void init(const AreaInitInfo& areaInitInfo) override;
+};
+}  // namespace al

--- a/lib/al/include/Library/Play/Area/ViewCtrlArea.h
+++ b/lib/al/include/Library/Play/Area/ViewCtrlArea.h
@@ -1,14 +1,16 @@
-#include "al/include/Library/Area/AreaObj.h"
-#include "al/include/Library/Placement/PlacementId.h"
+#pragma once
+
+#include "Library/Area/AreaObj.h"
+#include "Library/Placement/PlacementId.h"
 
 namespace al {
 class ViewCtrlArea : public AreaObj {
-private:
-    PlacementId* mPlacementId;
-
 public:
     ViewCtrlArea(const char* name);
 
     void init(const AreaInitInfo& areaInitInfo) override;
+
+private:
+    PlacementId* mPlacementId;
 };
 }  // namespace al

--- a/lib/al/include/Library/Play/Area/ViewCtrlArea.h
+++ b/lib/al/include/Library/Play/Area/ViewCtrlArea.h
@@ -1,9 +1,10 @@
 #pragma once
 
 #include "Library/Area/AreaObj.h"
-#include "Library/Placement/PlacementId.h"
 
 namespace al {
+class PlacementId;
+
 class ViewCtrlArea : public AreaObj {
 public:
     ViewCtrlArea(const char* name);

--- a/lib/al/include/Library/Play/Area/ViewCtrlArea.h
+++ b/lib/al/include/Library/Play/Area/ViewCtrlArea.h
@@ -1,0 +1,14 @@
+#include "al/include/Library/Area/AreaObj.h"
+#include "al/include/Library/Placement/PlacementId.h"
+
+namespace al {
+class ViewCtrlArea : public AreaObj {
+private:
+    PlacementId* mPlacementId;
+
+public:
+    ViewCtrlArea(const char* name);
+
+    void init(const AreaInitInfo& areaInitInfo) override;
+};
+}  // namespace al

--- a/lib/al/include/Library/Stage/ListenStageSwitch.h
+++ b/lib/al/include/Library/Stage/ListenStageSwitch.h
@@ -1,0 +1,22 @@
+#pragma once
+
+namespace al {
+class IUseStageSwitch;
+class FunctorBase;
+
+bool listenStageSwitchOn(al::IUseStageSwitch*, const char*, const al::FunctorBase&);
+bool listenStageSwitchOnAppear(al::IUseStageSwitch*, const al::FunctorBase&);
+bool listenStageSwitchOnKill(al::IUseStageSwitch*, const al::FunctorBase&);
+bool listenStageSwitchOnStart(al::IUseStageSwitch*, const al::FunctorBase&);
+bool listenStageSwitchOnStop(al::IUseStageSwitch*, const al::FunctorBase&);
+bool listenStageSwitchOff(al::IUseStageSwitch*, const char*, const al::FunctorBase&);
+bool listenStageSwitchOnOff(al::IUseStageSwitch*, const char*, const al::FunctorBase&,
+                            const al::FunctorBase&);
+bool listenStageSwitchOnOffAppear(al::IUseStageSwitch*, const al::FunctorBase&,
+                                  const al::FunctorBase&);
+bool listenStageSwitchOnOffKill(al::IUseStageSwitch*, const al::FunctorBase&,
+                                const al::FunctorBase&);
+bool listenStageSwitchOnOffStart(al::IUseStageSwitch*, const al::FunctorBase&,
+                                 const al::FunctorBase&);
+
+}  // namespace al

--- a/lib/al/include/Library/Stage/ListenStageSwitch.h
+++ b/lib/al/include/Library/Stage/ListenStageSwitch.h
@@ -4,19 +4,15 @@ namespace al {
 class IUseStageSwitch;
 class FunctorBase;
 
-bool listenStageSwitchOn(al::IUseStageSwitch*, const char*, const al::FunctorBase&);
-bool listenStageSwitchOnAppear(al::IUseStageSwitch*, const al::FunctorBase&);
-bool listenStageSwitchOnKill(al::IUseStageSwitch*, const al::FunctorBase&);
-bool listenStageSwitchOnStart(al::IUseStageSwitch*, const al::FunctorBase&);
-bool listenStageSwitchOnStop(al::IUseStageSwitch*, const al::FunctorBase&);
-bool listenStageSwitchOff(al::IUseStageSwitch*, const char*, const al::FunctorBase&);
-bool listenStageSwitchOnOff(al::IUseStageSwitch*, const char*, const al::FunctorBase&,
-                            const al::FunctorBase&);
-bool listenStageSwitchOnOffAppear(al::IUseStageSwitch*, const al::FunctorBase&,
-                                  const al::FunctorBase&);
-bool listenStageSwitchOnOffKill(al::IUseStageSwitch*, const al::FunctorBase&,
-                                const al::FunctorBase&);
-bool listenStageSwitchOnOffStart(al::IUseStageSwitch*, const al::FunctorBase&,
-                                 const al::FunctorBase&);
+bool listenStageSwitchOn(IUseStageSwitch*, const char*, const FunctorBase&);
+bool listenStageSwitchOnAppear(IUseStageSwitch*, const FunctorBase&);
+bool listenStageSwitchOnKill(IUseStageSwitch*, const FunctorBase&);
+bool listenStageSwitchOnStart(IUseStageSwitch*, const FunctorBase&);
+bool listenStageSwitchOnStop(IUseStageSwitch*, const FunctorBase&);
+bool listenStageSwitchOff(IUseStageSwitch*, const char*, const FunctorBase&);
+bool listenStageSwitchOnOff(IUseStageSwitch*, const char*, const FunctorBase&, const FunctorBase&);
+bool listenStageSwitchOnOffAppear(IUseStageSwitch*, const FunctorBase&, const FunctorBase&);
+bool listenStageSwitchOnOffKill(IUseStageSwitch*, const FunctorBase&, const FunctorBase&);
+bool listenStageSwitchOnOffStart(IUseStageSwitch*, const FunctorBase&, const FunctorBase&);
 
 }  // namespace al

--- a/lib/al/src/Library/Area/AreaObj.cpp
+++ b/lib/al/src/Library/Area/AreaObj.cpp
@@ -1,0 +1,83 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+#include "al/include/Library/Area/AreaInitInfo.h"
+#include "al/include/Library/Area/AreaObjGroup.h"
+#include "al/include/Library/Area/AreaShape.h"
+#include "al/include/Library/Placement/PlacementFunction.h"
+#include "al/include/Library/Placement/PlacementInfo.h"
+#include "al/include/Library/Stage/ListenStageSwitch.h"
+#include "al/include/Library/Stage/StageSwitchKeeper.h"
+#include "al/include/Library/Stage/StageSwitchUtil.h"
+#include "al/include/Library/Thread/FunctorV0M.h"
+
+namespace al {
+
+AreaObj::AreaObj(const char* name) : mName(name) {}
+
+const char* AreaObj::getName() const {
+    return mName;
+}
+
+StageSwitchKeeper* AreaObj::getStageSwitchKeeper() const {
+    return mStageSwitchKeeper;
+}
+
+void AreaObj::initStageSwitchKeeper() {
+    mStageSwitchKeeper = new StageSwitchKeeper();
+}
+
+void AreaObj::init(const AreaInitInfo& initInfo) {
+    mPlacementInfo = new PlacementInfo(initInfo);
+    mSceneObjHolder = initInfo.getSceneObjHolder();
+    tryGetMatrixTR(&mMatrixTR, *mPlacementInfo);
+    tryGetArg(&mPriority, *mPlacementInfo, "Priority");
+
+    const char* modelName = nullptr;
+    alPlacementFunction::tryGetModelName(&modelName, *mPlacementInfo);
+
+    AreaShapeFactory areaShapeFactory("エリアシェイプファクトリー");
+    AreaShape* (*creatorFunc)() = nullptr;
+    areaShapeFactory.getEntryIndex(modelName, &creatorFunc);
+    mAreaShape = creatorFunc();
+
+    mAreaShape->setBaseMtxPtr(&mMatrixTR);
+    sead::Vector3f scale({1.0, 1.0, 1.0});
+    tryGetScale(&scale, *mPlacementInfo);
+    mAreaShape->setScale(scale);
+
+    initStageSwitch(this, initInfo.getStageSwitchDirector(), initInfo);
+    if (listenStageSwitchOnOffAppear(
+            this, FunctorV0M<AreaObj*, void (AreaObj::*)()>(this, &AreaObj::invalidate),
+            FunctorV0M<AreaObj*, void (AreaObj::*)()>(this, &AreaObj::validate)))
+        invalidate();
+
+    if (listenStageSwitchOnKill(
+            this, FunctorV0M<AreaObj*, void (AreaObj::*)()>(this, &AreaObj::validate)))
+        validate();
+}
+
+bool AreaObj::isInVolume(const sead::Vector3f& position) const {
+    if (!isValid)
+        return false;
+    return mAreaShape->isInVolume(position);
+}
+
+bool AreaObj::isInVolumeOffset(const sead::Vector3f& position, f32 offset) const {
+    if (!isValid)
+        return false;
+    return mAreaShape->isInVolumeOffset(position, offset);
+}
+
+SceneObjHolder* AreaObj::getSceneObjHolder() const {
+    return mSceneObjHolder;
+}
+
+void AreaObj::validate() {
+    isValid = true;
+}
+
+void AreaObj::invalidate() {
+    isValid = false;
+}
+
+}  // namespace al

--- a/lib/al/src/Library/Area/AreaObj.cpp
+++ b/lib/al/src/Library/Area/AreaObj.cpp
@@ -1,14 +1,14 @@
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 
-#include "al/include/Library/Area/AreaInitInfo.h"
-#include "al/include/Library/Area/AreaObjGroup.h"
-#include "al/include/Library/Area/AreaShape.h"
-#include "al/include/Library/Placement/PlacementFunction.h"
-#include "al/include/Library/Placement/PlacementInfo.h"
-#include "al/include/Library/Stage/ListenStageSwitch.h"
-#include "al/include/Library/Stage/StageSwitchKeeper.h"
-#include "al/include/Library/Stage/StageSwitchUtil.h"
-#include "al/include/Library/Thread/FunctorV0M.h"
+#include "Library/Area/AreaInitInfo.h"
+#include "Library/Area/AreaObjGroup.h"
+#include "Library/Area/AreaShape.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Stage/ListenStageSwitch.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
 
 namespace al {
 

--- a/lib/al/src/Library/Area/AreaObj.cpp
+++ b/lib/al/src/Library/Area/AreaObj.cpp
@@ -37,11 +37,11 @@ void AreaObj::init(const AreaInitInfo& initInfo) {
 
     AreaShapeFactory areaShapeFactory("エリアシェイプファクトリー");
     AreaShape* (*creatorFunc)() = nullptr;
-    areaShapeFactory.getEntryIndex(modelName, &creatorFunc);
+    areaShapeFactory.getEntryIndex(&creatorFunc, modelName);
     mAreaShape = creatorFunc();
 
     mAreaShape->setBaseMtxPtr(&mMatrixTR);
-    sead::Vector3f scale({1.0, 1.0, 1.0});
+    sead::Vector3f scale = {1.0, 1.0, 1.0};
     tryGetScale(&scale, *mPlacementInfo);
     mAreaShape->setScale(scale);
 

--- a/lib/al/src/Library/Area/AreaObjDirector.cpp
+++ b/lib/al/src/Library/Area/AreaObjDirector.cpp
@@ -1,0 +1,166 @@
+#include "al/include/Library/Area/AreaObjDirector.h"
+
+#include "al/include/Library/Area/AreaInitInfo.h"
+#include "al/include/Library/Area/AreaObj.h"
+#include "al/include/Library/Area/AreaObjFactory.h"
+#include "al/include/Library/Area/AreaObjGroup.h"
+#include "al/include/Library/Area/AreaObjMtxConnecter.h"
+#include "al/include/Library/Placement/PlacementFunction.h"
+#include "al/include/Library/Placement/PlacementInfo.h"
+
+namespace al {
+
+AreaObjDirector::AreaObjDirector() {}
+
+void AreaObjDirector::init(const al::AreaObjFactory* factory) {
+    mFactory = factory;
+    mMtxConnecterHolder = new AreaObjMtxConnecterHolder(0x100);
+    s32 nFactoryEntries = mFactory->getNumFactoryEntries();
+    s32 areaGroupsSize = nFactoryEntries;
+    mAreaGroups = new AreaObjGroup*[areaGroupsSize];
+
+    for (s32 i = 0; i < nFactoryEntries; i++) {
+        mAreaGroups[i] = nullptr;
+    }
+}
+
+void AreaObjDirector::endInit() {}
+
+void AreaObjDirector::update() {
+    if (mMtxConnecterHolder == nullptr)
+        return;
+    mMtxConnecterHolder->update();
+}
+
+void AreaObjDirector::placement(const al::AreaInitInfo& initInfo) {
+    createAreaObjGroup(initInfo);
+    createAreaObjGroupBuffer();
+    placementAreaObj(initInfo);
+}
+
+void AreaObjDirector::placement(const al::AreaInitInfo* initInfoArray, s32 initInfoCount) {
+    for (s32 i = 0; i < initInfoCount; i++) {
+        createAreaObjGroup(initInfoArray[i]);
+    }
+
+    createAreaObjGroupBuffer();
+
+    for (s32 i = 0; i < initInfoCount; i++) {
+        placementAreaObj(initInfoArray[i]);
+    }
+}
+
+void AreaObjDirector::createAreaObjGroup(const al::AreaInitInfo& initInfo) {
+    al::PlacementInfo placementInfo(initInfo);
+
+    s32 pInfoCount = al::getCountPlacementInfo(placementInfo);
+    for (s32 i = 0; i < pInfoCount; i++) {
+        al::PlacementInfo placementInfo2;
+        al::tryGetPlacementInfoByIndex(&placementInfo2, placementInfo, i);
+        const char* pInfoName = nullptr;
+        al::tryGetObjectName(&pInfoName, placementInfo2);
+
+        AreaObjCreatorFunction creatorFunc = nullptr;
+        s32 factoryIx = mFactory->getEntryIndex(pInfoName, &creatorFunc);
+
+        if (creatorFunc == nullptr)
+            continue;
+        if (mAreaGroups[factoryIx] == nullptr) {
+            s32 size = mFactory->tryFindAddBufferSize(pInfoName);
+            mAreaGroups[factoryIx] = new AreaObjGroup(pInfoName, size);
+        }
+
+        mAreaGroups[factoryIx]->incrementCount();
+    }
+}
+
+void AreaObjDirector::createAreaObjGroupBuffer() {
+    for (s32 i = 0; i < mFactory->getAreaGroupCount(); i++) {
+        AreaGroupInfo* addBuffer = mFactory->getAreaGroupInfo() + i;
+        AreaObjCreatorFunction creatorFunc = nullptr;
+        s32 entryIndex = mFactory->getEntryIndex(addBuffer->name, &creatorFunc);
+        if (mAreaGroups[entryIndex] == nullptr)
+            mAreaGroups[entryIndex] = new AreaObjGroup(addBuffer->name, addBuffer->size);
+    }
+
+    s32 areaGroupCount = 0;
+    s32 nEntries = mFactory->getNumFactoryEntries();
+    for (s32 i = 0; i < nEntries; i++) {
+        if (mAreaGroups[i] == nullptr)
+            continue;
+        mAreaGroups[i]->createBuffer();
+        areaGroupCount++;
+
+        for (s32 areaGroupIx = i; areaGroupIx > 0; areaGroupIx--) {
+            AreaObjGroup* prevAreaObjGroup = mAreaGroups[areaGroupIx - 1];
+            if (prevAreaObjGroup != nullptr) {
+                if (strcmp(mAreaGroups[areaGroupIx]->getName(), prevAreaObjGroup->getName()) > -1)
+                    break;
+            }
+            mAreaGroups[areaGroupIx - 1] = mAreaGroups[areaGroupIx];
+            mAreaGroups[areaGroupIx] = prevAreaObjGroup;
+        }
+    }
+    mAreaGroupCount = areaGroupCount;
+}
+
+void AreaObjDirector::placementAreaObj(const al::AreaInitInfo& initInfo) {
+    PlacementInfo pInfo(initInfo);
+    s32 pInfoCount = getCountPlacementInfo(pInfo);
+    for (s32 j = 0; j < pInfoCount; j++) {
+        PlacementInfo pInfo2;
+        tryGetPlacementInfoByIndex(&pInfo2, pInfo, j);
+        const char* pInfoName = nullptr;
+        tryGetObjectName(&pInfoName, pInfo2);
+
+        AreaObjCreatorFunction creatorFunc = nullptr;
+        mFactory->getEntryIndex(pInfoName, &creatorFunc);
+        if (creatorFunc == nullptr)
+            continue;
+
+        const char* displayName;
+        getDisplayName(&displayName, pInfo2);
+        AreaObj* areaObj = creatorFunc(displayName);
+        AreaInitInfo initInfo2(pInfo2, initInfo);
+        areaObj->init(initInfo2);
+
+        AreaObjGroup* areaGroup = _getAreaObjGroup(pInfoName);
+
+        areaGroup->registerAreaObj(areaObj);
+        mMtxConnecterHolder->tryAddArea(areaObj, pInfo2);
+    }
+}
+
+AreaObjGroup* AreaObjDirector::getAreaObjGroup(const char* name) const {
+    // return _getAreaObjGroup(name); // doesn't match
+    s32 lower = 0;
+    s32 upper = mAreaGroupCount;
+    while (lower < upper) {
+        s32 i = (lower + upper) / 2;
+        s32 equalString = strcmp(name, mAreaGroups[i]->getName());
+        if (equalString == 0) {
+            return mAreaGroups[i];
+        } else if (equalString > 0) {
+            lower = i + 1;
+        } else
+            upper = i;
+    }
+    return nullptr;
+}
+
+bool AreaObjDirector::isExistAreaGroup(const char* name) const {
+    return _getAreaObjGroup(name) != nullptr;
+}
+
+AreaObj* AreaObjDirector::getInVolumeAreaObj(const char* name, const sead::Vector3f& position) {
+    AreaObjGroup* areaGroup = _getAreaObjGroup(name);
+    if (areaGroup == nullptr)
+        return nullptr;
+    return areaGroup->getInVolumeAreaObj(position);
+}
+
+AreaObjMtxConnecterHolder* AreaObjDirector::getMtxConnecterHolder() const {
+    return mMtxConnecterHolder;
+}
+
+}  // namespace al

--- a/lib/al/src/Library/Area/AreaObjDirector.cpp
+++ b/lib/al/src/Library/Area/AreaObjDirector.cpp
@@ -1,18 +1,18 @@
-#include "al/include/Library/Area/AreaObjDirector.h"
+#include "Library/Area/AreaObjDirector.h"
 
-#include "al/include/Library/Area/AreaInitInfo.h"
-#include "al/include/Library/Area/AreaObj.h"
-#include "al/include/Library/Area/AreaObjFactory.h"
-#include "al/include/Library/Area/AreaObjGroup.h"
-#include "al/include/Library/Area/AreaObjMtxConnecter.h"
-#include "al/include/Library/Placement/PlacementFunction.h"
-#include "al/include/Library/Placement/PlacementInfo.h"
+#include "Library/Area/AreaInitInfo.h"
+#include "Library/Area/AreaObj.h"
+#include "Library/Area/AreaObjFactory.h"
+#include "Library/Area/AreaObjGroup.h"
+#include "Library/Area/AreaObjMtxConnecter.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
 
 namespace al {
 
 AreaObjDirector::AreaObjDirector() {}
 
-void AreaObjDirector::init(const al::AreaObjFactory* factory) {
+void AreaObjDirector::init(const AreaObjFactory* factory) {
     mFactory = factory;
     mMtxConnecterHolder = new AreaObjMtxConnecterHolder(0x100);
     s32 nFactoryEntries = mFactory->getNumFactoryEntries();
@@ -32,13 +32,13 @@ void AreaObjDirector::update() {
     mMtxConnecterHolder->update();
 }
 
-void AreaObjDirector::placement(const al::AreaInitInfo& initInfo) {
+void AreaObjDirector::placement(const AreaInitInfo& initInfo) {
     createAreaObjGroup(initInfo);
     createAreaObjGroupBuffer();
     placementAreaObj(initInfo);
 }
 
-void AreaObjDirector::placement(const al::AreaInitInfo* initInfoArray, s32 initInfoCount) {
+void AreaObjDirector::placement(const AreaInitInfo* initInfoArray, s32 initInfoCount) {
     for (s32 i = 0; i < initInfoCount; i++) {
         createAreaObjGroup(initInfoArray[i]);
     }
@@ -50,15 +50,15 @@ void AreaObjDirector::placement(const al::AreaInitInfo* initInfoArray, s32 initI
     }
 }
 
-void AreaObjDirector::createAreaObjGroup(const al::AreaInitInfo& initInfo) {
-    al::PlacementInfo placementInfo(initInfo);
+void AreaObjDirector::createAreaObjGroup(const AreaInitInfo& initInfo) {
+    PlacementInfo placementInfo(initInfo);
 
-    s32 pInfoCount = al::getCountPlacementInfo(placementInfo);
+    s32 pInfoCount = getCountPlacementInfo(placementInfo);
     for (s32 i = 0; i < pInfoCount; i++) {
-        al::PlacementInfo placementInfo2;
-        al::tryGetPlacementInfoByIndex(&placementInfo2, placementInfo, i);
+        PlacementInfo placementInfo2;
+        tryGetPlacementInfoByIndex(&placementInfo2, placementInfo, i);
         const char* pInfoName = nullptr;
-        al::tryGetObjectName(&pInfoName, placementInfo2);
+        tryGetObjectName(&pInfoName, placementInfo2);
 
         AreaObjCreatorFunction creatorFunc = nullptr;
         s32 factoryIx = mFactory->getEntryIndex(pInfoName, &creatorFunc);
@@ -104,7 +104,7 @@ void AreaObjDirector::createAreaObjGroupBuffer() {
     mAreaGroupCount = areaGroupCount;
 }
 
-void AreaObjDirector::placementAreaObj(const al::AreaInitInfo& initInfo) {
+void AreaObjDirector::placementAreaObj(const AreaInitInfo& initInfo) {
     PlacementInfo pInfo(initInfo);
     s32 pInfoCount = getCountPlacementInfo(pInfo);
     for (s32 j = 0; j < pInfoCount; j++) {

--- a/lib/al/src/Library/Area/AreaObjFactory.cpp
+++ b/lib/al/src/Library/Area/AreaObjFactory.cpp
@@ -1,4 +1,4 @@
-#include "al/include/Library/Area/AreaObjFactory.h"
+#include "Library/Area/AreaObjFactory.h"
 #include "Library/Base/String.h"
 
 namespace al {

--- a/lib/al/src/Library/Area/AreaObjFactory.cpp
+++ b/lib/al/src/Library/Area/AreaObjFactory.cpp
@@ -1,0 +1,21 @@
+#include "al/include/Library/Area/AreaObjFactory.h"
+#include "Library/Base/String.h"
+
+namespace al {
+
+AreaObjFactory::AreaObjFactory(const char* factoryName)
+    : Factory<AreaObjCreatorFunction>(factoryName) {}
+
+s32 AreaObjFactory::tryFindAddBufferSize(const char* bufferName) const {
+    if (mAreaGroupInfo == nullptr || mNumBuffers < 1)
+        return 0;
+
+    s32 offset = 0;
+    while (!isEqualString(bufferName, mAreaGroupInfo[offset].name)) {
+        if (++offset >= mNumBuffers)
+            return 0;
+    }
+    return mAreaGroupInfo[offset].size;
+}
+
+}  // namespace al

--- a/lib/al/src/Library/Area/AreaObjFactory.cpp
+++ b/lib/al/src/Library/Area/AreaObjFactory.cpp
@@ -11,12 +11,11 @@ s32 AreaObjFactory::tryFindAddBufferSize(const char* bufferName) const {
     if (mAreaGroupInfo == nullptr || mNumBuffers < 1)
         return 0;
 
-    s32 offset = 0;
-    while (!isEqualString(bufferName, mAreaGroupInfo[offset].name)) {
-        if (++offset >= mNumBuffers)
-            return 0;
+    for (s32 i = 0; i < mNumBuffers; i++) {
+        if (isEqualString(bufferName, mAreaGroupInfo[i].name))
+            return mAreaGroupInfo[i].size;
     }
-    return mAreaGroupInfo[offset].size;
+    return 0;
 }
 
 }  // namespace al

--- a/lib/al/src/Library/Area/AreaObjFactory.cpp
+++ b/lib/al/src/Library/Area/AreaObjFactory.cpp
@@ -1,4 +1,5 @@
 #include "Library/Area/AreaObjFactory.h"
+
 #include "Library/Base/String.h"
 
 namespace al {

--- a/lib/al/src/Library/Area/AreaObjGroup.cpp
+++ b/lib/al/src/Library/Area/AreaObjGroup.cpp
@@ -1,6 +1,6 @@
-#include "al/include/Library/Area/AreaObjGroup.h"
+#include "Library/Area/AreaObjGroup.h"
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 
 namespace al {
 AreaObjGroup::AreaObjGroup(const char* groupName, const int capacity)

--- a/lib/al/src/Library/Area/AreaObjGroup.cpp
+++ b/lib/al/src/Library/Area/AreaObjGroup.cpp
@@ -37,6 +37,7 @@ AreaObj* AreaObjGroup::getInVolumeAreaObj(const sead::Vector3f& position) const 
 }
 
 void AreaObjGroup::incrementCount() {
+    // dev mistake?
     mCapacity += 1;
 }
 

--- a/lib/al/src/Library/Area/AreaObjGroup.cpp
+++ b/lib/al/src/Library/Area/AreaObjGroup.cpp
@@ -1,0 +1,51 @@
+#include "al/include/Library/Area/AreaObjGroup.h"
+
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+AreaObjGroup::AreaObjGroup(const char* groupName, const int capacity)
+    : mGroupName(groupName), mCapacity(capacity) {}
+
+void AreaObjGroup::createBuffer() {
+    if (mCapacity < 1) {
+        return;
+    }
+    mBuffer = new AreaObj*[mCapacity];
+}
+
+void AreaObjGroup::createBuffer(s32 capacity) {
+    mCapacity = capacity;
+    createBuffer();
+}
+
+AreaObj* AreaObjGroup::getAreaObj(const s32 index) const {
+    return mBuffer[index];
+}
+
+AreaObj* AreaObjGroup::getInVolumeAreaObj(const sead::Vector3f& position) const {
+    AreaObj* bestInVolumeAreaObj = nullptr;
+    for (s32 i = 0; i < mCount; i++) {
+        AreaObj* currentAreaObj = mBuffer[i];
+        if (bestInVolumeAreaObj == nullptr ||
+            bestInVolumeAreaObj->getPriority() <= currentAreaObj->getPriority()) {
+            if (currentAreaObj->isInVolume(position)) {
+                bestInVolumeAreaObj = currentAreaObj;
+            }
+        }
+    }
+    return bestInVolumeAreaObj;
+}
+
+void AreaObjGroup::incrementCount() {
+    mCapacity += 1;
+}
+
+void AreaObjGroup::registerAreaObj(AreaObj* newAreaObj) {
+    if (mCount >= mCapacity) {
+        return;
+    }
+    mBuffer[mCount] = newAreaObj;
+    mCount += 1;
+}
+
+}  // namespace al

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <sead/include/math/seadBoundBox.h>
 #include "al/include/Library/Area/AreaObj.h"
+#include "sead/include/math/seadBoundBox.h"
 
 namespace al {
 class ClippingJudge;
@@ -14,10 +14,6 @@ class BirdGatheringSpotArea : public al::AreaObj {
         sead::BoundBox3f mBoundBox = sead::BoundBox3f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
     };
 
-private:
-    s32 mBirdNumMax = 0;
-    AreaClippingInfo mClippingInfo;
-
 public:
     BirdGatheringSpotArea(const char* name);
 
@@ -28,4 +24,8 @@ public:
     bool isClipped() const;
     bool isGreaterPriorityNotClipped(const BirdGatheringSpotArea* other) const;
     void updateClipping(const al::ClippingJudge*, const sead::Vector3f&);
+
+private:
+    s32 mBirdNumMax = 0;
+    AreaClippingInfo mClippingInfo;
 };

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <sead/include/math/seadBoundBox.h>
+#include <math/seadBoundBox.h>
 
 #include "Library/Area/AreaObj.h"
 

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -20,7 +20,7 @@ public:
 
     void init(const al::AreaInitInfo& initInfo) override;
 
-    void calcRandomGroundTrans(sead::Vector3f trans) const;
+    void calcRandomGroundTrans(sead::Vector3f* trans) const;
     s32 getSightDistance() const;
     bool isClipped() const;
     bool isGreaterPriorityNotClipped(const BirdGatheringSpotArea* other) const;

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 #include "sead/include/math/seadBoundBox.h"
 
 namespace al {

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <sead/include/math/seadBoundBox.h>
+#include "al/include/Library/Area/AreaObj.h"
+
+namespace al {
+class ClippingJudge;
+}
+
+class BirdGatheringSpotArea : public al::AreaObj {
+    struct AreaClippingInfo {
+        bool mIsClipped = false;
+        f32 mSightDistance = 0.0;
+        sead::BoundBox3f mBoundBox = sead::BoundBox3f(0.0, 0.0, 0.0, 0.0, 0.0, 0.0);
+    };
+
+private:
+    s32 mBirdNumMax = 0;
+    AreaClippingInfo mClippingInfo;
+
+public:
+    BirdGatheringSpotArea(const char* name);
+
+    void init(const al::AreaInitInfo& initInfo) override;
+
+    void calcRandomGroundTrans(sead::Vector3f trans) const;
+    s32 getSightDistance() const;
+    bool isClipped() const;
+    bool isGreaterPriorityNotClipped(const BirdGatheringSpotArea* other) const;
+    void updateClipping(const al::ClippingJudge*, const sead::Vector3f&);
+};

--- a/src/AreaObj/BirdGatheringSpotArea.h
+++ b/src/AreaObj/BirdGatheringSpotArea.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <sead/include/math/seadBoundBox.h>
+
 #include "Library/Area/AreaObj.h"
-#include "sead/include/math/seadBoundBox.h"
 
 namespace al {
 class ClippingJudge;

--- a/src/AreaObj/ExtForceArea.h
+++ b/src/AreaObj/ExtForceArea.h
@@ -8,7 +8,8 @@ public:
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
 
-    void calcExtForce(sead::Vector3f, sead::Vector3f, sead::Vector3f, sead::Vector3f);
+    void calcExtForce(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&,
+                      const sead::Vector3f&) const;
 
 private:
     sead::Vector2f mUnknown;

--- a/src/AreaObj/ExtForceArea.h
+++ b/src/AreaObj/ExtForceArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 
 class ExtForceArea : public al::AreaObj {
 public:

--- a/src/AreaObj/ExtForceArea.h
+++ b/src/AreaObj/ExtForceArea.h
@@ -1,0 +1,14 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+class ExtForceArea : public al::AreaObj {
+private:
+    sead::Vector2f mUnknown;
+    f32 mMagnitude = 1.0;
+
+public:
+    ExtForceArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+
+    void calcExtForce(sead::Vector3f, sead::Vector3f, sead::Vector3f, sead::Vector3f);
+};

--- a/src/AreaObj/ExtForceArea.h
+++ b/src/AreaObj/ExtForceArea.h
@@ -1,14 +1,16 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 
 class ExtForceArea : public al::AreaObj {
-private:
-    sead::Vector2f mUnknown;
-    f32 mMagnitude = 1.0;
-
 public:
     ExtForceArea(const char* name);
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
 
     void calcExtForce(sead::Vector3f, sead::Vector3f, sead::Vector3f, sead::Vector3f);
+
+private:
+    sead::Vector2f mUnknown;
+    f32 mMagnitude = 1.0;
 };

--- a/src/AreaObj/ForceRecoveryKidsArea.h
+++ b/src/AreaObj/ForceRecoveryKidsArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <math/seadVectorFwd.h>
+#include <math/seadVector.h>
 
 #include "Library/Area/AreaObj.h"
 

--- a/src/AreaObj/ForceRecoveryKidsArea.h
+++ b/src/AreaObj/ForceRecoveryKidsArea.h
@@ -1,0 +1,13 @@
+#include "al/include/Library/Area/AreaObj.h"
+#include "math/seadVectorFwd.h"
+
+class ForceRecoveryKidsArea : public al::AreaObj {
+private:
+    sead::Vector3f mTrans;
+    sead::Vector3f mYRot;
+
+public:
+    ForceRecoveryKidsArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+};

--- a/src/AreaObj/ForceRecoveryKidsArea.h
+++ b/src/AreaObj/ForceRecoveryKidsArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class ForceRecoveryKidsArea : public al::AreaObj {

--- a/src/AreaObj/ForceRecoveryKidsArea.h
+++ b/src/AreaObj/ForceRecoveryKidsArea.h
@@ -1,13 +1,15 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class ForceRecoveryKidsArea : public al::AreaObj {
-private:
-    sead::Vector3f mTrans;
-    sead::Vector3f mYRot;
-
 public:
     ForceRecoveryKidsArea(const char* name);
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
+
+private:
+    sead::Vector3f mTrans;
+    sead::Vector3f mYRot;
 };

--- a/src/AreaObj/ForceRecoveryKidsArea.h
+++ b/src/AreaObj/ForceRecoveryKidsArea.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <math/seadVectorFwd.h>
+
 #include "Library/Area/AreaObj.h"
-#include "math/seadVectorFwd.h"
 
 class ForceRecoveryKidsArea : public al::AreaObj {
 public:

--- a/src/AreaObj/MoveArea2D.h
+++ b/src/AreaObj/MoveArea2D.h
@@ -1,0 +1,23 @@
+#include "al/include/Library/Area/AreaObj.h"
+#include "math/seadVectorFwd.h"
+
+class MoveArea2D : public al::AreaObj {
+private:
+    s32 mModelIndex;
+    f32 mSurfaceDistance;
+    f32 mGravityOffset;
+
+public:
+    MoveArea2D(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+
+    bool calcGravityCylinderCenterAxis(sead::Vector3f*, f32*, const sead::Vector3f&, bool) const;
+    bool calcGravityDir(sead::Vector3f*, f32*, const sead::Vector3f&) const;
+    bool calcGravityYDir(sead::Vector3f*, f32*) const;
+
+    bool calcSnapPower(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
+    bool calcSnapPowerCube(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
+    bool calcSnapPowerCylinder(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
+    bool calcSnapPowerDisk(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
+};

--- a/src/AreaObj/MoveArea2D.h
+++ b/src/AreaObj/MoveArea2D.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <math/seadVectorFwd.h>
+#include <math/seadVector.h>
 
 #include "Library/Area/AreaObj.h"
 

--- a/src/AreaObj/MoveArea2D.h
+++ b/src/AreaObj/MoveArea2D.h
@@ -1,12 +1,9 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class MoveArea2D : public al::AreaObj {
-private:
-    s32 mModelIndex;
-    f32 mSurfaceDistance;
-    f32 mGravityOffset;
-
 public:
     MoveArea2D(const char* name);
 
@@ -20,4 +17,9 @@ public:
     bool calcSnapPowerCube(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
     bool calcSnapPowerCylinder(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
     bool calcSnapPowerDisk(sead::Vector3f*, f32*, const sead::Vector3f&, f32);
+
+private:
+    s32 mModelIndex;
+    f32 mSurfaceDistance;
+    f32 mGravityOffset;
 };

--- a/src/AreaObj/MoveArea2D.h
+++ b/src/AreaObj/MoveArea2D.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class MoveArea2D : public al::AreaObj {

--- a/src/AreaObj/MoveArea2D.h
+++ b/src/AreaObj/MoveArea2D.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <math/seadVectorFwd.h>
+
 #include "Library/Area/AreaObj.h"
-#include "math/seadVectorFwd.h"
 
 class MoveArea2D : public al::AreaObj {
 public:

--- a/src/AreaObj/NpcForceMaterialCodeArea.h
+++ b/src/AreaObj/NpcForceMaterialCodeArea.h
@@ -1,0 +1,11 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+class NpcForceMaterialCodeArea : public al::AreaObj {
+private:
+    char* mMaterialCodeName = nullptr;
+
+public:
+    NpcForceMaterialCodeArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+};

--- a/src/AreaObj/NpcForceMaterialCodeArea.h
+++ b/src/AreaObj/NpcForceMaterialCodeArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 
 class NpcForceMaterialCodeArea : public al::AreaObj {
 public:

--- a/src/AreaObj/NpcForceMaterialCodeArea.h
+++ b/src/AreaObj/NpcForceMaterialCodeArea.h
@@ -1,11 +1,13 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 
 class NpcForceMaterialCodeArea : public al::AreaObj {
-private:
-    char* mMaterialCodeName = nullptr;
-
 public:
     NpcForceMaterialCodeArea(const char* name);
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
+
+private:
+    char* mMaterialCodeName = nullptr;
 };

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class RouteGuideArea : public al::AreaObj {

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <math/seadVectorFwd.h>
+#include <math/seadVector.h>
 
 #include "Library/Area/AreaObj.h"
 

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "Library/Area/AreaObj.h"
-
 #include <math/seadVectorFwd.h>
+
+#include "Library/Area/AreaObj.h"
 
 class RouteGuideArea : public al::AreaObj {
 public:

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,14 +1,16 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 #include "math/seadVectorFwd.h"
 
 class RouteGuideArea : public al::AreaObj {
-private:
-    sead::Vector3f mGuidePos = {0.0, 0.0, 0.0};
-    bool mIsGuide3D = false;
-
 public:
     RouteGuideArea(const char* name);
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
     void calcGuidePos(sead::Vector3f* guidePos) const;
+
+private:
+    sead::Vector3f mGuidePos = {0.0, 0.0, 0.0};
+    bool mIsGuide3D = false;
 };

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,0 +1,14 @@
+#include "al/include/Library/Area/AreaObj.h"
+#include "math/seadVectorFwd.h"
+
+class RouteGuideArea : public al::AreaObj {
+private:
+    sead::Vector3f mGuidePos = {0.0, 0.0, 0.0};
+    bool mIsGuide3D = false;
+
+public:
+    RouteGuideArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void calcGuidePos(sead::Vector3f* guidePos) const;
+};

--- a/src/AreaObj/RouteGuideArea.h
+++ b/src/AreaObj/RouteGuideArea.h
@@ -1,7 +1,8 @@
 #pragma once
 
 #include "Library/Area/AreaObj.h"
-#include "math/seadVectorFwd.h"
+
+#include <math/seadVectorFwd.h>
 
 class RouteGuideArea : public al::AreaObj {
 public:

--- a/src/AreaObj/StainArea.h
+++ b/src/AreaObj/StainArea.h
@@ -1,11 +1,13 @@
+#pragma once
+
 #include "al/include/Library/Area/AreaObj.h"
 
 class StainArea : public al::AreaObj {
-private:
-    s32 mStainType = 0;
-
 public:
     StainArea(const char* name);
 
     void init(const al::AreaInitInfo& areaInitInfo) override;
+
+private:
+    s32 mStainType = 0;
 };

--- a/src/AreaObj/StainArea.h
+++ b/src/AreaObj/StainArea.h
@@ -1,0 +1,11 @@
+#include "al/include/Library/Area/AreaObj.h"
+
+class StainArea : public al::AreaObj {
+private:
+    s32 mStainType = 0;
+
+public:
+    StainArea(const char* name);
+
+    void init(const al::AreaInitInfo& areaInitInfo) override;
+};

--- a/src/AreaObj/StainArea.h
+++ b/src/AreaObj/StainArea.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObj.h"
+#include "Library/Area/AreaObj.h"
 
 class StainArea : public al::AreaObj {
 public:

--- a/src/Scene/ProjectAreaFactory.cpp
+++ b/src/Scene/ProjectAreaFactory.cpp
@@ -7,6 +7,7 @@
 #include "AreaObj/NpcForceMaterialCodeArea.h"
 #include "AreaObj/RouteGuideArea.h"
 #include "AreaObj/StainArea.h"
+
 #include "Library/Area/AreaInitInfo.h"
 #include "Library/Area/AreaObj.h"
 #include "Library/Area/TrafficArea.h"

--- a/src/Scene/ProjectAreaFactory.cpp
+++ b/src/Scene/ProjectAreaFactory.cpp
@@ -1,0 +1,172 @@
+#include "Scene/ProjectAreaFactory.h"
+
+#include "AreaObj/BirdGatheringSpotArea.h"
+#include "AreaObj/ExtForceArea.h"
+#include "AreaObj/ForceRecoveryKidsArea.h"
+#include "AreaObj/MoveArea2D.h"
+#include "AreaObj/NpcForceMaterialCodeArea.h"
+#include "AreaObj/RouteGuideArea.h"
+#include "AreaObj/StainArea.h"
+#include "al/include/Library/Area/AreaInitInfo.h"
+#include "al/include/Library/Area/AreaObj.h"
+#include "al/include/Library/Area/TrafficArea.h"
+#include "al/include/Library/LiveActor/ActorInitInfo.h"
+#include "al/include/Library/Play/Area/CameraStartParamArea.h"
+#include "al/include/Library/Play/Area/SeBarrierArea.h"
+#include "al/include/Library/Play/Area/SePlayArea.h"
+#include "al/include/Library/Play/Area/ViewCtrlArea.h"
+
+namespace al {
+
+AreaObj* createAreaObj(const ActorInitInfo& actorInitInfo, const char* name) {
+    AreaInitInfo areaInitInfo;
+    areaInitInfo.set(actorInitInfo.getPlacementInfo(), actorInitInfo.getStageSwitchDirector(),
+                     actorInitInfo.getActorSceneObjHolder());
+    AreaObj* areaObj = new AreaObj(name);
+    areaObj->init(areaInitInfo);
+    return areaObj;
+}
+
+template <typename T>
+AreaObj* createAreaObjFunction(const char* name) {
+    return new T(name);
+}
+
+}  // namespace al
+
+static al::NameToCreator<al::AreaObjCreatorFunction> sAreaObjEntries[] = {
+    {"AlignDirectionArea", al::createAreaObjFunction<al::AreaObj>},
+    {"AudioEffectChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"BalloonInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"BgmChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"BgmSituationChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"BgmStopArea", al::createAreaObjFunction<al::AreaObj>},
+    {"BossRaidElectricArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraAngleVerticalRequestArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraArea2D", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraAreaKids", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraInSwitchOnArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CameraStopArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CarryBanArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ChangeStageArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ClippingFarArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CollectBgmPlayInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"CompassArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DamageBallBgmEnableArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DamageBallDestroyArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DeathArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DepthShadowArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DepthShadowClipArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DisablePaintDamageArea", al::createAreaObjFunction<al::AreaObj>},
+    {"DitherAnimNearInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"FastMoveCollisionArea", al::createAreaObjFunction<al::AreaObj>},
+    {"FireBlowerFireVisibleArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ForceCameraArea", al::createAreaObjFunction<al::AreaObj>},
+    {"GpuPerfArea", al::createAreaObjFunction<al::AreaObj>},
+    {"GraphicsArea", al::createAreaObjFunction<al::AreaObj>},
+    {"GroundShadowLengthReviseArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HackCancelArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HackCancelSwoonProhibitedArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HackerCheckArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HackerCheckKeepOnArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HackInvalidEscapeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HosuiFloorCheckSpecialArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HosuiHoverLevelKeepArea", al::createAreaObjFunction<al::AreaObj>},
+    {"HosuiRecoveryArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InformationArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InformationHackMovieArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InformationInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateInputFallArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidatePressStickCameraArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateRecoveryPosArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateRocketFlowerCameraArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateRouteGuideArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateStageMapArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateWanwanCameraArea", al::createAreaObjFunction<al::AreaObj>},
+    {"InvalidateWallClimbArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ItemVanishArea", al::createAreaObjFunction<al::AreaObj>},
+    {"KoopaDemoArea", al::createAreaObjFunction<al::AreaObj>},
+    {"LocationNameArea", al::createAreaObjFunction<al::AreaObj>},
+    {"LongInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"LowGravityArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MapSnapShotArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MeganePlayGuideChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MissRestartArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MoonBasementFallObjDecorationDes", al::createAreaObjFunction<al::AreaObj>},
+    {"MotorcycleFrontSnapArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MotorcycleInCheckArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MotorcycleInvalidGetOffArea", al::createAreaObjFunction<al::AreaObj>},
+    {"MoveDirectionKeepArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PaintDamageCheckLenSwitchArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ParallaxCorrectedCubeMapArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PlayerAnimArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PlayerMePlayArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PlayerMoveSmallPlanetArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PlayerShadowLengthArea", al::createAreaObjFunction<al::AreaObj>},
+    {"PoleGrabCeilNoSnapArea", al::createAreaObjFunction<al::AreaObj>},
+    {"RaceCourseOutArea", al::createAreaObjFunction<al::AreaObj>},
+    {"RecoveryArea", al::createAreaObjFunction<al::AreaObj>},
+    {"RecoveryBanArea", al::createAreaObjFunction<al::AreaObj>},
+    {"RestartArea", al::createAreaObjFunction<al::AreaObj>},
+    {"RouteGuideArrowScaleArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SeListenerChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SeSituationChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SessionBgmChangeArea", al::createAreaObjFunction<al::AreaObj>},
+    {"ShibakenFollowArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SnapMoveArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SnapShotInvalidCtrlArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SphinxRideGetOffForceArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SphinxRideInCheckArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SphinxRideInCheckAreaKeepOn", al::createAreaObjFunction<al::AreaObj>},
+    {"SphinxRideInRideOffCheckAreaKeep", al::createAreaObjFunction<al::AreaObj>},
+    {"StealthArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SubjectiveCameraInvalidArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SubjectiveCameraInvalidCameraThr", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOn2DArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOn2DExceptDokanInArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOnArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOnPlayerInWaterArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOnSenobiOnlyArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchKeepOnIgnoreOffAreaTarget", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchOn2DArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchOnArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchOnKoopa2DOnGroundArea", al::createAreaObjFunction<al::AreaObj>},
+    {"SwitchOnPlayerOnGroundArea", al::createAreaObjFunction<al::AreaObj>},
+    {"TalkMessageInfoPointArea", al::createAreaObjFunction<al::AreaObj>},
+    {"TemperatureArea", al::createAreaObjFunction<al::AreaObj>},
+    {"TitleLogoArea", al::createAreaObjFunction<al::AreaObj>},
+    {"YoshiTongueSnapArea", al::createAreaObjFunction<al::AreaObj>},
+    {"YukimaruRacerNoJumpArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WallCatchNoEntryArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WarningBikeSideWalkInArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WarpArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WaterArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WaterfallArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WetArea", al::createAreaObjFunction<al::AreaObj>},
+    {"WorldEndBorderArea", al::createAreaObjFunction<al::AreaObj>},
+    {"YukimaruRacerHoldJumpArea", al::createAreaObjFunction<al::AreaObj>},
+    {"YukimaruRacerMinimumSpeedEnforce", al::createAreaObjFunction<al::AreaObj>},
+    {"BirdGatheringSpotArea", al::createAreaObjFunction<BirdGatheringSpotArea>},
+    {"CameraStartParamArea", al::createAreaObjFunction<al::CameraStartParamArea>},
+    {"ExtForceArea", al::createAreaObjFunction<ExtForceArea>},
+    {"ForceRecoveryKidsArea", al::createAreaObjFunction<ForceRecoveryKidsArea>},
+    {"NpcForceMaterialCodeArea", al::createAreaObjFunction<NpcForceMaterialCodeArea>},
+    {"SePlayArea", al::createAreaObjFunction<al::SePlayArea>},
+    {"SeBarrierArea", al::createAreaObjFunction<al::SeBarrierArea>},
+    {"StainArea", al::createAreaObjFunction<StainArea>},
+    {"TrafficArea", al::createAreaObjFunction<al::TrafficArea>},
+    {"ViewCtrlArea", al::createAreaObjFunction<al::ViewCtrlArea>},
+    {"RouteGuideArea", al::createAreaObjFunction<RouteGuideArea>},
+    {"2DMoveArea", al::createAreaObjFunction<MoveArea2D>},
+    {"CameraStartParamAreaKids", al::createAreaObjFunction<al::CameraStartParamArea>},
+    {"RecoveryTargetPosKidsArea", al::createAreaObjFunction<ForceRecoveryKidsArea>},
+};
+
+static al::AreaGroupInfo sAreaGroupInfo[] = {{"GraphicsArea", 1}};
+
+// not matching
+ProjectAreaFactory::ProjectAreaFactory() : al::AreaObjFactory("エリア生成") {
+    initFactory(sAreaObjEntries);
+    setAreaGroupInfo(sAreaGroupInfo);
+}

--- a/src/Scene/ProjectAreaFactory.cpp
+++ b/src/Scene/ProjectAreaFactory.cpp
@@ -1,13 +1,5 @@
 #include "Scene/ProjectAreaFactory.h"
 
-#include "AreaObj/BirdGatheringSpotArea.h"
-#include "AreaObj/ExtForceArea.h"
-#include "AreaObj/ForceRecoveryKidsArea.h"
-#include "AreaObj/MoveArea2D.h"
-#include "AreaObj/NpcForceMaterialCodeArea.h"
-#include "AreaObj/RouteGuideArea.h"
-#include "AreaObj/StainArea.h"
-
 #include "Library/Area/AreaInitInfo.h"
 #include "Library/Area/AreaObj.h"
 #include "Library/Area/TrafficArea.h"
@@ -16,6 +8,14 @@
 #include "Library/Play/Area/SeBarrierArea.h"
 #include "Library/Play/Area/SePlayArea.h"
 #include "Library/Play/Area/ViewCtrlArea.h"
+
+#include "AreaObj/BirdGatheringSpotArea.h"
+#include "AreaObj/ExtForceArea.h"
+#include "AreaObj/ForceRecoveryKidsArea.h"
+#include "AreaObj/MoveArea2D.h"
+#include "AreaObj/NpcForceMaterialCodeArea.h"
+#include "AreaObj/RouteGuideArea.h"
+#include "AreaObj/StainArea.h"
 
 namespace al {
 

--- a/src/Scene/ProjectAreaFactory.cpp
+++ b/src/Scene/ProjectAreaFactory.cpp
@@ -7,14 +7,14 @@
 #include "AreaObj/NpcForceMaterialCodeArea.h"
 #include "AreaObj/RouteGuideArea.h"
 #include "AreaObj/StainArea.h"
-#include "al/include/Library/Area/AreaInitInfo.h"
-#include "al/include/Library/Area/AreaObj.h"
-#include "al/include/Library/Area/TrafficArea.h"
-#include "al/include/Library/LiveActor/ActorInitInfo.h"
-#include "al/include/Library/Play/Area/CameraStartParamArea.h"
-#include "al/include/Library/Play/Area/SeBarrierArea.h"
-#include "al/include/Library/Play/Area/SePlayArea.h"
-#include "al/include/Library/Play/Area/ViewCtrlArea.h"
+#include "Library/Area/AreaInitInfo.h"
+#include "Library/Area/AreaObj.h"
+#include "Library/Area/TrafficArea.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/Play/Area/CameraStartParamArea.h"
+#include "Library/Play/Area/SeBarrierArea.h"
+#include "Library/Play/Area/SePlayArea.h"
+#include "Library/Play/Area/ViewCtrlArea.h"
 
 namespace al {
 

--- a/src/Scene/ProjectAreaFactory.h
+++ b/src/Scene/ProjectAreaFactory.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "al/include/Library/Area/AreaObjFactory.h"
+
+class ProjectAreaFactory : public al::AreaObjFactory {
+public:
+    ProjectAreaFactory();
+};

--- a/src/Scene/ProjectAreaFactory.h
+++ b/src/Scene/ProjectAreaFactory.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "al/include/Library/Area/AreaObjFactory.h"
+#include "Library/Area/AreaObjFactory.h"
 
 class ProjectAreaFactory : public al::AreaObjFactory {
 public:


### PR DESCRIPTION
pasted PR comment from the other repo:

This covers
- Reversed `AreaObjDirector`'s methods and fixed some errors in its header
- `AreaObjFactory` header + reversed both methods
- Headers for `AreaObjMtxConnecter` and `AreaObjMtxConnecterHolder`
- 2 inlined functions in `Factory` to get AreaObj + AreaObjDirector stuff matching
- Headers for area objects used in the factory (includes `TrafficArea`, `CameraStartParam`, `SeBarrierArea`, `SePlayArea`, `ViewCtrlArea`, `BirdGatheringSpotArea`, `ExtForceArea`, `ForceRecoveryKidsArea`, `MoveArea2D`, `NpcForceMaterialCodeArea`, `RouteGuideArea`, and `StainArea`)
- `ProjectAreaFactory` header and a non-matching constructor


Things to sanity check:
- `AreaObjDirector::getAreaObjGroup` did not match when using the inlined `_getAreaObjGroup`. Instead, it only matches when I paste the exact same code into the public method. Inlining the binary search was necessary for several functions to match, but having 2 identical functions feels wrong.
- I don't know if I defined `BirdGatheringSpotArea::AreaClippingInfo` in the right spot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/23)
<!-- Reviewable:end -->
