### PR TITLE
Player: Implement PlayerActionVelocityControl

### DIFF
--- a/lib/al/Library/Math/MathAngleUtil.h
+++ b/lib/al/Library/Math/MathAngleUtil.h
@@ -34,6 +34,12 @@ bool isInAngleOnPlaneDegreeHV(const sead::Vector3f&, const sead::Vector3f&, cons
 
 void normalize(sead::Vector2f*, const sead::Vector2f&);
 void normalize(sead::Vector3f*, const sead::Vector3f&);
+void normalize(sead::Vector2f*);
+void normalize(sead::Vector3f*);
 bool tryNormalizeOrZero(sead::Vector3f*, const sead::Vector3f&);
 bool tryNormalizeOrZero(sead::Vector3f*);
+
+void alongVectorNormalH(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&,
+                        const sead::Vector3f&);
+
 }  // namespace al

--- a/lib/al/Library/Math/MathLengthUtil.h
+++ b/lib/al/Library/Math/MathLengthUtil.h
@@ -38,6 +38,8 @@ f32 normalize(f32, f32, f32);
 f32 normalize(s32, s32, s32);
 bool limitLength(sead::Vector2f*, const sead::Vector2f&, f32);
 bool limitLength(sead::Vector3f*, const sead::Vector3f&, f32);
+bool limitLength(sead::Vector2f*, f32);
+bool limitLength(sead::Vector3f*, f32);
 
 u32 getMaxAbsElementIndex(const sead::Vector3f&);
 void setLength(sead::Vector3f*, f32);

--- a/src/Player/PlayerActionVelocityControl.cpp
+++ b/src/Player/PlayerActionVelocityControl.cpp
@@ -1,0 +1,78 @@
+#include "Player/PlayerActionVelocityControl.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Math/MathAngleUtil.h"
+#include "Library/Math/MathLengthUtil.h"
+#include "Library/Math/MathUtil.h"
+
+#include "Player/PlayerActionFunction.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerActionVelocityControl::PlayerActionVelocityControl(al::LiveActor* actor,
+                                                         const IUsePlayerCollision* collision)
+    : mActor(actor) {
+    sead::Vector3f negGravity = -al::getGravity(actor);
+    if (collision)
+        rs::calcGroundNormalOrGravityDir(&negGravity, actor, collision);
+
+    sead::Vector3f up;
+    al::calcUpDir(&up, mActor);
+    al::normalize(&up);
+
+    sead::Vector3f front;
+    al::calcFrontDir(&front, mActor);
+    al::alongVectorNormalH(&front, front, up, negGravity);
+    al::normalize(&front);
+
+    mUp = negGravity;
+    mSide.setCross(negGravity, front);
+    al::normalize(&mSide);
+
+    al::parallelizeVec(&mVelocityFront, front, al::getVelocity(actor));
+    al::parallelizeVec(&mVelocitySide, mSide, al::getVelocity(actor));
+    mVelocityUp = al::getVelocity(actor) - mVelocityFront - mVelocitySide;
+}
+
+void PlayerActionVelocityControl::calcFrontBrake(f32 decel) {
+    mVelocityFront *= decel;
+}
+
+void PlayerActionVelocityControl::calcSideVelocityLimit(const sead::Vector3f& moveInput,
+                                                        f32 brakeSideAccel, f32 brakeSideRate,
+                                                        f32 maxSideSpeed) {
+    f32 stickPow = PlayerActionFunction::calcStickPow(moveInput.dot(mSide));
+    if (al::isNearZero(stickPow, 0.01f)) {
+        mVelocitySide *= brakeSideRate;
+        return;
+    }
+
+    mVelocitySide += (stickPow * brakeSideAccel) * mSide;
+    al::limitLength(&mVelocitySide, mVelocitySide, maxSideSpeed);
+}
+
+void PlayerActionVelocityControl::calcSideBrake(f32 decel) {
+    mVelocitySide *= decel;
+}
+
+void PlayerActionVelocityControl::calcTrample(f32 downVel) {
+    al::verticalizeVec(&mVelocityUp, al::getGravity(mActor), mVelocityUp);
+    mVelocityUp += al::getGravity(mActor) * downVel;
+}
+
+void PlayerActionVelocityControl::calcSnap(const sead::Vector3f& snapDir, f32 snapDistance) {
+    // requires to be this explicit to match. Both += and vector operations mismatch.
+    mVelocityUp.x = (snapDir.x * snapDistance) + mVelocityUp.x;
+    mVelocityUp.y = (snapDir.y * snapDistance) + mVelocityUp.y;
+    mVelocityUp.z = (snapDir.z * snapDistance) + mVelocityUp.z;
+}
+
+void PlayerActionVelocityControl::calcOnGround(const sead::Vector3f& groundNormal) {
+    al::verticalizeVec(&mVelocityFront, groundNormal, mVelocityFront);
+    al::verticalizeVec(&mVelocitySide, groundNormal, mVelocitySide);
+    al::verticalizeVec(&mVelocityUp, groundNormal, mVelocityUp);
+}
+
+void PlayerActionVelocityControl::apply() {
+    *al::getVelocityPtr(mActor) = mVelocityFront + mVelocitySide + mVelocityUp;
+}

--- a/src/Player/PlayerActionVelocityControl.h
+++ b/src/Player/PlayerActionVelocityControl.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
+
+class PlayerActionVelocityControl {
+public:
+    PlayerActionVelocityControl(al::LiveActor* actor, const IUsePlayerCollision* collider);
+
+    void calcFrontBrake(f32 decel);
+    void calcSideVelocityLimit(const sead::Vector3f& moveInput, f32 brakeSideAccel,
+                               f32 brakeSideRate, f32 maxSideSpeed);
+    void calcSideBrake(f32 decel);
+    void calcTrample(f32 downVel);
+    void calcSnap(const sead::Vector3f& snapDir, f32 snapDistance);
+    void calcOnGround(const sead::Vector3f& groundNormal);
+    void apply();
+
+private:
+    al::LiveActor* mActor;
+    sead::Vector3f mSide = sead::Vector3f::zero;
+    sead::Vector3f mUp = sead::Vector3f::zero;
+    sead::Vector3f mVelocityFront = sead::Vector3f::zero;
+    sead::Vector3f mVelocitySide = sead::Vector3f::zero;
+    sead::Vector3f mVelocityUp = sead::Vector3f::zero;
+};

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -21,5 +21,7 @@ bool isOnGroundForceRollingCode(const al::LiveActor*, const IUsePlayerCollision*
 bool isPlayerOnGround(const al::LiveActor*);
 bool isOnGround(const al::LiveActor*, const IUsePlayerCollision*);
 bool isJustLand(const IUsePlayerCollision*);
+void calcGroundNormalOrGravityDir(sead::Vector3f*, const al::LiveActor*,
+                                  const IUsePlayerCollision*);
 
 }  // namespace rs


### PR DESCRIPTION
This class is used as a helper for various calculations within specific functions of `PlayerStateRolling` and `PlayerStateSquat`. It splits the velocity of an actor into its three relative components (up, front, side), and can apply calculations to each one independently, before combining them back together into a single, new movement vector.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/92)
<!-- Reviewable:end -->
