### PR TITLE
Player: Implement PlayerJudgeStartSquat

### DIFF
--- a/src/Player/PlayerCarryKeeper.h
+++ b/src/Player/PlayerCarryKeeper.h
@@ -5,6 +5,7 @@
 class PlayerCarryKeeper {
 public:
     bool isThrowHold() const;
+    bool isCarry() const;
 
 private:
     u8 padding[0x70];

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -39,6 +39,7 @@ public:
     bool isHoldAction() const;
     bool isHoldJump() const;
     bool isHoldHipDrop() const;
+    bool isHoldSquat() const;
     bool isTriggerStartTalk() const;
     bool isTriggerStartWorldWarp() const;
     bool isTriggerCancelWorldWarp() const;

--- a/src/Player/PlayerJudgeStartSquat.cpp
+++ b/src/Player/PlayerJudgeStartSquat.cpp
@@ -1,0 +1,18 @@
+#include "Player/PlayerJudgeStartSquat.h"
+
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerCounterForceRun.h"
+#include "Player/PlayerInput.h"
+
+PlayerJudgeStartSquat::PlayerJudgeStartSquat(const PlayerInput* input,
+                                             const PlayerCounterForceRun* counterForceRun,
+                                             const PlayerCarryKeeper* carryKeeper)
+    : mInput(input), mCounterForceRun(counterForceRun), mCarryKeeper(carryKeeper) {}
+
+bool PlayerJudgeStartSquat::judge() const {
+    return !mCarryKeeper->isCarry() && mInput->isHoldSquat() && mCounterForceRun->getCounter() < 1;
+}
+
+void PlayerJudgeStartSquat::reset() {}
+
+void PlayerJudgeStartSquat::update() {}

--- a/src/Player/PlayerJudgeStartSquat.h
+++ b/src/Player/PlayerJudgeStartSquat.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+class PlayerInput;
+class PlayerCounterForceRun;
+class PlayerCarryKeeper;
+
+class PlayerJudgeStartSquat : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeStartSquat(const PlayerInput*, const PlayerCounterForceRun*,
+                          const PlayerCarryKeeper*);
+    void reset();
+    void update();
+    bool judge() const;
+
+private:
+    const PlayerInput* mInput;
+    const PlayerCounterForceRun* mCounterForceRun;
+    const PlayerCarryKeeper* mCarryKeeper;
+};
+static_assert(sizeof(PlayerJudgeStartSquat) == 0x20);


### PR DESCRIPTION
Another simple judge. Apparently, to initiate a `Squat`, you have to fulfill the following criteria:
1. Do not carry anything
2. Hold the `Squat` button
3. Not in a forced run, for example a rocket flower

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/88)
<!-- Reviewable:end -->
