### PR TITLE
Player: Implement PlayerCounterAfterUpperPunch

### DIFF
--- a/src/Player/PlayerCounterAfterUpperPunch.cpp
+++ b/src/Player/PlayerCounterAfterUpperPunch.cpp
@@ -1,0 +1,13 @@
+#include "Player/PlayerCounterAfterUpperPunch.h"
+
+#include "Player/PlayerTrigger.h"
+
+PlayerCounterAfterUpperPunch::PlayerCounterAfterUpperPunch() {}
+
+void PlayerCounterAfterUpperPunch::update(const PlayerTrigger* trigger) {
+    if (mCounter <= sead::Mathi::maxNumber() - 1)
+        mCounter++;
+
+    if (trigger->isOnUpperPunchHit())
+        mCounter = 0;
+}

--- a/src/Player/PlayerCounterAfterUpperPunch.h
+++ b/src/Player/PlayerCounterAfterUpperPunch.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <math/seadMathCalcCommon.h>
+
+class PlayerTrigger;
+
+class PlayerCounterAfterUpperPunch {
+public:
+    PlayerCounterAfterUpperPunch();
+    void update(const PlayerTrigger* trigger);
+
+private:
+    // yes, this is an u32, bounded by a signed s32
+    u32 mCounter = sead::Mathi::maxNumber();
+};
+static_assert(sizeof(PlayerCounterAfterUpperPunch) == 0x4);


### PR DESCRIPTION
Another counter, that will apparently just continuously count up after `UpperPunchHit` is triggered. I currently have no idea what this is even used for... only thing that would come to my mind is the hat in Bowser's, but ... why would that exist on `PlayerActorHakoniwa` in all stages?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/80)
<!-- Reviewable:end -->
