### PR TITLE
Library/Collision: Implement Sphere[Pose]Interpolator

### DIFF
--- a/lib/al/include/Library/Collision/KCollisionServer.h
+++ b/lib/al/include/Library/Collision/KCollisionServer.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+
+class SphereInterpolator {
+public:
+    SphereInterpolator() {}
+    void startInterp(const sead::Vector3f& posStart, const sead::Vector3f& posEnd, f32 sizeStart,
+                     f32 sizeEnd, f32 steps);
+    void nextStep();
+    void calcInterpPos(sead::Vector3f* pos) const;
+    void calcInterp(sead::Vector3f* pos, f32* size, sead::Vector3f* remainMoveVec) const;
+    void calcRemainMoveVector(sead::Vector3f* remainMoveVec) const;
+    void getMoveVector(sead::Vector3f* moveVec);
+    void calcStepMoveVector(sead::Vector3f* moveVec) const;
+
+private:
+    sead::Vector3f mPos;
+    sead::Vector3f mMove;
+    f32 mSizeStart;
+    f32 mSizeEnd;
+    f32 mStepSize;
+    f32 mCurrentStep;
+    f32 mPrevStep;
+};
+
+class SpherePoseInterpolator {
+public:
+    SpherePoseInterpolator() {}
+    void startInterp(const sead::Vector3f& posStart, const sead::Vector3f& posEnd, f32 sizeStart,
+                     f32 sizeEnd, const sead::Quatf& quatStart, const sead::Quatf& quatEnd,
+                     f32 steps);
+    void nextStep();
+    void calcInterpPos(sead::Vector3f* pos) const;
+    void calcInterp(sead::Vector3f* pos, f32* size, sead::Quatf* quat,
+                    sead::Vector3f* remainMoveVec) const;
+    void calcRemainMoveVector(sead::Vector3f* remainMoveVec) const;
+    f32 calcRadiusBaseScale(f32 unk) const;
+    void getMoveVector(sead::Vector3f* moveVec);
+
+private:
+    sead::Vector3f mPos;
+    sead::Vector3f mMove;
+    f32 mSizeStart;
+    f32 mSizeEnd;
+    sead::Quatf mQuatStart;
+    sead::Quatf mQuatEnd;
+    f32 mStepSize;
+    f32 mCurrentStep;
+    f32 mPrevStep;
+};
+
+}  // namespace al

--- a/lib/al/include/Library/Math/MathUtil.h
+++ b/lib/al/include/Library/Math/MathUtil.h
@@ -54,4 +54,8 @@ void lerpVec(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&, f32)
 void lerpVecHV(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&,
                f32, f32);
 
+f32 calcRate01(f32, f32, f32);
+
+f32 slerpQuat(sead::Quatf*, const sead::Quatf&, const sead::Quatf&, f32);
+
 }  // namespace al

--- a/lib/al/src/Library/Collision/KCollisionServer.cpp
+++ b/lib/al/src/Library/Collision/KCollisionServer.cpp
@@ -1,0 +1,126 @@
+#include "Library/Collision/KCollisionServer.h"
+
+#include "Library/Math/MathUtil.h"
+
+namespace al {
+
+void SphereInterpolator::startInterp(const sead::Vector3f& posStart, const sead::Vector3f& posEnd,
+                                     f32 sizeStart, f32 sizeEnd, f32 steps) {
+    mCurrentStep = 0.0f;
+    mPrevStep = 0.0f;
+    mPos = posStart;
+    mMove = posEnd - posStart;
+    mSizeStart = sizeStart;
+    mSizeEnd = sizeEnd;
+
+    f32 dist = mMove.length() + sizeEnd - sizeStart;
+    mStepSize = (dist <= 0.0f) ? 1.0f : steps / dist;
+}
+void SphereInterpolator::nextStep() {
+    // re-interpreting between f32/s32 required to match
+    s32 curStep = *(s32*)&mCurrentStep;
+    f32 stepAsFloat = *(f32*)&curStep;
+    f32 newStep = sead::Mathf::clampMax(stepAsFloat + mStepSize, 1.0f);
+    *(s32*)&mPrevStep = curStep;
+    mCurrentStep = newStep;
+}
+void SphereInterpolator::calcInterpPos(sead::Vector3f* pos) const {
+    f32 step = mCurrentStep;
+    pos->x = mMove.x * step + mPos.x;
+    pos->y = mMove.y * step + mPos.y;
+    pos->z = mMove.z * step + mPos.z;
+}
+void SphereInterpolator::calcInterp(sead::Vector3f* pos, f32* size,
+                                    sead::Vector3f* remainMoveVec) const {
+    calcInterpPos(pos);
+    *size = mSizeStart + (mSizeEnd - mSizeStart) * mCurrentStep;
+    calcRemainMoveVector(remainMoveVec);
+}
+void SphereInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec) const {
+    if (remainMoveVec) {
+        f32 remainStep = 1.0f - mCurrentStep;
+        remainMoveVec->x = mMove.x * remainStep;
+        remainMoveVec->y = mMove.y * remainStep;
+        remainMoveVec->z = mMove.z * remainStep;
+    }
+}
+void SphereInterpolator::getMoveVector(sead::Vector3f* moveVec) {
+    f32 step = mCurrentStep;
+    moveVec->x = mMove.x * step;
+    moveVec->y = mMove.y * step;
+    moveVec->z = mMove.z * step;
+}
+void SphereInterpolator::calcStepMoveVector(sead::Vector3f* moveVec) const {
+    f32 step = mCurrentStep - mPrevStep;
+    moveVec->x = mMove.x * step;
+    moveVec->y = mMove.y * step;
+    moveVec->z = mMove.z * step;
+}
+
+void SpherePoseInterpolator::startInterp(const sead::Vector3f& posStart,
+                                         const sead::Vector3f& posEnd, f32 sizeStart, f32 sizeEnd,
+                                         const sead::Quatf& quatStart, const sead::Quatf& quatEnd,
+                                         f32 steps) {
+    mCurrentStep = 0.0f;
+    mPrevStep = 0.0f;
+    mPos = posStart;
+    mMove = posEnd - posStart;
+
+    mQuatStart.x = quatStart.x;
+    mQuatStart.y = quatStart.y;
+    mQuatStart.z = quatStart.z;
+    mQuatStart.w = quatStart.w;
+
+    mQuatEnd.x = quatEnd.x;
+    mQuatEnd.y = quatEnd.y;
+    mQuatEnd.z = quatEnd.z;
+    mQuatEnd.w = quatEnd.w;
+
+    mSizeStart = sizeStart;
+    mSizeEnd = sizeEnd;
+
+    f32 dist = mMove.length() + sizeEnd - sizeStart;
+    mStepSize = (dist <= 0.0f) ? 1.0f : steps / dist;
+}
+
+void SpherePoseInterpolator::nextStep() {
+    // re-interpreting between f32/s32 required to match
+    s32 curStep = *(s32*)&mCurrentStep;
+    f32 stepAsFloat = *(f32*)&curStep;
+    f32 newStep = sead::Mathf::clampMax(stepAsFloat + mStepSize, 1.0f);
+    *(s32*)&mPrevStep = curStep;
+    mCurrentStep = newStep;
+}
+void SpherePoseInterpolator::calcInterpPos(sead::Vector3f* pos) const {
+    f32 step = mCurrentStep;
+    pos->x = mMove.x * step + mPos.x;
+    pos->y = mMove.y * step + mPos.y;
+    pos->z = mMove.z * step + mPos.z;
+}
+void SpherePoseInterpolator::calcInterp(sead::Vector3f* pos, f32* size, sead::Quatf* quat,
+                                        sead::Vector3f* remainMoveVec) const {
+    calcInterpPos(pos);
+    *size = mSizeStart + (mSizeEnd - mSizeStart) * mCurrentStep;
+    slerpQuat(quat, mQuatStart, mQuatEnd, mCurrentStep);
+    quat->normalize();
+    calcRemainMoveVector(remainMoveVec);
+}
+void SpherePoseInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec) const {
+    if (remainMoveVec) {
+        f32 remainStep = 1.0f - mCurrentStep;
+        remainMoveVec->x = mMove.x * remainStep;
+        remainMoveVec->y = mMove.y * remainStep;
+        remainMoveVec->z = mMove.z * remainStep;
+    }
+}
+f32 SpherePoseInterpolator::calcRadiusBaseScale(f32 unk) const {
+    return calcRate01(unk, 0.0f, mSizeEnd);
+}
+void SpherePoseInterpolator::getMoveVector(sead::Vector3f* moveVec) {
+    f32 step = mCurrentStep;
+    moveVec->x = mMove.x * step;
+    moveVec->y = mMove.y * step;
+    moveVec->z = mMove.z * step;
+}
+
+}  // namespace al


### PR DESCRIPTION
Adding two new classes here: `SphereInterpolator` and `SpherePoseInterpolator`. There's not much to say about it otherwise, I didn't manage to match one of the functions though, mainly due to the compiler picking the wrong assembly command for `fmin`: `fminnm`. I'm not sure what the difference is or why that one is used here, but if anyone has an idea or can improve it, that would be appreciated!

Here is a decomp.me of it: https://decomp.me/scratch/BfAs2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/37)
<!-- Reviewable:end -->
