### PR TITLE
Player: Implement PlayerCounterQuickTurnJump

### DIFF
--- a/src/Player/PlayerCounterQuickTurnJump.cpp
+++ b/src/Player/PlayerCounterQuickTurnJump.cpp
@@ -1,0 +1,22 @@
+#include "Player/PlayerCounterQuickTurnJump.h"
+
+#include "Library/Math/MathUtil.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerTrigger.h"
+
+PlayerCounterQuickTurnJump::PlayerCounterQuickTurnJump(const PlayerConst* pConst,
+                                                       const PlayerTrigger* trigger)
+    : mConst(pConst), mTrigger(trigger) {}
+
+void PlayerCounterQuickTurnJump::update() {
+    if (mTrigger->isOn(PlayerTrigger::EActionTrigger_QuickTurn)) {
+        mCounter = mConst->getQuickTurnJumpFrame();
+    } else {
+        mCounter = al::converge(mCounter, 0, 1);
+    }
+}
+
+bool PlayerCounterQuickTurnJump::isEnableTurnJump() const {
+    return mTrigger->isOn(PlayerTrigger::EActionTrigger_QuickTurn) || mCounter > 0;
+}

--- a/src/Player/PlayerCounterQuickTurnJump.h
+++ b/src/Player/PlayerCounterQuickTurnJump.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class PlayerConst;
+class PlayerTrigger;
+
+class PlayerCounterQuickTurnJump {
+public:
+    PlayerCounterQuickTurnJump(const PlayerConst* pConst, const PlayerTrigger* trigger);
+
+    void update();
+    bool isEnableTurnJump() const;
+
+private:
+    const PlayerConst* mConst;
+    const PlayerTrigger* mTrigger;
+    s32 mCounter = 0;
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -7,7 +7,9 @@ class PlayerTrigger {
 public:
     enum ECollisionTrigger : u32 {};
     enum EAttackSensorTrigger : u32 {};
-    enum EActionTrigger : u32 {};
+    enum EActionTrigger : u32 {
+        EActionTrigger_QuickTurn = 34,
+    };
     enum EReceiveSensorTrigger : u32 {};
     enum EPreMovementTrigger : u32 {};
     enum EDemoEndTrigger : u32 {};


### PR DESCRIPTION
Another simple class, responsible for detecting `QuickTurn`s and counting down from (default) `20`, allowing to initiate a `QuickTurnJump` in that window, and disallowing it again afterwards.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/62)
<!-- Reviewable:end -->
