### PR TITLE
Library/Nerve: New NerveSetupUtil-macros

### DIFF
--- a/lib/al/Library/Base/Macros.h
+++ b/lib/al/Library/Base/Macros.h
@@ -1,0 +1,87 @@
+#pragma once
+
+// https://stackoverflow.com/a/26408195/9275661
+#define __NARG__(...) __NARG_I_(__VA_ARGS__, __RSEQ_N())
+#define __NARG_I_(...) __ARG_N(__VA_ARGS__)
+#define __ARG_N(_1, _2, _3, _4, _5, _6, _7, _8, _9, _10, _11, _12, _13, _14, _15, _16, _17, _18,   \
+                _19, _20, _21, _22, _23, _24, _25, _26, _27, _28, _29, _30, _31, _32, _33, _34,    \
+                _35, _36, _37, _38, _39, _40, _41, _42, _43, _44, _45, _46, _47, _48, _49, _50,    \
+                _51, _52, _53, _54, _55, _56, _57, _58, _59, _60, _61, _62, _63, N, ...)           \
+    N
+#define __RSEQ_N()                                                                                 \
+    63, 62, 61, 60, 59, 58, 57, 56, 55, 54, 53, 52, 51, 50, 49, 48, 47, 46, 45, 44, 43, 42, 41,    \
+        40, 39, 38, 37, 36, 35, 34, 33, 32, 31, 30, 29, 28, 27, 26, 25, 24, 23, 22, 21, 20, 19,    \
+        18, 17, 16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1, 0
+#define _VFUNC_(name, n) name##n
+#define _VFUNC(name, n) _VFUNC_(name, n)
+#define VFUNC(func, ...) _VFUNC(func, __NARG__(__VA_ARGS__))
+
+// https://stackoverflow.com/a/11994395/9275661
+// adjusted to keep the first parameter the same for all "recursive" calls,
+// used to pass the class name to NERVE_MAKE macros
+#define FE_0(WHAT)
+#define FE_1(WHAT, X0, X1) WHAT(X0, X1)
+#define FE_2(WHAT, X0, X1, ...) WHAT(X0, X1) FE_1(WHAT, X0, __VA_ARGS__)
+#define FE_3(WHAT, X0, X1, ...) WHAT(X0, X1) FE_2(WHAT, X0, __VA_ARGS__)
+#define FE_4(WHAT, X0, X1, ...) WHAT(X0, X1) FE_3(WHAT, X0, __VA_ARGS__)
+#define FE_5(WHAT, X0, X1, ...) WHAT(X0, X1) FE_4(WHAT, X0, __VA_ARGS__)
+#define FE_6(WHAT, X0, X1, ...) WHAT(X0, X1) FE_5(WHAT, X0, __VA_ARGS__)
+#define FE_7(WHAT, X0, X1, ...) WHAT(X0, X1) FE_6(WHAT, X0, __VA_ARGS__)
+#define FE_8(WHAT, X0, X1, ...) WHAT(X0, X1) FE_7(WHAT, X0, __VA_ARGS__)
+#define FE_9(WHAT, X0, X1, ...) WHAT(X0, X1) FE_8(WHAT, X0, __VA_ARGS__)
+#define FE_10(WHAT, X0, X1, ...) WHAT(X0, X1) FE_9(WHAT, X0, __VA_ARGS__)
+#define FE_11(WHAT, X0, X1, ...) WHAT(X0, X1) FE_10(WHAT, X0, __VA_ARGS__)
+#define FE_12(WHAT, X0, X1, ...) WHAT(X0, X1) FE_11(WHAT, X0, __VA_ARGS__)
+#define FE_13(WHAT, X0, X1, ...) WHAT(X0, X1) FE_12(WHAT, X0, __VA_ARGS__)
+#define FE_14(WHAT, X0, X1, ...) WHAT(X0, X1) FE_13(WHAT, X0, __VA_ARGS__)
+#define FE_15(WHAT, X0, X1, ...) WHAT(X0, X1) FE_14(WHAT, X0, __VA_ARGS__)
+#define FE_16(WHAT, X0, X1, ...) WHAT(X0, X1) FE_15(WHAT, X0, __VA_ARGS__)
+#define FE_17(WHAT, X0, X1, ...) WHAT(X0, X1) FE_16(WHAT, X0, __VA_ARGS__)
+#define FE_18(WHAT, X0, X1, ...) WHAT(X0, X1) FE_17(WHAT, X0, __VA_ARGS__)
+#define FE_19(WHAT, X0, X1, ...) WHAT(X0, X1) FE_18(WHAT, X0, __VA_ARGS__)
+#define FE_20(WHAT, X0, X1, ...) WHAT(X0, X1) FE_19(WHAT, X0, __VA_ARGS__)
+#define FE_21(WHAT, X0, X1, ...) WHAT(X0, X1) FE_20(WHAT, X0, __VA_ARGS__)
+#define FE_22(WHAT, X0, X1, ...) WHAT(X0, X1) FE_21(WHAT, X0, __VA_ARGS__)
+#define FE_23(WHAT, X0, X1, ...) WHAT(X0, X1) FE_22(WHAT, X0, __VA_ARGS__)
+#define FE_24(WHAT, X0, X1, ...) WHAT(X0, X1) FE_23(WHAT, X0, __VA_ARGS__)
+#define FE_25(WHAT, X0, X1, ...) WHAT(X0, X1) FE_24(WHAT, X0, __VA_ARGS__)
+#define FE_26(WHAT, X0, X1, ...) WHAT(X0, X1) FE_25(WHAT, X0, __VA_ARGS__)
+#define FE_27(WHAT, X0, X1, ...) WHAT(X0, X1) FE_26(WHAT, X0, __VA_ARGS__)
+#define FE_28(WHAT, X0, X1, ...) WHAT(X0, X1) FE_27(WHAT, X0, __VA_ARGS__)
+#define FE_29(WHAT, X0, X1, ...) WHAT(X0, X1) FE_28(WHAT, X0, __VA_ARGS__)
+#define FE_30(WHAT, X0, X1, ...) WHAT(X0, X1) FE_29(WHAT, X0, __VA_ARGS__)
+#define FE_31(WHAT, X0, X1, ...) WHAT(X0, X1) FE_30(WHAT, X0, __VA_ARGS__)
+#define FE_32(WHAT, X0, X1, ...) WHAT(X0, X1) FE_31(WHAT, X0, __VA_ARGS__)
+#define FE_33(WHAT, X0, X1, ...) WHAT(X0, X1) FE_32(WHAT, X0, __VA_ARGS__)
+#define FE_34(WHAT, X0, X1, ...) WHAT(X0, X1) FE_33(WHAT, X0, __VA_ARGS__)
+#define FE_35(WHAT, X0, X1, ...) WHAT(X0, X1) FE_34(WHAT, X0, __VA_ARGS__)
+#define FE_36(WHAT, X0, X1, ...) WHAT(X0, X1) FE_35(WHAT, X0, __VA_ARGS__)
+#define FE_37(WHAT, X0, X1, ...) WHAT(X0, X1) FE_36(WHAT, X0, __VA_ARGS__)
+#define FE_38(WHAT, X0, X1, ...) WHAT(X0, X1) FE_37(WHAT, X0, __VA_ARGS__)
+#define FE_39(WHAT, X0, X1, ...) WHAT(X0, X1) FE_38(WHAT, X0, __VA_ARGS__)
+#define FE_40(WHAT, X0, X1, ...) WHAT(X0, X1) FE_39(WHAT, X0, __VA_ARGS__)
+#define FE_41(WHAT, X0, X1, ...) WHAT(X0, X1) FE_40(WHAT, X0, __VA_ARGS__)
+#define FE_42(WHAT, X0, X1, ...) WHAT(X0, X1) FE_41(WHAT, X0, __VA_ARGS__)
+#define FE_43(WHAT, X0, X1, ...) WHAT(X0, X1) FE_42(WHAT, X0, __VA_ARGS__)
+#define FE_44(WHAT, X0, X1, ...) WHAT(X0, X1) FE_43(WHAT, X0, __VA_ARGS__)
+#define FE_45(WHAT, X0, X1, ...) WHAT(X0, X1) FE_44(WHAT, X0, __VA_ARGS__)
+#define FE_46(WHAT, X0, X1, ...) WHAT(X0, X1) FE_45(WHAT, X0, __VA_ARGS__)
+#define FE_47(WHAT, X0, X1, ...) WHAT(X0, X1) FE_46(WHAT, X0, __VA_ARGS__)
+#define FE_48(WHAT, X0, X1, ...) WHAT(X0, X1) FE_47(WHAT, X0, __VA_ARGS__)
+#define FE_49(WHAT, X0, X1, ...) WHAT(X0, X1) FE_48(WHAT, X0, __VA_ARGS__)
+#define FE_50(WHAT, X0, X1, ...) WHAT(X0, X1) FE_49(WHAT, X0, __VA_ARGS__)
+#define FE_51(WHAT, X0, X1, ...) WHAT(X0, X1) FE_50(WHAT, X0, __VA_ARGS__)
+#define FE_52(WHAT, X0, X1, ...) WHAT(X0, X1) FE_51(WHAT, X0, __VA_ARGS__)
+#define FE_53(WHAT, X0, X1, ...) WHAT(X0, X1) FE_52(WHAT, X0, __VA_ARGS__)
+#define FE_54(WHAT, X0, X1, ...) WHAT(X0, X1) FE_53(WHAT, X0, __VA_ARGS__)
+#define FE_55(WHAT, X0, X1, ...) WHAT(X0, X1) FE_54(WHAT, X0, __VA_ARGS__)
+#define FE_56(WHAT, X0, X1, ...) WHAT(X0, X1) FE_55(WHAT, X0, __VA_ARGS__)
+#define FE_57(WHAT, X0, X1, ...) WHAT(X0, X1) FE_56(WHAT, X0, __VA_ARGS__)
+#define FE_58(WHAT, X0, X1, ...) WHAT(X0, X1) FE_57(WHAT, X0, __VA_ARGS__)
+#define FE_59(WHAT, X0, X1, ...) WHAT(X0, X1) FE_58(WHAT, X0, __VA_ARGS__)
+#define FE_60(WHAT, X0, X1, ...) WHAT(X0, X1) FE_59(WHAT, X0, __VA_ARGS__)
+#define FE_61(WHAT, X0, X1, ...) WHAT(X0, X1) FE_60(WHAT, X0, __VA_ARGS__)
+#define FE_62(WHAT, X0, X1, ...) WHAT(X0, X1) FE_61(WHAT, X0, __VA_ARGS__)
+#define FE_63(WHAT, X0, X1, ...) WHAT(X0, X1) FE_62(WHAT, X0, __VA_ARGS__)
+
+#define FOR_EACH(action, x0, ...) VFUNC(FE_, __VA_ARGS__)(action, x0, __VA_ARGS__)

--- a/lib/al/Library/Nerve/NerveSetupUtil.h
+++ b/lib/al/Library/Nerve/NerveSetupUtil.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <prim/seadStorageFor.h>
+
+#include "Library/Base/Macros.h"
 #include "Library/Nerve/Nerve.h"
+#include "Library/Nerve/NerveAction.h"
 #include "Library/Nerve/NerveKeeper.h"
 
 /*
@@ -13,16 +17,28 @@ namespace {
     NERVE_IMPL(ExampleUseCase, HackEnd);
     ...
 
-    struct {
-        NERVE_MAKE(ExampleUseCase, Wait);
-        NERVE_MAKE(ExampleUseCase, WaitHack);
-        NERVE_MAKE(ExampleUseCase, HackEnd);
-        ...
-    } NrvExampleUseCase;
+    NERVES_MAKE_STRUCT(ExampleUseCase, Wait, WaitHack, HackEnd, ...);
+    // or NERVES_MAKE_NOSTRUCT if they are not supposed to be in a struct
 
 }
 
 al::setNerve(this, &NrvExampleUseCase.Wait);
+
+
+Similar setup for NerveAction:
+
+namespace {
+    NERVE_ACTION_IMPL(ExampleUseCase, Wait);
+    NERVE_ACTION_IMPL_(ExampleUseCase, WaitHack, Wait);
+    NERVE_ACTION_IMPL(ExampleUseCase, HackEnd);
+    ...
+
+    NERVE_ACTIONS_MAKE_STRUCT(ExampleUseCase, Wait, WaitHack, HackEnd, ...);
+    // no NOSTRUCT variant, as the struct also contains a NerveActionCollector
+    // and no variants without it have been found so far
+}
+
+al::initNerveAction(this, "Hide", &NrvExampleUseCase.mCollector, 0);
 
 */
 
@@ -37,3 +53,35 @@ al::setNerve(this, &NrvExampleUseCase.Wait);
 #define NERVE_IMPL(Class, Action) NERVE_IMPL_(Class, Action, Action)
 
 #define NERVE_MAKE(Class, Action) Class##Nrv##Action Action;
+
+#define NERVES_MAKE_STRUCT(Class, ...)                                                             \
+    struct {                                                                                       \
+        FOR_EACH(NERVE_MAKE, Class, __VA_ARGS__)                                                   \
+    } Nrv##Class;
+
+#define NERVES_MAKE_NOSTRUCT(Class, ...) FOR_EACH(NERVE_MAKE, Class, __VA_ARGS__);
+
+#define NERVE_ACTION_IMPL_(Class, Action, ActionFunc)                                              \
+    class Class##Nrv##Action : public al::NerveAction {                                            \
+    public:                                                                                        \
+        void execute(al::NerveKeeper* keeper) const override {                                     \
+            (keeper->getParent<Class>())->exe##ActionFunc();                                       \
+        }                                                                                          \
+                                                                                                   \
+        const char* getActionName() const override { return #Action; }                             \
+    };
+
+#define NERVE_ACTION_IMPL(Class, Action) NERVE_ACTION_IMPL_(Class, Action, Action)
+
+#define NERVE_ACTION_MAKE(Class, Action) sead::StorageFor<Class##Nrv##Action> Action;
+
+#define NERVE_ACTION_CONSTRUCT(Class, Action) Action.constructDefault();
+
+#define NERVE_ACTIONS_MAKE_STRUCT(Class, ...)                                                      \
+    struct NrvStruct##Class {                                                                      \
+        FOR_EACH(NERVE_ACTION_MAKE, Class, __VA_ARGS__)                                            \
+                                                                                                   \
+        alNerveFunction::NerveActionCollector mCollector;                                          \
+                                                                                                   \
+        NrvStruct##Class() { FOR_EACH(NERVE_ACTION_CONSTRUCT, Class, __VA_ARGS__) }                \
+    } Nrv##Class;

--- a/lib/al/Library/Obj/AllDeadWatcher.h
+++ b/lib/al/Library/Obj/AllDeadWatcher.h
@@ -28,9 +28,6 @@ namespace {
 NERVE_IMPL(AllDeadWatcher, Watch);
 NERVE_IMPL(AllDeadWatcher, Wait);
 
-struct {
-    NERVE_MAKE(AllDeadWatcher, Watch);
-    NERVE_MAKE(AllDeadWatcher, Wait);
-} NrvAllDeadWatcher;
+NERVES_MAKE_STRUCT(AllDeadWatcher, Watch, Wait);
 }  // namespace
 }  // namespace al

--- a/lib/al/Library/Obj/BreakModel.cpp
+++ b/lib/al/Library/Obj/BreakModel.cpp
@@ -16,8 +16,7 @@ using namespace al;
 NERVE_IMPL(BreakModel, Wait);
 NERVE_IMPL(BreakModel, Break);
 
-NERVE_MAKE(BreakModel, Wait);
-NERVE_MAKE(BreakModel, Break);
+NERVES_MAKE_NOSTRUCT(BreakModel, Wait, Break);
 }  // namespace
 
 namespace al {

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -14,15 +14,8 @@ NERVE_IMPL(CameraVerticalAbsorber, Absorb);
 NERVE_IMPL(CameraVerticalAbsorber, Follow);
 NERVE_IMPL(CameraVerticalAbsorber, FollowClimbPole);
 
-struct {
-    NERVE_MAKE(CameraVerticalAbsorber, FollowGround);
-    NERVE_MAKE(CameraVerticalAbsorber, FollowAbsolute);
-    NERVE_MAKE(CameraVerticalAbsorber, FollowClimbPoleNoInterp);
-    NERVE_MAKE(CameraVerticalAbsorber, FollowSlow);
-    NERVE_MAKE(CameraVerticalAbsorber, Absorb);
-    NERVE_MAKE(CameraVerticalAbsorber, Follow);
-    NERVE_MAKE(CameraVerticalAbsorber, FollowClimbPole);
-} NrvCameraVerticalAbsorber;
+NERVES_MAKE_STRUCT(CameraVerticalAbsorber, FollowGround, FollowAbsolute, FollowClimbPoleNoInterp,
+                   FollowSlow, Absorb, Follow, FollowClimbPole);
 }  // namespace
 
 namespace al {

--- a/src/Amiibo/ItemAmiiboKoopa.cpp
+++ b/src/Amiibo/ItemAmiiboKoopa.cpp
@@ -15,11 +15,7 @@ namespace {
 NERVE_IMPL(ItemAmiiboKoopa, Wait);
 NERVE_IMPL(ItemAmiiboKoopa, Expand);
 
-struct {
-    NERVE_MAKE(ItemAmiiboKoopa, Wait);
-    NERVE_MAKE(ItemAmiiboKoopa, Expand);
-} NrvItemAmiiboKoopa;
-
+NERVES_MAKE_STRUCT(ItemAmiiboKoopa, Wait, Expand);
 }  // namespace
 
 ItemAmiiboKoopa::ItemAmiiboKoopa(const char* actorName) : al::LiveActor(actorName) {}

--- a/src/Boss/Mofumofu/MofumofuWarpHole.cpp
+++ b/src/Boss/Mofumofu/MofumofuWarpHole.cpp
@@ -26,15 +26,8 @@ NERVE_IMPL(MofumofuWarpHole, DashSign);
 NERVE_IMPL(MofumofuWarpHole, DashSignEnd);
 NERVE_IMPL_(MofumofuWarpHole, CloseAndDisappear, Close);
 
-NERVE_MAKE(MofumofuWarpHole, Close);
-NERVE_MAKE(MofumofuWarpHole, Disappear);
-NERVE_MAKE(MofumofuWarpHole, Appear);
-NERVE_MAKE(MofumofuWarpHole, HideMove);
-NERVE_MAKE(MofumofuWarpHole, HideWait);
-NERVE_MAKE(MofumofuWarpHole, Wait);
-NERVE_MAKE(MofumofuWarpHole, DashSign);
-NERVE_MAKE(MofumofuWarpHole, DashSignEnd);
-NERVE_MAKE(MofumofuWarpHole, CloseAndDisappear);
+NERVES_MAKE_NOSTRUCT(MofumofuWarpHole, Close, Disappear, Appear, HideMove, HideWait, Wait, DashSign,
+                     DashSignEnd, CloseAndDisappear);
 
 }  // namespace
 

--- a/src/Layout/BootLayout.cpp
+++ b/src/Layout/BootLayout.cpp
@@ -12,11 +12,7 @@ NERVE_IMPL(BootLayout, StartWipe);
 NERVE_IMPL(BootLayout, EndWipe);
 NERVE_IMPL(BootLayout, End);
 
-NERVE_MAKE(BootLayout, Appear);
-NERVE_MAKE(BootLayout, Wait);
-NERVE_MAKE(BootLayout, StartWipe);
-NERVE_MAKE(BootLayout, EndWipe);
-NERVE_MAKE(BootLayout, End);
+NERVES_MAKE_NOSTRUCT(BootLayout, Appear, Wait, StartWipe, EndWipe, End);
 }  // namespace
 
 BootLayout::BootLayout(const al::LayoutInitInfo& info) : al::LayoutActor("[起動]BootLoading") {

--- a/src/Layout/ButtonMiiverse.cpp
+++ b/src/Layout/ButtonMiiverse.cpp
@@ -15,15 +15,7 @@ NERVE_IMPL(ButtonMiiverse, Disable);
 NERVE_IMPL(ButtonMiiverse, HoldOn);
 NERVE_IMPL(ButtonMiiverse, HoldOff);
 
-struct {
-    NERVE_MAKE(ButtonMiiverse, Wait);
-    NERVE_MAKE(ButtonMiiverse, Decide);
-    NERVE_MAKE(ButtonMiiverse, OnWait);
-    NERVE_MAKE(ButtonMiiverse, Disable);
-    NERVE_MAKE(ButtonMiiverse, HoldOn);
-    NERVE_MAKE(ButtonMiiverse, HoldOff);
-} NrvButtonMiiverse;
-
+NERVES_MAKE_STRUCT(ButtonMiiverse, Wait, Decide, OnWait, Disable, HoldOn, HoldOff);
 }  // namespace
 
 ButtonMiiverse::ButtonMiiverse() : al::LayoutActor("Miiverse") {}

--- a/src/MapObj/AnagramAlphabet.cpp
+++ b/src/MapObj/AnagramAlphabet.cpp
@@ -6,9 +6,5 @@ namespace {
 NERVE_IMPL(AnagramAlphabet, Wait);
 NERVE_IMPL(AnagramAlphabet, Complete);
 
-struct {
-    NERVE_MAKE(AnagramAlphabet, Wait);
-    NERVE_MAKE(AnagramAlphabet, Complete);
-} NrvAnagramAlphabet;
-
+NERVES_MAKE_STRUCT(AnagramAlphabet, Wait, Complete);
 }  // namespace

--- a/src/MapObj/AnagramAlphabetCharacter.cpp
+++ b/src/MapObj/AnagramAlphabetCharacter.cpp
@@ -33,19 +33,8 @@ NERVE_IMPL(AnagramAlphabetCharacter, HackFall);
 NERVE_IMPL(AnagramAlphabetCharacter, HackGoal);
 NERVE_IMPL(AnagramAlphabetCharacter, Set);
 
-struct {
-    NERVE_MAKE(AnagramAlphabetCharacter, Wait);
-    NERVE_MAKE(AnagramAlphabetCharacter, WaitHack);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackEnd);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackStart);
-    NERVE_MAKE(AnagramAlphabetCharacter, Complete);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackWait);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackMove);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackFall);
-    NERVE_MAKE(AnagramAlphabetCharacter, HackGoal);
-    NERVE_MAKE(AnagramAlphabetCharacter, Set);
-} NrvAnagramAlphabetCharacter;
-
+NERVES_MAKE_STRUCT(AnagramAlphabetCharacter, Wait, WaitHack, HackEnd, HackStart, Complete, HackWait,
+                   HackMove, HackFall, HackGoal, Set);
 }  // namespace
 
 void AnagramAlphabetCharacter::init(const al::ActorInitInfo& info) {

--- a/src/MapObj/FireDrum2D.cpp
+++ b/src/MapObj/FireDrum2D.cpp
@@ -14,9 +14,7 @@ namespace {
 NERVE_IMPL(FireDrum2D, Wait);
 NERVE_IMPL(FireDrum2D, Burn);
 
-NERVE_MAKE(FireDrum2D, Wait);
-NERVE_MAKE(FireDrum2D, Burn);
-
+NERVES_MAKE_NOSTRUCT(FireDrum2D, Wait, Burn);
 }  // namespace
 
 FireDrum2D::FireDrum2D(const char* name) : LiveActor(name) {}

--- a/src/Player/Player.cpp
+++ b/src/Player/Player.cpp
@@ -24,8 +24,9 @@ NERVE_IMPL(Player, Run);
 NERVE_IMPL(Player, Jump);
 NERVE_IMPL(Player, Fall);
 NERVE_IMPL(Player, Damage);
-NERVE_MAKE(Player, Damage);
 
+// weird intermediate way that has no macro pre-defined
+NERVE_MAKE(Player, Damage);
 struct {
     NERVE_MAKE(Player, Fall);
     NERVE_MAKE(Player, Jump);

--- a/src/System/GameSystem.cpp
+++ b/src/System/GameSystem.cpp
@@ -3,13 +3,9 @@
 #include "Library/Nerve/NerveSetupUtil.h"
 
 namespace {
-
 NERVE_IMPL(GameSystem, Play);
 
-struct {
-    NERVE_MAKE(GameSystem, Play);
-} NrvGameSystem;
-
+NERVES_MAKE_STRUCT(GameSystem, Play);
 }  // namespace
 
 void GameSystem::init() {}


### PR DESCRIPTION
Utility things required for #90. Here, we noticed that macros for `NerveAction`s are required as well, but also that the structs for those include another object used to collect the nerves into a struct that can be searched to find actions by name. This object is placed at the end of the struct, but initialized first, which means that the other objects are not initialized at declaration, but at some later point within the dynamic initialization phase. To re-create this behaviour, these nerves are not stored as their usual type, as that would at least zero-initialize them before the helper struct, instead we just store a `StorageFor` and manually call their creation method during the constructor.

As this setup requires a major overhead with creating the struct and its constructor correctly, I have implemented macros to do the `MAKE` calls automatically. It currently supports up to 63 nerves in a single struct.

Similarly, I added a `MAKE` macro for creating standard nerves, and replaced all current occurences with it - apart from `Player`, which has a weird mix of struct- and nostruct-MAKEs that cannot be recreated with the shorter macro types, so this has to stay "manual" for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/91)
<!-- Reviewable:end -->
