### PR TITLE
Player: Implement PlayerContinuousLongJump

### DIFF
--- a/src/Player/PlayerContinuousLongJump.cpp
+++ b/src/Player/PlayerContinuousLongJump.cpp
@@ -1,0 +1,30 @@
+#include "Player/PlayerContinuousLongJump.h"
+
+#include "Player/PlayerConst.h"
+
+PlayerContinuousLongJump::PlayerContinuousLongJump(const PlayerConst* pConst) : mConst(pConst) {}
+
+void PlayerContinuousLongJump::countUp() {
+    mCount = (mCount + 1) % mConst->getContinuousLongJumpCount();
+    mTimer = 0;
+}
+
+void PlayerContinuousLongJump::update() {
+    if (mCount != 0) {
+        mTimer++;
+        if (mTimer >= mConst->getContinuousLongJumpTimer()) {
+            mCount = 0;
+            mTimer = 0;
+        }
+    }
+}
+
+constexpr const char* longJumpAnimNames[] = {"JumpBroad",  "JumpBroad2", "JumpBroad3",
+                                             "JumpBroad4", "JumpBroad5", "JumpBroad6",
+                                             "JumpBroad7", "JumpBroad8"};
+
+const char* PlayerContinuousLongJump::getLongJumpAnimName() const {
+    if (mCount >= 0 && mCount <= 7)
+        return longJumpAnimNames[mCount];
+    return nullptr;
+}

--- a/src/Player/PlayerContinuousLongJump.h
+++ b/src/Player/PlayerContinuousLongJump.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+class PlayerConst;
+
+class PlayerContinuousLongJump {
+public:
+    PlayerContinuousLongJump(const PlayerConst* pConst);
+
+    void countUp();
+    void update();
+    const char* getLongJumpAnimName() const;
+
+private:
+    const PlayerConst* mConst;
+    s32 mCount = 0;
+    s32 mTimer = 0;
+};


### PR DESCRIPTION
Seems like there is also a counter for the number of continuous long jumps in the game, which helps in selecting a different animation each time - resulting in a total of 8 possible, selectable values.

However, the `PlayerConst` limits this to a maximum of 3 values by default, resulting in the commonly-known animations. By overriding this, we can view some more animations that have not been used in the final game.

Looking at `PlayerAnimation.szs`, we can see `JumpBroad`, `JumpBroad2`, ..., `JumpBroad9` are existing animations. Which means that even when overriding the PlayerConst limit, there is still one animation left in the game files that cannot be viewed in-game *at all* without `exefs` mods.

To summarize again: Nintendo limited us to see 3/9 animations by `PlayerConst`, and 8/9 by the array of hardcoded, supported LongJump-Animation names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/54)
<!-- Reviewable:end -->
