### PR TITLE
Player: Implement PlayerJudgePreInputJump

### DIFF
--- a/src/Player/PlayerJudgePreInputJump.cpp
+++ b/src/Player/PlayerJudgePreInputJump.cpp
@@ -1,0 +1,27 @@
+#include "Player/PlayerJudgePreInputJump.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerInput.h"
+
+PlayerJudgePreInputJump::PlayerJudgePreInputJump(const PlayerConst* pConst,
+                                                 const PlayerInput* input,
+                                                 IJudge* judgeForceSlopeSlide)
+    : mConst(pConst), mInput(input), mJudgeForceSlopeSlide(judgeForceSlopeSlide) {}
+
+void PlayerJudgePreInputJump::reset() {
+    mRemainJumpFrame = 0;
+}
+
+void PlayerJudgePreInputJump::update() {
+    mRemainJumpFrame = sead::Mathi::clampMin(mRemainJumpFrame - 1, 0);
+
+    if (mInput->isTriggerJump()) {
+        mRemainJumpFrame = mConst->getContinuousJumpPreInputFrame();
+    }
+}
+
+bool PlayerJudgePreInputJump::judge() const {
+    return mRemainJumpFrame > 0;
+}

--- a/src/Player/PlayerJudgePreInputJump.h
+++ b/src/Player/PlayerJudgePreInputJump.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+class PlayerConst;
+class PlayerInput;
+
+class PlayerJudgePreInputJump : public al::HioNode, public IJudge {
+public:
+    PlayerJudgePreInputJump(const PlayerConst* pConst, const PlayerInput* input,
+                            IJudge* judgeForceSlopeSlide);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    IJudge* mJudgeForceSlopeSlide;
+    s32 mRemainJumpFrame = 0;
+};


### PR DESCRIPTION
This `IJudge` is responsible to checking whether a jump should be started. This also explains: Jump-Inputs can be buffered for 5 frames, for example before touching the ground, before the counter "runs out".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/46)
<!-- Reviewable:end -->
