### PR TITLE
`al/Library/Area`: Finish `AreaShapeOval`

### DIFF
--- a/lib/al/include/Library/Area/AreaShape.h
+++ b/lib/al/include/Library/Area/AreaShape.h
@@ -20,7 +20,7 @@ public:
                                      const sead::Vector3f&) const = 0;
     virtual bool calcLocalBoundingBox(sead::BoundBox3f*) const = 0;
 
-    sead::Vector3f getScale() const { return mScale; }
+    const sead::Vector3f& getScale() const { return mScale; }
 
     void setBaseMtxPtr(const sead::Matrix34f* baseMtxPtr);
     void setScale(const sead::Vector3f& scale);

--- a/lib/al/include/Library/Math/MathUtil.h
+++ b/lib/al/include/Library/Math/MathUtil.h
@@ -58,4 +58,7 @@ f32 calcRate01(f32, f32, f32);
 
 f32 slerpQuat(sead::Quatf*, const sead::Quatf&, const sead::Quatf&, f32);
 
+bool checkHitSegmentSphere(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&, f32,
+                           sead::Vector3f*, sead::Vector3f*);
+
 }  // namespace al

--- a/lib/al/src/Library/Area/AreaShapeOval.cpp
+++ b/lib/al/src/Library/Area/AreaShapeOval.cpp
@@ -2,6 +2,8 @@
 
 #include <math/seadMathCalcCommon.h>
 
+#include "Library/Math/MathUtil.h"
+
 namespace al {
 
 AreaShapeOval::AreaShapeOval() {}
@@ -13,7 +15,21 @@ bool AreaShapeOval::isInVolume(const sead::Vector3f& trans) const {
     return localPos.squaredLength() <= sead::Mathf::square(500.0f);
 }
 
-// bool AreaShapeOval::isInVolumeOffset(const sead::Vector3f& trans, f32 offset) const
+bool AreaShapeOval::isInVolumeOffset(const sead::Vector3f& trans, f32 offset) const {
+    sead::Vector3f scale = getScale();
+
+    // has to be this way around to match
+    if (scale.x == scale.y && scale.y == scale.z) {
+        sead::Vector3f baseTrans;
+        calcTrans(&baseTrans);
+        sead::Vector3f offsetTrans = trans - baseTrans;
+        f32 radius = scale.x * 500.0f + offset;
+
+        return offsetTrans.squaredLength() <= sead::Mathf::square(radius);
+    }
+
+    return false;
+}
 
 bool AreaShapeOval::calcNearestEdgePoint(sead::Vector3f* edgePoint,
                                          const sead::Vector3f& trans) const {
@@ -28,8 +44,26 @@ bool AreaShapeOval::calcNearestEdgePoint(sead::Vector3f* edgePoint,
     return true;
 }
 
-// bool AreaShapeOval::checkArrowCollision(sead::Vector3f*, sead::Vector3f*, const sead::Vector3f&,
-// const sead::Vector3f&) const
+bool AreaShapeOval::checkArrowCollision(sead::Vector3f* a2, sead::Vector3f* a3,
+                                        const sead::Vector3f& a4, const sead::Vector3f& a5) const {
+    sead::Vector3f localA4 = sead::Vector3f::zero;
+    calcLocalPos(&localA4, a4);
+    sead::Vector3f localA5 = sead::Vector3f::zero;
+    calcLocalPos(&localA5, a5);
+
+    sead::Vector3f tmp1 = {0, 0, 0};
+    sead::Vector3f tmp2 = {0, 0, 0};
+    calcWorldPos(&tmp1, localA4);
+    calcWorldPos(&tmp2, localA5);
+
+    if (!checkHitSegmentSphere(sead::Vector3f::zero, localA4, localA5, 500.0f, a3, a2))
+        return false;
+
+    calcWorldPos(a2, *a2);
+    calcWorldDir(a3, *a3);
+    *a3 *= (-1);
+    return true;
+}
 
 bool AreaShapeOval::calcLocalBoundingBox(sead::BoundBox3f* boundingBox) const {
     return false;


### PR DESCRIPTION
Cleaning up some of the branches around this repo, I found this: Seems like I worked on `AreaShapeOval` a while ago, didn't get one of the functions to match and stopped. Now, with this additional function matched (required flipping the `if` statement to _not_ using early returns), I'm happy to merge this in as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/43)
<!-- Reviewable:end -->
