### PR TITLE
lint: Only allow specific lines outside of visibility block in classes

### DIFF
--- a/lib/al/include/Library/Audio/AudioDirector.h
+++ b/lib/al/include/Library/Audio/AudioDirector.h
@@ -27,7 +27,7 @@ class PlayerHolder;
 
 class AudioDirector : public IUseAreaObj, public HioNode, public IAudioSystemPause {
 public:
-    class PauseSystemEntry {
+    struct PauseSystemEntry {
         const char* mName;
         bool _8;
         bool _9;

--- a/lib/al/include/Library/Audio/IAudioSystemPause.h
+++ b/lib/al/include/Library/Audio/IAudioSystemPause.h
@@ -3,6 +3,7 @@
 namespace al {
 
 class IAudioSystemPause {
+public:
     virtual void pauseSystem(bool, char const*, bool, f32, bool, bool, bool) = 0;
 };
 

--- a/lib/al/include/Library/Camera/SnapShotCameraCtrl.h
+++ b/lib/al/include/Library/Camera/SnapShotCameraCtrl.h
@@ -19,6 +19,20 @@ class ICameraInput;
 class IUseCollision;
 
 class SnapShotCameraCtrl : public NerveExecutor, public IUseAudioKeeper {
+public:
+    SnapShotCameraCtrl(SnapShotCameraSceneInfo const*);
+    void start(f32);
+    void load(ByamlIter const&);
+    void startReset(s32);
+    void update(const sead::LookAtCamera&, const IUseCollision*, const ICameraInput*);
+    void makeLookAtCameraPost(sead::LookAtCamera*) const;
+    void makeLookAtCameraLast(sead::LookAtCamera*) const;
+    void exeWait();
+    void exeReset();
+
+    f32 getFovyDegree() const { return mFovyDegree; };
+
+private:
     SnapShotCameraSceneInfo* mCameraSceneInfo;
     CameraParam* mParam;
     bool mIsValidLookAtOffset;
@@ -34,18 +48,5 @@ class SnapShotCameraCtrl : public NerveExecutor, public IUseAudioKeeper {
     f32 mRollTarget;
     u32 uVar2;
     bool bVar1;
-
-public:
-    SnapShotCameraCtrl(SnapShotCameraSceneInfo const*);
-    void start(f32);
-    void load(ByamlIter const&);
-    void startReset(s32);
-    void update(const sead::LookAtCamera&, const IUseCollision*, const ICameraInput*);
-    void makeLookAtCameraPost(sead::LookAtCamera*) const;
-    void makeLookAtCameraLast(sead::LookAtCamera*) const;
-    void exeWait();
-    void exeReset();
-
-    f32 getFovyDegree() const { return mFovyDegree; };
 };
 }  // namespace al

--- a/lib/al/include/Library/LiveActor/ActorPoseKeeper.h
+++ b/lib/al/include/Library/LiveActor/ActorPoseKeeper.h
@@ -334,6 +334,7 @@ void calcTransLocalOffset(sead::Vector3f*, const LiveActor* actor, const sead::V
 }  // namespace al
 
 class alActorPoseFunction {
+public:
     void calcBaseMtx(sead::Matrix34f* mtx, const al::LiveActor* actor);
     void updatePoseTRMSV(al::LiveActor* actor);
 };

--- a/lib/al/include/Library/LiveActor/LiveActor.h
+++ b/lib/al/include/Library/LiveActor/LiveActor.h
@@ -53,8 +53,6 @@ class LiveActor : public IUseNerve,
                   public IUseCollision,
                   public IUseRail,
                   public IUseHioNode {
-    friend class alActorFunction;
-
 public:
     LiveActor(const char* actorName);
 
@@ -126,6 +124,9 @@ public:
     ActorParamHolder* getActorParamHolder() const { return mActorParamHolder; }
 
     void setName(const char* newName) { mActorName = newName; }
+
+protected:
+    friend class alActorFunction;
 
 private:
     const char* mActorName;

--- a/lib/al/include/Library/LiveActor/SubActorKeeper.h
+++ b/lib/al/include/Library/LiveActor/SubActorKeeper.h
@@ -77,8 +77,6 @@ public:
 };
 
 class SubActorKeeper {
-    friend class alSubActorFunction;
-
 public:
     SubActorKeeper(LiveActor*);
     void registerSubActor(LiveActor*, u32);
@@ -86,6 +84,9 @@ public:
 
     static SubActorKeeper* create(LiveActor*);
     static SubActorKeeper* tryCreate(LiveActor*, const char*, s32);
+
+protected:
+    friend class alSubActorFunction;
 
 private:
     LiveActor* mRootActor;

--- a/lib/al/include/Library/Message/MessageSystem.h
+++ b/lib/al/include/Library/Message/MessageSystem.h
@@ -12,9 +12,9 @@ class MessageProjectEx;
 class MessageHolder;
 
 class MessageSystem {
+public:
     using MessageTreeMap = sead::StrTreeMap<256, MessageHolder*>;
 
-public:
     MessageSystem();
     void initMessageForChangeLanguage();
     bool tryInitMessageHolder(MessageTreeMap*, const char*, const char*, const char*);

--- a/lib/al/include/Library/Nerve/NerveAction.h
+++ b/lib/al/include/Library/Nerve/NerveAction.h
@@ -5,11 +5,12 @@
 
 namespace al {
 class NerveAction : public Nerve {
-    friend class alNerveFunction::NerveActionCollector;
-
 public:
     NerveAction();
     virtual const char* getActionName() const = 0;
+
+protected:
+    friend class alNerveFunction::NerveActionCollector;
 
 private:
     NerveAction* mNextAction = nullptr;

--- a/lib/al/include/Library/Nerve/NerveExecutor.h
+++ b/lib/al/include/Library/Nerve/NerveExecutor.h
@@ -14,6 +14,7 @@ class Nerve;
 class NerveKeeper;
 
 class NerveActionCtrl {
+public:
     NerveActionCtrl(alNerveFunction::NerveActionCollector*);
 
     NerveKeeper* findNerve(const char*) const;

--- a/lib/al/include/Library/Nerve/NerveStateCtrl.h
+++ b/lib/al/include/Library/Nerve/NerveStateCtrl.h
@@ -8,13 +8,13 @@
 namespace al {
 
 class NerveStateCtrl {
+public:
     struct State {
         NerveStateBase* state;
         const Nerve* nerve;
         const char* name;
     };
 
-public:
     NerveStateCtrl(s32 maxStates);
 
     void addState(NerveStateBase* state, const Nerve* nerve, const char* name);

--- a/lib/al/include/Library/Nerve/NerveUtil.h
+++ b/lib/al/include/Library/Nerve/NerveUtil.h
@@ -85,12 +85,13 @@ namespace alNerveFunction {
 void setNerveAction(al::IUseNerve* user, const char* action);
 
 class NerveActionCollector {
-    friend class al::NerveAction;
-
 public:
     NerveActionCollector();
 
     void addNerve(al::NerveAction* action);
+
+protected:
+    friend class al::NerveAction;
 
 private:
     s32 mActionCount = 0;

--- a/lib/al/include/Library/Placement/PlacementFunction.h
+++ b/lib/al/include/Library/Placement/PlacementFunction.h
@@ -239,6 +239,7 @@ bool tryGetDisplayScale(sead::Vector3f* scale, const ActorInitInfo& initInfo);
 }  // namespace al
 
 class alPlacementFunction {
+public:
     s32 getCameraId(const al::ActorInitInfo& initInfo);
     void getLinkGroupId(al::PlacementId* groupId, const al::ActorInitInfo& initInfo,
                         const char* linkName);

--- a/lib/al/include/Library/Resource/Resource.h
+++ b/lib/al/include/Library/Resource/Resource.h
@@ -49,6 +49,7 @@ private:
 };
 
 class AnimInfoTable {
+public:
     char size[0x18];
 };
 

--- a/lib/al/include/Library/System/SystemKit.h
+++ b/lib/al/include/Library/System/SystemKit.h
@@ -9,8 +9,6 @@ class ResourceSystem;
 class SaveDataDirector;
 
 class SystemKit {
-    friend class alProjectInterface;
-
 public:
     SystemKit();
 
@@ -23,6 +21,9 @@ public:
     FileLoader* getFileLoader() { return mFileLoader; }
     ResourceSystem* getResourceSystem() { return mResourceSystem; }
     SaveDataDirector* getSaveDataDirector() { return mSaveDataDirector; }
+
+protected:
+    friend class alProjectInterface;
 
 private:
     MemorySystem* mMemorySystem;

--- a/lib/al/include/Project/Light/ActorPrepassLightKeeper.h
+++ b/lib/al/include/Project/Light/ActorPrepassLightKeeper.h
@@ -16,6 +16,7 @@ class Resource;
 class ActorInitInfo;
 
 class ActorPrePassLightKeeper {
+public:
     class UserColor {
     public:
         UserColor();
@@ -27,7 +28,6 @@ class ActorPrePassLightKeeper {
     };
     static_assert(sizeof(UserColor) == 0x18);
 
-public:
     static bool isExistFile(const Resource*, const char*);
 
     ActorPrePassLightKeeper(LiveActor*);

--- a/lib/al/include/Project/Play/Graphics/IUseGridMesh.h
+++ b/lib/al/include/Project/Play/Graphics/IUseGridMesh.h
@@ -14,6 +14,7 @@ class QuadNode;
 class MeshQuadtree;
 
 class IUseGridMesh : public IUseHioNode {
+public:
     virtual void finalize() = 0;
     virtual s32 getGridMeshType() const = 0;
     virtual s32 getGridNum() const = 0;

--- a/src/Player/HackerJudge.h
+++ b/src/Player/HackerJudge.h
@@ -10,8 +10,6 @@ class LiveActor;
 }
 
 class HackerJudge : public al::HioNode, public IJudge {
-    IUsePlayerHack** mHacker;
-
 public:
     HackerJudge(IUsePlayerHack** parent) { mHacker = parent; };
     void reset() override;
@@ -19,6 +17,9 @@ public:
     bool judge() const override;
 
     IUsePlayerHack** getHacker() const { return mHacker; };
+
+private:
+    IUsePlayerHack** mHacker;
 };
 
 class HackerJudgeNormalFall : public HackerJudge {

--- a/src/Player/PlayerActorHakoniwa.h
+++ b/src/Player/PlayerActorHakoniwa.h
@@ -128,7 +128,8 @@ class PlayerJudgeWallHitDownForceRun;
 class PlayerJudgeWallHitDownRolling;
 class PlayerJudgeWallKeep;
 
-class PlayerActorHakoniwa : PlayerActorBase, IUseDimension {
+class PlayerActorHakoniwa : public PlayerActorBase, public IUseDimension {
+public:
     PlayerInfo* mPlayerInfo;
     PlayerConst* mPlayerConst;
     PlayerInput* mPlayerInput;

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -4,6 +4,7 @@
 #include <prim/seadBitFlag.h>
 
 class PlayerTrigger {
+public:
     enum ECollisionTrigger : u32 {};
     enum EAttackSensorTrigger : u32 {};
     enum EActionTrigger : u32 {};
@@ -12,7 +13,6 @@ class PlayerTrigger {
     enum EDemoEndTrigger : u32 {};
     enum EMaterialChangeTrigger : u32 {};
 
-public:
     PlayerTrigger();
     void set(ECollisionTrigger);
     void set(EAttackSensorTrigger);

--- a/src/System/Application.h
+++ b/src/System/Application.h
@@ -12,7 +12,6 @@ struct DrawSystemInfo;
 class RootTask;
 
 class Application {
-    friend class ApplicationFunction;
     SEAD_SINGLETON_DISPOSER(Application);
 
 public:
@@ -24,6 +23,9 @@ public:
     al::GameFrameworkNx* getGameFramework() const { return mGameFramework; }
     al::AccountHolder* getAccountHolder() const { return mAccountHolder; }
     al::DrawSystemInfo* getDrawSystemInfo() const { return mDrawSystemInfo; }
+
+protected:
+    friend class ApplicationFunction;
 
 private:
     al::SystemKit* mSystemKit;

--- a/src/System/ProjectInterface.h
+++ b/src/System/ProjectInterface.h
@@ -5,5 +5,6 @@ class SystemKit;
 }
 
 class alProjectInterface {
+public:
     static al::SystemKit* getSystemKit();
 };


### PR DESCRIPTION
As a preparation for more precise linter actions regarding visibility and naming of specific parts in classes, this PR will eliminate all lines outside of visibility blocks in classes, with a few exceptions:
- Empty lines - for obvious reasons
- `};` is a specifically defined as exception here, due to how this method is implemented (closing braces of the class), only relevant when a class does not have any content yet
- `SEAD_SINGLETON_DISPOSER` and `SEAD_RTTI_BASE` as well as `SEAD_RTTI_OVERRIDE`, as those should be given at the very top of the class and bring their own visibility modifiers at the start of the macro

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/27)
<!-- Reviewable:end -->
