### PR TITLE
Player: Implement PlayerJudgeForceSlopeSlide

### DIFF
--- a/src/Player/PlayerJudgeForceSlopeSlide.cpp
+++ b/src/Player/PlayerJudgeForceSlopeSlide.cpp
@@ -1,0 +1,21 @@
+#include "Player/PlayerJudgeForceSlopeSlide.h"
+
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/PlayerUtil.h"
+
+PlayerJudgeForceSlopeSlide::PlayerJudgeForceSlopeSlide(const al::LiveActor* player,
+                                                       const PlayerConst* pConst,
+                                                       const IUsePlayerCollision* collider)
+    : mPlayer(player), mConst(pConst), mCollider(collider) {}
+
+void PlayerJudgeForceSlopeSlide::reset() {
+    mIsForceSlide = false;
+}
+
+void PlayerJudgeForceSlopeSlide::update() {
+    mIsForceSlide = rs::isOnGroundForceSlideCode(mPlayer, mCollider, mConst);
+}
+
+bool PlayerJudgeForceSlopeSlide::judge() const {
+    return !rs::isPlayerHack(mPlayer) && mIsForceSlide;
+}

--- a/src/Player/PlayerJudgeForceSlopeSlide.h
+++ b/src/Player/PlayerJudgeForceSlopeSlide.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
+class PlayerConst;
+
+class PlayerJudgeForceSlopeSlide : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeForceSlopeSlide(const al::LiveActor* player, const PlayerConst* pConst,
+                               const IUsePlayerCollision* collider);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const IUsePlayerCollision* mCollider;
+    bool mIsForceSlide = false;
+};

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -15,5 +15,6 @@ f32 getGroundHeight(const IUsePlayerHeightCheck*);
 const sead::Vector3f& getCollidedWallNormal(const IUsePlayerCollision*);
 bool isCollidedGround(const IUsePlayerCollision*);
 bool isCollidedGroundRunAngle(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
+bool isOnGroundForceSlideCode(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 
 }  // namespace rs

--- a/src/Util/PlayerUtil.h
+++ b/src/Util/PlayerUtil.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace al {
+class LiveActor;
+}
+
+namespace rs {
+
+bool isPlayerHack(const al::LiveActor*);
+
+}


### PR DESCRIPTION
Similar to the `ForceRoll` judge, this one checks for the floor collision code - but also requires the player to *not* be in a hack at the same time. This one is also a bit more optimized towards performance, caching the result of the floor collision in `update`, and only reading the cached value in `judge`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/85)
<!-- Reviewable:end -->
