### PR TITLE
lint: All superclasses must be `public`

### DIFF
--- a/lib/al/include/Library/Camera/CameraDirector.h
+++ b/lib/al/include/Library/Camera/CameraDirector.h
@@ -33,7 +33,7 @@ class IUseAudioKeeper;
 class CameraRailHolder;
 class NameToCameraParamTransferFunc;
 
-class CameraDirector : public HioNode, IUseExecutor {
+class CameraDirector : public HioNode, public IUseExecutor {
 public:
     CameraDirector(s32 maxCameras);
     virtual ~CameraDirector();

--- a/lib/al/include/Library/LiveActor/LiveActorGroup.h
+++ b/lib/al/include/Library/LiveActor/LiveActorGroup.h
@@ -37,7 +37,7 @@ private:
 };
 
 template <class T>
-class DeriveActorGroup : LiveActorGroup {
+class DeriveActorGroup : public LiveActorGroup {
 public:
     s32 registerActor(T* actor) { LiveActorGroup::registerActor(actor); }
     void removeActor(const T* actor) { LiveActorGroup::removeActor(actor); }

--- a/lib/al/include/Library/Scene/GameDataHolderBase.h
+++ b/lib/al/include/Library/Scene/GameDataHolderBase.h
@@ -5,5 +5,5 @@
 #include "Library/Scene/ISceneObj.h"
 
 namespace al {
-class GameDataHolderBase : public ISceneObj, HioNode, IUseMessageSystem {};
+class GameDataHolderBase : public ISceneObj, public HioNode, public IUseMessageSystem {};
 }  // namespace al

--- a/lib/al/include/Library/Screen/ScreenFunction.h
+++ b/lib/al/include/Library/Screen/ScreenFunction.h
@@ -15,7 +15,7 @@ namespace al {
 class SceneCameraInfo;
 class ScreenCapture;
 
-class ScreenCaptureExecutor : IUseHioNode {
+class ScreenCaptureExecutor : public IUseHioNode {
 public:
     ScreenCaptureExecutor(s32);
     ~ScreenCaptureExecutor();

--- a/src/Layout/StageSceneLayout.h
+++ b/src/Layout/StageSceneLayout.h
@@ -17,7 +17,7 @@ class PlayGuideCamera;
 class PlayGuideBgm;
 class MapMini;
 
-class StageSceneLayout : al::NerveStateBase {
+class StageSceneLayout : public al::NerveStateBase {
 public:
     StageSceneLayout(const char*, const al::LayoutInitInfo&, const al::PlayerHolder*,
                      const al::SubCameraRenderer*);

--- a/src/MapObj/WorldMapEarth.h
+++ b/src/MapObj/WorldMapEarth.h
@@ -2,7 +2,7 @@
 
 #include "Library/LiveActor/LiveActor.h"
 
-class WorldMapEarth : al::LiveActor {
+class WorldMapEarth : public al::LiveActor {
 public:
     WorldMapEarth(const char* name);
     void init(const al::ActorInitInfo& initInfo) override;

--- a/src/Player/PlayerConst.h
+++ b/src/Player/PlayerConst.h
@@ -3,7 +3,7 @@
 #include "Library/HostIO/HioNode.h"
 #include "Library/Yaml/ByamlIter.h"
 
-class PlayerConst : al::HioNode {
+class PlayerConst : public al::HioNode {
 public:
     PlayerConst();
     PlayerConst(const al::ByamlIter&);

--- a/src/Player/PlayerModelChangerHakoniwa.h
+++ b/src/Player/PlayerModelChangerHakoniwa.h
@@ -12,7 +12,7 @@ class PlayerPainPartsKeeper;
 class PlayerCostumeInfo;
 class IUseDimension;
 
-class PlayerModelChangerHakoniwa : IPlayerModelChanger, al::HioNode {
+class PlayerModelChangerHakoniwa : public IPlayerModelChanger, public al::HioNode {
 public:
     PlayerModelChangerHakoniwa(const al::LiveActor*, PlayerModelHolder*, PlayerPainPartsKeeper*,
                                PlayerCostumeInfo*, const IUseDimension*);


### PR DESCRIPTION
This introduces another level of linter-magicness, geared towards detecting superclass specifications (`:`) that are missing a `public` statement. Currently, we have no instances of objects needing protected or private superclasses, so generally enforcing this seems like a good idea - and reduces the number of possible human-made errors along the way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/31)
<!-- Reviewable:end -->
