### PR TITLE
Host functions

### DIFF
--- a/lib/al/include/Library/Debug/Host.h
+++ b/lib/al/include/Library/Debug/Host.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+#include "Library/Base/String.h"
+
+namespace al {
+bool tryGetComputerName(sead::BufferedSafeStringBase<char>* computerName);
+s32 getComputerName(sead::BufferedSafeStringBase<char>* computerName);
+s32 getUserName(sead::BufferedSafeStringBase<char>* userName);
+void makeUniqueTemporaryFilename(sead::BufferedSafeStringBase<char>* out, const char* fileName);
+void expandEnvironmentString(
+    sead::BufferedSafeStringBase<char>* out,
+    const sead::SafeStringBase<char>& envStr);       // TODO: Needs FUN_710086f65c
+void* FUN_710086f65c(long* param_1, long* param_2);  // TODO: Find what is this function
+void makeTmpExpandEnvironmentString(
+    const sead::SafeStringBase<char>& envStr);  // TODO: Needs FUN_710086f65c
+StringTmp<128> makeTmpFileFullPath(const char* fileName);
+char* getALCommon();
+}  // namespace al

--- a/lib/al/include/Library/Debug/Host.h
+++ b/lib/al/include/Library/Debug/Host.h
@@ -1,19 +1,18 @@
 #pragma once
 
 #include <prim/seadSafeString.h>
+
 #include "Library/Base/String.h"
 
 namespace al {
-bool tryGetComputerName(sead::BufferedSafeStringBase<char>* computerName);
-s32 getComputerName(sead::BufferedSafeStringBase<char>* computerName);
-s32 getUserName(sead::BufferedSafeStringBase<char>* userName);
-void makeUniqueTemporaryFilename(sead::BufferedSafeStringBase<char>* out, const char* fileName);
-void expandEnvironmentString(
-    sead::BufferedSafeStringBase<char>* out,
-    const sead::SafeStringBase<char>& envStr);       // TODO: Needs FUN_710086f65c
-void* FUN_710086f65c(long* param_1, long* param_2);  // TODO: Find what is this function
-void makeTmpExpandEnvironmentString(
-    const sead::SafeStringBase<char>& envStr);  // TODO: Needs FUN_710086f65c
+bool tryGetComputerName(sead::BufferedSafeString* computerName);
+void getComputerName(sead::BufferedSafeString* computerName);
+void getUserName(sead::BufferedSafeString* userName);
+void makeUniqueTemporaryFilename(sead::BufferedSafeString* out, const char* fileName);
+void expandEnvironmentString(sead::BufferedSafeString* out, const sead::SafeString& envStr);
+void FUN_710086f65c(sead::BufferedSafeString* out,
+                    const sead::SafeString& envStr);  // TODO: Find what is this function
+sead::FixedSafeString<128> makeTmpExpandEnvironmentString(const sead::SafeString& envStr);
 StringTmp<128> makeTmpFileFullPath(const char* fileName);
-char* getALCommon();
+const char* getALCommon();
 }  // namespace al

--- a/lib/al/src/Library/Debug/Host.cpp
+++ b/lib/al/src/Library/Debug/Host.cpp
@@ -4,30 +4,47 @@
 #include <nn/os.h>
 
 namespace al {
-s32 getComputerName(sead::BufferedSafeStringBase<char>* computerName) {
+void getComputerName(sead::BufferedSafeString* computerName) {
+    tryGetComputerName(computerName);
+}
+
+bool tryGetComputerName(sead::BufferedSafeString* computerName) {
     computerName->format("");
     computerName->format("");
 
-    return sead::EnvUtil::getEnvironmentVariable(computerName, "COMPUTERNAME");
+    return sead::EnvUtil::getEnvironmentVariable(computerName, "COMPUTERNAME") > 0;
 }
 
-bool tryGetComputerName(sead::BufferedSafeStringBase<char>* computerName) {
-    return getComputerName(computerName) > 0;
-}
-
-s32 getUserName(sead::BufferedSafeStringBase<char>* userName) {
+void getUserName(sead::BufferedSafeString* userName) {
     userName->format("");
     userName->format("");
 
-    return sead::EnvUtil::getEnvironmentVariable(userName, "USERNAME");
+    sead::EnvUtil::getEnvironmentVariable(userName, "USERNAME");
 }
 
-void makeUniqueTemporaryFilename(sead::BufferedSafeStringBase<char>* out, const char* fileName) {
-    sead::FixedSafeString<0x80> computerName;
+void makeUniqueTemporaryFilename(sead::BufferedSafeString* out, const char* fileName) {
+    sead::FixedSafeString<128> computerName;
     getComputerName(&computerName);
 
     nn::os::Tick time = nn::os::GetSystemTick();
     out->format("%s_%012lld%s", computerName.cstr(), time, fileName);
+}
+
+void expandEnvironmentString(sead::BufferedSafeString* out, const sead::SafeString& envStr) {
+    out->clear();
+
+    FUN_710086f65c(out, envStr);
+}
+
+// void FUN_710086f65c(sead::BufferedSafeString* out, const sead::SafeString& envStr) {}
+
+sead::FixedSafeString<128> makeTmpExpandEnvironmentString(const sead::SafeString& envStr) {
+    sead::FixedSafeString<128> tmp;
+    tmp.clear();
+
+    FUN_710086f65c(&tmp, envStr);
+
+    return tmp;
 }
 
 StringTmp<128> makeTmpFileFullPath(const char* fileName) {
@@ -35,7 +52,7 @@ StringTmp<128> makeTmpFileFullPath(const char* fileName) {
                           fileName != nullptr ? fileName : "");
 }
 
-char* getALCommon() {
-    return (char*)"${AL_TOOL_ROOT}/ALCommon";
+const char* getALCommon() {
+    return "${AL_TOOL_ROOT}/ALCommon";
 }
 }  // namespace al

--- a/lib/al/src/Library/Debug/Host.cpp
+++ b/lib/al/src/Library/Debug/Host.cpp
@@ -1,0 +1,41 @@
+#include "Library/Debug/Host.h"
+
+#include <devenv/seadEnvUtil.h>
+#include <nn/os.h>
+
+namespace al {
+s32 getComputerName(sead::BufferedSafeStringBase<char>* computerName) {
+    computerName->format("");
+    computerName->format("");
+
+    return sead::EnvUtil::getEnvironmentVariable(computerName, "COMPUTERNAME");
+}
+
+bool tryGetComputerName(sead::BufferedSafeStringBase<char>* computerName) {
+    return getComputerName(computerName) > 0;
+}
+
+s32 getUserName(sead::BufferedSafeStringBase<char>* userName) {
+    userName->format("");
+    userName->format("");
+
+    return sead::EnvUtil::getEnvironmentVariable(userName, "USERNAME");
+}
+
+void makeUniqueTemporaryFilename(sead::BufferedSafeStringBase<char>* out, const char* fileName) {
+    sead::FixedSafeString<0x80> computerName;
+    getComputerName(&computerName);
+
+    nn::os::Tick time = nn::os::GetSystemTick();
+    out->format("%s_%012lld%s", computerName.cstr(), time, fileName);
+}
+
+StringTmp<128> makeTmpFileFullPath(const char* fileName) {
+    return StringTmp<128>("${TEMP}/%012lld%s", nn::os::GetSystemTick(),
+                          fileName != nullptr ? fileName : "");
+}
+
+char* getALCommon() {
+    return (char*)"${AL_TOOL_ROOT}/ALCommon";
+}
+}  // namespace al

--- a/lib/al/src/Library/Debug/Host.cpp
+++ b/lib/al/src/Library/Debug/Host.cpp
@@ -40,9 +40,8 @@ void expandEnvironmentString(sead::BufferedSafeString* out, const sead::SafeStri
 
 sead::FixedSafeString<128> makeTmpExpandEnvironmentString(const sead::SafeString& envStr) {
     sead::FixedSafeString<128> tmp;
-    tmp.clear();
 
-    FUN_710086f65c(&tmp, envStr);
+    expandEnvironmentString(&tmp, envStr);
 
     return tmp;
 }


### PR DESCRIPTION
This PR adds `Host` header and an implementation for almost every functions except `expandEnvironmentString`, `makeTmpExpandEnvironmentString` and a function that has no debug symbols.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/44)
<!-- Reviewable:end -->
