### PR TITLE
Player: Implement PlayerCounterForceRun

### DIFF
--- a/lib/al/include/Library/Math/MathUtil.h
+++ b/lib/al/include/Library/Math/MathUtil.h
@@ -61,4 +61,6 @@ f32 slerpQuat(sead::Quatf*, const sead::Quatf&, const sead::Quatf&, f32);
 bool checkHitSegmentSphere(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&, f32,
                            sead::Vector3f*, sead::Vector3f*);
 
+s32 converge(s32, s32, s32);
+
 }  // namespace al

--- a/src/Player/PlayerCounterForceRun.cpp
+++ b/src/Player/PlayerCounterForceRun.cpp
@@ -1,0 +1,14 @@
+#include "Player/PlayerCounterForceRun.h"
+
+#include "Library/Math/MathUtil.h"
+
+PlayerCounterForceRun::PlayerCounterForceRun() {}
+
+void PlayerCounterForceRun::setupForceRun(s32 frames, f32 speed) {
+    mCounter = frames;
+    mSpeed = speed;
+}
+
+void PlayerCounterForceRun::update() {
+    mCounter = al::converge(mCounter, 0, 1);
+}

--- a/src/Player/PlayerCounterForceRun.h
+++ b/src/Player/PlayerCounterForceRun.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class PlayerCounterForceRun {
+public:
+    PlayerCounterForceRun();
+
+    void setupForceRun(s32 frames, f32 speed);
+    void update();
+
+    s32 getCounter() const { return mCounter; }
+    f32 getSpeed() const { return mSpeed; }
+
+private:
+    s32 mCounter = 0;
+    f32 mSpeed = 0.0f;
+};


### PR DESCRIPTION
Simple little class that is just used for storing the current `ForceRun` state (for example rocket flowers, and ... I think that's all), consisting of the duration and speed. If the `mCounter` hits zero, `mSpeed` is ignored, but stay at its old value.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/52)
<!-- Reviewable:end -->
