### PR TITLE
dev: Add Devcontainer setup for VS-Code

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+WORKDIR /app
+
+# avoid errors/configuration issues while installing other packages
+ARG DEBIAN_FRONTEND=noninteractive
+ARG TZ=Etc/UTC
+RUN apt update
+RUN apt install -y tzdata
+
+# install git for collaboration management
+RUN apt install -y git
+
+# install dependencies for building and running the project
+RUN apt install -y ccache clang cmake curl less libncurses6 libssl-dev ninja-build pip pkg-config python3-full xdelta3
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+RUN pip install --break-system-packages ansiwrap capstone colorama cxxfilt pyelftools python-Levenshtein toml watchdog
+
+# install dependencies for code environment
+RUN apt install -y clangd clang-format clang-tidy
+
+# install (outdated) libtinfo5, required for old clang version
+RUN curl -o libtinfo5_6.4-2_amd64.deb http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.4-2_amd64.deb && dpkg -i libtinfo5_6.4-2_amd64.deb && rm -f libtinfo5_6.4-2_amd64.deb
+
+ENTRYPOINT ["bash"]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,15 @@
+{
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "xaver.clang-format",
+                "llvm-vs-code-extensions.vscode-clangd"
+            ]
+        }
+    },
+    // mark root git repo and all submodules as safe
+    "postStartCommand": "git config --global --add safe.directory ${containerWorkspaceFolder} && git submodule --quiet foreach --recursive pwd | xargs -I% git config --global --add safe.directory %"
+}

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ The instructions below assume that you are using Linux (native or WSL) or macOS.
 
 ## 1. Set up dependencies
 
+You can either set up all dependencies on your standard installation, or use a Visual Studio Code Dev Container. If you choose to do the latter, you can skip this section, just clone and open the folder in VS-Code, press F1 and select `Dev Containers: Rebuild and Reopen in Container`. You can copy the NSO executable into the container using `docker cp /path/to/main.nso [container-id]:/workspaces/main.nso`, where `[container-id]` is the ID listed in `docker container ls`.
+
 * Python 3.6 or newer with [pip](https://pip.pypa.io/en/stable/installation/)
 * Ninja
 * CMake 3.13+
@@ -25,6 +27,12 @@ Ubuntu users can install those dependencies by running:
 
 ```shell
 sudo apt install python3 ninja-build cmake ccache xdelta3 clang libssl-dev libncurses5
+```
+
+If you are running Ubuntu 23.10 or later, the `libncurses5` package won't be available anymore. You can install it from the archive using:
+
+```shell
+wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.4-2_amd64.deb && sudo dpkg -i libtinfo5_6.4-2_amd64.deb && rm -f libtinfo5_6.4-2_amd64.deb
 ```
 
 Additionally, you'll also need:


### PR DESCRIPTION
Exactly what it says in the title. Also, I've added a bit of documentation about how to set up that one, and for installing the dependencies "natively" on Ubuntu 24.04, which has removed the `libncurses5` and `libtinfo5` packages, which will then need to be installed manually from a  `deb`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/63)
<!-- Reviewable:end -->
