### PR TITLE
Player: Implement PlayerJumpMessageRequest

### DIFF
--- a/src/Player/PlayerJumpMessageRequest.cpp
+++ b/src/Player/PlayerJumpMessageRequest.cpp
@@ -1,0 +1,13 @@
+#include "Player/PlayerJumpMessageRequest.h"
+
+PlayerJumpMessageRequest::PlayerJumpMessageRequest() {}
+
+void PlayerJumpMessageRequest::clear() {
+    mJumpType = PlayerJumpType::Standard;
+    mJumpPower = 0.0f;
+    mExtendFrame = 0;
+    mTurnJumpAngle = {0.0f, 0.0f, 0.0f};
+    mActorTrans = {0.0f, 0.0f, 0.0f};
+    mIsSpinClockwise = false;
+    mIsEnableStandUp = false;
+}

--- a/src/Player/PlayerJumpMessageRequest.h
+++ b/src/Player/PlayerJumpMessageRequest.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+enum class PlayerJumpType : u32 {
+    Standard = 0,
+    // more unknown
+};
+
+struct PlayerJumpMessageRequest {
+    PlayerJumpMessageRequest();
+    void clear();
+
+    PlayerJumpType mJumpType = PlayerJumpType::Standard;
+    f32 mJumpPower = 0;
+    s32 mExtendFrame = 0;
+    sead::Vector3f mTurnJumpAngle = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mActorTrans = {0.0f, 0.0f, 0.0f};
+    bool mIsSpinClockwise = 0;
+    bool mIsEnableStandUp = 0;
+};


### PR DESCRIPTION
This class/struct contains data used to start different types of jumps. A standard jump (standing still, just press A) has type `0`, I didn't try to research other types yet, as they are magic numbers inlined across the whole binary.

I chose to create this as `struct`, as all usages (except `clear()`) are accessing class members directly. Using `get/set` for *all* members sounds wrong, but I'm open to discuss about this if there are other opinions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/47)
<!-- Reviewable:end -->
