### PR TITLE
Player: Implement PlayerContinuousJump

### DIFF
--- a/src/Player/PlayerContinuousJump.cpp
+++ b/src/Player/PlayerContinuousJump.cpp
@@ -1,0 +1,31 @@
+#include "Player/PlayerContinuousJump.h"
+
+#include "Player/PlayerConst.h"
+
+PlayerContinuousJump::PlayerContinuousJump(const PlayerConst* pConst) : mConst(pConst) {}
+
+void PlayerContinuousJump::update(bool shouldCountDown) {
+    if (!shouldCountDown) {
+        clear();
+        return;
+    }
+
+    if (mCount > 0) {
+        mTimer++;
+        if (mTimer >= mConst->getContinuousJumpTimer()) {
+            clear();
+        }
+    }
+}
+
+void PlayerContinuousJump::clear() {
+    mLastJumpDir = {0.0f, 0.0f, 0.0f};
+    mCount = 0;
+    mTimer = mConst->getContinuousJumpTimer();
+}
+
+void PlayerContinuousJump::countUp(const sead::Vector3f& jumpDir) {
+    mLastJumpDir = jumpDir;
+    mCount = (mCount + 1) % mConst->getContinuousJumpCount();
+    mTimer = 0;
+}

--- a/src/Player/PlayerContinuousJump.h
+++ b/src/Player/PlayerContinuousJump.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+class PlayerConst;
+
+class PlayerContinuousJump {
+public:
+    PlayerContinuousJump(const PlayerConst* pConst);
+    void update(bool shouldCountDown);
+    void clear();
+    void countUp(const sead::Vector3f& jumpDir);
+
+private:
+    const PlayerConst* mConst;
+    u32 mCount = 0;
+    u32 mTimer = 0;
+    sead::Vector3f mLastJumpDir = {0.0f, 0.0f, 0.0f};
+};


### PR DESCRIPTION
Simple class that is responsible for storing the last jump, which allows for checking whether a double/triple jump is still going in the same direction. If the current nerve is not `Wait` or `Run`, the state will be cleared immediately: For example, it's not possible to double-jump out of a LongJump.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/53)
<!-- Reviewable:end -->
