### PR TITLE
Player: Implement PlayerCounterAfterCapCatch

### DIFF
--- a/src/Player/PlayerCounterAfterCapCatch.cpp
+++ b/src/Player/PlayerCounterAfterCapCatch.cpp
@@ -1,0 +1,23 @@
+#include "Player/PlayerCounterAfterCapCatch.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerTrigger.h"
+
+PlayerCounterAfterCapCatch::PlayerCounterAfterCapCatch(const PlayerConst* pConst,
+                                                       const PlayerTrigger* trigger)
+    : mConst(pConst), mTrigger(trigger) {}
+
+void PlayerCounterAfterCapCatch::update(const PlayerTrigger* trigger) {
+    if (mCounter <= sead::Mathi::maxNumber() - 1)
+        mCounter++;
+
+    if (trigger->isOn(PlayerTrigger::EAttackSensorTrigger_val0))
+        mCounter = 0;
+}
+
+bool PlayerCounterAfterCapCatch::isCapCatch() const {
+    if (mTrigger->isOn(PlayerTrigger::EAttackSensorTrigger_val0))
+        return true;
+
+    return mCounter <= mConst->getEnableActionFrameCapCatch();
+}

--- a/src/Player/PlayerCounterAfterCapCatch.h
+++ b/src/Player/PlayerCounterAfterCapCatch.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <math/seadMathCalcCommon.h>
+
+class PlayerConst;
+class PlayerTrigger;
+
+class PlayerCounterAfterCapCatch {
+public:
+    PlayerCounterAfterCapCatch(const PlayerConst* pConst, const PlayerTrigger* trigger);
+    void update(const PlayerTrigger* trigger);
+    bool isCapCatch() const;
+
+private:
+    const PlayerConst* mConst;
+    const PlayerTrigger* mTrigger;
+    // yes, this is an u32, bounded by a signed s32
+    u32 mCounter = sead::Mathi::maxNumber();
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -6,7 +6,10 @@
 class PlayerTrigger {
 public:
     enum ECollisionTrigger : u32 {};
-    enum EAttackSensorTrigger : u32 {};
+    enum EAttackSensorTrigger : u32 {
+        // used in PlayerCounterAfterCapCatch
+        EAttackSensorTrigger_val0 = 0,
+    };
     enum EActionTrigger : u32 {
         EActionTrigger_QuickTurn = 34,
     };


### PR DESCRIPTION
This `Counter` counts the number of frames since some `AttackSensorTrigger` has triggered. Based on the context, I would believe that this is the Cap "attacking" the player, but I don't feel like the amount of information available here is enough to confidently name the `enum` entry.

After the `AttackSensor` has been triggered, the `CapCatch` action can be executed for (default) `10` frames.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/75)
<!-- Reviewable:end -->
