### PR TITLE
lint: Add more header-line-specific lint passes

### DIFF
--- a/lib/al/include/Library/Camera/CameraDirector.h
+++ b/lib/al/include/Library/Camera/CameraDirector.h
@@ -98,8 +98,8 @@ private:
     CameraParamTransfer* mParamTransfer;
     const CameraResourceHolder* mCameraResourceHolder;
     CameraFlagCtrl* mFlagCtrl;
-    void* customThing;
+    void* unk;
     CameraInSwitchOnAreaDirector* mInSwitchOnAreaDirector;
-    void* anotherCustomThing;
+    void* unk2;
 };
 }  // namespace al

--- a/lib/al/include/Library/Camera/SnapShotCameraCtrl.h
+++ b/lib/al/include/Library/Camera/SnapShotCameraCtrl.h
@@ -7,8 +7,8 @@
 #include "Library/Yaml/ByamlIter.h"
 
 struct CameraParam {
-    bool gotMin;
-    bool gotMax;
+    bool mHasMin;
+    bool mHasMax;
     f32 mMinFovyDegree;
     f32 mMaxFovyDegree;
 };
@@ -37,16 +37,16 @@ private:
     CameraParam* mParam;
     bool mIsValidLookAtOffset;
     sead::Vector3f mLookAtOffset;
-    sead::Vector3f vVar1;
+    sead::Vector3f unk1;
     bool mIsValidZoomFovy;
     f32 mFovyDegree;
-    f32 fVar2;
-    f32 fVar3;
+    f32 unk2;
+    f32 unk3;
     f32 mMaxZoomOutFovyDegree;
     bool mIsValidRoll;
     f32 mRollDegree;
     f32 mRollTarget;
-    u32 uVar2;
-    bool bVar1;
+    u32 unk4;
+    bool unk5;
 };
 }  // namespace al

--- a/lib/al/include/Library/LiveActor/ActorPoseKeeper.h
+++ b/lib/al/include/Library/LiveActor/ActorPoseKeeper.h
@@ -34,7 +34,7 @@ public:
     virtual void calcBaseMtx(sead::Matrix34f* mtx) const = 0;
 
 protected:  // protected so it's visible to all sub-classes (TFSV, TFGSV, ...)
-    sead::Vector3f mTrans{0, 0, 0};
+    sead::Vector3f mTrans = {0, 0, 0};
 
     static sead::Vector3f sDefaultVelocity;
 };
@@ -57,8 +57,8 @@ public:
 
 protected:  // protected so it's visible to all sub-classes (TFGSV, TFUSV)
     sead::Vector3f mFront = sead::Vector3f::ez;
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
 };
 
 class ActorPoseKeeperTFGSV : public ActorPoseKeeperTFSV {
@@ -74,7 +74,7 @@ public:
     void calcBaseMtx(sead::Matrix34f* mtx) const override;
 
 private:
-    sead::Vector3f mGravity{0.0, -1.0, 0.0};
+    sead::Vector3f mGravity = {0.0, -1.0, 0.0};
 };
 
 class ActorPoseKeeperTFUSV : public ActorPoseKeeperTFSV {
@@ -112,8 +112,8 @@ public:
 
 private:
     sead::Quatf mQuat = sead::Quatf::unit;
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
 };
 
 class ActorPoseKeeperTQGSV : public ActorPoseKeeperBase {
@@ -136,9 +136,9 @@ public:
 
 private:
     sead::Quatf mQuat = sead::Quatf::unit;
-    sead::Vector3f mGravity{0.0, -1.0, 0.0};
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mGravity = {0.0, -1.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
 };
 
 class ActorPoseKeeperTQGMSV : public ActorPoseKeeperBase {
@@ -163,9 +163,9 @@ public:
 
 private:
     sead::Quatf mQuat = sead::Quatf::unit;
-    sead::Vector3f mGravity{0.0, -1.0, 0.0};
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mGravity = {0.0, -1.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
     sead::Matrix34f mMtx = sead::Matrix34f::ident;
 };
 
@@ -186,9 +186,9 @@ public:
     void calcBaseMtx(sead::Matrix34f* mtx) const override;
 
 private:
-    sead::Vector3f mRotate{0.0, 0.0, 0.0};
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mRotate = {0.0, 0.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
 };
 
 class ActorPoseKeeperTRMSV : public ActorPoseKeeperBase {
@@ -210,9 +210,9 @@ public:
     void calcBaseMtx(sead::Matrix34f* mtx) const override;
 
 private:
-    sead::Vector3f mRotate{0.0, 0.0, 0.0};
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mRotate = {0.0, 0.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
     sead::Matrix34f mMtx;  // manually set in the ctor
 };
 
@@ -237,10 +237,10 @@ public:
     void calcBaseMtx(sead::Matrix34f* mtx) const override;
 
 private:
-    sead::Vector3f mRotate{0.0, 0.0, 0.0};
-    sead::Vector3f mGravity{0.0, -1.0, 0.0};
-    sead::Vector3f mScale{1.0, 1.0, 1.0};
-    sead::Vector3f mVelocity{0.0, 0.0, 0.0};
+    sead::Vector3f mRotate = {0.0, 0.0, 0.0};
+    sead::Vector3f mGravity = {0.0, -1.0, 0.0};
+    sead::Vector3f mScale = {1.0, 1.0, 1.0};
+    sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
     sead::Matrix34f mMtx;
 };
 

--- a/lib/al/include/Library/MapObj/FixMapParts.h
+++ b/lib/al/include/Library/MapObj/FixMapParts.h
@@ -13,6 +13,6 @@ public:
     bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
 
 private:
-    bool mStatic = false;
+    bool mIsStatic = false;
 };
 }  // namespace al

--- a/lib/al/include/Library/Obj/PartsModel.h
+++ b/lib/al/include/Library/Obj/PartsModel.h
@@ -37,7 +37,7 @@ private:
     sead::Vector3f mLocalScale = sead::Vector3f(1.0f, 1.0f, 1.0f);
     bool mIsUseFollowMtxScale = false;
     bool mIsUseLocalScale = false;
-    bool mUpdate = true;
+    bool mIsUpdate = true;
 };
 
 }  // namespace al

--- a/lib/al/include/Library/Play/Camera/CameraVerticalAbsorber.h
+++ b/lib/al/include/Library/Play/Camera/CameraVerticalAbsorber.h
@@ -44,7 +44,7 @@ private:
     f32 mAbsorbScreenPosDown;
     bool mAdvanceAbsorbUp;
     f32 mAdvanceAbsorbScreenPosUp;
-    bool isExistCollisionUnderTarget;
+    bool mIsExistCollisionUnderTarget;
     sead::Vector3f mUnderTargetCollisionPos;
     sead::Vector3f mUnderTargetCollisionNormal;
     f32 mLerp2;
@@ -54,11 +54,11 @@ private:
     sead::Vector3f mPrevTargetTrans;
     sead::Vector3f mTargetFront;
     sead::Vector3f mPrevTargetFront;
-    bool isNoCameraPosAbsorb;
-    bool isInvalidated;
-    bool unusedBool;
-    bool isStopUpdate;
-    bool isKeepInFrame;
+    bool mIsNoCameraPosAbsorb;
+    bool mIsInvalidated;
+    bool mUnusedBool;
+    bool mIsStopUpdate;
+    bool mIsKeepInFrame;
 };
 static_assert(sizeof(CameraVerticalAbsorber) == 0x1B0);
 

--- a/lib/al/include/Library/Play/Camera/CameraVerticalAbsorber.h
+++ b/lib/al/include/Library/Play/Camera/CameraVerticalAbsorber.h
@@ -42,7 +42,7 @@ private:
     f32 mLerp1;
     f32 mAbsorbScreenPosUp;
     f32 mAbsorbScreenPosDown;
-    bool mAdvanceAbsorbUp;
+    bool mIsAdvanceAbsorbUp;
     f32 mAdvanceAbsorbScreenPosUp;
     bool mIsExistCollisionUnderTarget;
     sead::Vector3f mUnderTargetCollisionPos;
@@ -56,7 +56,7 @@ private:
     sead::Vector3f mPrevTargetFront;
     bool mIsNoCameraPosAbsorb;
     bool mIsInvalidated;
-    bool mUnusedBool;
+    bool unk_unusedBool;
     bool mIsStopUpdate;
     bool mIsKeepInFrame;
 };

--- a/lib/al/include/Library/Rail/Rail.h
+++ b/lib/al/include/Library/Rail/Rail.h
@@ -39,7 +39,7 @@ private:
     RailPart* mRailPart = nullptr;
     s32 mRailPartCount = 0;
     s32 mRailPointsCount = 0;
-    bool isClosed = false;
+    bool mIsClosed = false;
 };
 
 }  // namespace al

--- a/lib/al/include/Library/Shadow/DepthShadowMapCtrl.h
+++ b/lib/al/include/Library/Shadow/DepthShadowMapCtrl.h
@@ -37,7 +37,7 @@ public:
 
 private:
     LiveActor* mLiveActor;
-    sead::Vector3f lightDir;
+    sead::Vector3f mLightDir;
     bool mIsAppendSubActor;
     sead::PtrArray<DepthShadowMapInfo> mDepthShadowMaps;
     sead::PtrArray<ModelDrawerDepthShadowMap> mModelDrawerDepthShadowMaps;

--- a/lib/al/include/Library/Yaml/ByamlData.h
+++ b/lib/al/include/Library/Yaml/ByamlData.h
@@ -68,7 +68,7 @@ public:
 
 private:
     const u8* mData;
-    bool isRev;
+    bool mIsRev;
 };
 
 class ByamlArrayIter {
@@ -84,6 +84,6 @@ public:
 
 private:
     const u8* mData;
-    bool isRev;
+    bool mIsRev;
 };
 }  // namespace al

--- a/lib/al/include/Library/Yaml/ByamlHeader.h
+++ b/lib/al/include/Library/Yaml/ByamlHeader.h
@@ -40,7 +40,7 @@ public:
 
 private:
     const u8* mData = nullptr;
-    bool isRev = false;
+    bool mIsRev = false;
 };
 }  // namespace al
 

--- a/lib/al/include/Library/Yaml/Writer/ByamlWriterData.h
+++ b/lib/al/include/Library/Yaml/Writer/ByamlWriterData.h
@@ -224,8 +224,8 @@ public:
     ByamlWriterData* getValue() { return mValue; }
 
 private:
-    void* selfReference = this;
-    void* test2 = nullptr;
+    void* mSelfReference = this;
+    void* unk = nullptr;
     const char* mKey;
     ByamlWriterData* mValue;
 };

--- a/lib/al/include/Project/Action/ActionFlagCtrl.h
+++ b/lib/al/include/Project/Action/ActionFlagCtrl.h
@@ -38,6 +38,6 @@ private:
     s32 mInfoCount = 0;
     ActionFlagCtrlInfo** mInfos = nullptr;
     ActionFlagCtrlInfo* mLastFlag = nullptr;
-    bool mBool = false;
+    bool mIsBool = false;
 };
 }  // namespace al

--- a/lib/al/include/Project/Item/ActorScoreKeeper.h
+++ b/lib/al/include/Project/Item/ActorScoreKeeper.h
@@ -22,7 +22,7 @@ private:
     inline void allocArray();
     inline void putEntry(s32 index, const ByamlIter& iter);
 
-    Entry* array;
-    s32 size;
+    Entry* mArray;
+    s32 mSize;
 };
 }  // namespace al

--- a/lib/al/src/Library/Camera/SnapShotCameraCtrl.cpp
+++ b/lib/al/src/Library/Camera/SnapShotCameraCtrl.cpp
@@ -10,9 +10,9 @@ void SnapShotCameraCtrl::load(ByamlIter const& iter) {
     if (!tryGetByamlIterByKey(&param, iter, "SnapShotParam"))
         return;
     if (tryGetByamlF32(&mParam->mMinFovyDegree, param, "MinFovyDegree"))
-        mParam->gotMin = true;
+        mParam->mHasMin = true;
     if (tryGetByamlF32(&mParam->mMinFovyDegree, param, "MinFovyDegree"))
-        mParam->gotMax = true;
+        mParam->mHasMax = true;
 }
 
 }  // namespace al

--- a/lib/al/src/Library/MapObj/FixMapParts.cpp
+++ b/lib/al/src/Library/MapObj/FixMapParts.cpp
@@ -17,7 +17,7 @@ void FixMapParts::init(const ActorInitInfo& info) {
     registActorToDemoInfo(this, info);
 
     if (getModelKeeper() != nullptr && !isExistAction(this) && !isViewDependentModel(this)) {
-        mStatic = true;
+        mIsStatic = true;
     }
 }
 void FixMapParts::appear() {
@@ -27,11 +27,11 @@ void FixMapParts::appear() {
         tryStartAction(this, "Appear");
 }
 void FixMapParts::movement() {
-    if (!mStatic)
+    if (!mIsStatic)
         LiveActor::movement();
 }
 void FixMapParts::calcAnim() {
-    if (!mStatic)
+    if (!mIsStatic)
         LiveActor::calcAnim();
     else
         calcViewModel(this);

--- a/lib/al/src/Library/Obj/PartsModel.cpp
+++ b/lib/al/src/Library/Obj/PartsModel.cpp
@@ -116,7 +116,7 @@ void PartsModel::updatePose() {
     sead::Matrix34f poseMtx;
     sead::Matrix34f jointMtx;
 
-    if (!mUpdate)
+    if (!mIsUpdate)
         return;
     if (mIsUseLocalPos) {
         jointMtx = *mJointMtx;

--- a/lib/al/src/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/src/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -53,7 +53,7 @@ void CameraVerticalAbsorber::start(const sead::Vector3f& pos, const CameraStartI
 
     mPrevTargetTrans = pos;
 
-    if (mUnusedBool || mIsInvalidated ||
+    if (unk_unusedBool || mIsInvalidated ||
         alCameraPoserFunction::isPlayerTypeNotTouchGround(mCameraPoser))
         return setNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute);
     if (alCameraPoserFunction::isTargetClimbPole(mCameraPoser))
@@ -85,7 +85,7 @@ void CameraVerticalAbsorber::load(const ByamlIter& data) {
 
     if (!it.tryGetIterByKey(&it2, "AdvanceAbsorbUp"))
         return;
-    mAdvanceAbsorbUp = true;
+    mIsAdvanceAbsorbUp = true;
     mAdvanceAbsorbScreenPosUp = getByamlKeyFloat(it2, "AdvanceAbsorbScreenPosUp");
 }
 
@@ -102,7 +102,7 @@ void CameraVerticalAbsorber::update() {
     mLookAtCamera.getUp() = mCameraPoser->getCameraUp();
     if (mLookAtCamera.getUp().length() > 0.f)
         mLookAtCamera.getUp().normalize();
-    if (!mUnusedBool && !mIsInvalidated) {
+    if (!unk_unusedBool && !mIsInvalidated) {
         mLookAtCamera.getAt() -= mTargetInterp;
         if (!mIsNoCameraPosAbsorb) {
             mLookAtCamera.getPos() -= mTargetInterp;

--- a/lib/al/src/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/src/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -38,7 +38,7 @@ void CameraVerticalAbsorber::exeFollowAbsolute() {
 }
 
 void CameraVerticalAbsorber::invalidate() {
-    isInvalidated = true;
+    mIsInvalidated = true;
     if (!isNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute))
         setNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute);
 }
@@ -53,7 +53,7 @@ void CameraVerticalAbsorber::start(const sead::Vector3f& pos, const CameraStartI
 
     mPrevTargetTrans = pos;
 
-    if (unusedBool || isInvalidated ||
+    if (mUnusedBool || mIsInvalidated ||
         alCameraPoserFunction::isPlayerTypeNotTouchGround(mCameraPoser))
         return setNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute);
     if (alCameraPoserFunction::isTargetClimbPole(mCameraPoser))
@@ -91,7 +91,7 @@ void CameraVerticalAbsorber::load(const ByamlIter& data) {
 
 // NON_MATCHING
 void CameraVerticalAbsorber::update() {
-    if (isStopUpdate)
+    if (mIsStopUpdate)
         return;
     sead::Vector3f gravity{};
     alCameraPoserFunction::calcTargetGravity(&gravity, mCameraPoser);
@@ -102,9 +102,9 @@ void CameraVerticalAbsorber::update() {
     mLookAtCamera.getUp() = mCameraPoser->getCameraUp();
     if (mLookAtCamera.getUp().length() > 0.f)
         mLookAtCamera.getUp().normalize();
-    if (!unusedBool && !isInvalidated) {
+    if (!mUnusedBool && !mIsInvalidated) {
         mLookAtCamera.getAt() -= mTargetInterp;
-        if (!isNoCameraPosAbsorb) {
+        if (!mIsNoCameraPosAbsorb) {
             mLookAtCamera.getPos() -= mTargetInterp;
         }
     }
@@ -124,7 +124,7 @@ void CameraVerticalAbsorber::update() {
     }
     updateNerve();
     sead::Vector3f prevTargetTrans = sead::Vector3f::zero;
-    if (!isKeepInFrame) {
+    if (!mIsKeepInFrame) {
         prevTargetTrans = mTargetInterp;
     } else {
         sead::Vector3f offsetTrans = sead::Vector3f::zero;

--- a/lib/al/src/Library/Rail/Rail.cpp
+++ b/lib/al/src/Library/Rail/Rail.cpp
@@ -10,8 +10,8 @@ namespace al {
 Rail::Rail() = default;
 // NON_MATCHING: mismatch during `mRailPart`-array creation
 void Rail::init(const PlacementInfo& info) {
-    isClosed = false;
-    tryGetArg(&isClosed, info, "IsClosed");
+    mIsClosed = false;
+    tryGetArg(&mIsClosed, info, "IsClosed");
     PlacementInfo railPointsInfo;
     tryGetPlacementInfoByKey(&railPointsInfo, info, "RailPoints");
     mRailPointsCount = getCountPlacementInfo(railPointsInfo);
@@ -35,7 +35,7 @@ void Rail::init(const PlacementInfo& info) {
         return;
     }
 
-    mRailPartCount = (isClosed ? 1 : 0) + mRailPointsCount - 1;
+    mRailPartCount = (mIsClosed ? 1 : 0) + mRailPointsCount - 1;
     mRailPart = new RailPart[mRailPartCount];
 
     f32 totalLength = 0;
@@ -116,7 +116,7 @@ f32 Rail::getLengthToPoint(s32 index) const {
     return mRailPart[index - 1].getTotalDistance();
 }
 void Rail::calcRailPointPos(sead::Vector3f* pos, s32 index) const {
-    if (isClosed || index != mRailPointsCount - 1)
+    if (mIsClosed || index != mRailPointsCount - 1)
         return mRailPart[index].calcStartPos(pos);
 
     return mRailPart[index - 1].calcEndPos(pos);
@@ -178,7 +178,7 @@ void Rail::calcNearestRailPointPos(sead::Vector3f* rail_pos, const sead::Vector3
     }
 }
 f32 Rail::normalizeLength(f32 distance) const {
-    if (isClosed) {
+    if (mIsClosed) {
         f32 distanceOnRail = modf(distance, getTotalLength());
         if (distanceOnRail < 0.0)
             distanceOnRail += getTotalLength();

--- a/lib/al/src/Library/Yaml/ByamlData.cpp
+++ b/lib/al/src/Library/Yaml/ByamlData.cpp
@@ -36,8 +36,8 @@ s32 ByamlHashPair::getValue(bool isRev) const {
     return isRev ? bswap_32(mValue) : mValue;
 }
 
-ByamlHashIter::ByamlHashIter(const u8* data, bool isRev_) : mData(data), isRev(isRev_) {}
-ByamlHashIter::ByamlHashIter() : mData(nullptr), isRev(false) {}
+ByamlHashIter::ByamlHashIter(const u8* data, bool isRev_) : mData(data), mIsRev(isRev_) {}
+ByamlHashIter::ByamlHashIter() : mData(nullptr), mIsRev(false) {}
 
 const ByamlHashPair* ByamlHashIter::findPair(s32 key) const {
     const ByamlHashPair* pairTable = getPairTable();
@@ -50,7 +50,7 @@ const ByamlHashPair* ByamlHashIter::findPair(s32 key) const {
     while (lowerBound < upperBound) {
         s32 avg = (lowerBound + upperBound) / 2;
         const ByamlHashPair* pair = &pairTable[avg];
-        s32 result = key - pair->getKey(isRev);
+        s32 result = key - pair->getKey(mIsRev);
         if (result == 0) {
             return pair;
         }
@@ -68,7 +68,7 @@ bool ByamlHashIter::getDataByIndex(ByamlData* data, s32 index) const {
     if (((s32)getSize()) < 1)
         return false;
 
-    data->set(&getPairTable()[index], isRev);
+    data->set(&getPairTable()[index], mIsRev);
     return true;
 }
 // NON_MATCHING: minor additional instructions, probably not inlined
@@ -91,7 +91,7 @@ bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     while (true) {
         s32 avg = (lowerBound + upperBound) / 2;
         pair = &pairTable[avg];
-        s32 result = key - pair->getKey(isRev);
+        s32 result = key - pair->getKey(mIsRev);
         if (result == 0) {
             break;
         }
@@ -105,7 +105,7 @@ bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     }
     if (pair == nullptr)
         return false;
-    data->set(pair, isRev);
+    data->set(pair, mIsRev);
     return true;
 }
 const u8* ByamlHashIter::getOffsetData(u32 off) const {
@@ -128,11 +128,11 @@ u32 ByamlHashIter::getSize() const {
     if (!mData)
         return 0;
     u32 val = *reinterpret_cast<const u32*>(mData);
-    return isRev ? bswap_24(val >> 8) : val >> 8;
+    return mIsRev ? bswap_24(val >> 8) : val >> 8;
 }
 
-ByamlArrayIter::ByamlArrayIter(const u8* data, bool isRev_) : mData(data), isRev(isRev_) {}
-ByamlArrayIter::ByamlArrayIter() : mData(nullptr), isRev(false) {}
+ByamlArrayIter::ByamlArrayIter(const u8* data, bool isRev_) : mData(data), mIsRev(isRev_) {}
+ByamlArrayIter::ByamlArrayIter() : mData(nullptr), mIsRev(false) {}
 
 bool ByamlArrayIter::getDataByIndex(ByamlData* data, s32 index) const {
     if (index < 0)
@@ -140,7 +140,7 @@ bool ByamlArrayIter::getDataByIndex(ByamlData* data, s32 index) const {
     if (((s32)getSize()) <= index)
         return false;
 
-    data->set(getTypeTable()[index], getDataTable()[index], isRev);
+    data->set(getTypeTable()[index], getDataTable()[index], mIsRev);
     return true;
 }
 // NON_MATCHING: regalloc
@@ -152,7 +152,7 @@ const u8* ByamlArrayIter::getOffsetData(u32 off) const {
 }
 u32 ByamlArrayIter::getSize() const {
     u32 val = *reinterpret_cast<const u32*>(mData);
-    return isRev ? bswap_24(val >> 8) : val >> 8;
+    return mIsRev ? bswap_24(val >> 8) : val >> 8;
 }
 const u8* ByamlArrayIter::getTypeTable() const {
     return mData + 4;

--- a/lib/al/src/Library/Yaml/ByamlHeader.cpp
+++ b/lib/al/src/Library/Yaml/ByamlHeader.cpp
@@ -38,11 +38,11 @@ u32 ByamlHeader::getDataOffset() const {
 ByamlStringTableIter::ByamlStringTableIter() = default;
 
 ByamlStringTableIter::ByamlStringTableIter(const u8* data, bool isRev)
-    : mData(data), isRev(isRev) {}
+    : mData(data), mIsRev(isRev) {}
 
 s32 ByamlStringTableIter::getSize() const {
     u32 type_and_size = *reinterpret_cast<const u32*>(mData);
-    return isRev ? bswap_24(type_and_size >> 8) : type_and_size >> 8;
+    return mIsRev ? bswap_24(type_and_size >> 8) : type_and_size >> 8;
 }
 
 const u32* ByamlStringTableIter::getAddressTable() const {
@@ -52,7 +52,7 @@ const u32* ByamlStringTableIter::getAddressTable() const {
 }
 
 u32 ByamlStringTableIter::getStringAddress(s32 idx) const {
-    if (isRev)
+    if (mIsRev)
         return bswap_32(getAddressTable()[idx]);
 
     return getAddressTable()[idx];
@@ -61,7 +61,7 @@ u32 ByamlStringTableIter::getStringAddress(s32 idx) const {
 // NON_MATCHING: regalloc
 u32 ByamlStringTableIter::getEndAddress() const {
     u32 val = getAddressTable()[getSize()];
-    return isRev ? bswap_32(val) : val;
+    return mIsRev ? bswap_32(val) : val;
 }
 const char* ByamlStringTableIter::getString(s32 index) const {
     return reinterpret_cast<const char*>(&mData[getStringAddress(index)]);

--- a/lib/al/src/Project/Action/ActionFlagCtrl.cpp
+++ b/lib/al/src/Project/Action/ActionFlagCtrl.cpp
@@ -23,7 +23,7 @@ ActionFlagCtrl* ActionFlagCtrl::tryCreate(LiveActor* actor, const char* name) {
 }
 void ActionFlagCtrl::start(const char* name) {
     mLastFlag = findFlagInfo(name);
-    mBool = false;
+    mIsBool = false;
     if (!mLastFlag)
         return;
 
@@ -39,7 +39,7 @@ ActionFlagCtrlInfo* ActionFlagCtrl::findFlagInfo(const char* name) const {
     return nullptr;
 }
 void ActionFlagCtrl::update(f32 frame, f32 frameRate, f32 frameMax, bool isStop) {
-    if (!mLastFlag || !mBool)
+    if (!mLastFlag || !mIsBool)
         return;
     if (!mHitSensorKeeper)
         return;

--- a/lib/al/src/Project/Item/ActorScoreKeeper.cpp
+++ b/lib/al/src/Project/Item/ActorScoreKeeper.cpp
@@ -7,29 +7,29 @@ ActorScoreKeeper::ActorScoreKeeper() = default;
 
 void ActorScoreKeeper::init(const ByamlIter& iter) {
     if (iter.isTypeArray()) {
-        size = iter.getSize();
+        mSize = iter.getSize();
         allocArray();
-        for (s32 i = 0; i < size; i++) {
+        for (s32 i = 0; i < mSize; i++) {
             ByamlIter subIter;
             iter.tryGetIterByIndex(&subIter, i);
             putEntry(i, subIter);
         }
     } else {
-        size = 1;
+        mSize = 1;
         allocArray();
         putEntry(0, iter);
     }
 }
 
 inline void ActorScoreKeeper::allocArray() {
-    Entry* local_array = new Entry[size];
-    if (size)
-        memset(local_array, 0, sizeof(Entry) * size);
-    array = local_array;
+    Entry* local_array = new Entry[mSize];
+    if (mSize)
+        memset(local_array, 0, sizeof(Entry) * mSize);
+    mArray = local_array;
 }
 
 inline void ActorScoreKeeper::putEntry(s32 index, const ByamlIter& iter) {
-    auto& entry = array[index];
+    auto& entry = mArray[index];
     iter.tryGetStringByKey(&entry.factorName, "FactorName");
     iter.tryGetStringByKey(&entry.categoryName, "CategoryName");
 }

--- a/src/Npc/Achievement.cpp
+++ b/src/Npc/Achievement.cpp
@@ -6,5 +6,5 @@
 Achievement::Achievement(const AchievementInfo* info) : mInfo(info) {}
 
 bool Achievement::isGet(GameDataHolderAccessor accessor) const {
-    return mGet || rs::checkGetAchievement(accessor, mInfo->mName);
+    return mIsGet || rs::checkGetAchievement(accessor, mInfo->mName);
 }

--- a/src/Npc/Achievement.h
+++ b/src/Npc/Achievement.h
@@ -10,6 +10,6 @@ public:
     bool isGet(GameDataHolderAccessor) const;
 
 private:
-    bool mGet = false;
+    bool mIsGet = false;
     const AchievementInfo* mInfo;
 };

--- a/src/Npc/AchievementInfoReader.cpp
+++ b/src/Npc/AchievementInfoReader.cpp
@@ -18,7 +18,7 @@ void AchievementInfoReader::init() {  // TODO minor mismatches during loop
     al::ByamlIter achievementInfoArray;
     if (achievementInfo.tryGetIterByKey(&achievementInfoArray, "AchievementInfoArray")) {
         auto size = achievementInfoArray.getSize();
-        array.allocBuffer(size, nullptr);
+        mAchievements.allocBuffer(size, nullptr);
 
         for (u32 i = 0; i < size; i++) {
             al::ByamlIter iter;
@@ -32,15 +32,15 @@ void AchievementInfoReader::init() {  // TODO minor mismatches during loop
                 s32 level = -1;
                 iter.tryGetIntByKey(&level, "Level");
 
-                array.pushBack(new AchievementInfo(name, num, level, note));
+                mAchievements.pushBack(new AchievementInfo(name, num, level, note));
             }
         }
     }
 }
 
 s32 AchievementInfoReader::tryFindIndexByName(const char* name) const {
-    for (s32 i = 0; i < array.size(); i++) {
-        if (al::isEqualString(name, array[i]->mName))
+    for (s32 i = 0; i < mAchievements.size(); i++) {
+        if (al::isEqualString(name, mAchievements[i]->mName))
             return i;
     }
     return -1;

--- a/src/Npc/AchievementInfoReader.h
+++ b/src/Npc/AchievementInfoReader.h
@@ -21,10 +21,10 @@ public:
     void init();
     s32 tryFindIndexByName(const char*) const;
 
-    AchievementInfo* get(s32 index) { return array[index]; }
-    s32 size() { return array.size(); }
-    s32 capacity() { return array.capacity(); }
+    AchievementInfo* get(s32 index) { return mAchievements[index]; }
+    s32 size() { return mAchievements.size(); }
+    s32 capacity() { return mAchievements.capacity(); }
 
 private:
-    sead::PtrArray<AchievementInfo> array;
+    sead::PtrArray<AchievementInfo> mAchievements;
 };

--- a/src/Player/PlayerHackKeeper.h
+++ b/src/Player/PlayerHackKeeper.h
@@ -18,5 +18,5 @@ public:
 
 private:
     char padding[0x68];
-    al::LiveActor* currentHackActor;
+    al::LiveActor* mCurrentHackActor;
 };

--- a/src/Player/PlayerHackStartShaderCtrl.h
+++ b/src/Player/PlayerHackStartShaderCtrl.h
@@ -20,7 +20,7 @@ public:
 private:
     al::LiveActor* mParent;
     s32 mTime;
-    bool mActive;
+    bool mIsActive;
     sead::Color4f mColor;
     sead::Quatf mQuat;
     PlayerHackStartShaderParam* mParam;

--- a/src/Player/PlayerInput.cpp
+++ b/src/Player/PlayerInput.cpp
@@ -16,7 +16,7 @@ PlayerInput::PlayerInput(const al::LiveActor*, const IUsePlayerCollision*, const
 }  // FIXME remove this
 
 bool PlayerInput::isEnableCarry() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
 
     return PlayerInputFunction::isHoldAction(mLiveActor,
@@ -24,7 +24,7 @@ bool PlayerInput::isEnableCarry() const {
 }
 
 bool PlayerInput::isTriggerCarryStart() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
 
     return PlayerInputFunction::isTriggerAction(mLiveActor,
@@ -32,54 +32,54 @@ bool PlayerInput::isTriggerCarryStart() const {
 }
 
 bool PlayerInput::isTriggerCarryRelease() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
 
     if (PlayerInputFunction::isTriggerAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor)))
         return true;
 
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
 
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerSwingActionMario() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
 
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerCarryReleaseBySwing() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!PlayerInputFunction::isTriggerAction(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor))) {
-        if (mDisableInput)
+        if (mIsDisableInput)
             return false;
         if (!mJoyPadAccelPoseAnalyzer1->isSwingAnyHand())
             return false;
     }
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerAction(mLiveActor,
                                                 PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto* dimension = mDimension;
     if (dimension && rs::is2D(dimension) && rs::isIn2DArea(dimension)) {
-        if (!mDisableInput && mJoyPadAccelPoseAnalyzer1->isSwingAnyHand())
+        if (!mIsDisableInput && mJoyPadAccelPoseAnalyzer1->isSwingAnyHand())
             return true;
     }
     return PlayerInputFunction::isTriggerJump(mLiveActor,
@@ -87,32 +87,32 @@ bool PlayerInput::isTriggerJump() const {
 }
 
 bool PlayerInput::isTriggerHipDrop() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerSubAction(mLiveActor,
                                                    PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerHeadSliding() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (PlayerInputFunction::isTriggerAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor)))
         return true;
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerPaddle() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerJump(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerRolling(bool a1) const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!PlayerInputFunction::isHoldSubAction(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor)) &&
@@ -121,19 +121,19 @@ bool PlayerInput::isTriggerRolling(bool a1) const {
     if (PlayerInputFunction::isTriggerAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor)))
         return true;
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerRollingRestartSwing() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerRollingCancelHipDrop(bool a1) const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!PlayerInputFunction::isHoldSubAction(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor)) &&
@@ -142,40 +142,40 @@ bool PlayerInput::isTriggerRollingCancelHipDrop(bool a1) const {
     if (PlayerInputFunction::isTriggerAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor)))
         return true;
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerHackAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerAction(mLiveActor,
                                                 PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerHackJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerJump(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerHackSwing() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerHackEnd() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto inputPort = PlayerFunction::getPlayerInputPort(mLiveActor);
     return PlayerInputFunction::isTriggerSubAction(mLiveActor, inputPort);
 }
 
 bool PlayerInput::isTriggerHackSeparateJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -184,7 +184,7 @@ bool PlayerInput::isTriggerHackSeparateJump() const {
 }
 
 bool PlayerInput::isTriggerSeparateCapJangoHelp() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -195,7 +195,7 @@ bool PlayerInput::isTriggerSeparateCapJangoHelp() const {
 }
 
 bool PlayerInput::isHoldHackSeparateJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -204,21 +204,21 @@ bool PlayerInput::isHoldHackSeparateJump() const {
 }
 
 bool PlayerInput::isTriggerGetOff() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerSubAction(mLiveActor,
                                                    PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto* dimension = mDimension;
     if (dimension && rs::is2D(dimension) && rs::isIn2DArea(dimension) && _88 > 0) {
@@ -229,46 +229,46 @@ bool PlayerInput::isHoldJump() const {
 }
 
 bool PlayerInput::isHoldHipDrop() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldSubAction(mLiveActor,
                                                 PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerStartTalk() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerTalk(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerStartWorldWarp() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerStartWorldWarp(
         mLiveActor, PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerCancelWorldWarp() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isTriggerCancelWorldWarp(
         mLiveActor, PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerSpinCap() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto inputPort = PlayerFunction::getPlayerInputPort(mLiveActor);
     if (PlayerInputFunction::isTriggerAction(mLiveActor, inputPort))
         return true;
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerToggleStayCap() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -277,11 +277,11 @@ bool PlayerInput::isTriggerToggleStayCap() const {
 }
 
 bool PlayerInput::isTriggerSpinAttackSeparate() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
-    if (!mDisableInput && mJoyPadAccelPoseAnalyzer1->isSwingAnyHand())
+    if (!mIsDisableInput && mJoyPadAccelPoseAnalyzer1->isSwingAnyHand())
         return true;
     return PlayerInputFunction::isTriggerAction(mLiveActor, al::getPlayerControllerPort(0));
 }
@@ -291,59 +291,59 @@ s32 PlayerInput::getSeparatePlay1P() {
 }
 
 bool PlayerInput::isTriggerCapReturn() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor)) {
-        if (mDisableInput)
+        if (mIsDisableInput)
             return false;
         auto inputPort = PlayerFunction::getPlayerInputPort(mLiveActor);
         if (PlayerInputFunction::isTriggerAction(mLiveActor, inputPort))
             return true;
-        if (mDisableInput)
+        if (mIsDisableInput)
             return false;
         return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
     }
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     auto inputPort = al::getPlayerControllerPort(1);
     if (PlayerInputFunction::isTriggerAction(mLiveActor, inputPort))
         return true;
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     return mJoyPadAccelPoseAnalyzer2->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerCapAttackSeparate() const {
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     auto inputPort = al::getPlayerControllerPort(1);
     if (PlayerInputFunction::isTriggerAction(mLiveActor, inputPort))
         return true;
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     return mJoyPadAccelPoseAnalyzer2->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerSwingActionCap() const {
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     return mJoyPadAccelPoseAnalyzer2->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerCapSingleHandThrow() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isTriggerCapDoubleHandThrow() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingDoubleHandSameDir();
 }
 
 bool PlayerInput::isTriggerCapSeparateJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -352,7 +352,7 @@ bool PlayerInput::isTriggerCapSeparateJump() const {
 }
 
 bool PlayerInput::isTriggerCapSeparateHipDrop() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor))
         return false;
@@ -361,40 +361,40 @@ bool PlayerInput::isTriggerCapSeparateHipDrop() const {
 }
 
 bool PlayerInput::isTriggerSwingPoleClimbFast() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
 }
 
 bool PlayerInput::isHoldPoleClimbDown() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldSubAction(mLiveActor,
                                                 PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerAppendCapAttack(bool a1) const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (!rs::isSeparatePlay(mLiveActor) || a1) {
-        if (mDisableInput)
+        if (mIsDisableInput)
             return false;
         return mJoyPadAccelPoseAnalyzer1->isSwingAnyHand();
     }
-    if (mDisableInput || !rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || !rs::isSeparatePlay(mLiveActor))
         return false;
     return mJoyPadAccelPoseAnalyzer2->isSwingAnyHand();
 }
 
 bool PlayerInput::isHoldSpinCap() const {
-    if (mDisableInput || rs::isSeparatePlay(mLiveActor))
+    if (mIsDisableInput || rs::isSeparatePlay(mLiveActor))
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldCapAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     if (rs::isSeparatePlay(mLiveActor))
         return !PlayerInputFunction::isTriggerAction(mLiveActor, al::getPlayerControllerPort(1));
@@ -403,70 +403,70 @@ bool PlayerInput::isHoldCapAction() const {
 }
 
 bool PlayerInput::isHoldPoleClimbFast() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldWallCatchMoveFast() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldHackAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isHoldHackJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldJump(mLiveActor,
                                            PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isTriggerChange2D() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto inputPort = PlayerFunction::getPlayerInputPort(mLiveActor);
     return al::isPadTriggerZL(inputPort) || al::isPadTriggerZR(inputPort);
 }
 
 bool PlayerInput::isTriggerChange3D() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     auto inputPort = PlayerFunction::getPlayerInputPort(mLiveActor);
     return al::isPadTriggerZL(inputPort) || al::isPadTriggerZR(inputPort);
 }
 
 bool PlayerInput::isReleaseJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isReleaseJump(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isReleaseHackAction() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isReleaseAction(mLiveActor,
                                                 PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isReleaseHackJump() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isReleaseJump(mLiveActor,
                                               PlayerFunction::getPlayerInputPort(mLiveActor));
 }
 
 bool PlayerInput::isEnableDashInput() const {
-    if (mDisableInput)
+    if (mIsDisableInput)
         return false;
     return PlayerInputFunction::isHoldAction(mLiveActor,
                                              PlayerFunction::getPlayerInputPort(mLiveActor));

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -84,7 +84,7 @@ private:
     al::JoyPadAccelPoseAnalyzer* mJoyPadAccelPoseAnalyzer2;
     s32 _88;
     void* gap2[1];
-    bool mDisableInput;
+    bool mIsDisableInput;
     void* gap3[20];
 };
 static_assert(sizeof(PlayerInput) == 0x140);

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -85,6 +85,6 @@ private:
     s32 _88;
     void* gap2[1];
     bool mDisableInput;
-    void* fillToSize[20];
+    void* gap3[20];
 };
 static_assert(sizeof(PlayerInput) == 0x140);

--- a/src/Player/PlayerModelChangerHakoniwa.h
+++ b/src/Player/PlayerModelChangerHakoniwa.h
@@ -44,19 +44,19 @@ public:
 private:
     const al::LiveActor* mLiveActor;
     bool mIsChange;
-    bool mModeIs2D;
+    bool mIsMode2D;
     al::LiveActor* mLiveActor2;
     PlayerModelHolder* mPlayerModelHolder;
     PlayerPainPartsKeeper* mPlayerPainPartsKeeper;
     PlayerCostumeInfo* mPlayerCostumeInfo;
     const IUseDimension* mIUseDimension;
-    bool mVisibilityNeedsSync;
+    bool mIsVisibilityNeedsSync;
     bool mIsModelVisible;
     bool mIsSilhouetteVisible;
     bool mIsShadowMaskVisible;
     bool mIsBlinkingFromDamage;
     s32 mDamageTimer;
-    bool mMusicStarted;
+    bool mIsMusicStarted;
     bool mIsNeedHairControl;
     bool mIsNeedSyncBodyHair;
     bool mIsSyncFaceBeard;

--- a/src/Player/PlayerModelHolder.cpp
+++ b/src/Player/PlayerModelHolder.cpp
@@ -13,7 +13,7 @@ void PlayerModelHolder::registerModel(al::LiveActor* liveActor, const char* name
 void PlayerModelHolder::changeModel(const char* name) {
     for (auto it = mBuffer.begin(), end = mBuffer.end(); it != end; ++it) {
         if (al::isEqualString(it->mName, sead::SafeString(name))) {
-            currentModel = &*it;
+            mCurrentModel = &*it;
             return;
         }
     }
@@ -25,7 +25,7 @@ al::LiveActor* PlayerModelHolder::findModelActor(const char* name) const {
             return it->mLiveActor;
         }
     }
-    return currentModel->mLiveActor;
+    return mCurrentModel->mLiveActor;
 }
 
 al::LiveActor* PlayerModelHolder::tryFindModelActor(const char* name) const {
@@ -38,9 +38,9 @@ al::LiveActor* PlayerModelHolder::tryFindModelActor(const char* name) const {
 }
 
 bool PlayerModelHolder::isCurrentModelLabel(const char* name) const {
-    return al::isEqualString(currentModel->mName.cstr(), name);
+    return al::isEqualString(mCurrentModel->mName.cstr(), name);
 }
 
 bool PlayerModelHolder::isCurrentModelLabelSubString(const char* name) const {
-    return al::isEqualSubString(currentModel->mName.cstr(), name);
+    return al::isEqualSubString(mCurrentModel->mName.cstr(), name);
 }

--- a/src/Player/PlayerModelHolder.h
+++ b/src/Player/PlayerModelHolder.h
@@ -24,6 +24,6 @@ public:
 
 private:
     sead::PtrArray<Entry> mBuffer;
-    Entry* currentModel = nullptr;
+    Entry* mCurrentModel = nullptr;
     sead::FixedSafeString<128> _10 = sead::FixedSafeString<128>("");
 };

--- a/src/Player/PlayerPainPartsKeeper.cpp
+++ b/src/Player/PlayerPainPartsKeeper.cpp
@@ -30,7 +30,7 @@ void PlayerPainPartsKeeper::updateNeedle() {
         else
             al::showModelIfHide(mNeedlesActor);
 
-        if (mEnableTimer)
+        if (mIsEnableTimer)
             mTimer++;
         if (mTimer < 3600)
             return;

--- a/src/Player/PlayerPainPartsKeeper.h
+++ b/src/Player/PlayerPainPartsKeeper.h
@@ -25,7 +25,7 @@ private:
     const al::LiveActor* mLiveActor;
     const PlayerCostumeInfo* mPlayerCostumeInfo;
     f32 mModelAlphaMask = 1;
-    bool mEnableTimer = true;
+    bool mIsEnableTimer = true;
     al::LiveActor* mPlayerFaceActor = nullptr;
     al::PartsModel* mNeedlesActor = nullptr;
     s32 mTimer = 0;

--- a/src/System/GameDataFile.h
+++ b/src/System/GameDataFile.h
@@ -63,5 +63,5 @@ private:
     unsigned char padding_6A8[0x6A8];
     GameProgressData* mGameProgressData;
     char padding_9F0[0x340];
-    s32 curWorldId;
+    s32 mCurWorldId;
 };

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -96,7 +96,7 @@ private:
     u32 field_40;
     u32 mRequireSaveFrame;
     bool mIsInvalidSaveForMoonGet;
-    bool mChangeStageRelated;
+    bool unk_changeStageRelated;
     u8 field_4A;
     u8 field_4B;
     u32 field_4C;

--- a/src/Util/ActorDimensionKeeper.cpp
+++ b/src/Util/ActorDimensionKeeper.cpp
@@ -3,17 +3,17 @@
 #include "Util/IUseDimension.h"
 
 void ActorDimensionKeeper::validate() {
-    isValid = true;
+    mIsValid = true;
 }
 
 void ActorDimensionKeeper::invalidate() {
-    isValid = false;
+    mIsValid = false;
 
-    if (is2D) {
-        is2D = false;
-        isIn2DArea = false;
-        isCurrently2D = false;
-        isCanChange3D = true;
+    if (mIs2D) {
+        mIs2D = false;
+        mIsIn2DArea = false;
+        mIsCurrently2D = false;
+        mIsCanChange3D = true;
     }
 }
 

--- a/src/Util/ActorDimensionKeeper.h
+++ b/src/Util/ActorDimensionKeeper.h
@@ -17,20 +17,20 @@ public:
     void forceEndChange2DKeep();
     bool update();
 
-    bool getIs2D() const { return is2D; }
-    bool getIsIn2DArea() const { return isIn2DArea; }
-    bool getIsCurrently2D() const { return isCurrently2D; }
-    bool getIsCanChange2D() const { return isCanChange2D; }
-    bool getIsCanChange3D() const { return isCanChange3D; }
+    bool getIs2D() const { return mIs2D; }
+    bool getIsIn2DArea() const { return mIsIn2DArea; }
+    bool getIsCurrently2D() const { return mIsCurrently2D; }
+    bool getIsCanChange2D() const { return mIsCanChange2D; }
+    bool getIsCanChange3D() const { return mIsCanChange3D; }
 
 private:
     const al::LiveActor* mLiveActor;
-    bool isValid = true;
-    bool is2D = false;
-    bool isIn2DArea = false;
-    bool isCurrently2D = false;
-    bool isCanChange2D = false;
-    bool isCanChange3D = false;
+    bool mIsValid = true;
+    bool mIs2D = false;
+    bool mIsIn2DArea = false;
+    bool mIsCurrently2D = false;
+    bool mIsCanChange2D = false;
+    bool mIsCanChange3D = false;
     In2DAreaMoveControl* mIn2DAreaMoveControl = nullptr;
 };
 static_assert(sizeof(ActorDimensionKeeper) == 0x18);

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -241,6 +241,10 @@ def header_check_line(line, path, visibility, should_start_class):
     elif visibility == -1:  # inside class, but not in a visibility block
         allowed = line in ["", "};"] or line.startswith("SEAD_SINGLETON_DISPOSER") or line.startswith("SEAD_RTTI_BASE") or line.startswith("SEAD_RTTI_OVERRIDE")
         CHECK(lambda a:allowed, line, "Inside class, but not in a visibility block, only empty lines and closing brace allowed!", path)
+    elif visibility == 0:  # public
+        if "(" in line:  # function
+            function_name = line.split("(")[-2].split(" ")[-1]
+            CHECK(lambda a:not function_name.endswith("_"), line, "Functions ending with an underscore are either protected or private!", path)
 
 def header_no_offset_comments(c, path):
     for line in c.splitlines():

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -272,6 +272,12 @@ def header_check_line(line, path, visibility, should_start_class):
             allowed_name = (var_name.startswith("m") and var_name[1].isupper()) or any([var_name.startswith(p) for p in PREFIXES])
             CHECK(lambda a:allowed_name, line, "Member variables must be prefixed with `m`!", path)
 
+        if var_type == "bool":
+            BOOL_PREFIXES = ["mIs", "mHas"]
+            allowed_name = any([var_name.startswith(p) and (var_name[len(p)].isupper() or var_name[len(p)].isdigit()) for p in BOOL_PREFIXES]) or any([var_name.startswith(p) for p in PREFIXES])
+            if path.endswith("ByamlWriterData.h") and var_name == "mValue": return
+            CHECK(lambda a:allowed_name, line, "Boolean member variables must start with `mIs` or `mHas`!", path)
+
 def header_no_offset_comments(c, path):
     for line in c.splitlines():
         CHECK(lambda a:"// 0x" not in a, line, "Offset comments are not allowed in headers!", path)


### PR DESCRIPTION
- As written in the contribution guide (and somewhat common among C++ projects), member variables should be prefixed with `m`, followed by an uppercase letter.
- As discussed in the Discord, boolean variables should start with `mIs`. I also added `mHas` to the allowed prefixes, as booleans are also used to indicate whether other variables are available, which is better described with `mHas`.
- Unrelated: Functions ending with `_` are commonly non-public functions, at least that's been the rule across libraries like `sead` and `agl`. If this rule doesn't hold for SMO, the respective linter code can be removed again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/34)
<!-- Reviewable:end -->
