### PR TITLE
Player: Implement PlayerJudgeSpeedCheckFall

### DIFF
--- a/src/Player/PlayerJudgeSpeedCheckFall.cpp
+++ b/src/Player/PlayerJudgeSpeedCheckFall.cpp
@@ -1,0 +1,30 @@
+#include "Player/PlayerJudgeSpeedCheckFall.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/StageSceneFunction.h"
+
+PlayerJudgeSpeedCheckFall::PlayerJudgeSpeedCheckFall(const al::LiveActor* player,
+                                                     const IUsePlayerCollision* collision,
+                                                     const PlayerConst* pConst,
+                                                     const IJudge* judgeWaterSurfaceRun)
+    : mPlayer(player), mCollision(collision), mConst(pConst),
+      mJudgeStartWaterSurfaceRun(judgeWaterSurfaceRun) {}
+
+void PlayerJudgeSpeedCheckFall::reset() {
+    mFramesNoCollideGround = 0;
+}
+
+void PlayerJudgeSpeedCheckFall::update() {
+    if (!rs::isCollidedGroundRunAngle(mPlayer, mCollision, mConst)) {
+        if (mFramesNoCollideGround <= 4)
+            mFramesNoCollideGround++;
+    } else {
+        mFramesNoCollideGround = 0;
+    }
+}
+
+bool PlayerJudgeSpeedCheckFall::judge() const {
+    return !rs::isJudge(mJudgeStartWaterSurfaceRun) && mFramesNoCollideGround > 4;
+}

--- a/src/Player/PlayerJudgeSpeedCheckFall.h
+++ b/src/Player/PlayerJudgeSpeedCheckFall.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
+class PlayerConst;
+
+class PlayerJudgeSpeedCheckFall : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeSpeedCheckFall(const al::LiveActor* player, const IUsePlayerCollision* collision,
+                              const PlayerConst* pConst, const IJudge* judgeWaterSurfaceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const IUsePlayerCollision* mCollision;
+    const PlayerConst* mConst;
+    const IJudge* mJudgeStartWaterSurfaceRun;
+    s32 mFramesNoCollideGround = 0;
+};

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -2,10 +2,16 @@
 
 #include <basis/seadTypes.h>
 
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
 class IUsePlayerHeightCheck;
+class PlayerConst;
 
 namespace rs {
 
 f32 getGroundHeight(const IUsePlayerHeightCheck*);
+bool isCollidedGroundRunAngle(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 
-}
+}  // namespace rs


### PR DESCRIPTION
This class seems to be responsible for managing Coyote-Time when the player runs off an edge, or when the ground is removed beneath the player. This can be confirmed with creating a little mod that will just override the `judge()` with `return false;`, resulting in a behaviour like this:
https://twitter.com/MDruide1/status/1796858571168035140

With this in mind and looking at the code again, we can deduce that the player has either 4 or 5 frames (depending on execution order) before switching to the `Fall` nerve/state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/51)
<!-- Reviewable:end -->
