### PR TITLE
lint: Apply `SeparateDefinitionBlocks`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,6 +58,7 @@ PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 ReflowComments:  true
 RemoveBracesLLVM: true
+SeparateDefinitionBlocks: Always
 SortIncludes:    true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true

--- a/lib/al/Library/Action/ActorActionKeeper.cpp
+++ b/lib/al/Library/Action/ActorActionKeeper.cpp
@@ -72,6 +72,7 @@ void ActorActionKeeper::init() {
     if (mFlagCtrl)
         mFlagCtrl->initPost();
 }
+
 bool ActorActionKeeper::startAction(const char* name) {
     mIsActionRunning = true;
     if (!mNerveActionCtrl)
@@ -79,6 +80,7 @@ bool ActorActionKeeper::startAction(const char* name) {
 
     return mAnimCtrl && mAnimCtrl->start(name);
 }
+
 void ActorActionKeeper::tryStartActionNoAnim(const char* string) {
     if (mFlagCtrl)
         mFlagCtrl->start(string);
@@ -93,5 +95,6 @@ void ActorActionKeeper::tryStartActionNoAnim(const char* string) {
     if (mScreenEffectCtrl)
         mScreenEffectCtrl->startAction(string);
 }
+
 void ActorActionKeeper::updatePrev() {}
 }  // namespace al

--- a/lib/al/Library/Area/AreaInitInfo.h
+++ b/lib/al/Library/Area/AreaInitInfo.h
@@ -17,7 +17,9 @@ public:
              SceneObjHolder* sceneObjHolder);
 
     const PlacementInfo& getPlacementInfo() const { return mPlacementInfo; }
+
     StageSwitchDirector* getStageSwitchDirector() const { return mStageSwitchDirector; }
+
     SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
 
 private:

--- a/lib/al/Library/Area/SwitchAreaDirector.h
+++ b/lib/al/Library/Area/SwitchAreaDirector.h
@@ -27,6 +27,7 @@ public:
 private:
     void* filler[9];
 };
+
 static_assert(sizeof(SwitchAreaDirector) == 0x50);
 
 }  // namespace al

--- a/lib/al/Library/Audio/AudioKeeper.h
+++ b/lib/al/Library/Audio/AudioKeeper.h
@@ -32,12 +32,17 @@ public:
     void kill();
 
     AudioEventController* getAudioEventController() const { return mAudioEventController; };
+
     AudioEffectController* getAudioEffectController() const { return mAudioEffectController; };
+
     AudioRequestKeeperSyncedBgm* getAudioRequestKeeperSyncedBgm() const {
         return mAudioRequestKeeperSyncedBgm;
     };
+
     SeKeeper* getSeKeeper() const { return mSeKeeper; };
+
     BgmKeeper* getBgmKeeper() const { return mBgmKeeper; };
+
     AudioMic* getAudioMic() const { return mAudioMic; };
 
 private:
@@ -48,6 +53,7 @@ private:
     BgmKeeper* mBgmKeeper;
     AudioMic* mAudioMic;
 };
+
 static_assert(sizeof(AudioKeeper) == 0x38);
 
 }  // namespace al

--- a/lib/al/Library/Audio/System/AudioSystemInfo.h
+++ b/lib/al/Library/Audio/System/AudioSystemInfo.h
@@ -11,6 +11,7 @@ public:
     AudioSystemInfo();
 
     SeDataBase* getSeDataBase() const { return mSeDataBase; }
+
     BgmDataBase* getBgmDataBase() const { return mBgmDataBase; }
 
 private:

--- a/lib/al/Library/Base/StringUtil.h
+++ b/lib/al/Library/Base/StringUtil.h
@@ -44,6 +44,7 @@ public:
         sead::FixedSafeString<L>::formatV(format, args);
         va_end(args);
     }
+
     ~StringTmp() = default;
 };
 }  // namespace al

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -103,7 +103,9 @@ public:
     f32 getFovyDegree() const;
 
     sead::Vector3f getPosition() const { return mPosition; };
+
     sead::Vector3f getTargetTrans() const { return mTargetTrans; };
+
     sead::Vector3f getCameraUp() const { return mCameraUp; };
 
 private:

--- a/lib/al/Library/Clipping/ViewIdHolder.cpp
+++ b/lib/al/Library/Clipping/ViewIdHolder.cpp
@@ -6,6 +6,7 @@
 
 namespace al {
 ViewIdHolder::ViewIdHolder() {}
+
 ViewIdHolder* ViewIdHolder::tryCreate(const PlacementInfo& placementInfo) {
     if (calcLinkChildNum(placementInfo, "ViewGroup") < 1) {
         return nullptr;
@@ -15,6 +16,7 @@ ViewIdHolder* ViewIdHolder::tryCreate(const PlacementInfo& placementInfo) {
         return holder;
     }
 }
+
 void ViewIdHolder::init(const PlacementInfo& placementInfo) {
     mNumPlacements = calcLinkChildNum(placementInfo, "ViewGroup");
     mPlacementIds = new PlacementId[mNumPlacements];
@@ -26,6 +28,7 @@ void ViewIdHolder::init(const PlacementInfo& placementInfo) {
         }
     }
 }
+
 PlacementId& ViewIdHolder::getViewId(s32 idx) const {
     return mPlacementIds[idx];
 }

--- a/lib/al/Library/Collision/KCollisionServer.cpp
+++ b/lib/al/Library/Collision/KCollisionServer.cpp
@@ -16,6 +16,7 @@ void SphereInterpolator::startInterp(const sead::Vector3f& posStart, const sead:
     f32 dist = mMove.length() + sizeEnd - sizeStart;
     mStepSize = (dist <= 0.0f) ? 1.0f : steps / dist;
 }
+
 void SphereInterpolator::nextStep() {
     // re-interpreting between f32/s32 required to match
     s32 curStep = *(s32*)&mCurrentStep;
@@ -24,18 +25,21 @@ void SphereInterpolator::nextStep() {
     *(s32*)&mPrevStep = curStep;
     mCurrentStep = newStep;
 }
+
 void SphereInterpolator::calcInterpPos(sead::Vector3f* pos) const {
     f32 step = mCurrentStep;
     pos->x = mMove.x * step + mPos.x;
     pos->y = mMove.y * step + mPos.y;
     pos->z = mMove.z * step + mPos.z;
 }
+
 void SphereInterpolator::calcInterp(sead::Vector3f* pos, f32* size,
                                     sead::Vector3f* remainMoveVec) const {
     calcInterpPos(pos);
     *size = mSizeStart + (mSizeEnd - mSizeStart) * mCurrentStep;
     calcRemainMoveVector(remainMoveVec);
 }
+
 void SphereInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec) const {
     if (remainMoveVec) {
         f32 remainStep = 1.0f - mCurrentStep;
@@ -44,12 +48,14 @@ void SphereInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec) con
         remainMoveVec->z = mMove.z * remainStep;
     }
 }
+
 void SphereInterpolator::getMoveVector(sead::Vector3f* moveVec) {
     f32 step = mCurrentStep;
     moveVec->x = mMove.x * step;
     moveVec->y = mMove.y * step;
     moveVec->z = mMove.z * step;
 }
+
 void SphereInterpolator::calcStepMoveVector(sead::Vector3f* moveVec) const {
     f32 step = mCurrentStep - mPrevStep;
     moveVec->x = mMove.x * step;
@@ -91,12 +97,14 @@ void SpherePoseInterpolator::nextStep() {
     *(s32*)&mPrevStep = curStep;
     mCurrentStep = newStep;
 }
+
 void SpherePoseInterpolator::calcInterpPos(sead::Vector3f* pos) const {
     f32 step = mCurrentStep;
     pos->x = mMove.x * step + mPos.x;
     pos->y = mMove.y * step + mPos.y;
     pos->z = mMove.z * step + mPos.z;
 }
+
 void SpherePoseInterpolator::calcInterp(sead::Vector3f* pos, f32* size, sead::Quatf* quat,
                                         sead::Vector3f* remainMoveVec) const {
     calcInterpPos(pos);
@@ -105,6 +113,7 @@ void SpherePoseInterpolator::calcInterp(sead::Vector3f* pos, f32* size, sead::Qu
     quat->normalize();
     calcRemainMoveVector(remainMoveVec);
 }
+
 void SpherePoseInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec) const {
     if (remainMoveVec) {
         f32 remainStep = 1.0f - mCurrentStep;
@@ -113,9 +122,11 @@ void SpherePoseInterpolator::calcRemainMoveVector(sead::Vector3f* remainMoveVec)
         remainMoveVec->z = mMove.z * remainStep;
     }
 }
+
 f32 SpherePoseInterpolator::calcRadiusBaseScale(f32 unk) const {
     return calcRate01(unk, 0.0f, mSizeEnd);
 }
+
 void SpherePoseInterpolator::getMoveVector(sead::Vector3f* moveVec) {
     f32 step = mCurrentStep;
     moveVec->x = mMove.x * step;

--- a/lib/al/Library/Collision/KCollisionServer.h
+++ b/lib/al/Library/Collision/KCollisionServer.h
@@ -8,6 +8,7 @@ namespace al {
 class SphereInterpolator {
 public:
     SphereInterpolator() {}
+
     void startInterp(const sead::Vector3f& posStart, const sead::Vector3f& posEnd, f32 sizeStart,
                      f32 sizeEnd, f32 steps);
     void nextStep();
@@ -30,6 +31,7 @@ private:
 class SpherePoseInterpolator {
 public:
     SpherePoseInterpolator() {}
+
     void startInterp(const sead::Vector3f& posStart, const sead::Vector3f& posEnd, f32 sizeStart,
                      f32 sizeEnd, const sead::Quatf& quatStart, const sead::Quatf& quatEnd,
                      f32 steps);

--- a/lib/al/Library/Controller/GamePadSystem.h
+++ b/lib/al/Library/Controller/GamePadSystem.h
@@ -30,6 +30,7 @@ private:
     sead::Buffer<sead::WFixedSafeString<256>> mControllerNames;
     AudioSystem* mAudioSystem;
 };
+
 static_assert(sizeof(GamePadSystem) == 0x30);
 
 }  // namespace al

--- a/lib/al/Library/Controller/InputFunction.cpp
+++ b/lib/al/Library/Controller/InputFunction.cpp
@@ -21,114 +21,151 @@ bool isPadTrigger(s32 port, s32 button) {
 bool isPadTriggerA(s32 port) {
     return isPadTrigger(port, 1);
 }
+
 bool isPadTriggerB(s32 port) {
     return isPadTrigger(port, 1 << 1);
 }
+
 bool isPadTriggerX(s32 port) {
     return isPadTrigger(port, 1 << 3);
 }
+
 bool isPadTriggerY(s32 port) {
     return isPadTrigger(port, 1 << 4);
 }
+
 bool isPadTriggerZL(s32 port) {
     return isPadTrigger(port, 1 << 2);
 }
+
 bool isPadTriggerZR(s32 port) {
     return isPadTrigger(port, 1 << 5);
 }
+
 bool isPadTriggerL(s32 port) {
     return isPadTrigger(port, 1 << 13);
 }
+
 bool isPadTriggerR(s32 port) {
     return isPadTrigger(port, 1 << 14);
 }
+
 bool isPadTrigger1(s32 port) {
     return isPadTrigger(port, 1 << 7);
 }
+
 bool isPadTrigger2(s32 port) {
     return isPadTrigger(port, 1 << 6);
 }
+
 bool isPadTriggerUp(s32 port) {
     return isPadTrigger(port, 1 << 16);
 }
+
 bool isPadTriggerDown(s32 port) {
     return isPadTrigger(port, 1 << 17);
 }
+
 bool isPadTriggerLeft(s32 port) {
     return isPadTrigger(port, 1 << 18);
 }
+
 bool isPadTriggerRight(s32 port) {
     return isPadTrigger(port, 1 << 19);
 }
+
 bool isPadTriggerLeftUp(s32 port) {
     return isPadHoldLeftUp(port) && (getController(port)->isTrig(0x50000));
 }
+
 bool isPadTriggerLeftDown(s32 port) {
     return isPadHoldLeftDown(port) && (getController(port)->isTrig(0x60000));
 }
+
 bool isPadTriggerRightUp(s32 port) {
     return isPadHoldRightUp(port) && (getController(port)->isTrig(0x90000));
 }
+
 bool isPadTriggerRightDown(s32 port) {
     return isPadHoldRightDown(port) && (getController(port)->isTrig(0xA0000));
 }
+
 bool isPadTriggerHome(s32 port) {
     return isPadTrigger(port, 1 << 8);
 }
+
 bool isPadTriggerStart(s32 port) {
     return isPadTrigger(port, 1 << 11);
 }
+
 bool isPadTriggerSelect(s32 port) {
     return isPadTrigger(port, 1 << 12);
 }
+
 bool isPadTriggerPlus(s32 port) {
     return isPadTrigger(port, 1 << 10);
 }
+
 bool isPadTriggerMinus(s32 port) {
     return isPadTrigger(port, 1 << 9);
 }
+
 bool isPadTriggerTouch() {
     return isPadTrigger(getTouchPanelPort(), 1 << 15);
 }
+
 bool isPadTriggerUpLeftStick(s32 port) {
     return isPadTrigger(port, 1 << 20);
 }
+
 bool isPadTriggerDownLeftStick(s32 port) {
     return isPadTrigger(port, 1 << 21);
 }
+
 bool isPadTriggerLeftLeftStick(s32 port) {
     return isPadTrigger(port, 1 << 22);
 }
+
 bool isPadTriggerRightLeftStick(s32 port) {
     return isPadTrigger(port, 1 << 23);
 }
+
 bool isPadTriggerUpRightStick(s32 port) {
     return isPadTrigger(port, 1 << 24);
 }
+
 bool isPadTriggerDownRightStick(s32 port) {
     return isPadTrigger(port, 1 << 25);
 }
+
 bool isPadTriggerLeftRightStick(s32 port) {
     return isPadTrigger(port, 1 << 26);
 }
+
 bool isPadTriggerRightRightStick(s32 port) {
     return isPadTrigger(port, 1 << 27);
 }
+
 bool isPadTriggerAnyABXY(s32 port) {
     return isPadTriggerA(port) || isPadTriggerB(port) || isPadTriggerX(port) || isPadTriggerY(port);
 }
+
 bool isPadTriggerAny(s32 port) {
     return isPadTrigger(port, 0xFFF7FFF);
 }
+
 bool isPadTriggerLeftStick(s32 port) {
     return isPadTrigger(port, 0xF00000);
 }
+
 bool isPadTriggerRightStick(s32 port) {
     return isPadTrigger(port, 0xF000000);
 }
+
 bool isPadTriggerPressLeftStick(s32 port) {
     return isPadTrigger1(port);
 }
+
 bool isPadTriggerPressRightStick(s32 port) {
     return isPadTrigger2(port);
 }
@@ -136,87 +173,115 @@ bool isPadTriggerPressRightStick(s32 port) {
 bool isPadRepeat(s32 port, s32 button) {
     return getController(port)->isTrigWithRepeat(button);
 }
+
 bool isPadRepeatA(s32 port) {
     return isPadRepeat(port, 1);
 }
+
 bool isPadRepeatB(s32 port) {
     return isPadRepeat(port, 1 << 1);
 }
+
 bool isPadRepeatX(s32 port) {
     return isPadRepeat(port, 1 << 3);
 }
+
 bool isPadRepeatY(s32 port) {
     return isPadRepeat(port, 1 << 4);
 }
+
 bool isPadRepeatZL(s32 port) {
     return isPadRepeat(port, 1 << 2);
 }
+
 bool isPadRepeatZR(s32 port) {
     return isPadRepeat(port, 1 << 5);
 }
+
 bool isPadRepeatL(s32 port) {
     return isPadRepeat(port, 1 << 13);
 }
+
 bool isPadRepeatR(s32 port) {
     return isPadRepeat(port, 1 << 14);
 }
+
 bool isPadRepeat1(s32 port) {
     return isPadRepeat(port, 1 << 7);
 }
+
 bool isPadRepeat2(s32 port) {
     return isPadRepeat(port, 1 << 6);
 }
+
 bool isPadRepeatUp(s32 port) {
     return isPadRepeat(port, 1 << 16);
 }
+
 bool isPadRepeatDown(s32 port) {
     return isPadRepeat(port, 1 << 17);
 }
+
 bool isPadRepeatLeft(s32 port) {
     return isPadRepeat(port, 1 << 18);
 }
+
 bool isPadRepeatRight(s32 port) {
     return isPadRepeat(port, 1 << 19);
 }
+
 bool isPadRepeatHome(s32 port) {
     return isPadRepeat(port, 1 << 8);
 }
+
 bool isPadRepeatStart(s32 port) {
     return isPadRepeat(port, 1 << 11);
 }
+
 bool isPadRepeatSelect(s32 port) {
     return isPadRepeat(port, 1 << 12);
 }
+
 bool isPadRepeatPlus(s32 port) {
     return isPadRepeat(port, 1 << 10);
 }
+
 bool isPadRepeatMinus(s32 port) {
     return isPadRepeat(port, 1 << 9);
 }
+
 bool isPadRepeatTouch() {
     return isPadRepeat(getTouchPanelPort(), 1 << 15);
 }
+
 bool isPadRepeatUpLeftStick(s32 port) {
     return isPadRepeat(port, 1 << 20);
 }
+
 bool isPadRepeatDownLeftStick(s32 port) {
     return isPadRepeat(port, 1 << 21);
 }
+
 bool isPadRepeatLeftLeftStick(s32 port) {
     return isPadRepeat(port, 1 << 22);
 }
+
 bool isPadRepeatRightLeftStick(s32 port) {
     return isPadRepeat(port, 1 << 23);
 }
+
 bool isPadRepeatUpRightStick(s32 port) {
     return isPadRepeat(port, 1 << 24);
 }
+
 bool isPadRepeatDownRightStick(s32 port) {
     return isPadRepeat(port, 1 << 25);
 }
+
 bool isPadRepeatLeftRightStick(s32 port) {
     return isPadRepeat(port, 1 << 26);
 }
+
 bool isPadRepeatRightRightStick(s32 port) {
     return isPadRepeat(port, 1 << 27);
 }
@@ -224,117 +289,155 @@ bool isPadRepeatRightRightStick(s32 port) {
 bool isPadHoldPressLeftStick(s32 port) {
     return isPadHold1(port);
 }
+
 bool isPadHoldPressRightStick(s32 port) {
     return isPadHold2(port);
 }
+
 bool isPadHold(s32 port, s32 button) {
     return getController(port)->isHold(button);
 }
+
 bool isPadHoldA(s32 port) {
     return isPadHold(port, 1);
 }
+
 bool isPadHoldB(s32 port) {
     return isPadHold(port, 1 << 1);
 }
+
 bool isPadHoldX(s32 port) {
     return isPadHold(port, 1 << 3);
 }
+
 bool isPadHoldY(s32 port) {
     return isPadHold(port, 1 << 4);
 }
+
 bool isPadHoldZL(s32 port) {
     return isPadHold(port, 1 << 2);
 }
+
 bool isPadHoldZR(s32 port) {
     return isPadHold(port, 1 << 5);
 }
+
 bool isPadHoldL(s32 port) {
     return isPadHold(port, 1 << 13);
 }
+
 bool isPadHoldR(s32 port) {
     return isPadHold(port, 1 << 14);
 }
+
 bool isPadHold1(s32 port) {
     return isPadHold(port, 1 << 7);
 }
+
 bool isPadHold2(s32 port) {
     return isPadHold(port, 1 << 6);
 }
+
 bool isPadHoldUp(s32 port) {
     return isPadHold(port, 1 << 16);
 }
+
 bool isPadHoldDown(s32 port) {
     return isPadHold(port, 1 << 17);
 }
+
 bool isPadHoldLeft(s32 port) {
     return isPadHold(port, 1 << 18);
 }
+
 bool isPadHoldRight(s32 port) {
     return isPadHold(port, 1 << 19);
 }
+
 bool isPadHoldLeftUp(s32 port) {
     return getController(port)->isHoldAll(0x50000);
 }
+
 bool isPadHoldLeftDown(s32 port) {
     return getController(port)->isHoldAll(0x60000);
 }
+
 bool isPadHoldRightUp(s32 port) {
     return getController(port)->isHoldAll(0x90000);
 }
+
 bool isPadHoldRightDown(s32 port) {
     return getController(port)->isHoldAll(0xA0000);
 }
+
 bool isPadHoldHome(s32 port) {
     return isPadHold(port, 1 << 8);
 }
+
 bool isPadHoldStart(s32 port) {
     return isPadHold(port, 1 << 11);
 }
+
 bool isPadHoldSelect(s32 port) {
     return isPadHold(port, 1 << 12);
 }
+
 bool isPadHoldPlus(s32 port) {
     return isPadHold(port, 1 << 10);
 }
+
 bool isPadHoldMinus(s32 port) {
     return isPadHold(port, 1 << 9);
 }
+
 bool isPadHoldAny(s32 port) {
     return isPadHold(port, 0xFFF7FFF);
 }
+
 bool isPadHoldAnyWithoutStick(s32 port) {
     return isPadHold(port, 0xF7FFF);
 }
+
 bool isPadHoldTouch() {
     return isPadHold(getTouchPanelPort(), 1 << 15);
 }
+
 bool isPadHoldUpLeftStick(s32 port) {
     return isPadHold(port, 1 << 20);
 }
+
 bool isPadHoldDownLeftStick(s32 port) {
     return isPadHold(port, 1 << 21);
 }
+
 bool isPadHoldLeftLeftStick(s32 port) {
     return isPadHold(port, 1 << 22);
 }
+
 bool isPadHoldRightLeftStick(s32 port) {
     return isPadHold(port, 1 << 23);
 }
+
 bool isPadHoldUpRightStick(s32 port) {
     return isPadHold(port, 1 << 24);
 }
+
 bool isPadHoldDownRightStick(s32 port) {
     return isPadHold(port, 1 << 25);
 }
+
 bool isPadHoldLeftRightStick(s32 port) {
     return isPadHold(port, 1 << 26);
 }
+
 bool isPadHoldRightRightStick(s32 port) {
     return isPadHold(port, 1 << 27);
 }
+
 bool isPadHoldLeftStick(s32 port) {
     return isPadHold(port, 0xF00000);
 }
+
 bool isPadHoldRightStick(s32 port) {
     return isPadHold(port, 0xF000000);
 }
@@ -342,87 +445,115 @@ bool isPadHoldRightStick(s32 port) {
 bool isPadRelease(s32 port, s32 button) {
     return getController(port)->isRelease(button);
 }
+
 bool isPadReleaseA(s32 port) {
     return isPadRelease(port, 1);
 }
+
 bool isPadReleaseB(s32 port) {
     return isPadRelease(port, 1 << 1);
 }
+
 bool isPadReleaseX(s32 port) {
     return isPadRelease(port, 1 << 3);
 }
+
 bool isPadReleaseY(s32 port) {
     return isPadRelease(port, 1 << 4);
 }
+
 bool isPadReleaseZL(s32 port) {
     return isPadRelease(port, 1 << 2);
 }
+
 bool isPadReleaseZR(s32 port) {
     return isPadRelease(port, 1 << 5);
 }
+
 bool isPadReleaseL(s32 port) {
     return isPadRelease(port, 1 << 13);
 }
+
 bool isPadReleaseR(s32 port) {
     return isPadRelease(port, 1 << 14);
 }
+
 bool isPadRelease1(s32 port) {
     return isPadRelease(port, 1 << 7);
 }
+
 bool isPadRelease2(s32 port) {
     return isPadRelease(port, 1 << 6);
 }
+
 bool isPadReleaseUp(s32 port) {
     return isPadRelease(port, 1 << 16);
 }
+
 bool isPadReleaseDown(s32 port) {
     return isPadRelease(port, 1 << 17);
 }
+
 bool isPadReleaseLeft(s32 port) {
     return isPadRelease(port, 1 << 18);
 }
+
 bool isPadReleaseRight(s32 port) {
     return isPadRelease(port, 1 << 19);
 }
+
 bool isPadReleaseHome(s32 port) {
     return isPadRelease(port, 1 << 8);
 }
+
 bool isPadReleaseStart(s32 port) {
     return isPadRelease(port, 1 << 11);
 }
+
 bool isPadReleaseSelect(s32 port) {
     return isPadRelease(port, 1 << 12);
 }
+
 bool isPadReleasePlus(s32 port) {
     return isPadRelease(port, 1 << 10);
 }
+
 bool isPadReleaseMinus(s32 port) {
     return isPadRelease(port, 1 << 9);
 }
+
 bool isPadReleaseTouch() {
     return isPadRelease(getTouchPanelPort(), 1 << 15);
 }
+
 bool isPadReleaseUpLeftStick(s32 port) {
     return isPadRelease(port, 1 << 20);
 }
+
 bool isPadReleaseDownLeftStick(s32 port) {
     return isPadRelease(port, 1 << 21);
 }
+
 bool isPadReleaseLeftLeftStick(s32 port) {
     return isPadRelease(port, 1 << 22);
 }
+
 bool isPadReleaseRightLeftStick(s32 port) {
     return isPadRelease(port, 1 << 23);
 }
+
 bool isPadReleaseUpRightStick(s32 port) {
     return isPadRelease(port, 1 << 24);
 }
+
 bool isPadReleaseDownRightStick(s32 port) {
     return isPadRelease(port, 1 << 25);
 }
+
 bool isPadReleaseLeftRightStick(s32 port) {
     return isPadRelease(port, 1 << 26);
 }
+
 bool isPadReleaseRightRightStick(s32 port) {
     return isPadRelease(port, 1 << 27);
 }
@@ -430,6 +561,7 @@ bool isPadReleaseRightRightStick(s32 port) {
 const sead::Vector2f& getLeftStick(s32 port) {
     return getController(port)->getLeftStick();
 }
+
 const sead::Vector2f& getRightStick(s32 port) {
     return getController(port)->getRightStick();
 }
@@ -446,6 +578,7 @@ void getPadCrossDir(sead::Vector2f* vec, s32 port) {
     if (isPadHoldRight(port))
         vec->x = 1;
 }
+
 void getPadCrossDirSideways(sead::Vector2f* vec, s32 port) {
     vec->x = 0;
     vec->y = 0;
@@ -494,21 +627,26 @@ s32 getPlayerControllerPort(s32 playerNo) {
         manager->getControllerByOrder(sead::ControllerDefine::ControllerId::_15, playerNo);
     return manager->findControllerPort(controller);
 }
+
 s32 getTouchPanelPort() {
     auto* manager = sead::ControllerMgr::instance();
     sead::Controller* controller =
         manager->getControllerByOrder(sead::ControllerDefine::ControllerId::_16, 0);
     return manager->findControllerPort(controller);
 }
+
 s32 getMainControllerPort() {
     return getPlayerControllerPort(0);
 }
+
 s32 getMainJoyPadDoublePort() {
     return getMainControllerPort();
 }
+
 s32 getMainJoyPadSingleRightPort() {
     return 1;
 }
+
 s32 getMainJoyPadSingleLeftPort() {
     return 2;
 }

--- a/lib/al/Library/Draw/GraphicsFunction.h
+++ b/lib/al/Library/Draw/GraphicsFunction.h
@@ -4,6 +4,7 @@
 namespace nn::g3d {
 class MaterialObj;
 }
+
 // TODO: Someone should add this to sead!
 namespace sead {
 class GraphicsContext;

--- a/lib/al/Library/Draw/GraphicsSystemInfo.h
+++ b/lib/al/Library/Draw/GraphicsSystemInfo.h
@@ -32,6 +32,7 @@ public:
 private:
     void* filler[312];
 };
+
 static_assert(sizeof(GraphicsSystemInfo) == 0x9c0);
 
 }  // namespace al

--- a/lib/al/Library/Execute/ActorExecuteInfo.cpp
+++ b/lib/al/Library/Execute/ActorExecuteInfo.cpp
@@ -4,10 +4,12 @@ namespace al {
 ActorExecuteInfo::ActorExecuteInfo(ExecuteRequestKeeper* keeper) {
     mRequestKeeper = keeper;
 }
+
 void ActorExecuteInfo::addUpdater(ExecutorActorExecuteBase* updater) {
     mUpdaters[mUpdaterCount] = updater;
     mUpdaterCount++;
 }
+
 void ActorExecuteInfo::addDrawer(ModelDrawerBase* drawer) {
     mDrawers[mDrawerCount] = drawer;
     mDrawerCount++;

--- a/lib/al/Library/Execute/ActorExecuteInfo.h
+++ b/lib/al/Library/Execute/ActorExecuteInfo.h
@@ -20,6 +20,7 @@ private:
     s32 mDrawerCount = 0;
     ModelDrawerBase* mDrawers[11] = {};
 };
+
 static_assert(sizeof(ActorExecuteInfo) == 0x90);
 
 }  // namespace al

--- a/lib/al/Library/Execute/LayoutExecuteInfo.cpp
+++ b/lib/al/Library/Execute/LayoutExecuteInfo.cpp
@@ -7,6 +7,7 @@ void LayoutExecuteInfo::addUpdater(ExecutorListLayoutUpdate* updater) {
     mUpdaters[mUpdaterCount] = updater;
     mUpdaterCount++;
 }
+
 void LayoutExecuteInfo::addDrawer(ExecutorListLayoutDrawBase* drawer) {
     mDrawers[mDrawerCount] = drawer;
     mDrawerCount++;

--- a/lib/al/Library/Factory/Factory.h
+++ b/lib/al/Library/Factory/Factory.h
@@ -20,6 +20,7 @@ public:
         : mFactoryName(factoryName) {
         initFactory(entries);
     }
+
     template <s32 N>
     inline void initFactory(NameToCreator<T> (&entries)[N]) {
         mFactoryEntries = entries;

--- a/lib/al/Library/HitSensor/HitSensorKeeper.h
+++ b/lib/al/Library/HitSensor/HitSensorKeeper.h
@@ -28,6 +28,7 @@ private:
     s32 mSensorCount;
     HitSensor** mSensors;
 };
+
 static_assert(sizeof(HitSensorKeeper) == 0x10);
 
 }  // namespace al

--- a/lib/al/Library/Layout/LayoutActor.cpp
+++ b/lib/al/Library/Layout/LayoutActor.cpp
@@ -15,36 +15,47 @@ void LayoutActor::appear() {
     updateLayoutPaneRecursive(this);
     calcAnim(false);
 }
+
 void LayoutActor::initLayoutPartsActorKeeper(s32 capacity) {
     mLayoutPartsActorKeeper = new LayoutPartsActorKeeper(capacity);
 }
+
 void LayoutActor::initLayoutKeeper(LayoutKeeper* layoutKeeper) {
     mLayoutKeeper = layoutKeeper;
 }
+
 NerveKeeper* LayoutActor::getNerveKeeper() const {
     return mNerveKeeper;
 }
+
 const char* LayoutActor::getName() const {
     return mName.cstr();
 }
+
 EffectKeeper* LayoutActor::getEffectKeeper() const {
     return mEffectKeeper;
 }
+
 AudioKeeper* LayoutActor::getAudioKeeper() const {
     return mAudioKeeper;
 }
+
 LayoutActionKeeper* LayoutActor::getLayoutActionKeeper() const {
     return mLayoutActionKeeper;
 }
+
 LayoutKeeper* LayoutActor::getLayoutKeeper() const {
     return mLayoutKeeper;
 }
+
 CameraDirector* LayoutActor::getCameraDirector() const {
     return mLayoutSceneInfo->getCameraDirector();
 }
+
 SceneObjHolder* LayoutActor::getSceneObjHolder() const {
     return mLayoutSceneInfo->getSceneObjHolder();
 }
+
 const MessageSystem* LayoutActor::getMessageSystem() const {
     return mLayoutSceneInfo->getMessageSystem();
 }

--- a/lib/al/Library/Layout/LayoutActor.h
+++ b/lib/al/Library/Layout/LayoutActor.h
@@ -42,7 +42,9 @@ public:
 
     virtual void appear();
     virtual void kill();
+
     virtual void control() {}
+
     virtual void calcAnim(bool recursive);
     virtual void movement();
 

--- a/lib/al/Library/Layout/LayoutPartsActorKeeper.cpp
+++ b/lib/al/Library/Layout/LayoutPartsActorKeeper.cpp
@@ -4,14 +4,17 @@
 
 namespace al {
 void LayoutPartsActorKeeper::resisterPartsActor(LayoutActor* actor) {}
+
 void LayoutPartsActorKeeper::appear() {
     for (s32 i = 0; i < mNumActors; i++)
         mPartsActors[i]->appear();
 }
+
 void LayoutPartsActorKeeper::calcAnim(bool recursive) {
     for (s32 i = 0; i < mNumActors; i++)
         mPartsActors[i]->calcAnim(recursive);
 }
+
 LayoutPartsActorKeeper::LayoutPartsActorKeeper(s32 maxActors) : mMaxActors(maxActors) {
     mPartsActors = new LayoutActor*[maxActors];
 }

--- a/lib/al/Library/Layout/LayoutSceneInfo.h
+++ b/lib/al/Library/Layout/LayoutSceneInfo.h
@@ -14,11 +14,17 @@ class GamePadSystem;
 class LayoutSceneInfo {
 public:
     LayoutSceneInfo();
+
     eui::FontMgr* getFontMgr() const { return mFontMgr; }
+
     CameraDirector* getCameraDirector() const { return mCameraDirector; }
+
     PadRumbleDirector* getPadRumbleDirector() const { return mPadRumbleDirector; }
+
     SceneObjHolder* getSceneObjHolder() const { return mSceneObjHolder; }
+
     const MessageSystem* getMessageSystem() const { return mMessageSystem; }
+
     const GamePadSystem* getGamePadSystem() const { return mGamePadSystem; }
 
 private:

--- a/lib/al/Library/LiveActor/ActorActionFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorActionFunction.cpp
@@ -15,6 +15,7 @@ void startAction(LiveActor* actor, const char* actionName) {
         tryStartVisAnimIfExistForAction(actor, actionName);
     }
 }
+
 bool tryStartAction(LiveActor* actor, const char* actionName) {
     if (!actor->getActorActionKeeper() || !actor->getActorActionKeeper()->getAnimCtrl() ||
         !actor->getActorActionKeeper()->getAnimCtrl()->isExistAction(actionName)) {

--- a/lib/al/Library/LiveActor/ActorAnimFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorAnimFunction.cpp
@@ -14,110 +14,138 @@ void startSklAnim(LiveActor* actor, const char* animName) {
     startSklAnimBlendInterpole(actor, nullptr, animName, nullptr, nullptr, nullptr, nullptr,
                                nullptr);
 }
+
 void startSklAnimInterpole(LiveActor* actor, const char* animName0, const char* animName1) {
     startSklAnimBlendInterpole(actor, animName1, animName0, nullptr, nullptr, nullptr, nullptr,
                                nullptr);
 }
+
 bool tryStartSklAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isSklAnimExist(actor) || !getSkl(actor)->isSklAnimExist(animName))
         return false;
     startSklAnim(actor, animName);
     return true;
 }
+
 bool isSklAnimExist(const LiveActor* actor, const char* animName) {
     return isSklAnimExist(actor) && getSkl(actor)->isSklAnimExist(animName);
 }
+
 bool tryStartSklAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isSklAnimPlaying(actor, animName, 0))
         return false;
     startSklAnim(actor, animName);
     return true;
 }
+
 bool isSklAnimPlaying(const LiveActor* actor, const char* animName, s32 index) {
     const char* playingName = getPlayingSklAnimName(actor, index);
     return playingName && isEqualString(animName, playingName);
 }
+
 void startSklAnimBlend(LiveActor* actor, const char* animName0, const char* animName1,
                        const char* animName2, const char* animName3, const char* animName4,
                        const char* animName5) {
     startSklAnimBlendInterpole(actor, nullptr, animName0, animName1, animName2, animName3,
                                animName4, animName5);
 }
+
 void startSklAnimBlendInterpole(LiveActor* actor, const char* animName0, const char* animName1,
                                 const char* animName2, const char* animName3, const char* animName4,
                                 const char* animName5, const char* animName6) {
     getSkl(actor)->startSklAnim(animName0, animName1, animName2, animName3, animName4, animName5,
                                 animName6);
 }
+
 void clearSklAnimInterpole(LiveActor* actor) {
     getSkl(actor)->reset();
 }
+
 bool isSklAnimExist(const LiveActor* actor) {
     return getSkl(actor) != nullptr;
 }
+
 bool isSklAnimEnd(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isSklAnimEnd(index);
 }
+
 bool isSklAnimOneTime(const LiveActor* actor, const char* animName) {
     return getSkl(actor)->isSklAnimOneTime(animName);
 }
+
 bool isSklAnimOneTime(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isSklAnimOneTime(index);
 }
+
 bool isSklAnimPlaying(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isSklAnimPlaying(index);
 }
+
 const char* getPlayingSklAnimName(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getPlayingSklAnimName(index);
 }
+
 f32 getSklAnimFrame(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getSklAnimFrame(index);
 }
+
 f32 getSklAnimFrameRate(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getSklAnimFrameRate(index);
 }
+
 f32 getSklAnimFrameMax(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getSklAnimFrameMax(index);
 }
+
 f32 getSklAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getSkl(actor)->getSklAnimFrameMax(animName);
 }
+
 void setSklAnimFrame(LiveActor* actor, f32 frame, s32 index) {
     getSkl(actor)->setSklAnimFrame(index, frame);
 }
+
 void setSklAnimFrameRate(LiveActor* actor, f32 frameRate, s32 index) {
     getSkl(actor)->setSklAnimFrameRate(index, frameRate);
 }
+
 void setSklAnimFrameAndStop(LiveActor* actor, f32 frame, s32 index) {
     setSklAnimFrame(actor, frame, index);
     setSklAnimFrameRate(actor, 0.0, index);
 }
+
 s32 getSklAnimBlendNum(const LiveActor* actor) {
     return getSkl(actor)->getSklAnimBlendNum();
 }
+
 f32 getSklAnimBlendWeight(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getSklAnimBlendWeight(index);
 }
+
 void setSklAnimBlendWeight(LiveActor* actor, f32 weight, s32 index) {
     setSklBlendWeight(actor, index, weight);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightDouble(LiveActor* actor, f32 weight) {
     setSklBlendWeight(actor, 0, weight);
     setSklBlendWeight(actor, 1, 1 - weight);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightDouble(LiveActor* actor, f32 weight0, f32 weight1) {
     setSklBlendWeight(actor, 0, weight0);
     setSklBlendWeight(actor, 1, weight1);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightTriple(LiveActor* actor, f32 weight0, f32 weight1, f32 weight2) {
     setSklBlendWeight(actor, 0, weight0);
     setSklBlendWeight(actor, 1, weight1);
     setSklBlendWeight(actor, 2, weight2);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightQuad(LiveActor* actor, f32 weight0, f32 weight1, f32 weight2,
                                f32 weight3) {
     setSklBlendWeight(actor, 0, weight0);
@@ -126,6 +154,7 @@ void setSklAnimBlendWeightQuad(LiveActor* actor, f32 weight0, f32 weight1, f32 w
     setSklBlendWeight(actor, 3, weight3);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightFivefold(LiveActor* actor, f32 weight0, f32 weight1, f32 weight2,
                                    f32 weight3, f32 weight4) {
     setSklBlendWeight(actor, 0, weight0);
@@ -135,6 +164,7 @@ void setSklAnimBlendWeightFivefold(LiveActor* actor, f32 weight0, f32 weight1, f
     setSklBlendWeight(actor, 4, weight4);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendWeightSixfold(LiveActor* actor, f32 weight0, f32 weight1, f32 weight2,
                                   f32 weight3, f32 weight4, f32 weight5) {
     setSklBlendWeight(actor, 0, weight0);
@@ -145,6 +175,7 @@ void setSklAnimBlendWeightSixfold(LiveActor* actor, f32 weight0, f32 weight1, f3
     setSklBlendWeight(actor, 5, weight5);
     getSkl(actor)->calcSklAnim();
 }
+
 void setSklAnimBlendFrameAll(LiveActor* actor, f32 frame, bool isSync) {
     AnimPlayerSkl* sklAnim = getSkl(actor);
 
@@ -163,6 +194,7 @@ void setSklAnimBlendFrameAll(LiveActor* actor, f32 frame, bool isSync) {
                 getSkl(actor)->setSklAnimFrame(j, frame);
     }
 }
+
 void setSklAnimBlendFrameRateAll(LiveActor* actor, f32 frameRate, bool isSync) {
     AnimPlayerSkl* sklAnim = getSkl(actor);
 
@@ -181,455 +213,583 @@ void setSklAnimBlendFrameRateAll(LiveActor* actor, f32 frameRate, bool isSync) {
                 getSkl(actor)->setSklAnimFrameRate(j, frameRate);
     }
 }
+
 void startMtpAnim(LiveActor* actor, const char* animName) {
     getMtp(actor)->startAnim(animName);
     updateModelDraw(actor);
 }
+
 void startMtpAnimAndSetFrameAndStop(LiveActor* actor, const char* animName, f32 frame) {
     startMtpAnim(actor, animName);
     setMtpAnimFrame(actor, frame);
     setMtpAnimFrameRate(actor, 0.0);
 }
+
 void setMtpAnimFrameRate(LiveActor* actor, f32 frameRate) {
     getMtp(actor)->setAnimFrameRate(frameRate);
 }
+
 void setMtpAnimFrame(LiveActor* actor, f32 frame) {
     getMtp(actor)->setAnimFrame(frame);
     updateModelDraw(actor);
 }
+
 bool tryStartMtpAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isMtpAnimExist(actor) || !getMtp(actor)->isAnimExist(animName))
         return false;
     startMtpAnim(actor, animName);
     return true;
 }
+
 bool isMtpAnimExist(const LiveActor* actor, const char* animName) {
     return getMtp(actor) && getMtp(actor)->isAnimExist(animName);
 }
+
 bool tryStartMtpAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isMtpAnimPlaying(actor, animName))
         return false;
     startMtpAnim(actor, animName);
     return true;
 }
+
 bool isMtpAnimPlaying(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingMtpAnimName(actor));
 }
+
 void clearMtpAnim(LiveActor* actor) {
     getMtp(actor)->clearAnim();
     updateModelDraw(actor);
 }
+
 bool isMtpAnimExist(const LiveActor* actor) {
     return getMtp(actor) != nullptr;
 }
+
 bool isMtpAnimEnd(const LiveActor* actor) {
     return getMtp(actor)->isAnimEnd();
 }
+
 bool isMtpAnimOneTime(const LiveActor* actor, const char* animName) {
     return getMtp(actor)->isAnimOneTime(animName);
 }
+
 bool isMtpAnimOneTime(const LiveActor* actor) {
     return getMtp(actor)->isAnimOneTime();
 }
+
 const char* getPlayingMtpAnimName(const LiveActor* actor) {
     return getMtp(actor)->getPlayingAnimName();
 }
+
 bool isMtpAnimPlaying(const LiveActor* actor) {
     return isMtpAnimExist(actor) && getMtp(actor)->isAnimPlaying();
 }
+
 f32 getMtpAnimFrame(const LiveActor* actor) {
     return getMtp(actor)->getAnimFrame();
 }
+
 f32 getMtpAnimFrameRate(const LiveActor* actor) {
     return getMtp(actor)->getAnimFrameRate();
 }
+
 f32 getMtpAnimFrameMax(const LiveActor* actor) {
     return getMtp(actor)->getAnimFrameMax();
 }
+
 f32 getMtpAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getMtp(actor)->getAnimFrameMax(animName);
 }
+
 void setMtpAnimFrameAndStop(LiveActor* actor, f32 frame) {
     setMtpAnimFrame(actor, frame);
     setMtpAnimFrameRate(actor, 0.0);
 }
+
 void setMtpAnimFrameAndStopEnd(LiveActor* actor) {
     setMtpAnimFrameAndStop(actor, getMtpAnimFrameMax(actor));
 }
+
 void startMclAnim(LiveActor* actor, const char* animName) {
     getMcl(actor)->startAnim(animName);
 }
+
 bool isMclAnimExist(const LiveActor* actor) {
     return getMcl(actor) != nullptr;
 }
+
 bool isMclAnimExist(const LiveActor* actor, const char* animName) {
     return isMclAnimExist(actor) && getMcl(actor)->isAnimExist(animName);
 }
+
 bool tryStartMclAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isMclAnimExist(actor) || !getMcl(actor)->isAnimExist(animName))
         return false;
     startMclAnim(actor, animName);
     return true;
 }
+
 bool tryStartMclAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isMclAnimPlaying(actor, animName))
         return false;
     startMclAnim(actor, animName);
     return true;
 }
+
 bool isMclAnimPlaying(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingMclAnimName(actor));
 }
+
 void clearMclAnim(LiveActor* actor) {
     getMcl(actor)->clearAnim();
 }
+
 bool isMclAnimEnd(const LiveActor* actor) {
     return getMcl(actor)->isAnimEnd();
 }
+
 bool isMclAnimOneTime(const LiveActor* actor, const char* animName) {
     return getMcl(actor)->isAnimOneTime(animName);
 }
+
 bool isMclAnimOneTime(const LiveActor* actor) {
     return getMcl(actor)->isAnimOneTime();
 }
+
 const char* getPlayingMclAnimName(const LiveActor* actor) {
     return getMcl(actor)->getPlayingAnimName();
 }
+
 bool isMclAnimPlaying(const LiveActor* actor) {
     return isMclAnimExist(actor) && getMcl(actor)->isAnimPlaying();
 }
+
 f32 getMclAnimFrame(const LiveActor* actor) {
     return getMcl(actor)->getAnimFrame();
 }
+
 f32 getMclAnimFrameRate(const LiveActor* actor) {
     return getMcl(actor)->getAnimFrameRate();
 }
+
 f32 getMclAnimFrameMax(const LiveActor* actor) {
     return getMcl(actor)->getAnimFrameMax();
 }
+
 f32 getMclAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getMcl(actor)->getAnimFrameMax(animName);
 }
+
 void setMclAnimFrame(LiveActor* actor, f32 frame) {
     getMcl(actor)->setAnimFrame(frame);
 }
+
 void setMclAnimFrameRate(LiveActor* actor, f32 frameRate) {
     getMcl(actor)->setAnimFrameRate(frameRate);
 }
+
 void startMclAnimAndSetFrameAndStop(LiveActor* actor, const char* animName, f32 frame) {
     startMclAnim(actor, animName);
     setMclAnimFrame(actor, frame);
     setMclAnimFrameRate(actor, 0.0);
 }
+
 void setMclAnimFrameAndStop(LiveActor* actor, f32 frame) {
     setMclAnimFrame(actor, frame);
     setMclAnimFrameRate(actor, 0.0);
 }
+
 void setMclAnimNormalFrameAndStop(LiveActor* actor, f32 frame) {
     setMclAnimFrame(actor, frame * getMclAnimFrameMax(actor));
     setMclAnimFrameRate(actor, 0.0);
 }
+
 void setMclAnimFrameAndStopEnd(LiveActor* actor) {
     setMclAnimFrame(actor, getMclAnimFrameMax(actor));
     setMclAnimFrameRate(actor, 0.0);
 }
+
 void startMtsAnim(LiveActor* actor, const char* animName) {
     getMts(actor)->startAnim(animName);
 }
+
 void startMtsAnimAndSetFrameAndStop(LiveActor* actor, const char* animName, f32 frame) {
     startMtsAnim(actor, animName);
     setMtsAnimFrame(actor, frame);
     setMtsAnimFrameRate(actor, 0.0);
 }
+
 void setMtsAnimFrame(LiveActor* actor, f32 frame) {
     getMts(actor)->setAnimFrame(frame);
 }
+
 void setMtsAnimFrameRate(LiveActor* actor, f32 frameRate) {
     getMts(actor)->setAnimFrameRate(frameRate);
 }
+
 bool tryStartMtsAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isMtsAnimExist(actor) || !getMts(actor)->isAnimExist(animName))
         return false;
     startMtsAnim(actor, animName);
     return true;
 }
+
 bool isMtsAnimExist(const LiveActor* actor, const char* animName) {
     return isMtsAnimExist(actor) && getMts(actor)->isAnimExist(animName);
 }
+
 bool tryStartMtsAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isMtsAnimPlaying(actor, animName))
         return false;
     startMtsAnim(actor, animName);
     return true;
 }
+
 bool isMtsAnimPlaying(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingMtsAnimName(actor));
 }
+
 void clearMtsAnim(LiveActor* actor) {
     getMts(actor)->clearAnim();
 }
+
 bool isMtsAnimExist(const LiveActor* actor) {
     return getMts(actor) != nullptr;
 }
+
 bool isMtsAnimEnd(const LiveActor* actor) {
     return getMts(actor)->isAnimEnd();
 }
+
 bool isMtsAnimOneTime(const LiveActor* actor, const char* animName) {
     return getMts(actor)->isAnimOneTime(animName);
 }
+
 bool isMtsAnimOneTime(const LiveActor* actor) {
     return getMts(actor)->isAnimOneTime();
 }
+
 const char* getPlayingMtsAnimName(const LiveActor* actor) {
     return getMts(actor)->getPlayingAnimName();
 }
+
 bool isMtsAnimPlaying(const LiveActor* actor) {
     return isMtsAnimExist(actor) && getMts(actor)->isAnimPlaying();
 }
+
 f32 getMtsAnimFrame(const LiveActor* actor) {
     return getMts(actor)->getAnimFrame();
 }
+
 f32 getMtsAnimFrameRate(const LiveActor* actor) {
     return getMts(actor)->getAnimFrameRate();
 }
+
 f32 getMtsAnimFrameMax(const LiveActor* actor) {
     return getMts(actor)->getAnimFrameMax();
 }
+
 f32 getMtsAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getMts(actor)->getAnimFrameMax(animName);
 }
+
 void setMtsAnimFrameAndStop(LiveActor* actor, f32 frame) {
     setMtsAnimFrame(actor, frame);
     setMtsAnimFrameRate(actor, 0.0);
 }
+
 void setMtsAnimFrameAndStopEnd(LiveActor* actor) {
     setMtsAnimFrame(actor, getMtsAnimFrameMax(actor));
     setMtsAnimFrameRate(actor, 0.0);
 }
+
 void createMatAnimSlotForMcl(LiveActor* actor) {
     createMat(actor, 0);
 }
+
 void createMatAnimSlotForMtp(LiveActor* actor) {
     createMat(actor, 1);
 }
+
 void createMatAnimSlotForMts(LiveActor* actor) {
     createMat(actor, 2);
 }
+
 void startMatAnim(LiveActor* actor, const char* animName) {
     getMat(actor)->startAnim(animName);
     updateModelDraw(actor);
 }
+
 void startMatAnimAndSetFrameAndStop(LiveActor* actor, const char* animName, f32 frame) {
     startMatAnim(actor, animName);
     setMatAnimFrame(actor, frame);
     setMatAnimFrameRate(actor, 0.0);
 }
+
 void setMatAnimFrame(LiveActor* actor, f32 frame) {
     getMat(actor)->setAnimFrame(frame);
 }
+
 void setMatAnimFrameRate(LiveActor* actor, f32 frameRate) {
     getMat(actor)->setAnimFrameRate(frameRate);
 }
+
 bool tryStartMatAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isMatAnimExist(actor) || !getMat(actor)->isAnimExist(animName))
         return false;
     startMatAnim(actor, animName);
     return true;
 }
+
 bool isMatAnimExist(const LiveActor* actor, const char* animName) {
     return isMatAnimExist(actor) && getMat(actor)->isAnimExist(animName);
 }
+
 bool tryStartMatAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isMatAnimPlaying(actor, animName))
         return false;
     startMatAnim(actor, animName);
     return true;
 }
+
 bool isMatAnimPlaying(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingMatAnimName(actor));
 }
+
 void clearMatAnim(LiveActor* actor) {
     getMat(actor)->clearAnim();
 }
+
 bool isMatAnimExist(const LiveActor* actor) {
     return getMat(actor) != nullptr;
 }
+
 bool isMatAnimEnd(const LiveActor* actor) {
     return getMat(actor)->isAnimEnd();
 }
+
 bool isMatAnimOneTime(const LiveActor* actor, const char* animName) {
     return getMat(actor)->isAnimOneTime(animName);
 }
+
 bool isMatAnimOneTime(const LiveActor* actor) {
     return getMat(actor)->isAnimOneTime();
 }
+
 const char* getPlayingMatAnimName(const LiveActor* actor) {
     return getMat(actor)->getPlayingAnimName();
 }
+
 bool isMatAnimPlaying(const LiveActor* actor) {
     return isMatAnimExist(actor) && getMat(actor)->isAnimPlaying();
 }
+
 f32 getMatAnimFrame(const LiveActor* actor) {
     return getMat(actor)->getAnimFrame();
 }
+
 f32 getMatAnimFrameRate(const LiveActor* actor) {
     return getMat(actor)->getAnimFrameRate();
 }
+
 f32 getMatAnimFrameMax(const LiveActor* actor) {
     return getMat(actor)->getAnimFrameMax();
 }
+
 f32 getMatAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getMat(actor)->getAnimFrameMax(animName);
 }
+
 void setMatAnimFrameAndStop(LiveActor* actor, f32 frame) {
     setMatAnimFrame(actor, frame);
     setMatAnimFrameRate(actor, 0.0);
 }
+
 void setMatAnimFrameAndStopEnd(LiveActor* actor) {
     setMatAnimFrame(actor, getMatAnimFrameMax(actor));
     setMatAnimFrameRate(actor, 0.0);
 }
+
 void startVisAnim(LiveActor* actor, const char* animName) {
     getVis(actor)->startAnim(animName);
     updateActorSystem(actor);
 }
+
 bool tryStartVisAnimIfExist(LiveActor* actor, const char* animName) {
     if (!isVisAnimExist(actor) || !getVis(actor)->isAnimExist(animName))
         return false;
     startVisAnim(actor, animName);
     return true;
 }
+
 bool isVisAnimExist(const LiveActor* actor, const char* animName) {
     return getVis(actor) && getVis(actor)->isAnimExist(animName);
 }
+
 bool tryStartVisAnimIfNotPlaying(LiveActor* actor, const char* animName) {
     if (isVisAnimPlaying(actor, animName))
         return false;
     startVisAnim(actor, animName);
     return true;
 }
+
 bool isVisAnimPlaying(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingVisAnimName(actor));
 }
+
 void clearVisAnim(LiveActor* actor) {
     getVis(actor)->clearAnim();
 }
+
 bool isVisAnimExist(const LiveActor* actor) {
     return getVis(actor) != nullptr;
 }
+
 bool isVisAnimEnd(const LiveActor* actor) {
     return getVis(actor)->isAnimEnd();
 }
+
 bool isVisAnimOneTime(const LiveActor* actor, const char* animName) {
     return getVis(actor)->isAnimOneTime(animName);
 }
+
 bool isVisAnimOneTime(const LiveActor* actor) {
     return getVis(actor)->isAnimOneTime();
 }
+
 const char* getPlayingVisAnimName(const LiveActor* actor) {
     return getVis(actor)->getPlayingAnimName();
 }
+
 bool isVisAnimPlaying(const LiveActor* actor) {
     return isVisAnimExist(actor) && getVis(actor)->isAnimPlaying();
 }
+
 f32 getVisAnimFrame(const LiveActor* actor) {
     return getVis(actor)->getAnimFrame();
 }
+
 f32 getVisAnimFrameRate(const LiveActor* actor) {
     return getVis(actor)->getAnimFrameRate();
 }
+
 f32 getVisAnimFrameMax(const LiveActor* actor) {
     return getVis(actor)->getAnimFrameMax();
 }
+
 f32 getVisAnimFrameMax(const LiveActor* actor, const char* animName) {
     return getVis(actor)->getAnimFrameMax(animName);
 }
+
 void setVisAnimFrame(LiveActor* actor, f32 frame) {
     getVis(actor)->setAnimFrame(frame);
     updateActorSystem(actor);
 }
+
 void setVisAnimFrameRate(LiveActor* actor, f32 frameRate) {
     getVis(actor)->setAnimFrameRate(frameRate);
 }
+
 void setVisAnimFrameAndStop(LiveActor* actor, f32 frame) {
     setVisAnimFrame(actor, frame);
     setVisAnimFrameRate(actor, 0.0);
 }
+
 void setVisAnimFrameAndStopEnd(LiveActor* actor) {
     setVisAnimFrame(actor, getVisAnimFrameMax(actor));
     setVisAnimFrameRate(actor, 0.0);
 }
+
 void startVisAnimAndSetFrameAndStop(LiveActor* actor, const char* animName, f32 frame) {
     startVisAnim(actor, animName);
     setVisAnimFrame(actor, frame);
     setVisAnimFrameRate(actor, 0.0);
 }
+
 void startVisAnimForAction(LiveActor* actor, const char* animName) {
     getVisForAction(actor)->startAnim(animName);
     updateActorSystem(actor);
 }
+
 bool tryStartVisAnimIfExistForAction(LiveActor* actor, const char* animName) {
     if (!isVisAnimExist(actor) || !getVis(actor)->isAnimExist(animName))
         return false;
     startVisAnimForAction(actor, animName);
     return true;
 }
+
 bool tryStartVisAnimIfNotPlayingForAction(LiveActor* actor, const char* animName) {
     if (isVisAnimPlayingForAction(actor, animName))
         return false;
     startVisAnimForAction(actor, animName);
     return true;
 }
+
 bool isVisAnimPlayingForAction(const LiveActor* actor, const char* animName) {
     return isEqualString(animName, getPlayingVisAnimNameForAction(actor));
 }
+
 void clearVisAnimForAction(LiveActor* actor) {
     getVisForAction(actor)->clearAnim();
 }
+
 bool isVisAnimEndForAction(const LiveActor* actor) {
     return getVisForAction(actor)->isAnimEnd();
 }
+
 bool isVisAnimOneTimeForAction(const LiveActor* actor, const char* animName) {
     return getVisForAction(actor)->isAnimOneTime(animName);
 }
+
 bool isVisAnimOneTimeForAction(const LiveActor* actor) {
     return getVisForAction(actor)->isAnimOneTime();
 }
+
 const char* getPlayingVisAnimNameForAction(const LiveActor* actor) {
     return getVisForAction(actor)->getPlayingAnimName();
 }
+
 bool isVisAnimPlayingForAction(const LiveActor* actor) {
     return getVisForAction(actor) && getVisForAction(actor)->isAnimPlaying();
 }
+
 f32 getVisAnimFrameForAction(const LiveActor* actor) {
     return getVisForAction(actor)->getAnimFrame();
 }
+
 f32 getVisAnimFrameRateForAction(const LiveActor* actor) {
     return getVisForAction(actor)->getAnimFrameRate();
 }
+
 f32 getVisAnimFrameMaxForAction(const LiveActor* actor) {
     return getVisForAction(actor)->getAnimFrameMax();
 }
+
 void setVisAnimFrameForAction(LiveActor* actor, f32 frame) {
     getVisForAction(actor)->setAnimFrame(frame);
     updateActorSystem(actor);
 }
+
 void setVisAnimFrameRateForAction(LiveActor* actor, f32 frameRate) {
     getVisForAction(actor)->setAnimFrameRate(frameRate);
 }
+
 void setVisAnimFrameAndStopForAction(LiveActor* actor, f32 frame) {
     setVisAnimFrameForAction(actor, frame);
     setVisAnimFrameRateForAction(actor, 0.0);
 }
+
 void setVisAnimFrameAndStopEndForAction(LiveActor* actor) {
     setVisAnimFrameForAction(actor, getVisAnimFrameMaxForAction(actor));
     setVisAnimFrameRateForAction(actor, 0.0);
 }
+
 void startVisAnimAndSetFrameAndStopForAction(LiveActor* actor, const char* animName, f32 frame) {
     startVisAnimForAction(actor, animName);
     setVisAnimFrameForAction(actor, frame);
     setVisAnimFrameRateForAction(actor, 0.0);
 }
+
 void setAllAnimFrame(LiveActor* actor, f32 frame) {
     if (isSklAnimExist(actor))
         setSklAnimFrame(actor, frame, 0);
@@ -642,6 +802,7 @@ void setAllAnimFrame(LiveActor* actor, f32 frame) {
     if (isVisAnimExist(actor))
         setVisAnimFrame(actor, frame);
 }
+
 void setAllAnimFrameRate(LiveActor* actor, f32 frameRate) {
     if (isSklAnimExist(actor))
         setSklAnimFrameRate(actor, frameRate, 0);
@@ -654,10 +815,12 @@ void setAllAnimFrameRate(LiveActor* actor, f32 frameRate) {
     if (isVisAnimExist(actor))
         setVisAnimFrameRate(actor, frameRate);
 }
+
 void startPartialSklAnim(LiveActor* actor, const char* animName, s32 partCount, s32 value,
                          const SklAnimRetargettingInfo* info) {
     getSkl(actor)->startPartialAnim(animName, partCount, value, info);
 }
+
 void startPartialSklAnimWithInterpolate(LiveActor* actor, const char* animName, s32 partCount,
                                         s32 value, s32 interpol,
                                         const SklAnimRetargettingInfo* info) {
@@ -665,42 +828,54 @@ void startPartialSklAnimWithInterpolate(LiveActor* actor, const char* animName, 
     startPartialSklAnim(actor, animName, partCount, value, info);
     sklAnim->prepareAnimInterpDirect(interpol);
 }
+
 void clearPartialSklAnim(LiveActor* actor, s32 index) {
     getSkl(actor)->clearPartialAnim(index);
 }
+
 void clearPartialSklAnimWithInterpolate(LiveActor* actor, s32 partIndex, s32 interpol) {
     AnimPlayerSkl* sklAnim = getSkl(actor);
     clearPartialSklAnim(actor, partIndex);
     sklAnim->prepareAnimInterpDirect(interpol);
 }
+
 bool isPartialSklAnimEnd(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isPartialAnimEnd(index);
 }
+
 bool isPartialSklAnimOneTime(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isPartialAnimOneTime(index);
 }
+
 bool isPartialSklAnimAttached(const LiveActor* actor, s32 index) {
     return getSkl(actor)->isPartialAnimAttached(index);
 }
+
 bool isPartialSklAnimPlaying(const LiveActor* actor, const char* partsName, s32 index) {
     return isPartialSklAnimAttached(actor, index) &&
            isEqualString(partsName, getPlayingPartialSklAnimName(actor, index));
 }
+
 const char* getPlayingPartialSklAnimName(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getPlayingPartialSklAnimName(index);
 }
+
 f32 getPartialSklAnimFrame(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getPartialAnimFrame(index);
 }
+
 void setPartialSklAnimFrame(LiveActor* actor, s32 index, f32 frame) {
     getSkl(actor)->setPartialAnimFrame(index, frame);
 }
+
 f32 getPartialSklAnimFrameRate(const LiveActor* actor, s32 index) {
     return getSkl(actor)->getPartialAnimFrameRate(index);
 }
+
 void setPartialSklAnimFrameRate(LiveActor* actor, s32 index, f32 frameRate) {
     getSkl(actor)->setPartialAnimFrameRate(index, frameRate);
 }
+
 void setBaseMtxAndCalcAnim(LiveActor* actor, const sead::Matrix34f& matrix,
                            const sead::Vector3f& vector) {
     return actor->getModelKeeper()->calc(matrix, vector);

--- a/lib/al/Library/LiveActor/ActorAnimFunction.h
+++ b/lib/al/Library/LiveActor/ActorAnimFunction.h
@@ -19,33 +19,43 @@ struct SklAnimRetargettingInfo;
 inline AnimPlayerSkl* getSkl(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimSkl();
 }
+
 inline AnimPlayerMat* getMtp(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimMtp();
 }
+
 inline AnimPlayerMat* getMcl(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimMcl();
 }
+
 inline AnimPlayerMat* getMts(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimMts();
 }
+
 inline AnimPlayerMat* getMat(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimMat();
 }
+
 inline AnimPlayerVis* getVis(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimVis();
 }
+
 inline AnimPlayerVis* getVisForAction(const LiveActor* actor) {
     return actor->getModelKeeper()->getAnimVisForAction();
 }
+
 inline void updateModelDraw(const LiveActor* actor) {
     actor->getModelKeeper()->getModelCtrl()->recreateDisplayList();
 }
+
 inline void updateActorSystem(LiveActor* actor) {
     alActorSystemFunction::updateExecutorDraw(actor);
 }
+
 inline void setSklBlendWeight(const LiveActor* actor, u32 index, f32 weight) {
     getSkl(actor)->setSklAnimBlendWeight(index, weight);
 }
+
 inline void createMat(const LiveActor* actor, s32 programType) {
     actor->getModelKeeper()->createMatAnimForProgram(programType);
 }

--- a/lib/al/Library/LiveActor/ActorClippingFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorClippingFunction.cpp
@@ -7,6 +7,7 @@ namespace al {
 bool isClipped(const LiveActor* actor) {
     return actor->getFlags()->isClipped;
 }
+
 bool isInvalidClipping(const LiveActor* actor) {
     return actor->getFlags()->isClippingInvalid;
 }

--- a/lib/al/Library/LiveActor/ActorFlagFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorFlagFunction.cpp
@@ -7,53 +7,71 @@ namespace al {
 bool isAlive(const LiveActor* actor) {
     return !actor->getFlags()->isDead;
 }
+
 bool isDead(const LiveActor* actor) {
     return actor->getFlags()->isDead;
 }
+
 bool isNoCollide(const LiveActor* actor) {
     return actor->getFlags()->isCollideOff;
 }
+
 void onCalcAnim(LiveActor* actor) {
     actor->getFlags()->isCalcAnim = true;
 }
+
 void offCalcAnim(LiveActor* actor) {
     actor->getFlags()->isCalcAnim = false;
 }
+
 void validateShadow(LiveActor* actor) {}
+
 void invalidateShadow(LiveActor* actor) {}
+
 void onCollide(LiveActor* actor) {
     actor->getFlags()->isCollideOff = false;
 }
+
 void offCollide(LiveActor* actor) {
     actor->getFlags()->isCollideOff = true;
 }
+
 void validateMaterialCode(LiveActor* actor) {
     actor->getFlags()->isMaterialCodeValid = true;
 }
+
 void invalidateMaterialCode(LiveActor* actor) {
     actor->getFlags()->isMaterialCodeValid = false;
 }
+
 void validatePuddleMaterial(LiveActor* actor) {
     actor->getFlags()->isPuddleMaterialValid = true;
 }
+
 void invalidatePuddleMaterial(LiveActor* actor) {
     actor->getFlags()->isPuddleMaterialValid = false;
 }
+
 bool isAreaTarget(const LiveActor* actor) {
     return actor->getFlags()->isAreaTargetOn;
 }
+
 void onAreaTarget(LiveActor* actor) {
     actor->getFlags()->isAreaTargetOn = true;
 }
+
 void offAreaTarget(LiveActor* actor) {
     actor->getFlags()->isAreaTargetOn = true;
 }
+
 bool isUpdateMovementEffectAudioCollisionSensor(const LiveActor* actor) {
     return actor->getFlags()->isUpdateOn;
 }
+
 void onUpdateMovementEffectAudioCollisionSensor(LiveActor* actor) {
     actor->getFlags()->isUpdateOn = true;
 }
+
 void offUpdateMovementEffectAudioCollisionSensor(LiveActor* actor) {
     actor->getFlags()->isUpdateOn = false;
 }

--- a/lib/al/Library/LiveActor/ActorInitInfo.h
+++ b/lib/al/Library/LiveActor/ActorInitInfo.h
@@ -76,7 +76,9 @@ public:
     void initNoViewId(const PlacementInfo*, const ActorInitInfo&);
 
     const LayoutInitInfo& getLayoutInitInfo() const { return *mLayoutInitInfo; }
+
     const PlacementInfo& getPlacementInfo() const { return *mPlacementInfo; }
+
     const ActorSceneInfo& getActorSceneInfo() const { return mActorSceneInfo; }
 
 private:

--- a/lib/al/Library/LiveActor/ActorModelFunction.h
+++ b/lib/al/Library/LiveActor/ActorModelFunction.h
@@ -10,6 +10,7 @@
 namespace agl {
 class UniformBlock;
 }
+
 namespace nn::gfx {
 class ResTexture;
 }

--- a/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
+++ b/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
@@ -14,60 +14,78 @@ static void rotationAndTranslationFromMatrix(sead::Vector3f& trans, sead::Vector
 }
 
 ActorPoseKeeperBase::ActorPoseKeeperBase() = default;
+
 const sead::Vector3f& ActorPoseKeeperBase::getRotate() const {
     return sead::Vector3f::zero;
 }
+
 const sead::Vector3f& ActorPoseKeeperBase::getScale() const {
     return sead::Vector3f::ones;
 }
+
 const sead::Vector3f& ActorPoseKeeperBase::getVelocity() const {
     return sead::Vector3f::zero;
 }
+
 const sead::Vector3f& ActorPoseKeeperBase::getFront() const {
     return sead::Vector3f::ez;
 }
+
 const sead::Vector3f& ActorPoseKeeperBase::getUp() const {
     return sead::Vector3f::ey;
 }
+
 const sead::Quatf& ActorPoseKeeperBase::getQuat() const {
     return sead::Quatf::unit;
 }
+
 const sead::Vector3f& ActorPoseKeeperBase::getGravity() const {
     return sDefaultVelocity;
 }
+
 const sead::Matrix34f& ActorPoseKeeperBase::getMtx() const {
     return sead::Matrix34f::ident;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getRotatePtr() {
     return nullptr;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getScalePtr() {
     return nullptr;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getVelocityPtr() {
     return nullptr;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getFrontPtr() {
     return nullptr;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getUpPtr() {
     return nullptr;
 }
+
 sead::Quatf* ActorPoseKeeperBase::getQuatPtr() {
     return nullptr;
 }
+
 sead::Vector3f* ActorPoseKeeperBase::getGravityPtr() {
     return nullptr;
 }
+
 sead::Matrix34f* ActorPoseKeeperBase::getMtxPtr() {
     return nullptr;
 }
+
 void ActorPoseKeeperBase::copyPose(const ActorPoseKeeperBase* other) {
     sead::Matrix34f mtx;
     mtx = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0};
     other->calcBaseMtx(&mtx);
     updatePoseMtx(&mtx);
 }
+
 void ActorPoseKeeperBase::updatePoseRotate(const sead::Vector3f& rot) {
     sead::Quatf quat;
     quat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
@@ -76,40 +94,51 @@ void ActorPoseKeeperBase::updatePoseRotate(const sead::Vector3f& rot) {
 }
 
 ActorPoseKeeperTFSV::ActorPoseKeeperTFSV() = default;
+
 const sead::Vector3f& ActorPoseKeeperTFSV::getFront() const {
     return mFront;
 }
+
 sead::Vector3f* ActorPoseKeeperTFSV::getFrontPtr() {
     return &mFront;
 }
+
 const sead::Vector3f& ActorPoseKeeperTFSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTFSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTFSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTFSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTFSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
 }
+
 void ActorPoseKeeperTFSV::updatePoseRotate(const sead::Vector3f& rot) {
     sead::Quatf quat;
     quat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
                 sead::Mathf::deg2rad(rot.z));
     calcQuatFront(&mFront, quat);
 }
+
 void ActorPoseKeeperTFSV::updatePoseQuat(const sead::Quatf& quat) {
     calcQuatFront(&mFront, quat);
 }
+
 void ActorPoseKeeperTFSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mtx->getBase(mFront, 2);
     mtx->getBase(mTrans, 3);
 }
+
 void ActorPoseKeeperTFSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     makeMtxFrontUpPos(mtx, mFront, -getGravity(), mTrans);
 }
@@ -119,12 +148,15 @@ ActorPoseKeeperTFGSV::ActorPoseKeeperTFGSV() = default;
 const sead::Vector3f& ActorPoseKeeperTFGSV::getGravity() const {
     return mGravity;
 }
+
 sead::Vector3f* ActorPoseKeeperTFGSV::getGravityPtr() {
     return &mGravity;
 }
+
 void ActorPoseKeeperTFGSV::updatePoseTrans(const sead::Vector3f& trans) {
     ActorPoseKeeperTFSV::updatePoseTrans(trans);
 }
+
 void ActorPoseKeeperTFGSV::updatePoseRotate(const sead::Vector3f& rot) {
     sead::Quatf quat;
     quat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
@@ -134,16 +166,19 @@ void ActorPoseKeeperTFGSV::updatePoseRotate(const sead::Vector3f& rot) {
     calcQuatUp(&mGravity, quat);
     mGravity *= -1;
 }
+
 void ActorPoseKeeperTFGSV::updatePoseQuat(const sead::Quatf& quat) {
     ActorPoseKeeperTFSV::updatePoseQuat(quat);
     calcQuatUp(&mGravity, quat);
     mGravity *= -1;
 }
+
 void ActorPoseKeeperTFGSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     ActorPoseKeeperTFSV::updatePoseMtx(mtx);
     mtx->getBase(mGravity, 1);
     mGravity *= -1;
 }
+
 void ActorPoseKeeperTFGSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     makeMtxUpFrontPos(mtx, -getGravity(), getFront(), mTrans);
 }
@@ -153,12 +188,15 @@ ActorPoseKeeperTFUSV::ActorPoseKeeperTFUSV() = default;
 const sead::Vector3f& ActorPoseKeeperTFUSV::getUp() const {
     return mUp;
 }
+
 sead::Vector3f* ActorPoseKeeperTFUSV::getUpPtr() {
     return &mUp;
 }
+
 void ActorPoseKeeperTFUSV::updatePoseTrans(const sead::Vector3f& trans) {
     ActorPoseKeeperTFSV::updatePoseTrans(trans);
 }
+
 void ActorPoseKeeperTFUSV::updatePoseRotate(const sead::Vector3f& rot) {
     sead::Quatf quat;
     quat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
@@ -167,14 +205,17 @@ void ActorPoseKeeperTFUSV::updatePoseRotate(const sead::Vector3f& rot) {
     ActorPoseKeeperTFSV::updatePoseQuat(quat);
     calcQuatUp(&mUp, quat);
 }
+
 void ActorPoseKeeperTFUSV::updatePoseQuat(const sead::Quatf& quat) {
     ActorPoseKeeperTFSV::updatePoseQuat(quat);
     calcQuatUp(&mUp, quat);
 }
+
 void ActorPoseKeeperTFUSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     ActorPoseKeeperTFSV::updatePoseMtx(mtx);
     mtx->getBase(mUp, 1);
 }
+
 void ActorPoseKeeperTFUSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     if (mIsFrontUp)
         makeMtxFrontUpPos(mtx, getFront(), getUp(), mTrans);
@@ -187,38 +228,48 @@ ActorPoseKeeperTQSV::ActorPoseKeeperTQSV() = default;
 const sead::Quatf& ActorPoseKeeperTQSV::getQuat() const {
     return mQuat;
 }
+
 sead::Quatf* ActorPoseKeeperTQSV::getQuatPtr() {
     return &mQuat;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTQSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTQSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTQSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
 }
+
 void ActorPoseKeeperTQSV::updatePoseRotate(const sead::Vector3f& rot) {
     mQuat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
                  sead::Mathf::deg2rad(rot.z));
 }
+
 void ActorPoseKeeperTQSV::updatePoseQuat(const sead::Quatf& quat) {
     mQuat.x = quat.x;
     mQuat.y = quat.y;
     mQuat.z = quat.z;
     mQuat.w = quat.w;
 }
+
 void ActorPoseKeeperTQSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mtx->toQuat(mQuat);
     mtx->getBase(mTrans, 3);
 }
+
 void ActorPoseKeeperTQSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     mtx->makeQT(mQuat, mTrans);
 }
@@ -228,44 +279,56 @@ ActorPoseKeeperTQGSV::ActorPoseKeeperTQGSV() = default;
 const sead::Quatf& ActorPoseKeeperTQGSV::getQuat() const {
     return mQuat;
 }
+
 sead::Quatf* ActorPoseKeeperTQGSV::getQuatPtr() {
     return &mQuat;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGSV::getGravity() const {
     return mGravity;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGSV::getGravityPtr() {
     return &mGravity;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTQGSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
 }
+
 void ActorPoseKeeperTQGSV::updatePoseRotate(const sead::Vector3f& rot) {
     mQuat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
                  sead::Mathf::deg2rad(rot.z));
 }
+
 void ActorPoseKeeperTQGSV::updatePoseQuat(const sead::Quatf& quat) {
     mQuat.x = quat.x;
     mQuat.y = quat.y;
     mQuat.z = quat.z;
     mQuat.w = quat.w;
 }
+
 void ActorPoseKeeperTQGSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mtx->toQuat(mQuat);
     mtx->getTranslation(mTrans);
 }
+
 void ActorPoseKeeperTQGSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     mtx->makeQT(mQuat, mTrans);
 }
@@ -275,42 +338,54 @@ ActorPoseKeeperTQGMSV::ActorPoseKeeperTQGMSV() = default;
 const sead::Quatf& ActorPoseKeeperTQGMSV::getQuat() const {
     return mQuat;
 }
+
 sead::Quatf* ActorPoseKeeperTQGMSV::getQuatPtr() {
     return &mQuat;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGMSV::getGravity() const {
     return mGravity;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGMSV::getGravityPtr() {
     return &mGravity;
 }
+
 const sead::Matrix34f& ActorPoseKeeperTQGMSV::getMtx() const {
     return mMtx;
 }
+
 sead::Matrix34f* ActorPoseKeeperTQGMSV::getMtxPtr() {
     return &mMtx;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGMSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGMSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTQGMSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTQGMSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTQGMSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
     mMtx.makeQT(mQuat, mTrans);
 }
+
 void ActorPoseKeeperTQGMSV::updatePoseRotate(const sead::Vector3f& rot) {
     mQuat.setRPY(sead::Mathf::deg2rad(rot.x), sead::Mathf::deg2rad(rot.y),
                  sead::Mathf::deg2rad(rot.z));
     mMtx.makeQT(mQuat, mTrans);
 }
+
 void ActorPoseKeeperTQGMSV::updatePoseQuat(const sead::Quatf& quat) {
     mQuat.x = quat.x;
     mQuat.y = quat.y;
@@ -318,11 +393,13 @@ void ActorPoseKeeperTQGMSV::updatePoseQuat(const sead::Quatf& quat) {
     mQuat.w = quat.w;
     mMtx.makeQT(mQuat, mTrans);
 }
+
 void ActorPoseKeeperTQGMSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mtx->toQuat(mQuat);
     mtx->getTranslation(mTrans);
     mMtx.makeQT(mQuat, mTrans);
 }
+
 void ActorPoseKeeperTQGMSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     *mtx = mMtx;
 }
@@ -332,36 +409,46 @@ ActorPoseKeeperTRSV::ActorPoseKeeperTRSV() = default;
 const sead::Vector3f& ActorPoseKeeperTRSV::getRotate() const {
     return mRotate;
 }
+
 sead::Vector3f* ActorPoseKeeperTRSV::getRotatePtr() {
     return &mRotate;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTRSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTRSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTRSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
 }
+
 void ActorPoseKeeperTRSV::updatePoseRotate(const sead::Vector3f& rot) {
     mRotate = rot;
 }
+
 void ActorPoseKeeperTRSV::updatePoseQuat(const sead::Quatf& quat) {
     sead::Vector3f tmp;
     quat.calcRPY(tmp);
     mRotate = {sead::Mathf::rad2deg(tmp.x), sead::Mathf::rad2deg(tmp.y),
                sead::Mathf::rad2deg(tmp.z)};
 }
+
 void ActorPoseKeeperTRSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     rotationAndTranslationFromMatrix(mTrans, mRotate, mtx);
 }
+
 void ActorPoseKeeperTRSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     makeMtxRotateTrans(mtx, getRotate(), mTrans);
 }
@@ -373,37 +460,47 @@ ActorPoseKeeperTRMSV::ActorPoseKeeperTRMSV() {
 const sead::Vector3f& ActorPoseKeeperTRMSV::getRotate() const {
     return mRotate;
 }
+
 sead::Vector3f* ActorPoseKeeperTRMSV::getRotatePtr() {
     return &mRotate;
 }
+
 const sead::Matrix34f& ActorPoseKeeperTRMSV::getMtx() const {
     return mMtx;
 }
+
 sead::Matrix34f* ActorPoseKeeperTRMSV::getMtxPtr() {
     return &mMtx;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRMSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTRMSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRMSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTRMSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTRMSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
     sead::Vector3f rot = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot, mTrans);
 }
+
 void ActorPoseKeeperTRMSV::updatePoseRotate(const sead::Vector3f& rot) {
     mRotate = rot;
     sead::Vector3f rot2 = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot2, mTrans);
 }
+
 void ActorPoseKeeperTRMSV::updatePoseQuat(const sead::Quatf& quat) {
     sead::Vector3f tmp;
     quat.calcRPY(tmp);
@@ -411,10 +508,12 @@ void ActorPoseKeeperTRMSV::updatePoseQuat(const sead::Quatf& quat) {
     sead::Vector3f rot = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot, mTrans);
 }
+
 void ActorPoseKeeperTRMSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mMtx = *mtx;
     rotationAndTranslationFromMatrix(mTrans, mRotate, mtx);
 }
+
 void ActorPoseKeeperTRMSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     *mtx = mMtx;
 }
@@ -427,43 +526,55 @@ ActorPoseKeeperTRGMSV::ActorPoseKeeperTRGMSV() {
 const sead::Vector3f& ActorPoseKeeperTRGMSV::getRotate() const {
     return mRotate;
 }
+
 sead::Vector3f* ActorPoseKeeperTRGMSV::getRotatePtr() {
     return &mRotate;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRGMSV::getGravity() const {
     return mGravity;
 }
+
 sead::Vector3f* ActorPoseKeeperTRGMSV::getGravityPtr() {
     return &mGravity;
 }
+
 const sead::Matrix34f& ActorPoseKeeperTRGMSV::getMtx() const {
     return mMtx;
 }
+
 sead::Matrix34f* ActorPoseKeeperTRGMSV::getMtxPtr() {
     return &mMtx;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRGMSV::getScale() const {
     return mScale;
 }
+
 sead::Vector3f* ActorPoseKeeperTRGMSV::getScalePtr() {
     return &mScale;
 }
+
 const sead::Vector3f& ActorPoseKeeperTRGMSV::getVelocity() const {
     return mVelocity;
 }
+
 sead::Vector3f* ActorPoseKeeperTRGMSV::getVelocityPtr() {
     return &mVelocity;
 }
+
 void ActorPoseKeeperTRGMSV::updatePoseTrans(const sead::Vector3f& trans) {
     mTrans = trans;
     sead::Vector3f rot = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot, mTrans);
 }
+
 void ActorPoseKeeperTRGMSV::updatePoseRotate(const sead::Vector3f& rot) {
     mRotate = rot;
     sead::Vector3f rot2 = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot2, mTrans);
 }
+
 void ActorPoseKeeperTRGMSV::updatePoseQuat(const sead::Quatf& quat) {
     sead::Vector3f tmp;
     quat.calcRPY(tmp);
@@ -471,10 +582,12 @@ void ActorPoseKeeperTRGMSV::updatePoseQuat(const sead::Quatf& quat) {
     sead::Vector3f rot = getRotate() * (sead::numbers::pi / 180);
     mMtx.makeRT(rot, mTrans);
 }
+
 void ActorPoseKeeperTRGMSV::updatePoseMtx(const sead::Matrix34f* mtx) {
     mMtx = *mtx;
     rotationAndTranslationFromMatrix(mTrans, mRotate, mtx);
 }
+
 void ActorPoseKeeperTRGMSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     *mtx = mMtx;
 }

--- a/lib/al/Library/LiveActor/LiveActor.cpp
+++ b/lib/al/Library/LiveActor/LiveActor.cpp
@@ -22,25 +22,33 @@ NerveKeeper* LiveActor::getNerveKeeper() const {
 const char* LiveActor::getName() const {
     return mActorName;
 }
+
 EffectKeeper* LiveActor::getEffectKeeper() const {
     return mEffectKeeper;
 }
+
 AudioKeeper* LiveActor::getAudioKeeper() const {
     return mAudioKeeper;
 }
+
 StageSwitchKeeper* LiveActor::getStageSwitchKeeper() const {
     return mStageSwitchKeeper;
 }
 
 void LiveActor::init(const ActorInitInfo&) {}
+
 void LiveActor::attackSensor(HitSensor*, HitSensor*) {}
+
 bool LiveActor::receiveMsg(const SensorMsg*, HitSensor*, HitSensor*) {
     return 0;
 }
+
 bool LiveActor::receiveMsgScreenPoint(const SensorMsg*, ScreenPointer*, ScreenPointTarget*) {
     return 0;
 }
+
 void LiveActor::control() {}
+
 void LiveActor::draw() const {}
 
 void LiveActor::initAfterPlacement() {
@@ -52,45 +60,58 @@ void LiveActor::initAfterPlacement() {
 void LiveActor::appear() {
     makeActorAlive();
 }
+
 void LiveActor::kill() {
     makeActorDead();
 }
+
 RailRider* LiveActor::getRailRider() const {
     if (mRailKeeper)
         return mRailKeeper->getRailRider();
     return nullptr;
 }
+
 ActorSceneInfo* LiveActor::getSceneInfo() const {
     return mSceneInfo;
 }
+
 void LiveActor::initPoseKeeper(ActorPoseKeeperBase* poseKeeper) {
     mPoseKeeper = poseKeeper;
 }
+
 void LiveActor::initExecuteInfo(ActorExecuteInfo* executeInfo) {
     mExecuteInfo = executeInfo;
 }
+
 void LiveActor::initModelKeeper(ModelKeeper* modelKeeper) {
     mModelKeeper = modelKeeper;
     offUpdateMovementEffectAudioCollisionSensor(this);
 }
+
 void LiveActor::initActionKeeper(ActorActionKeeper* actionKeeper) {
     mActorActionKeeper = actionKeeper;
 }
+
 void LiveActor::initNerveKeeper(NerveKeeper* nerveKeeper) {
     mNerveKeeper = nerveKeeper;
 }
+
 void LiveActor::initAudioKeeper(AudioKeeper* audioKeeper) {
     mAudioKeeper = audioKeeper;
 }
+
 void LiveActor::initActorPrePassLightKeeper(ActorPrePassLightKeeper* lightKeeper) {
     mActorPrePassLightKeeper = lightKeeper;
 }
+
 void LiveActor::initActorOcclusionKeeper(ActorOcclusionKeeper* occlusionKeeper) {
     mActorOcclusionKeeper = occlusionKeeper;
 }
+
 void LiveActor::initSubActorKeeper(SubActorKeeper* subActorKeeper) {
     mSubActorKeeper = subActorKeeper;
 }
+
 void LiveActor::initSceneInfo(ActorSceneInfo* sceneInfo) {
     mSceneInfo = sceneInfo;
 }

--- a/lib/al/Library/LiveActor/LiveActor.h
+++ b/lib/al/Library/LiveActor/LiveActor.h
@@ -105,22 +105,39 @@ public:
     void initSceneInfo(ActorSceneInfo*);
 
     LiveActorFlag* getFlags() const { return mFlags; }
+
     ModelKeeper* getModelKeeper() const { return mModelKeeper; }
+
     ActorPoseKeeperBase* getPoseKeeper() const { return mPoseKeeper; }
+
     ActorExecuteInfo* getExecuteInfo() const { return mExecuteInfo; }
+
     ActorActionKeeper* getActorActionKeeper() const { return mActorActionKeeper; }
+
     ActorItemKeeper* getActorItemKeeper() const { return mActorItemKeeper; }
+
     ActorScoreKeeper* getActorScoreKeeper() const { return mActorScoreKeeper; }
+
     Collider* getCollider() const { return mCollider; }
+
     CollisionParts* getCollisionParts() const { return mCollisionParts; }
+
     HitSensorKeeper* getHitSensorKeeper() const { return mHitSensorKeeper; }
+
     ScreenPointKeeper* getScreenPointKeeper() const { return mScreenPointKeeper; }
+
     HitReactionKeeper* getHitReactionKeeper() const { return mHitReactionKeeper; }
+
     RailKeeper* getRailKeeper() const { return mRailKeeper; }
+
     ShadowKeeper* getShadowKeeper() const { return mShadowKeeper; }
+
     ActorPrePassLightKeeper* getActorPrePassLightKeeper() const { return mActorPrePassLightKeeper; }
+
     ActorOcclusionKeeper* getActorOcclusionKeeper() const { return mActorOcclusionKeeper; }
+
     SubActorKeeper* getSubActorKeeper() const { return mSubActorKeeper; }
+
     ActorParamHolder* getActorParamHolder() const { return mActorParamHolder; }
 
     void setName(const char* newName) { mActorName = newName; }

--- a/lib/al/Library/LiveActor/LiveActorFlag.h
+++ b/lib/al/Library/LiveActor/LiveActorFlag.h
@@ -18,6 +18,7 @@ struct LiveActorFlag {
 
     LiveActorFlag();
 };
+
 static_assert(sizeof(LiveActorFlag) == 0xC);
 
 }  // namespace al

--- a/lib/al/Library/LiveActor/LiveActorGroup.h
+++ b/lib/al/Library/LiveActor/LiveActorGroup.h
@@ -27,6 +27,7 @@ public:
     void makeActorDeadAll();
 
     s32 getActorCount() const { return mActorCount; }
+
     LiveActor* getActor(s32 idx) const { return mActors[idx]; }
 
 private:
@@ -40,16 +41,27 @@ template <class T>
 class DeriveActorGroup : public LiveActorGroup {
 public:
     s32 registerActor(T* actor) { LiveActorGroup::registerActor(actor); }
+
     void removeActor(const T* actor) { LiveActorGroup::removeActor(actor); }
+
     void removeActorAll() { LiveActorGroup::removeActorAll(); }
+
     bool isExistActor(const T* actor) const { return LiveActorGroup::isExistActor(actor); }
+
     bool isFull() const { return LiveActorGroup::isFull(); }
+
     s32 calcAliveActorNum() const { return LiveActorGroup::calcAliveActorNum(); }
+
     T* getDeadActor() const { return LiveActorGroup::getDeadActor(); }
+
     T* tryFindDeadActor() const { return LiveActorGroup::tryFindDeadActor(); }
+
     void appearAll() { LiveActorGroup::appearAll(); }
+
     void killAll() { LiveActorGroup::killAll(); }
+
     void makeActorAliveAll() { LiveActorGroup::makeActorAliveAll(); }
+
     void makeActorDeadAll() { LiveActorGroup::makeActorDeadAll(); }
 };
 }  // namespace al

--- a/lib/al/Library/LiveActor/SubActorKeeper.cpp
+++ b/lib/al/Library/LiveActor/SubActorKeeper.cpp
@@ -25,6 +25,7 @@ void SubActorKeeper::registerSubActor(LiveActor* subActor, u32 syncType) {
     mBuffer[mCurActorCount] = new SubActorInfo(subActor, static_cast<SubActorSync>(syncType));
     mCurActorCount++;
 }
+
 // NON-MATCHING
 void SubActorKeeper::init(const ActorInitInfo& initInfo, const char* suffix, s32 maxSubActors) {
     sead::FixedSafeString<0x80> actorInitFileName;
@@ -232,6 +233,7 @@ void SubActorKeeper::init(const ActorInitInfo& initInfo, const char* suffix, s32
 SubActorKeeper* SubActorKeeper::create(LiveActor* rootActor) {
     return new SubActorKeeper(rootActor);
 }
+
 SubActorKeeper* SubActorKeeper::tryCreate(LiveActor* rootActor, const char* suffix,
                                           s32 maxSubActors) {
     sead::FixedSafeString<0x80> actorInitFileName;

--- a/lib/al/Library/LiveActor/SubActorKeeper.h
+++ b/lib/al/Library/LiveActor/SubActorKeeper.h
@@ -85,6 +85,7 @@ struct SubActorSync {
         cAlphaMask = 1 << 3,                             // 8
         cAll = cAppear | cClipping | cHide | cAlphaMask  // 15
     };
+
     AL_BITS(SubActorSync);
 };
 

--- a/lib/al/Library/MapObj/FixMapParts.cpp
+++ b/lib/al/Library/MapObj/FixMapParts.cpp
@@ -9,6 +9,7 @@
 
 namespace al {
 FixMapParts::FixMapParts(const char* name) : LiveActor(name) {}
+
 void FixMapParts::init(const ActorInitInfo& info) {
     const char* suffix = nullptr;
     tryGetStringArg(&suffix, info, "Suffix");
@@ -19,22 +20,26 @@ void FixMapParts::init(const ActorInitInfo& info) {
     if (getModelKeeper() != nullptr && !isExistAction(this) && !isViewDependentModel(this))
         mIsStatic = true;
 }
+
 void FixMapParts::appear() {
     LiveActor::appear();
 
     if (isExistModel(this))
         tryStartAction(this, "Appear");
 }
+
 void FixMapParts::movement() {
     if (!mIsStatic)
         LiveActor::movement();
 }
+
 void FixMapParts::calcAnim() {
     if (!mIsStatic)
         LiveActor::calcAnim();
     else
         calcViewModel(this);
 }
+
 bool FixMapParts::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
     if (isMsgAskSafetyPoint(message))
         return !isValidSwitchAppear(this) && !isValidSwitchKill(this);

--- a/lib/al/Library/Math/MathRandomUtil.cpp
+++ b/lib/al/Library/Math/MathRandomUtil.cpp
@@ -8,9 +8,11 @@ f32 getRandom() {
     u32 random = (sead::GlobalRandom::instance()->getU32() >> 9) | 0x3F800000;
     return (*reinterpret_cast<f32*>(&random)) - 1;
 }
+
 f32 getRandom(f32 factor) {
     return getRandom(0.f, factor);
 }
+
 f32 getRandom(f32 min, f32 max) {
     return (getRandom() * (max - min)) + min;
 }
@@ -18,6 +20,7 @@ f32 getRandom(f32 min, f32 max) {
 s32 getRandom(s32 factor) {
     return getRandom(0, factor);
 }
+
 s32 getRandom(s32 min, s32 max) {
     return (s32)getRandom((f32)min, (f32)max);
 }
@@ -25,6 +28,7 @@ s32 getRandom(s32 min, s32 max) {
 f32 getRandomDegree() {
     return getRandom(360.f);
 }
+
 f32 getRandomRadian() {
     return getRandom(6.2832f);
 }

--- a/lib/al/Library/Math/MathUtil.cpp
+++ b/lib/al/Library/Math/MathUtil.cpp
@@ -45,9 +45,11 @@ f32 normalize(s32 var, s32 min, s32 max) {
 f32 easeIn(f32 var) {
     return (((var * -0.5f) + 1.5f) * var) * var;
 }
+
 f32 easeOut(f32 var) {
     return (((var * -0.5f) * var) + 1.5f) * var;
 }
+
 f32 easeInOut(f32 var) {
     return (((var * -2.0f) + 3.0f) * var) * var;
 }
@@ -75,6 +77,7 @@ s32 sign(s32 var) {
 f32 squareIn(f32 var) {
     return var * var;
 }
+
 f32 squareOut(f32 var) {
     return (2.0f - var) * var;
 }
@@ -82,6 +85,7 @@ f32 squareOut(f32 var) {
 f32 powerIn(f32 x, f32 y) {
     return powf(x, y);
 }
+
 f32 powerOut(f32 x, f32 y) {
     return powf(x, 1.0 / y);
 }

--- a/lib/al/Library/Matrix/MatrixUtil.h
+++ b/lib/al/Library/Matrix/MatrixUtil.h
@@ -15,6 +15,7 @@ template <typename T>
 struct Matrix43 {
     T m[3][4];
 };
+
 using Matrix43f = Matrix43<f32>;
 
 void makeMtxRotateTrans(sead::Matrix34f*, const sead::Vector3f&, const sead::Vector3f&);

--- a/lib/al/Library/Model/ModelDisplayListController.h
+++ b/lib/al/Library/Model/ModelDisplayListController.h
@@ -18,6 +18,7 @@ private:
     GraphicsSystemInfo* mGraphicsSystemInfo;
     void* filler[4];
 };
+
 static_assert(sizeof(ModelDisplayListController) == 0x30);
 
 }  // namespace al

--- a/lib/al/Library/Model/ModelDrawBufferUpdater.h
+++ b/lib/al/Library/Model/ModelDrawBufferUpdater.h
@@ -12,6 +12,7 @@ public:
 private:
     void* filler[3];
 };
+
 static_assert(sizeof(ModelDrawBufferUpdater) == 0x18);
 
 }  // namespace al

--- a/lib/al/Library/Model/ModelGroup.h
+++ b/lib/al/Library/Model/ModelGroup.h
@@ -17,6 +17,7 @@ public:
 private:
     void* filler[2];
 };
+
 static_assert(sizeof(ModelGroup) == 0x18);
 
 }  // namespace al

--- a/lib/al/Library/Model/ModelKeeper.h
+++ b/lib/al/Library/Model/ModelKeeper.h
@@ -24,12 +24,19 @@ public:
     void createMatAnimForProgram(s32);
 
     ModelCtrl* getModelCtrl() const { return mModelCtrl; }
+
     AnimPlayerSkl* getAnimSkl() const { return mAnimSkl; }
+
     AnimPlayerMat* getAnimMtp() const { return mAnimMtp; }
+
     AnimPlayerMat* getAnimMts() const { return mAnimMts; }
+
     AnimPlayerMat* getAnimMcl() const { return mAnimMcl; }
+
     AnimPlayerMat* getAnimMat() const { return mAnimMat; }
+
     AnimPlayerVis* getAnimVis() const { return mAnimVis; }
+
     AnimPlayerVis* getAnimVisForAction() const { return mAnimVisForAction; }
 
 private:

--- a/lib/al/Library/Nature/NatureDirector.h
+++ b/lib/al/Library/Nature/NatureDirector.h
@@ -15,6 +15,7 @@ private:
     AreaObjGroup* mWaterAreaGroup;
     FluidSurfaceHolder* mFluidSurfaceHolder;
 };
+
 static_assert(sizeof(NatureDirector) == 0x10);
 
 }  // namespace al

--- a/lib/al/Library/Nerve/NerveAction.cpp
+++ b/lib/al/Library/Nerve/NerveAction.cpp
@@ -20,6 +20,7 @@ namespace alNerveFunction {
 NerveActionCollector::NerveActionCollector() {
     sCurrentCollector = this;
 }
+
 void NerveActionCollector::addNerve(al::NerveAction* action) {
     if (!mHead)
         mHead = action;

--- a/lib/al/Library/Nerve/NerveKeeper.cpp
+++ b/lib/al/Library/Nerve/NerveKeeper.cpp
@@ -9,9 +9,11 @@ NerveKeeper::NerveKeeper(IUseNerve* parent, const Nerve* nerve, s32 maxStates)
     if (maxStates > 0)
         mStateCtrl = new NerveStateCtrl(maxStates);
 }
+
 void NerveKeeper::initNerveAction(NerveActionCtrl* actionCtrl) {
     mActionCtrl = actionCtrl;
 }
+
 void NerveKeeper::setNerve(const Nerve* nextNerve) {
     if (mStep >= 0 && mCurrentNerve != nullptr)
         mCurrentNerve->executeOnEnd(this);
@@ -31,12 +33,14 @@ void NerveKeeper::tryChangeNerve() {
         mStep = 0;
     }
 }
+
 void NerveKeeper::update() {
     tryChangeNerve();
     mCurrentNerve->execute(this);
     mStep++;
     tryChangeNerve();
 }
+
 const Nerve* NerveKeeper::getCurrentNerve() const {
     return mNextNerve ? mNextNerve : mCurrentNerve;
 }

--- a/lib/al/Library/Nerve/NerveKeeper.h
+++ b/lib/al/Library/Nerve/NerveKeeper.h
@@ -19,8 +19,11 @@ public:
     const Nerve* getCurrentNerve() const;
 
     s32 getCurrentStep() const { return mStep; }
+
     bool isNewNerve() const { return mNextNerve != nullptr; }
+
     NerveStateCtrl* getStateCtrl() const { return mStateCtrl; }
+
     NerveActionCtrl* getActionCtrl() const { return mActionCtrl; }
 
     template <typename T>

--- a/lib/al/Library/Nerve/NerveStateBase.cpp
+++ b/lib/al/Library/Nerve/NerveStateBase.cpp
@@ -2,6 +2,7 @@
 
 namespace al {
 NerveStateBase::NerveStateBase(const char* stateName) : NerveExecutor(stateName) {}
+
 NerveStateBase::~NerveStateBase() = default;
 
 void NerveStateBase::init() {}

--- a/lib/al/Library/Nerve/NerveUtil.cpp
+++ b/lib/al/Library/Nerve/NerveUtil.cpp
@@ -8,13 +8,16 @@ namespace al {
 void setNerve(IUseNerve* user, const Nerve* nerve) {
     user->getNerveKeeper()->setNerve(nerve);
 }
+
 void setNerveAtStep(IUseNerve* user, const Nerve* nerve, s32 step) {
     if (user->getNerveKeeper()->getCurrentStep() == step)
         user->getNerveKeeper()->setNerve(nerve);
 }
+
 bool isStep(const IUseNerve* user, s32 step) {
     return user->getNerveKeeper()->getCurrentStep() == step;
 }
+
 void setNerveAtGreaterEqualStep(IUseNerve* user, const Nerve* nerve, s32 step) {
     if (user->getNerveKeeper()->getCurrentStep() >= step)
         user->getNerveKeeper()->setNerve(nerve);
@@ -23,42 +26,53 @@ void setNerveAtGreaterEqualStep(IUseNerve* user, const Nerve* nerve, s32 step) {
 s32 getNerveStep(const IUseNerve* user) {
     return user->getNerveKeeper()->getCurrentStep();
 }
+
 const Nerve* getCurrentNerve(const IUseNerve* user) {
     return user->getNerveKeeper()->getCurrentNerve();
 }
+
 bool isFirstStep(const IUseNerve* user) {
     return isStep(user, 0);
 }
+
 bool isGreaterStep(const IUseNerve* user, s32 step) {
     return user->getNerveKeeper()->getCurrentStep() > step;
 }
+
 bool isGreaterEqualStep(const IUseNerve* user, s32 step) {
     return user->getNerveKeeper()->getCurrentStep() >= step;
 }
+
 bool isLessStep(const IUseNerve* user, s32 step) {
     return user->getNerveKeeper()->getCurrentStep() < step;
 }
+
 bool isLessEqualStep(const IUseNerve* user, s32 step) {
     return user->getNerveKeeper()->getCurrentStep() <= step;
 }
+
 bool isInRangeStep(const IUseNerve* user, s32 startStep, s32 endStep) {
     NerveKeeper* nerveKeeper = user->getNerveKeeper();
     return startStep <= nerveKeeper->getCurrentStep() && nerveKeeper->getCurrentStep() <= endStep;
 }
+
 bool isIntervalStep(const IUseNerve* user, s32 interval, s32 offset) {
     s32 currentStep = user->getNerveKeeper()->getCurrentStep() - offset;
     if (currentStep < 0)
         return false;
     return currentStep == (interval != 0 ? currentStep / interval : 0) * interval;
 }
+
 bool isIntervalOnOffStep(const IUseNerve* user, s32 interval, s32 offset) {
     if (interval == 0)
         return false;
     return ((user->getNerveKeeper()->getCurrentStep() - offset) / interval) == 0;
 }
+
 bool isNerve(const IUseNerve* user, const Nerve* nerve) {
     return user->getNerveKeeper()->getCurrentNerve() == nerve;
 }
+
 bool isNewNerve(const IUseNerve* user) {
     return user->getNerveKeeper()->isNewNerve();
 }

--- a/lib/al/Library/Obj/BreakModel.h
+++ b/lib/al/Library/Obj/BreakModel.h
@@ -24,6 +24,7 @@ private:
     bool mIsValid = false;
     s32 mStep = 0;
 };
+
 static_assert(sizeof(BreakModel) == 0x140, "al::BreakModel Size");
 
 }  // namespace al

--- a/lib/al/Library/Obj/ModelDrawParts.h
+++ b/lib/al/Library/Obj/ModelDrawParts.h
@@ -8,6 +8,7 @@ class ModelDrawParts : public LiveActor {
 public:
     ModelDrawParts(const char*, const LiveActor*, const ActorInitInfo&, const char*);
 };
+
 static_assert(sizeof(ModelDrawParts) == 0x108, "ModelDrawParts Size");
 
 }  // namespace al

--- a/lib/al/Library/Obj/PartsModel.cpp
+++ b/lib/al/Library/Obj/PartsModel.cpp
@@ -22,16 +22,20 @@ void PartsModel::endClipped() {
     LiveActor::endClipped();
     updatePose();
 }
+
 void PartsModel::calcAnim() {
     updatePose();
     LiveActor::calcAnim();
 }
+
 void PartsModel::attackSensor(HitSensor* target, HitSensor* source) {
     mParentModel->attackSensor(target, source);
 }
+
 bool PartsModel::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
     return mParentModel->receiveMsg(message, source, target);
 }
+
 void PartsModel::initPartsDirect(LiveActor* parent, const ActorInitInfo& initInfo,
                                  const char* arcName, const sead::Matrix34f* jointMtx,
                                  const sead::Vector3f& localTrans,
@@ -49,6 +53,7 @@ void PartsModel::initPartsDirect(LiveActor* parent, const ActorInitInfo& initInf
     mLocalRotate = localRotate;
     mLocalScale = localScale;
 }
+
 void PartsModel::initPartsSuffix(LiveActor* parent, const ActorInitInfo& initInfo,
                                  const char* arcName, const char* suffix,
                                  const sead::Matrix34f* jointMtx, bool useFollowMtxScale) {
@@ -60,6 +65,7 @@ void PartsModel::initPartsSuffix(LiveActor* parent, const ActorInitInfo& initInf
     registerSubActor(parent, this);
     makeActorAlive();
 }
+
 void PartsModel::initPartsMtx(LiveActor* parent, const ActorInitInfo& initInfo, const char* arcName,
                               const sead::Matrix34f* jointMtx, bool useFollowMtxScale) {
     mParentModel = parent;
@@ -70,11 +76,13 @@ void PartsModel::initPartsMtx(LiveActor* parent, const ActorInitInfo& initInfo, 
     registerSubActor(parent, this);
     makeActorAlive();
 }
+
 void PartsModel::initPartsFixFile(LiveActor* parent, const ActorInitInfo& initInfo,
                                   const char* arcName, const char* arcSuffix, const char* suffix) {
     initPartsFixFileNoRegister(parent, initInfo, arcName, arcSuffix, suffix);
     registerSubActor(parent, this);
 }
+
 void PartsModel::initPartsFixFileNoRegister(LiveActor* parent, const ActorInitInfo& initInfo,
                                             const char* arcName, const char* arcSuffix,
                                             const char* suffix) {
@@ -111,6 +119,7 @@ void PartsModel::initPartsFixFileNoRegister(LiveActor* parent, const ActorInitIn
 
     makeActorAlive();
 }
+
 // NON-MATCHING: needs to have proper matrix math implemented still
 void PartsModel::updatePose() {
     sead::Matrix34f poseMtx;
@@ -138,10 +147,12 @@ void PartsModel::updatePose() {
     if (mIsUseFollowMtxScale || mIsUseLocalScale) {
     }
 }
+
 void PartsModel::offSyncAppearAndHide() {
     offSyncAppearSubActor(mParentModel, this);
     offSyncHideSubActor(mParentModel, this);
 }
+
 void PartsModel::onSyncAppearAndHide() {
     onSyncHideSubActor(mParentModel, this);
 

--- a/lib/al/Library/Obj/SilhouetteModel.cpp
+++ b/lib/al/Library/Obj/SilhouetteModel.cpp
@@ -15,5 +15,6 @@ SilhouetteModel::SilhouetteModel(LiveActor* parent, const ActorInitInfo& initInf
     initExecutorDraw(this, initInfo, category);
     makeActorAlive();
 }
+
 void SilhouetteModel::movement() {}
 }  // namespace al

--- a/lib/al/Library/Obj/SimpleCircleShadowXZ.h
+++ b/lib/al/Library/Obj/SimpleCircleShadowXZ.h
@@ -32,6 +32,7 @@ private:
     s32 mInterpoleStep;
     s32 mInterpoleFrame;
 };
+
 static_assert(sizeof(SimpleCircleShadowXZ) == 0x180, "DepthShadowModel Size");
 
 }  // namespace al

--- a/lib/al/Library/Placement/PlacementInfo.h
+++ b/lib/al/Library/Placement/PlacementInfo.h
@@ -12,6 +12,7 @@ public:
     void set(const ByamlIter& placement_iter, const ByamlIter& zone_iter);
 
     const ByamlIter& getPlacementIter() const { return mPlacementIter; }
+
     const ByamlIter& getZoneIter() const { return mZoneIter; }
 
 private:

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.h
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.h
@@ -60,6 +60,7 @@ private:
     bool mIsStopUpdate;
     bool mIsKeepInFrame;
 };
+
 static_assert(sizeof(CameraVerticalAbsorber) == 0x1B0);
 
 }  // namespace al

--- a/lib/al/Library/Play/Layout/SimpleLayoutTextHolder.h
+++ b/lib/al/Library/Play/Layout/SimpleLayoutTextHolder.h
@@ -22,6 +22,7 @@ private:
 
 struct SimpleLayoutTextHolderEntry {
     SimpleLayoutTextHolderEntry(SimpleLayoutText* e) : text(e) {}
+
     SimpleLayoutText* text;
 };
 

--- a/lib/al/Library/Play/Layout/SimplePopupMessageLayout.h
+++ b/lib/al/Library/Play/Layout/SimplePopupMessageLayout.h
@@ -6,6 +6,7 @@
 
 namespace al {
 class LayoutInitInfo;
+
 class SimplePopupMessageLayout : public LayoutActor {
 public:
     SimplePopupMessageLayout(const char* name, const char* layoutName, const LayoutInitInfo& info,

--- a/lib/al/Library/Rail/Graph.h
+++ b/lib/al/Library/Rail/Graph.h
@@ -13,8 +13,11 @@ public:
         inline Vertex(s32 size, s32 index) : mIndex(index) { mEdges.allocBuffer(size, nullptr); }
 
         const sead::PtrArray<Edge>& getEdges() const { return mEdges; }
+
         s32 getIndex() const { return mIndex; }
+
         void addEdge(Edge* edge) { mEdges.pushBack(edge); }
+
         void tryAddEdge(Edge* edge) {
             for (s32 i = 0; i < mEdges.size(); i++)
                 if (mEdges[i] == edge)
@@ -26,15 +29,18 @@ public:
         sead::PtrArray<Edge> mEdges;
         s32 mIndex;
     };
+
     static_assert(sizeof(Vertex) == 0x18);
 
     class Edge {
     public:
         Edge(Vertex* vertex1, Vertex* vertex2, f32 weight)
             : mVertex1(vertex1), mVertex2(vertex2), mWeight(weight) {}
+
         virtual f32 getWeight() const;
 
         Vertex* getVertex1() const { return mVertex1; }
+
         Vertex* getVertex2() const { return mVertex2; }
 
     private:
@@ -42,6 +48,7 @@ public:
         Vertex* mVertex2;
         f32 mWeight;
     };
+
     static_assert(sizeof(Edge) == 0x20);
 
     Graph(s32 verticesSize, s32 edgesSize);
@@ -59,6 +66,7 @@ private:
     sead::PtrArray<Vertex> mVertices;
     sead::PtrArray<Edge> mEdges;
 };
+
 static_assert(sizeof(Graph) == 0x20);
 
 }  // namespace al

--- a/lib/al/Library/Rail/Rail.cpp
+++ b/lib/al/Library/Rail/Rail.cpp
@@ -8,6 +8,7 @@
 namespace al {
 
 Rail::Rail() = default;
+
 // NON_MATCHING: mismatch during `mRailPart`-array creation
 void Rail::init(const PlacementInfo& info) {
     mIsClosed = false;
@@ -58,12 +59,14 @@ void Rail::init(const PlacementInfo& info) {
         mRailPart[i].setTotalDistance(totalLength);
     }
 }
+
 void Rail::calcPos(sead::Vector3f* pos, f32 distance) const {
     const RailPart* part = nullptr;
     f32 partDistance = 0;
     getIncludedSection(&part, &partDistance, distance);
     part->calcPos(pos, part->calcCurveParam(partDistance));
 }
+
 // FIXME: minor reorderings
 s32 Rail::getIncludedSection(const RailPart** part, f32* partDistance, f32 distance) const {
     f32 distanceOnRail = normalizeLength(distance);
@@ -89,12 +92,14 @@ s32 Rail::getIncludedSection(const RailPart** part, f32* partDistance, f32 dista
 
     return maxRailPart;
 }
+
 void Rail::calcDirection(sead::Vector3f* direction, f32 distance) const {
     const RailPart* part = nullptr;
     f32 partDistance = 0;
     getIncludedSection(&part, &partDistance, distance);
     part->calcDir(direction, part->calcCurveParam(partDistance));
 }
+
 void Rail::calcPosDir(sead::Vector3f* position, sead::Vector3f* direction, f32 distance) const {
     const RailPart* part = nullptr;
     f32 partDistance = 0;
@@ -103,23 +108,28 @@ void Rail::calcPosDir(sead::Vector3f* position, sead::Vector3f* direction, f32 d
     part->calcPos(position, curveParam);
     part->calcDir(direction, curveParam);
 }
+
 f32 Rail::getTotalLength() const {
     return mRailPart[mRailPartCount - 1].getTotalDistance();
 }
+
 f32 Rail::getPartLength(s32 index) const {
     return mRailPart[index].getPartLength();
 }
+
 f32 Rail::getLengthToPoint(s32 index) const {
     if (index == 0)
         return 0;
     return mRailPart[index - 1].getTotalDistance();
 }
+
 void Rail::calcRailPointPos(sead::Vector3f* pos, s32 index) const {
     if (mIsClosed || index != mRailPointsCount - 1)
         return mRailPart[index].calcStartPos(pos);
 
     return mRailPart[index - 1].calcEndPos(pos);
 }
+
 void Rail::calcNearestRailPointPosFast(sead::Vector3f* rail_pos, u32* index,
                                        const sead::Vector3f& pos) const {
     u32 rail_points_count = mRailPointsCount;
@@ -141,6 +151,7 @@ void Rail::calcNearestRailPointPosFast(sead::Vector3f* rail_pos, u32* index,
         curr_index += (i & 1);  // only increases every second iteration
     }
 }
+
 void Rail::calcNearestRailPointNo(s32* index, const sead::Vector3f& pos) const {
     sead::Vector3f tmp = sead::Vector3f::zero;
     calcRailPointPos(&tmp, 0);
@@ -157,6 +168,7 @@ void Rail::calcNearestRailPointNo(s32* index, const sead::Vector3f& pos) const {
         curr_index++;
     }
 }
+
 // NON_MATCHING: mismatch in storing *rail_pos = tmp; (stp instead of two strs)
 void Rail::calcNearestRailPointPos(sead::Vector3f* rail_pos, const sead::Vector3f& pos) const {
     if (mRailPointsCount == 0)
@@ -176,6 +188,7 @@ void Rail::calcNearestRailPointPos(sead::Vector3f* rail_pos, const sead::Vector3
         curr_index++;
     }
 }
+
 f32 Rail::normalizeLength(f32 distance) const {
     if (mIsClosed) {
         f32 distanceOnRail = modf(distance, getTotalLength());
@@ -186,11 +199,13 @@ f32 Rail::normalizeLength(f32 distance) const {
 
     return sead::Mathf::clamp(distance, 0.0, getTotalLength());
 }
+
 // FIXME diff issue due to bug in tools/check
 f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval) const {
     f32 tmp;
     return calcNearestRailPosCoord(pos, interval, &tmp);
 }
+
 // FIXME diff issue due to bug in tools/check
 f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval, f32* distance) const {
     *distance = sead::Mathf::maxNumber();
@@ -214,6 +229,7 @@ f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval, f32* 
         bestParam = bestParam + mRailPart[bestIndex - 1].getTotalDistance();
     return bestParam;
 }
+
 // FIXME diff issue due to bug in tools/check
 f32 Rail::calcNearestRailPos(sead::Vector3f* rail_pos, const sead::Vector3f& pos,
                              f32 interval) const {
@@ -224,6 +240,7 @@ f32 Rail::calcNearestRailPos(sead::Vector3f* rail_pos, const sead::Vector3f& pos
     part->calcPos(rail_pos, part->calcCurveParam(partDistance));
     return coord;
 }
+
 bool Rail::isNearRailPoint(f32 distance, f32 epsilon) const {
     const RailPart* part = nullptr;
     f32 partDistance;
@@ -231,6 +248,7 @@ bool Rail::isNearRailPoint(f32 distance, f32 epsilon) const {
 
     return (partDistance < epsilon) || ((part->getPartLength() - partDistance) < epsilon);
 }
+
 s32 Rail::calcRailPointNum(f32 distance1, f32 distance2) const {
     if ((distance2 - distance1) < 0.01f)
         return 0;
@@ -243,6 +261,7 @@ s32 Rail::calcRailPointNum(f32 distance1, f32 distance2) const {
     return ((sec2 - sec1) + (partDistance1 < 0.01f)) +
            ((part2->getPartLength() - partDistance2) < 0.01f);
 }
+
 // FIXME regalloc in length calculation
 f32 Rail::getIncludedSectionLength(f32* partDistance, f32* length, f32 distance) const {
     const RailPart* part = nullptr;
@@ -252,15 +271,18 @@ f32 Rail::getIncludedSectionLength(f32* partDistance, f32* length, f32 distance)
         *length = partLength - *partDistance;
     return partLength;
 }
+
 s32 Rail::getIncludedSectionIndex(f32 distance) const {
     return getIncludedSection(nullptr, nullptr, distance);
 }
+
 bool Rail::isIncludeBezierRailPart() const {
     for (s32 i = 0; i < mRailPartCount; i++)
         if (isBezierRailPart(i))
             return true;
     return false;
 }
+
 bool Rail::isBezierRailPart(s32 index) const {
     return mRailPart[index].isBezierCurve();
 }

--- a/lib/al/Library/Rail/RailKeeper.cpp
+++ b/lib/al/Library/Rail/RailKeeper.cpp
@@ -9,6 +9,7 @@ RailKeeper::RailKeeper(const PlacementInfo& info) {
     rail->init(info);
     mRailRider = new RailRider(rail);
 }
+
 RailRider* RailKeeper::getRailRider() const {
     return mRailRider;
 }

--- a/lib/al/Library/Rail/RailPart.cpp
+++ b/lib/al/Library/Rail/RailPart.cpp
@@ -9,6 +9,7 @@
 namespace al {
 
 RailPart::RailPart() = default;
+
 void RailPart::init(const sead::Vector3f& start, const sead::Vector3f& startHandle,
                     const sead::Vector3f& endHandle, const sead::Vector3f& end) {
     sead::Vector3f startDiff = start - startHandle;
@@ -21,13 +22,16 @@ void RailPart::init(const sead::Vector3f& start, const sead::Vector3f& startHand
         mBezierCurve->set(start, startHandle, endHandle, end);
     }
 }
+
 void RailPart::calcPos(sead::Vector3f* pos, f32 param) const {
     return mBezierCurve ? mBezierCurve->calcPos(pos, param) : mLinearCurve->calcPos(pos, param);
 }
+
 void RailPart::calcVelocity(sead::Vector3f* vel, f32 param) const {
     return mBezierCurve ? mBezierCurve->calcVelocity(vel, param) :
                           mLinearCurve->calcVelocity(vel, param);
 }
+
 void RailPart::calcDir(sead::Vector3f* dir, f32 param) const {
     calcVelocity(dir, param);
     if (!isNearZero(*dir, 0.001)) {
@@ -48,33 +52,41 @@ void RailPart::calcDir(sead::Vector3f* dir, f32 param) const {
     else
         normalize(dir);
 }
+
 void RailPart::calcStartPos(sead::Vector3f* pos) const {
     return mBezierCurve ? mBezierCurve->calcStartPos(pos) : mLinearCurve->calcStartPos(pos);
 }
+
 void RailPart::calcEndPos(sead::Vector3f* pos) const {
     return mBezierCurve ? mBezierCurve->calcEndPos(pos) : mLinearCurve->calcEndPos(pos);
 }
+
 f32 RailPart::calcLength(f32 startParam, f32 endParam, s32 stepCount) const {
     return mBezierCurve ? mBezierCurve->calcLength(startParam, endParam, stepCount) :
                           mLinearCurve->calcLength(startParam, endParam);
 }
+
 f32 RailPart::calcCurveParam(f32 param) const {
     return mBezierCurve ? mBezierCurve->calcCurveParam(param) : mLinearCurve->calcCurveParam(param);
 }
+
 f32 RailPart::calcNearestParam(const sead::Vector3f& pos, f32 interval) const {
     return mBezierCurve ? mBezierCurve->calcNearestParam(pos, interval) :
                           mLinearCurve->calcNearestParam(pos);
 }
+
 void RailPart::calcNearestPos(sead::Vector3f* nearest, const sead::Vector3f& pos,
                               f32 interval) const {
     return mBezierCurve ? mBezierCurve->calcNearestPos(nearest, pos, interval) :
                           mLinearCurve->calcNearestPos(nearest, pos);
 }
+
 f32 RailPart::calcNearestLength(f32* param, const sead::Vector3f& pos, f32 max,
                                 f32 interval) const {
     return mBezierCurve ? mBezierCurve->calcNearestLength(param, pos, max, interval) :
                           mLinearCurve->calcNearestLength(param, pos, max);
 }
+
 f32 RailPart::getPartLength() const {
     return mBezierCurve ? mBezierCurve->getLength() : mLinearCurve->getLength();
 }

--- a/lib/al/Library/Rail/RailPart.h
+++ b/lib/al/Library/Rail/RailPart.h
@@ -24,7 +24,9 @@ public:
     f32 getPartLength() const;
 
     void setTotalDistance(f32 len) { mTotalDistance = len; }
+
     f32 getTotalDistance() const { return mTotalDistance; }
+
     bool isBezierCurve() const { return mBezierCurve != nullptr; }
 
 private:

--- a/lib/al/Library/Resource/ActorResourceHolder.h
+++ b/lib/al/Library/Resource/ActorResourceHolder.h
@@ -23,6 +23,7 @@ public:
 private:
     void* filler[9];
 };
+
 static_assert(sizeof(ActorResourceHolder) == 0x48);
 
 }  // namespace al

--- a/lib/al/Library/Resource/Resource.h
+++ b/lib/al/Library/Resource/Resource.h
@@ -42,6 +42,7 @@ public:
     const char* getArchiveName() const;
 
     ActorInitResourceData* getResData() const { return mData; }
+
     nn::g3d::ResFile* getResFile() const { return mResFile; }
 
 private:
@@ -61,7 +62,9 @@ public:
     void initResourceData(const char*, bool);
 
     bool hasAnimData() const { return mHasAnimData; }
+
     Resource* getModelRes() const { return mModelRes; }
+
     Resource* getAnimRes() const { return mAnimRes; }
 
 private:

--- a/lib/al/Library/Scene/ISceneObj.cpp
+++ b/lib/al/Library/Scene/ISceneObj.cpp
@@ -3,10 +3,13 @@
 namespace al {
 
 ISceneObj::~ISceneObj() {}
+
 const char* ISceneObj::getSceneObjName() const {
     return "";
 }
+
 void ISceneObj::initAfterPlacementSceneObj(const ActorInitInfo&) {}
+
 void ISceneObj::initSceneObj() {}
 
 }  // namespace al

--- a/lib/al/Library/Scene/SceneObjHolder.cpp
+++ b/lib/al/Library/Scene/SceneObjHolder.cpp
@@ -24,9 +24,11 @@ ISceneObj* SceneObjHolder::create(s32 index) {
 ISceneObj* SceneObjHolder::tryGetObj(s32 index) const {
     return mSceneObjArray[index];
 }
+
 ISceneObj* SceneObjHolder::getObj(s32 index) const {
     return mSceneObjArray[index];
 }
+
 bool SceneObjHolder::isExist(s32 index) const {
     return mSceneObjArray[index] != nullptr;
 }

--- a/lib/al/Library/Screen/ScreenPointDirector.h
+++ b/lib/al/Library/Screen/ScreenPointDirector.h
@@ -26,6 +26,7 @@ public:
 private:
     ScreenPointCheckGroup* mCheckGroup;
 };
+
 static_assert(sizeof(ScreenPointDirector) == 0x8);
 
 }  // namespace al

--- a/lib/al/Library/Sequence/Sequence.cpp
+++ b/lib/al/Library/Sequence/Sequence.cpp
@@ -3,6 +3,7 @@
 namespace al {
 
 void Sequence::init(const SequenceInitInfo& initInfo) {}
+
 void Sequence::kill() {
     mIsAlive = false;
 }

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -23,7 +23,9 @@ public:
     virtual void kill();
     virtual void drawMain() const;
     virtual void drawSub() const;
+
     virtual bool isDisposable() { return false; }
+
     virtual Scene* getCurrentScene() const;
     virtual SceneCreator* getSceneCreator() const override;
     virtual void setSceneCreator(SceneCreator* sceneCreator) override;

--- a/lib/al/Library/Shadow/ShadowKeeper.h
+++ b/lib/al/Library/Shadow/ShadowKeeper.h
@@ -19,6 +19,7 @@ private:
     ShadowMaskCtrl* mShadowMaskCtrl = nullptr;
     DepthShadowMapCtrl* mDepthShadowMapCtrl = nullptr;
 };
+
 static_assert(sizeof(ShadowKeeper) == 0x10);
 
 }  // namespace al

--- a/lib/al/Library/Stage/StageInfo.cpp
+++ b/lib/al/Library/Stage/StageInfo.cpp
@@ -10,9 +10,11 @@ StageInfo::StageInfo(Resource* resource, const ByamlIter& placement_iter,
     mPlacementInfo = new PlacementInfo();
     mPlacementInfo->set(placement_iter, zone_iter);
 }
+
 const ByamlIter& StageInfo::getPlacementIter() const {
     return mPlacementInfo->getPlacementIter();
 }
+
 const ByamlIter& StageInfo::getZoneIter() const {
     return mPlacementInfo->getZoneIter();
 }

--- a/lib/al/Library/Stage/StageSwitchKeeper.h
+++ b/lib/al/Library/Stage/StageSwitchKeeper.h
@@ -44,6 +44,7 @@ public:
 private:
     void* filler[3];
 };
+
 static_assert(sizeof(StageSwitchDirector) == 0x20);
 
 bool tryOnStageSwitch(IUseStageSwitch*, const char*);

--- a/lib/al/Library/System/SystemKit.h
+++ b/lib/al/Library/System/SystemKit.h
@@ -18,8 +18,11 @@ public:
     void createSaveDataSystem();
 
     MemorySystem* getMemorySystem() { return mMemorySystem; }
+
     FileLoader* getFileLoader() { return mFileLoader; }
+
     ResourceSystem* getResourceSystem() { return mResourceSystem; }
+
     SaveDataDirector* getSaveDataDirector() { return mSaveDataDirector; }
 
 protected:

--- a/lib/al/Library/Thread/AsyncFunctorThread.h
+++ b/lib/al/Library/Thread/AsyncFunctorThread.h
@@ -27,5 +27,6 @@ private:
     FunctorBase* mFunctor = nullptr;
     bool mIsDone = true;
 };
+
 static_assert(sizeof(AsyncFunctorThread) == 0x20);
 }  // namespace al

--- a/lib/al/Library/Thread/FunctorV0M.h
+++ b/lib/al/Library/Thread/FunctorV0M.h
@@ -7,6 +7,7 @@ public:
     inline FunctorBase(const FunctorBase& copy) = default;
     virtual void operator()() const = 0;
     virtual FunctorBase* clone() const = 0;
+
     virtual ~FunctorBase() {}
 };
 
@@ -19,6 +20,7 @@ public:
     inline FunctorV0M(const FunctorV0M<T, F>& copy) = default;
 
     void operator()() const override { (mObjPointer->*mFunctor)(); }
+
     FunctorV0M<T, F>* clone() const override { return new FunctorV0M<T, F>(*this); }
 
 private:

--- a/lib/al/Library/Yaml/ByamlData.cpp
+++ b/lib/al/Library/Yaml/ByamlData.cpp
@@ -37,6 +37,7 @@ s32 ByamlHashPair::getValue(bool isRev) const {
 }
 
 ByamlHashIter::ByamlHashIter(const u8* data, bool isRev_) : mData(data), mIsRev(isRev_) {}
+
 ByamlHashIter::ByamlHashIter() : mData(nullptr), mIsRev(false) {}
 
 const ByamlHashPair* ByamlHashIter::findPair(s32 key) const {
@@ -61,6 +62,7 @@ const ByamlHashPair* ByamlHashIter::findPair(s32 key) const {
     }
     return nullptr;
 }
+
 bool ByamlHashIter::getDataByIndex(ByamlData* data, s32 index) const {
     if (!mData)
         return false;
@@ -70,6 +72,7 @@ bool ByamlHashIter::getDataByIndex(ByamlData* data, s32 index) const {
     data->set(&getPairTable()[index], mIsRev);
     return true;
 }
+
 // NON_MATCHING: minor additional instructions, probably not inlined
 bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     if (!mData)
@@ -106,9 +109,11 @@ bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     data->set(pair, mIsRev);
     return true;
 }
+
 const u8* ByamlHashIter::getOffsetData(u32 off) const {
     return &mData[off];
 }
+
 const ByamlHashPair* ByamlHashIter::getPairByIndex(s32 index) const {
     if (index < 0)
         return nullptr;
@@ -117,11 +122,13 @@ const ByamlHashPair* ByamlHashIter::getPairByIndex(s32 index) const {
 
     return &getPairTable()[index];
 }
+
 const ByamlHashPair* ByamlHashIter::getPairTable() const {
     if (!mData)
         return nullptr;
     return reinterpret_cast<const ByamlHashPair*>(mData + 4);
 }
+
 u32 ByamlHashIter::getSize() const {
     if (!mData)
         return 0;
@@ -130,6 +137,7 @@ u32 ByamlHashIter::getSize() const {
 }
 
 ByamlArrayIter::ByamlArrayIter(const u8* data, bool isRev_) : mData(data), mIsRev(isRev_) {}
+
 ByamlArrayIter::ByamlArrayIter() : mData(nullptr), mIsRev(false) {}
 
 bool ByamlArrayIter::getDataByIndex(ByamlData* data, s32 index) const {
@@ -141,17 +149,21 @@ bool ByamlArrayIter::getDataByIndex(ByamlData* data, s32 index) const {
     data->set(getTypeTable()[index], getDataTable()[index], mIsRev);
     return true;
 }
+
 // NON_MATCHING: regalloc
 const u32* ByamlArrayIter::getDataTable() const {
     return reinterpret_cast<const u32*>(getOffsetData((getSize() + 7) & 0xFFFFFFFC));
 }
+
 const u8* ByamlArrayIter::getOffsetData(u32 off) const {
     return &mData[off];
 }
+
 u32 ByamlArrayIter::getSize() const {
     u32 val = *reinterpret_cast<const u32*>(mData);
     return mIsRev ? bswap_24(val >> 8) : val >> 8;
 }
+
 const u8* ByamlArrayIter::getTypeTable() const {
     return mData + 4;
 }

--- a/lib/al/Library/Yaml/ByamlHeader.cpp
+++ b/lib/al/Library/Yaml/ByamlHeader.cpp
@@ -63,12 +63,15 @@ u32 ByamlStringTableIter::getEndAddress() const {
     u32 val = getAddressTable()[getSize()];
     return mIsRev ? bswap_32(val) : val;
 }
+
 const char* ByamlStringTableIter::getString(s32 index) const {
     return reinterpret_cast<const char*>(&mData[getStringAddress(index)]);
 }
+
 s32 ByamlStringTableIter::getStringSize(s32 index) const {
     return getStringAddress(index + 1) - getStringAddress(index) - 1;
 }
+
 s32 ByamlStringTableIter::findStringIndex(const char* str) const {
     s32 lowerBound = 0;
     s32 upperBound = getSize();
@@ -127,6 +130,7 @@ const char* getDataTypeString(s32 type) {
         return "Unknown";
     };
 }
+
 al::ByamlStringTableIter getHashKeyTable(const u8* data) {
     const al::ByamlHeader* header = reinterpret_cast<const al::ByamlHeader*>(data);
     s32 off = header->getHashKeyTableOffset();
@@ -134,6 +138,7 @@ al::ByamlStringTableIter getHashKeyTable(const u8* data) {
         return {};
     return {&data[off], header->isInvertOrder()};
 }
+
 al::ByamlStringTableIter getStringTable(const u8* data) {
     const al::ByamlHeader* header = reinterpret_cast<const al::ByamlHeader*>(data);
     s32 off = header->getStringTableOffset();

--- a/lib/al/Library/Yaml/ByamlIter.cpp
+++ b/lib/al/Library/Yaml/ByamlIter.cpp
@@ -6,6 +6,7 @@
 
 namespace al {
 ByamlIter::ByamlIter() : mData(nullptr), mRootNode(nullptr) {}
+
 ByamlIter::ByamlIter(const u8* data) : mData(data), mRootNode(nullptr) {
     if (!data)
         return;
@@ -21,20 +22,25 @@ ByamlIter::ByamlIter(const u8* data) : mData(data), mRootNode(nullptr) {
 
     mRootNode = &mData[header->getDataOffset()];
 }
+
 ByamlIter::ByamlIter(const u8* data, const u8* root_node) : mData(data), mRootNode(root_node) {}
 
 bool ByamlIter::isValid() const {
     return mData != nullptr;
 }
+
 bool ByamlIter::isTypeHash() const {
     return mRootNode ? mRootNode[0] == ByamlDataType::TYPE_HASH : false;
 }
+
 bool ByamlIter::isTypeArray() const {
     return mRootNode ? mRootNode[0] == ByamlDataType::TYPE_ARRAY : false;
 }
+
 bool ByamlIter::isTypeContainer() const {
     return isTypeHash() || isTypeArray();
 }
+
 // NON_MATCHING: stack allocated differently
 bool ByamlIter::isExistKey(const char* key) const {
     if (!mRootNode || *mRootNode != ByamlDataType::TYPE_HASH)
@@ -47,6 +53,7 @@ bool ByamlIter::isExistKey(const char* key) const {
     ByamlHashIter iter = {mRootNode, isInvertOrder()};
     return iter.findPair(index);
 }
+
 s32 ByamlIter::getKeyIndex(const char* key) const {
     ByamlStringTableIter hash = alByamlLocalUtil::getHashKeyTable(mData);
     if (!hash.isValidate())
@@ -54,9 +61,11 @@ s32 ByamlIter::getKeyIndex(const char* key) const {
 
     return hash.findStringIndex(key);
 }
+
 bool ByamlIter::isInvertOrder() const {
     return mHeader->isInvertOrder();
 }
+
 s32 ByamlIter::getSize() const {
     if (!mRootNode)
         return false;
@@ -66,6 +75,7 @@ s32 ByamlIter::getSize() const {
         return header->getCount(isInvertOrder());
     return 0;
 }
+
 ByamlIter ByamlIter::getIterByIndex(s32 index) const {
     ByamlData data;
     if (!getByamlDataByIndex(&data, index))
@@ -77,6 +87,7 @@ ByamlIter ByamlIter::getIterByIndex(s32 index) const {
     }
     return {mData, &mData[data.getValue()]};
 }
+
 bool ByamlIter::getByamlDataByIndex(ByamlData* data, s32 index) const {
     if (!mRootNode)
         return false;
@@ -90,6 +101,7 @@ bool ByamlIter::getByamlDataByIndex(ByamlData* data, s32 index) const {
     }
     return false;
 }
+
 ByamlIter ByamlIter::getIterByKey(const char* key) const {
     ByamlData data;
     if (!getByamlDataByKey(&data, key))
@@ -101,6 +113,7 @@ ByamlIter ByamlIter::getIterByKey(const char* key) const {
     }
     return {mData, &mData[data.getValue()]};
 }
+
 bool ByamlIter::getByamlDataByKey(ByamlData* data, const char* key) const {
     if (!mRootNode || *mRootNode != ByamlDataType::TYPE_HASH)
         return false;
@@ -128,6 +141,7 @@ bool ByamlIter::getByamlDataByKey(ByamlData* data, const char* key) const {
     }
     return false;
 }
+
 bool ByamlIter::getByamlDataByKeyIndex(ByamlData* data, s32 index) const {
     if (!mRootNode || *mRootNode != ByamlDataType::TYPE_HASH)
         return false;
@@ -135,6 +149,7 @@ bool ByamlIter::getByamlDataByKeyIndex(ByamlData* data, s32 index) const {
     ByamlHashIter iter = {mRootNode, isInvertOrder()};
     return iter.getDataByKey(data, index);
 }
+
 bool ByamlIter::getByamlDataAndKeyName(ByamlData* data, const char** key, s32 index) const {
     if (!mRootNode || *mRootNode != ByamlDataType::TYPE_HASH)
         return false;
@@ -153,13 +168,16 @@ bool ByamlIter::getByamlDataAndKeyName(ByamlData* data, const char** key, s32 in
     *key = hash_table.getString(pair->getKey(isInvertOrder()));
     return true;
 }
+
 bool ByamlIter::getKeyName(const char** key, s32 index) const {
     return getByamlDataAndKeyName(nullptr, key, index);
 }
+
 bool ByamlIter::tryGetIterByIndex(ByamlIter* iter, s32 index) const {
     *iter = getIterByIndex(index);
     return iter->isValid();
 }
+
 bool ByamlIter::tryGetIterAndKeyNameByIndex(ByamlIter* iter, const char** key, s32 index) const {
     ByamlData data;
     if (!getByamlDataAndKeyName(&data, key, index)) {
@@ -174,10 +192,12 @@ bool ByamlIter::tryGetIterAndKeyNameByIndex(ByamlIter* iter, const char** key, s
         *iter = {mData, nullptr};
     return true;
 }
+
 bool ByamlIter::tryGetIterByKey(ByamlIter* iter, const char* key) const {
     *iter = getIterByKey(key);
     return iter->isValid();
 }
+
 bool ByamlIter::tryConvertIter(ByamlIter* iter, const ByamlData* data) const {
     if (data->getType() == ByamlDataType::TYPE_ARRAY ||
         data->getType() == ByamlDataType::TYPE_HASH) {
@@ -198,6 +218,7 @@ bool ByamlIter::tryGetStringByIndex(const char** value, s32 index) const {
 
     return tryConvertString(value, &data);
 }
+
 bool ByamlIter::tryGetStringByKey(const char** value, const char* key) const {
     ByamlData data;
     if (!getByamlDataByKey(&data, key))
@@ -219,6 +240,7 @@ bool ByamlIter::tryConvertString(const char** value, const ByamlData* data) cons
 
     return true;
 }
+
 bool ByamlIter::tryGetBinaryByIndex(const u8** value, s32* size, s32 index) const {
     ByamlData data;
     if (!getByamlDataByIndex(&data, index))
@@ -226,6 +248,7 @@ bool ByamlIter::tryGetBinaryByIndex(const u8** value, s32* size, s32 index) cons
 
     return tryConvertBinary(value, size, &data);
 }
+
 bool ByamlIter::tryGetBinaryByKey(const u8** value, s32* size, const char* key) const {
     ByamlData data;
     if (!getByamlDataByKey(&data, key))
@@ -233,6 +256,7 @@ bool ByamlIter::tryGetBinaryByKey(const u8** value, s32* size, const char* key) 
 
     return tryConvertBinary(value, size, &data);
 }
+
 bool ByamlIter::tryConvertBinary(const u8** value, s32* size, const ByamlData* data) const {
     if (data->getType() != ByamlDataType::TYPE_STRING)
         return false;
@@ -314,6 +338,7 @@ bool ByamlIter::tryGetFloatByIndex(f32* value, s32 index) const {
 
     return tryConvertFloat(value, &data);
 }
+
 bool ByamlIter::tryGetFloatByKey(f32* value, const char* key) const {
     ByamlData data;
     if (!getByamlDataByKey(&data, key))
@@ -323,6 +348,7 @@ bool ByamlIter::tryGetFloatByKey(f32* value, const char* key) const {
         return false;
     return tryConvertFloat(value, &data);
 }
+
 bool ByamlIter::tryConvertFloat(f32* value, const ByamlData* data) const {
     if (data->getType() != ByamlDataType::TYPE_FLOAT)
         return false;

--- a/lib/al/Library/Yaml/ByamlIter.h
+++ b/lib/al/Library/Yaml/ByamlIter.h
@@ -65,6 +65,7 @@ private:
         const u8* mData;
         const ByamlHeader* mHeader;
     };
+
     const u8* mRootNode;
 };
 }  // namespace al

--- a/lib/al/Library/Yaml/ByamlUtil.cpp
+++ b/lib/al/Library/Yaml/ByamlUtil.cpp
@@ -286,12 +286,15 @@ bool tryGetByamlKeyAndIntByIndex(const char** key, s32* pOut, const ByamlIter& r
 const char* getByamlKeyString(const ByamlIter& rIter, const char* key) {
     return tryGetByamlKeyStringOrNULL(rIter, key);
 }
+
 s32 getByamlKeyInt(const ByamlIter& rIter, const char* key) {
     return tryGetByamlKeyIntOrZero(rIter, key);
 }
+
 f32 getByamlKeyFloat(const ByamlIter& rIter, const char* key) {
     return tryGetByamlKeyFloatOrZero(rIter, key);
 }
+
 bool getByamlKeyBool(const ByamlIter& rIter, const char* key) {
     return tryGetByamlKeyBoolOrFalse(rIter, key);
 }
@@ -307,6 +310,7 @@ void getByamlIterByIndex(ByamlIter* pOut, const ByamlIter& rIter, s32 index) {
 bool isTypeBoolByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_BOOL>(rIter, index);
 }
+
 bool isTypeBoolByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_BOOL>(rIter, pKey);
 }
@@ -314,6 +318,7 @@ bool isTypeBoolByKey(const ByamlIter& rIter, const char* pKey) {
 bool isTypeIntByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_INT>(rIter, index);
 }
+
 bool isTypeIntByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_INT>(rIter, pKey);
 }
@@ -321,6 +326,7 @@ bool isTypeIntByKey(const ByamlIter& rIter, const char* pKey) {
 bool isTypeFloatByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_FLOAT>(rIter, index);
 }
+
 bool isTypeFloatByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_FLOAT>(rIter, pKey);
 }
@@ -328,6 +334,7 @@ bool isTypeFloatByKey(const ByamlIter& rIter, const char* pKey) {
 bool isTypeStringByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_STRING>(rIter, index);
 }
+
 bool isTypeStringByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_STRING>(rIter, pKey);
 }
@@ -335,6 +342,7 @@ bool isTypeStringByKey(const ByamlIter& rIter, const char* pKey) {
 bool isTypeArrayByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_ARRAY>(rIter, index);
 }
+
 bool isTypeArrayByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_ARRAY>(rIter, pKey);
 }
@@ -342,6 +350,7 @@ bool isTypeArrayByKey(const ByamlIter& rIter, const char* pKey) {
 bool isTypeHashByIndex(const ByamlIter& rIter, s32 index) {
     return isTypeByIndex<ByamlDataType::TYPE_HASH>(rIter, index);
 }
+
 bool isTypeHashByKey(const ByamlIter& rIter, const char* pKey) {
     return isTypeByKey<ByamlDataType::TYPE_HASH>(rIter, pKey);
 }
@@ -354,11 +363,13 @@ void printByamlIter(const u8* data) {
     ByamlIter iter = {data};
     printByamlIter(iter);
 }
+
 void printByamlIter(const ByamlIter& iter) {
     u32 data_off = iter.getHeader()->getDataOffset();
     PrintParams param = {0, data_off, nullptr};
     printByamlIter_(iter, &param);
 }
+
 void printByamlIter_(const ByamlIter& iter, PrintParams* param) {
     s32 size = iter.getSize();
     for (s32 i = 0; i < size; ++i) {

--- a/lib/al/Library/Yaml/ByamlUtil.h
+++ b/lib/al/Library/Yaml/ByamlUtil.h
@@ -60,6 +60,7 @@ bool isTypeByIndex(const ByamlIter& rIter, s32 index) {
         return data.getType() == T;
     return false;
 }
+
 template <ByamlDataType T>
 bool isTypeByKey(const ByamlIter& rIter, const char* key) {
     ByamlData data;
@@ -67,6 +68,7 @@ bool isTypeByKey(const ByamlIter& rIter, const char* key) {
         return data.getType() == T;
     return false;
 }
+
 bool isTypeBoolByIndex(const ByamlIter&, s32);
 bool isTypeBoolByKey(const ByamlIter&, const char*);
 bool isTypeIntByIndex(const ByamlIter&, s32);

--- a/lib/al/Library/Yaml/Writer/ByamlWriter.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriter.cpp
@@ -40,34 +40,42 @@ void ByamlWriter::addBool(bool value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addBool(value);
 }
+
 void ByamlWriter::addInt(s32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addInt(value);
 }
+
 void ByamlWriter::addUInt(u32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addUInt(value);
 }
+
 void ByamlWriter::addFloat(f32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addFloat(value);
 }
+
 void ByamlWriter::addInt64(s64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addInt64(value, mBigDataList);
 }
+
 void ByamlWriter::addUInt64(u64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addUInt64(value, mBigDataList);
 }
+
 void ByamlWriter::addDouble(f64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addDouble(value, mBigDataList);
 }
+
 void ByamlWriter::addString(const char* value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addString(value);
 }
+
 void ByamlWriter::addNull() {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addNull();
@@ -77,34 +85,42 @@ void ByamlWriter::addBool(const char* key, bool value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addBool(key, value);
 }
+
 void ByamlWriter::addInt(const char* key, s32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addInt(key, value);
 }
+
 void ByamlWriter::addUInt(const char* key, u32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addUInt(key, value);
 }
+
 void ByamlWriter::addFloat(const char* key, f32 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addFloat(key, value);
 }
+
 void ByamlWriter::addInt64(const char* key, s64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addInt64(key, value, mBigDataList);
 }
+
 void ByamlWriter::addUInt64(const char* key, u64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addUInt64(key, value, mBigDataList);
 }
+
 void ByamlWriter::addDouble(const char* key, f64 value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addDouble(key, value, mBigDataList);
 }
+
 void ByamlWriter::addString(const char* key, const char* value) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addString(key, value);
 }
+
 void ByamlWriter::addNull(const char* key) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     mContainerStack[mCurrentContainerIndex]->addNull(key);
@@ -113,9 +129,11 @@ void ByamlWriter::addNull(const char* key) {
 ByamlWriterContainer* ByamlWriter::getCurrentContainer() {
     return mContainerStack[mCurrentContainerIndex];
 }
+
 ByamlWriterArray* ByamlWriter::getArrayCurrentContainer() {
     return static_cast<ByamlWriterArray*>(getCurrentContainer());
 }
+
 ByamlWriterHash* ByamlWriter::getHashCurrentContainer() {
     return static_cast<ByamlWriterHash*>(getCurrentContainer());
 }
@@ -125,6 +143,7 @@ void ByamlWriter::pushContainer(ByamlWriterContainer* container) {
     mContainerStack[mCurrentContainerIndex] = container;
     mContainerList.pushBack(new sead::TListNode<ByamlWriterContainer*>(container));
 }
+
 void ByamlWriter::pushHash() {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     auto* hash = new ByamlWriterHash(mStringTable1, mStringTable2);
@@ -133,6 +152,7 @@ void ByamlWriter::pushHash() {
 
     pushContainer(hash);
 }
+
 void ByamlWriter::pushArray() {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     auto* array = new ByamlWriterArray(mStringTable2);
@@ -141,6 +161,7 @@ void ByamlWriter::pushArray() {
 
     pushContainer(array);
 }
+
 void ByamlWriter::pushHash(const char* key) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     auto* hash = new ByamlWriterHash(mStringTable1, mStringTable2);
@@ -148,6 +169,7 @@ void ByamlWriter::pushHash(const char* key) {
 
     pushContainer(hash);
 }
+
 void ByamlWriter::pushArray(const char* key) {
     sead::ScopedCurrentHeapSetter setter{mHeap};
     auto* array = new ByamlWriterArray(mStringTable2);
@@ -159,9 +181,11 @@ void ByamlWriter::pushArray(const char* key) {
 void ByamlWriter::pushIter(const ByamlIter& iter) {
     pushLocalIter(iter, nullptr);
 }
+
 void ByamlWriter::pushIter(const char* key, const ByamlIter& iter) {
     pushLocalIter(iter, key);
 }
+
 void ByamlWriter::pushLocalIter(const ByamlIter& iter, const char* iterKey) {
     if (!iter.isValid())
         return;
@@ -278,9 +302,11 @@ void ByamlWriter::pushLocalIter(const ByamlIter& iter, const char* iterKey) {
 void ByamlWriter::pop() {
     mCurrentContainerIndex--;
 }
+
 u32 ByamlWriter::calcHeaderSize() const {
     return 16;
 }
+
 u32 ByamlWriter::calcPackSize() const {
     u32 size = 16;
     if (mStringTable1)
@@ -293,6 +319,7 @@ u32 ByamlWriter::calcPackSize() const {
         size += container->calcPackSize();
     return size;
 }
+
 // NON_MATCHING: offsetBigDataList increased "too early"
 void ByamlWriter::write(sead::WriteStream* stream) {
     stream->writeU16(0x4259);

--- a/lib/al/Library/Yaml/Writer/ByamlWriterBigDataList.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterBigDataList.cpp
@@ -5,19 +5,23 @@
 namespace al {
 
 ByamlWriterBigDataList::ByamlWriterBigDataList() = default;
+
 ByamlWriterBigDataList::~ByamlWriterBigDataList() {
     while (auto* node = mList.popBack())
         delete node;
 }
+
 void ByamlWriterBigDataList::addData(ByamlWriterBigData* data) {
     mList.pushBack(new sead::TListNode<ByamlWriterBigData*>(data));
 }
+
 u32 ByamlWriterBigDataList::calcPackSize() const {
     u32 size = 0;
     for (auto& node : mList)
         size += node->calcBigDataSize();
     return size;
 }
+
 s32 ByamlWriterBigDataList::setOffset(s32 offset) {
     for (auto& node : mList) {
         node->setOffset(offset);
@@ -25,6 +29,7 @@ s32 ByamlWriterBigDataList::setOffset(s32 offset) {
     }
     return offset;
 }
+
 void ByamlWriterBigDataList::write(sead::WriteStream* stream) {
     for (auto& node : mList)
         node->writeBigData(stream);

--- a/lib/al/Library/Yaml/Writer/ByamlWriterData.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterData.cpp
@@ -11,58 +11,79 @@ namespace al {
 u32 ByamlWriterData::calcPackSize() const {
     return 4;
 }
+
 u8 ByamlWriterData::getTypeCode() const {
     return 0;
 }
+
 bool ByamlWriterData::isContainer() const {
     return false;
 }
+
 void ByamlWriterData::makeIndex() {}
+
 void ByamlWriterData::print(s32) const {}
+
 void ByamlWriterData::printIndent(s32) const {}
+
 ByamlWriterData::~ByamlWriterData() {}
 
 ByamlWriterBool::ByamlWriterBool(bool value) : mValue(value) {}
+
 u8 ByamlWriterBool::getTypeCode() const {
     return 0xD0;
 }
+
 void ByamlWriterBool::print(s32) const {}
+
 void ByamlWriterBool::write(sead::WriteStream* stream) const {
     stream->writeU32(mValue);
 }
 
 ByamlWriterInt::ByamlWriterInt(s32 value) : mValue(value) {}
+
 u8 ByamlWriterInt::getTypeCode() const {
     return 0xD1;
 }
+
 void ByamlWriterInt::print(s32) const {}
+
 void ByamlWriterInt::write(sead::WriteStream* stream) const {
     stream->writeS32(mValue);
 }
 
 ByamlWriterFloat::ByamlWriterFloat(f32 value) : mValue(value) {}
+
 u8 ByamlWriterFloat::getTypeCode() const {
     return 0xD2;
 }
+
 void ByamlWriterFloat::print(s32) const {}
+
 void ByamlWriterFloat::write(sead::WriteStream* stream) const {
     stream->writeF32(mValue);
 }
 
 ByamlWriterUInt::ByamlWriterUInt(u32 value) : mValue(value) {}
+
 u8 ByamlWriterUInt::getTypeCode() const {
     return 0xD3;
 }
+
 void ByamlWriterUInt::print(s32) const {}
+
 void ByamlWriterUInt::write(sead::WriteStream* stream) const {
     stream->writeU32(mValue);
 }
 
 ByamlWriterNull::ByamlWriterNull() = default;
+
 u8 ByamlWriterNull::getTypeCode() const {
     return 0xFF;
 }
+
 void ByamlWriterNull::print(s32) const {}
+
 void ByamlWriterNull::write(sead::WriteStream* stream) const {
     stream->writeU32(0);
 }
@@ -71,10 +92,13 @@ ByamlWriterString::ByamlWriterString(const char* string, ByamlWriterStringTable*
     : mString(nullptr), mStringTable(stringTable) {
     mString = mStringTable->tryAdd(string);
 }
+
 u8 ByamlWriterString::getTypeCode() const {
     return 0xA0;
 }
+
 void ByamlWriterString::print(s32) const {}
+
 void ByamlWriterString::write(sead::WriteStream* stream) const {
     stream->writeU32(mStringTable->calcIndex(mString));
 }
@@ -82,46 +106,62 @@ void ByamlWriterString::write(sead::WriteStream* stream) const {
 ByamlWriterBigData::ByamlWriterBigData(ByamlWriterBigDataList* list) : mList(list) {
     mList->addData(this);
 }
+
 ByamlWriterBigData::~ByamlWriterBigData() = default;
+
 void ByamlWriterBigData::write(sead::WriteStream* stream) const {
     stream->writeU32(mOffset);
 }
+
 u32 ByamlWriterBigData::calcBigDataSize() const {
     return 8;
 }
+
 void ByamlWriterBigData::writeBigData(sead::WriteStream*) const {}
 
 ByamlWriterInt64::ByamlWriterInt64(s64 value, ByamlWriterBigDataList* list)
     : ByamlWriterBigData(list), mValue(value) {}
+
 ByamlWriterInt64::~ByamlWriterInt64() = default;
+
 u8 ByamlWriterInt64::getTypeCode() const {
     return 0xD4;
 }
+
 void ByamlWriterInt64::writeBigData(sead::WriteStream* stream) const {
     stream->writeS64(mValue);
 }
+
 void ByamlWriterInt64::print(s32) const {}
 
 ByamlWriterUInt64::ByamlWriterUInt64(u64 value, ByamlWriterBigDataList* list)
     : ByamlWriterBigData(list), mValue(value) {}
+
 ByamlWriterUInt64::~ByamlWriterUInt64() = default;
+
 u8 ByamlWriterUInt64::getTypeCode() const {
     return 0xD5;
 }
+
 void ByamlWriterUInt64::writeBigData(sead::WriteStream* stream) const {
     stream->writeU64(mValue);
 }
+
 void ByamlWriterUInt64::print(s32) const {}
 
 ByamlWriterDouble::ByamlWriterDouble(f64 value, ByamlWriterBigDataList* list)
     : ByamlWriterBigData(list), mValue(value) {}
+
 ByamlWriterDouble::~ByamlWriterDouble() = default;
+
 u8 ByamlWriterDouble::getTypeCode() const {
     return 0xD6;
 }
+
 void ByamlWriterDouble::writeBigData(sead::WriteStream* stream) const {
     stream->writeU64(*reinterpret_cast<const u64*>(&mValue));
 }
+
 void ByamlWriterDouble::print(s32) const {}
 
 bool ByamlWriterContainer::isContainer() const {
@@ -129,44 +169,69 @@ bool ByamlWriterContainer::isContainer() const {
 }
 
 void ByamlWriterContainer::addBool(const char*, bool) {}
+
 void ByamlWriterContainer::addInt(const char*, s32) {}
+
 void ByamlWriterContainer::addUInt(const char*, u32) {}
+
 void ByamlWriterContainer::addFloat(const char*, f32) {}
+
 void ByamlWriterContainer::addInt64(const char*, s64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addUInt64(const char*, u64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addDouble(const char*, f64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addString(const char*, const char*) {}
+
 void ByamlWriterContainer::addHash(const char*, ByamlWriterHash*) {}
+
 void ByamlWriterContainer::addArray(const char*, ByamlWriterArray*) {}
+
 void ByamlWriterContainer::addNull(const char*) {}
 
 void ByamlWriterContainer::addBool(bool) {}
+
 void ByamlWriterContainer::addInt(s32) {}
+
 void ByamlWriterContainer::addUInt(u32) {}
+
 void ByamlWriterContainer::addFloat(f32) {}
+
 void ByamlWriterContainer::addInt64(s64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addUInt64(u64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addDouble(f64, ByamlWriterBigDataList*) {}
+
 void ByamlWriterContainer::addString(const char*) {}
+
 void ByamlWriterContainer::addHash(ByamlWriterHash*) {}
+
 void ByamlWriterContainer::addArray(ByamlWriterArray*) {}
+
 void ByamlWriterContainer::addNull() {}
 
 void ByamlWriterContainer::writeContainer(sead::WriteStream*) const {}
+
 bool ByamlWriterContainer::isHash() const {
     return false;
 }
+
 bool ByamlWriterContainer::isArray() const {
     return false;
 }
+
 void ByamlWriterContainer::deleteData() {}
 
 ByamlWriterArray::ByamlWriterArray(ByamlWriterStringTable* stringTable)
     : mStringTable(stringTable) {}
+
 ByamlWriterArray::~ByamlWriterArray() {
     while (auto* node = mList.popBack())
         delete node;
 }
+
 void ByamlWriterArray::deleteData() {
     for (auto it = mList.robustBegin(); it != mList.robustEnd(); ++it) {
         if (!it->mData->isContainer()) {
@@ -175,9 +240,11 @@ void ByamlWriterArray::deleteData() {
         }
     }
 }
+
 u32 ByamlWriterArray::calcPackSize() const {
     return mList.size() * 4 + ((mList.size() + 7) & 0xFFFFFFFC);
 }
+
 void ByamlWriterArray::addData(ByamlWriterData* data) {
     mList.pushBack(new sead::TListNode<ByamlWriterData*>(data));
 }
@@ -185,33 +252,43 @@ void ByamlWriterArray::addData(ByamlWriterData* data) {
 void ByamlWriterArray::addBool(bool value) {
     addData(new ByamlWriterBool(value));
 }
+
 void ByamlWriterArray::addInt(s32 value) {
     addData(new ByamlWriterInt(value));
 }
+
 void ByamlWriterArray::addUInt(u32 value) {
     addData(new ByamlWriterUInt(value));
 }
+
 void ByamlWriterArray::addFloat(f32 value) {
     addData(new ByamlWriterFloat(value));
 }
+
 void ByamlWriterArray::addInt64(s64 value, ByamlWriterBigDataList* list) {
     addData(new ByamlWriterInt64(value, list));
 }
+
 void ByamlWriterArray::addUInt64(u64 value, ByamlWriterBigDataList* list) {
     addData(new ByamlWriterUInt64(value, list));
 }
+
 void ByamlWriterArray::addDouble(f64 value, ByamlWriterBigDataList* list) {
     addData(new ByamlWriterDouble(value, list));
 }
+
 void ByamlWriterArray::addString(const char* value) {
     addData(new ByamlWriterString(value, mStringTable));
 }
+
 void ByamlWriterArray::addHash(ByamlWriterHash* hash) {
     addData(hash);
 }
+
 void ByamlWriterArray::addArray(ByamlWriterArray* array) {
     addData(array);
 }
+
 void ByamlWriterArray::addNull() {
     addData(new ByamlWriterNull());
 }
@@ -219,6 +296,7 @@ void ByamlWriterArray::addNull() {
 u8 ByamlWriterArray::getTypeCode() const {
     return 0xC0;
 }
+
 void ByamlWriterArray::writeContainer(sead::WriteStream* stream) const {
     stream->writeU8(0xC0);
     alByamlLocalUtil::writeU24(stream, mList.size());
@@ -236,13 +314,16 @@ void ByamlWriterArray::writeContainer(sead::WriteStream* stream) const {
     for (auto& node : mList)
         node->write(stream);
 }
+
 void ByamlWriterArray::write(sead::WriteStream* stream) const {
     stream->writeU32(getOffset());
 }
+
 void ByamlWriterArray::print(s32 unknown) const {
     for (auto node : mList)
         node->print(unknown + 1);
 }
+
 bool ByamlWriterArray::isArray() const {
     return true;
 }
@@ -253,43 +334,56 @@ ByamlWriterHashPair::ByamlWriterHashPair(const char* key, ByamlWriterData* value
 ByamlWriterHash::ByamlWriterHash(ByamlWriterStringTable* stringTable1,
                                  ByamlWriterStringTable* stringTable2)
     : mStringTable1(stringTable1), mStringTable2(stringTable2) {}
+
 ByamlWriterHash::~ByamlWriterHash() {
     while (auto* node = mList.popBack())
         delete node;
 }
+
 u32 ByamlWriterHash::calcPackSize() const {
     return mList.size() * 8 + 4;
 }
+
 void ByamlWriterHash::addBool(const char* key, bool value) {
     addData(key, new ByamlWriterBool(value));
 }
+
 void ByamlWriterHash::addInt(const char* key, s32 value) {
     addData(key, new ByamlWriterInt(value));
 }
+
 void ByamlWriterHash::addUInt(const char* key, u32 value) {
     addData(key, new ByamlWriterUInt(value));
 }
+
 void ByamlWriterHash::addFloat(const char* key, f32 value) {
     addData(key, new ByamlWriterFloat(value));
 }
+
 void ByamlWriterHash::addInt64(const char* key, s64 value, ByamlWriterBigDataList* list) {
     addData(key, new ByamlWriterInt64(value, list));
 }
+
 void ByamlWriterHash::addUInt64(const char* key, u64 value, ByamlWriterBigDataList* list) {
     addData(key, new ByamlWriterUInt64(value, list));
 }
+
 void ByamlWriterHash::addDouble(const char* key, f64 value, ByamlWriterBigDataList* list) {
     addData(key, new ByamlWriterDouble(value, list));
 }
+
 void ByamlWriterHash::addString(const char* key, const char* value) {
     addData(key, new ByamlWriterString(value, mStringTable2));
 }
+
 void ByamlWriterHash::addHash(const char* key, ByamlWriterHash* value) {
     addData(key, value);
 }
+
 void ByamlWriterHash::addArray(const char* key, ByamlWriterArray* value) {
     addData(key, value);
 }
+
 void ByamlWriterHash::addNull(const char* key) {
     addData(key, new ByamlWriterNull());
 }
@@ -297,9 +391,11 @@ void ByamlWriterHash::addNull(const char* key) {
 u8 ByamlWriterHash::getTypeCode() const {
     return 0xC1;
 }
+
 void ByamlWriterHash::write(sead::WriteStream* stream) const {
     stream->writeU32(getOffset());
 }
+
 bool ByamlWriterHash::isHash() const {
     return true;
 }

--- a/lib/al/Library/Yaml/Writer/ByamlWriterData.h
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterData.h
@@ -74,6 +74,7 @@ public:
 };
 
 class ByamlWriterStringTable;
+
 class ByamlWriterString : public ByamlWriterData {
 public:
     ByamlWriterString(const char*, ByamlWriterStringTable*);
@@ -177,6 +178,7 @@ public:
     virtual void deleteData();
 
     s32 getOffset() const { return mOffset; }
+
     void setOffset(s32 offset) { mOffset = offset; }
 
 private:
@@ -214,6 +216,7 @@ private:
     sead::TList<ByamlWriterData*> mList;
     ByamlWriterStringTable* mStringTable;
 };
+
 static_assert(sizeof(ByamlWriterArray) == 0x30);
 
 class ByamlWriterHashPair : public sead::ListNode {
@@ -221,6 +224,7 @@ public:
     ByamlWriterHashPair(const char*, ByamlWriterData*);
 
     const char* getKey() { return mKey; }
+
     ByamlWriterData* getValue() { return mValue; }
 
 private:
@@ -229,6 +233,7 @@ private:
     const char* mKey;
     ByamlWriterData* mValue;
 };
+
 static_assert(sizeof(ByamlWriterHashPair) == 0x30);
 
 class ByamlWriterHash : public ByamlWriterContainer {
@@ -263,6 +268,7 @@ private:
     ByamlWriterStringTable* mStringTable1;
     ByamlWriterStringTable* mStringTable2;
 };
+
 static_assert(sizeof(ByamlWriterHash) == 0x38);
 
 }  // namespace al

--- a/lib/al/Library/Yaml/Writer/ByamlWriterStringTable.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterStringTable.cpp
@@ -8,6 +8,7 @@
 namespace al {
 
 ByamlWriterStringTable::ByamlWriterStringTable() = default;
+
 ByamlWriterStringTable::~ByamlWriterStringTable() {
     while (auto* node = mList.popBack()) {
         node->mList = nullptr;
@@ -15,6 +16,7 @@ ByamlWriterStringTable::~ByamlWriterStringTable() {
         delete node;
     }
 }
+
 inline char* add(const char* string, sead::TList<const char*>& list) {
     s32 length = ((strlen(string) << 32) + 0x100000000LL) >> 32;
     char* array = new char[length];
@@ -23,6 +25,7 @@ inline char* add(const char* string, sead::TList<const char*>& list) {
     list.pushBack(node);
     return array;
 }
+
 const char* ByamlWriterStringTable::tryAdd(const char* string) {
     for (auto it = mList.robustBegin(); it != mList.robustEnd(); ++it) {
         s32 result = strcmp(string, it->mData);
@@ -44,23 +47,28 @@ const char* ByamlWriterStringTable::tryAdd(const char* string) {
     mList.pushBack(node);
     return result;
 }
+
 u32 ByamlWriterStringTable::calcHeaderSize() const {
     return (4 * mList.size()) + 8;
 }
+
 u32 ByamlWriterStringTable::calcContentSize() const {
     u32 size = 0;
     for (auto& node : mList)
         size += strlen(node) + 1;
     return (size + 3) & 0xFFFFFFFC;
 }
+
 u32 ByamlWriterStringTable::calcPackSize() const {
     if (isEmpty())
         return 0;
     return calcHeaderSize() + calcContentSize();
 }
+
 bool ByamlWriterStringTable::isEmpty() const {
     return mList.size() == 0;
 }
+
 u32 ByamlWriterStringTable::calcIndex(const char* data) const {
     s32 i = 0;
     for (auto& node : mList) {
@@ -70,6 +78,7 @@ u32 ByamlWriterStringTable::calcIndex(const char* data) const {
     }
     return -1;
 }
+
 void ByamlWriterStringTable::write(sead::WriteStream* stream) const {
     if (isEmpty())
         return;
@@ -101,6 +110,7 @@ void ByamlWriterStringTable::write(sead::WriteStream* stream) const {
     for (s32 j = 0; j < v16; j++)
         stream->writeU8(0);
 }
+
 void ByamlWriterStringTable::print() const {
     for (auto& node : mList)
         ;

--- a/lib/al/Project/Action/ActionFlagCtrl.cpp
+++ b/lib/al/Project/Action/ActionFlagCtrl.cpp
@@ -21,6 +21,7 @@ ActionFlagCtrl* ActionFlagCtrl::tryCreate(LiveActor* actor, const char* name) {
 
     return new ActionFlagCtrl(actor, name);
 }
+
 void ActionFlagCtrl::start(const char* name) {
     mLastFlag = findFlagInfo(name);
     mIsBool = false;
@@ -30,6 +31,7 @@ void ActionFlagCtrl::start(const char* name) {
     startCtrlFlag();
     startCtrlSensor();
 }
+
 ActionFlagCtrlInfo* ActionFlagCtrl::findFlagInfo(const char* name) const {
     for (s32 i = 0; i < mInfoCount; i++) {
         ActionFlagCtrlInfo* flagInfo = mInfos[i];
@@ -38,6 +40,7 @@ ActionFlagCtrlInfo* ActionFlagCtrl::findFlagInfo(const char* name) const {
     }
     return nullptr;
 }
+
 void ActionFlagCtrl::update(f32 frame, f32 frameRate, f32 frameMax, bool isStop) {
     if (!mLastFlag || !mIsBool)
         return;

--- a/lib/al/Project/Anim/AnimPlayerBase.cpp
+++ b/lib/al/Project/Anim/AnimPlayerBase.cpp
@@ -2,6 +2,7 @@
 
 namespace al {
 AnimPlayerBase::AnimPlayerBase() {}
+
 void AnimPlayerBase::updateLast() {
     _10 = false;
 }

--- a/lib/al/Project/Bgm/BgmInfo.cpp
+++ b/lib/al/Project/Bgm/BgmInfo.cpp
@@ -8,6 +8,7 @@ BgmChangeableParams::BgmChangeableParams() {}
 void BgmChangeableParams::calcPitch(f32 value) {
     exp2f(value / 12);
 }
+
 void BgmChangeableParams::operator=(const BgmChangeableParams& value) {
     mVolume = value.mVolume;
     mPitch = value.mPitch;
@@ -22,11 +23,13 @@ void BgmChangeableParams::operator=(const BgmChangeableParams& value) {
     mTrackVolume4 = value.mTrackVolume4;
     mTrackVolume5 = value.mTrackVolume5;
 }
+
 BgmUserInfo::BgmUserInfo() {}
 
 s32 BgmUserInfo::compareInfo(const BgmUserInfo* info_1, const BgmUserInfo* info_2) {
     return strcmp(info_1->mName, info_2->mName);
 }
+
 s32 BgmUserInfo::compareInfoByKey(const BgmUserInfo* info, const char* string) {
     return strcmp(info->mName, string);
 }

--- a/lib/al/Project/Clipping/ClippingDirector.h
+++ b/lib/al/Project/Clipping/ClippingDirector.h
@@ -35,6 +35,7 @@ public:
 private:
     void* filler[6];
 };
+
 static_assert(sizeof(ClippingDirector) == 0x38);
 
 }  // namespace al

--- a/lib/al/Project/Execute/ExecuteAsyncExecutor.h
+++ b/lib/al/Project/Execute/ExecuteAsyncExecutor.h
@@ -28,18 +28,21 @@ public:
     ExecuteAsyncExecutorUpdate(const ExecuteDirector* director, const char* name,
                                sead::CoreId coreId)
         : ExecuteAsyncExecutor(director, name, coreId) {}
+
     ~ExecuteAsyncExecutorUpdate() override;
     void execute() override;
 
 private:
     // missing
 };
+
 static_assert(sizeof(ExecuteAsyncExecutorUpdate) == 0x28);
 
 class ExecuteAsyncExecutorDraw : public ExecuteAsyncExecutor {
 public:
     ExecuteAsyncExecutorDraw(const ExecuteDirector* director, const char* name, sead::CoreId coreId)
         : ExecuteAsyncExecutor(director, name, coreId) {}
+
     ~ExecuteAsyncExecutorDraw() override;
     void execute() override;
 

--- a/lib/al/Project/Gravity/GravityHolder.h
+++ b/lib/al/Project/Gravity/GravityHolder.h
@@ -16,6 +16,7 @@ public:
 private:
     void* filler[2];
 };
+
 static_assert(sizeof(GravityHolder) == 0x10);
 
 }  // namespace al

--- a/lib/al/Project/HitSensor/HitSensorDirector.h
+++ b/lib/al/Project/HitSensor/HitSensorDirector.h
@@ -22,6 +22,7 @@ public:
 private:
     void* filler[8];
 };
+
 static_assert(sizeof(HitSensorDirector) == 0x48);
 
 }  // namespace al

--- a/lib/al/Project/Light/ActorPrepassLightKeeper.h
+++ b/lib/al/Project/Light/ActorPrepassLightKeeper.h
@@ -26,6 +26,7 @@ public:
         ParameterStringRef* mName;
         ParameterC4f* mColor;
     };
+
     static_assert(sizeof(UserColor) == 0x18);
 
     static bool isExistFile(const Resource*, const char*);
@@ -52,5 +53,6 @@ private:
     LiveActor* mLiveActor;
     bool mIsIgnorePrePassLightYaml;
 };
+
 static_assert(sizeof(ActorPrePassLightKeeper) == 0x50);
 }  // namespace al

--- a/lib/al/Project/Memory/MemorySystem.h
+++ b/lib/al/Project/Memory/MemorySystem.h
@@ -30,14 +30,23 @@ public:
     void removeNamedHeap(const char* heapName);
 
     sead::ExpHeap* getStationedHeap() { return mStationedHeap; }
+
     sead::ExpHeap* getSequenceHeap() { return mSequenceHeap; }
+
     sead::ExpHeap* getSceneResourceHeap() { return mSceneResourceHeap; }
+
     sead::ExpHeap* getSceneHeap() { return mSceneHeap; }
+
     sead::ExpHeap* getPlayerResourceHeap() { return mPlayerResourceHeap; }
+
     sead::ExpHeap* getCourseSelectResourceHeap() { return mCourseSelectResourceHeap; }
+
     sead::ExpHeap* getCourseSelectHeap() { return mCourseSelectHeap; }
+
     sead::ExpHeap* getWorldResourceHeap() { return mWorldResourceHeap; }
+
     AudioResourceDirector* getAudioResourceDirector() { return mAudioResourceDirector; }
+
     void setAudioResourceDirector(AudioResourceDirector* audioResourceDirector) {
         mAudioResourceDirector = audioResourceDirector;
     }

--- a/lib/al/Project/Rail/LinearCurve.cpp
+++ b/lib/al/Project/Rail/LinearCurve.cpp
@@ -14,17 +14,21 @@ void LinearCurve::set(const sead::Vector3f& start, const sead::Vector3f& end) {
     mDiff.z = end.z - start.z;
     mDistance = sead::Mathf::sqrt(mDiff.x * mDiff.x + mDiff.y * mDiff.y + mDiff.z * mDiff.z);
 }
+
 void LinearCurve::calcPos(sead::Vector3f* pos, f32 param) const {
     pos->x = (mDiff.x * param) + mStart.x;
     pos->y = (mDiff.y * param) + mStart.y;
     pos->z = (mDiff.z * param) + mStart.z;
 }
+
 void LinearCurve::calcVelocity(sead::Vector3f* vel, f32 param) const {
     *vel = mDiff;
 }
+
 f32 LinearCurve::calcLength(f32 param_start, f32 param_end) const {
     return mDistance * sead::Mathf::abs(param_end - param_start);
 }
+
 f32 LinearCurve::calcCurveParam(f32 param) const {
     if (isNearZero(mDistance, 0.001))
         return 0;

--- a/src/Amiibo/SearchAmiiboDataTable.h
+++ b/src/Amiibo/SearchAmiiboDataTable.h
@@ -24,6 +24,7 @@ struct SearchAmiiboDataTableEntries {
         for (auto& entry : e)
             entry.init();
     };
+
     SearchAmiiboData e[3];
 };
 

--- a/src/Boss/BarrierField.cpp
+++ b/src/Boss/BarrierField.cpp
@@ -61,7 +61,9 @@ void BarrierField::disappearByShineGet() {
 }
 
 void BarrierField::exeAppear() {}
+
 void BarrierField::exeAppearBreedaMoonWorld() {}
+
 void BarrierField::exeHide() {}
 
 void BarrierField::exeDisappear() {

--- a/src/Boss/Mofumofu/MofumofuWarpHole.cpp
+++ b/src/Boss/Mofumofu/MofumofuWarpHole.cpp
@@ -50,45 +50,57 @@ void MofumofuWarpHole::appear() {
 void MofumofuWarpHole::disappear() {
     al::setNerve(this, &Disappear);
 }
+
 void MofumofuWarpHole::close() {
     al::setNerve(this, &Close);
 }
+
 void MofumofuWarpHole::closeAndDisappear() {
     al::setNerve(this, &CloseAndDisappear);
 }
+
 void MofumofuWarpHole::open() {
     al::setNerve(this, &Appear);
 }
+
 void MofumofuWarpHole::startHideMove() {
     al::setNerve(this, &HideMove);
 }
+
 void MofumofuWarpHole::startDashSign() {
     al::setNerve(this, &DashSign);
 }
+
 bool MofumofuWarpHole::isWait() const {
     return al::isNerve(this, &Wait);
 }
+
 bool MofumofuWarpHole::isHideWait() const {
     return al::isNerve(this, &HideWait);
 }
+
 void MofumofuWarpHole::calcDashSignFront(sead::Vector3f* front) const {
     al::calcJointFrontDir(front, this, "DashSign");
 }
+
 void MofumofuWarpHole::exeAppear() {
     if (al::isFirstStep(this))
         al::startAction(this, "Appear");
     al::setNerveAtActionEnd(this, &Wait);
 }
+
 void MofumofuWarpHole::exeWait() {
     if (al::isFirstStep(this))
         al::startAction(this, "Wait");
 }
+
 void MofumofuWarpHole::exeDisappear() {
     if (al::isFirstStep(this))
         al::startAction(this, "Disappear");
     if (!al::isEffectEmitting(this, "Disappear"))
         kill();
 }
+
 void MofumofuWarpHole::exeClose() {
     if (al::isFirstStep(this))
         al::startAction(this, "Disappear");
@@ -100,11 +112,14 @@ void MofumofuWarpHole::exeClose() {
             al::setNerve(this, &HideWait);
     }
 }
+
 void MofumofuWarpHole::exeHideWait() {}
+
 void MofumofuWarpHole::exeHideMove() {
     if (al::isFirstStep(this))
         al::startAction(this, "Move");
 }
+
 void MofumofuWarpHole::exeDashSign() {
     if (al::isFirstStep(this)) {
         al::startAction(this, "DashSign");
@@ -137,6 +152,7 @@ void MofumofuWarpHole::exeDashSign() {
     al::makeQuatFrontUp(&gap, v21, v20);
     al::setNerveAtGreaterEqualStep(this, &DashSignEnd, 120);
 }
+
 void MofumofuWarpHole::exeDashSignEnd() {
     if (al::isFirstStep(this))
         al::startAction(this, "DashSignEnd");

--- a/src/Npc/AchievementHolder.cpp
+++ b/src/Npc/AchievementHolder.cpp
@@ -18,6 +18,7 @@ void AchievementHolder::init(const al::ActorInitInfo&) {
     for (s32 i = 0; i < mArray.capacity(); i++)
         mArray.pushBack(new Achievement(mAchievementInfoReader->get(i)));
 }
+
 void AchievementHolder::init() {
     mAchievementInfoReader = new AchievementInfoReader();
     mAchievementInfoReader->init();

--- a/src/Npc/AchievementInfoReader.h
+++ b/src/Npc/AchievementInfoReader.h
@@ -22,7 +22,9 @@ public:
     s32 tryFindIndexByName(const char*) const;
 
     AchievementInfo* get(s32 index) { return mAchievements[index]; }
+
     s32 size() { return mAchievements.size(); }
+
     s32 capacity() { return mAchievements.capacity(); }
 
 private:

--- a/src/Player/CollisionShapeInfo.cpp
+++ b/src/Player/CollisionShapeInfo.cpp
@@ -6,21 +6,29 @@ CollisionShapeInfoBase::CollisionShapeInfoBase(CollisionShapeId id, const char* 
 const sead::Vector3f& CollisionShapeInfoBase::getBoundingCenter() const {
     return sead::Vector3f::zero;
 }
+
 const sead::Vector3f& CollisionShapeInfoBase::getBoundingCenterWorld() const {
     return sead::Vector3f::zero;
 }
+
 f32 CollisionShapeInfoBase::getBoundingRadius() const {
     return 0.0f;
 }
+
 f32 CollisionShapeInfoBase::getBoundingRadiusWorld() const {
     return 0.0f;
 }
+
 f32 CollisionShapeInfoBase::getCheckStepRange() const {
     return 100000.0f;
 }
+
 f32 CollisionShapeInfoBase::getCheckStepRangeWorld() const {
     return 100000.0f;
 }
+
 void CollisionShapeInfoBase::updateShapeOffset(const sead::Vector3f& offset) {}
+
 void CollisionShapeInfoBase::calcWorldShapeInfo(const sead::Matrix34f& matrix, f32) {}
+
 void CollisionShapeInfoBase::calcRelativeShapeInfo(const sead::Matrix34f& matrix) {}

--- a/src/Player/HackerJudge.h
+++ b/src/Player/HackerJudge.h
@@ -5,6 +5,7 @@
 #include "Player/IJudge.h"
 
 class IUsePlayerHack;
+
 namespace al {
 class LiveActor;
 }
@@ -12,6 +13,7 @@ class LiveActor;
 class HackerJudge : public al::HioNode, public IJudge {
 public:
     HackerJudge(IUsePlayerHack** parent) { mHacker = parent; };
+
     void reset() override;
     void update() override;
     bool judge() const override;

--- a/src/Player/Player.cpp
+++ b/src/Player/Player.cpp
@@ -27,6 +27,7 @@ NERVE_IMPL(Player, Damage);
 
 // weird intermediate way that has no macro pre-defined
 NERVE_MAKE(Player, Damage);
+
 struct {
     NERVE_MAKE(Player, Fall);
     NERVE_MAKE(Player, Jump);

--- a/src/Player/PlayerActorBase.cpp
+++ b/src/Player/PlayerActorBase.cpp
@@ -1,42 +1,67 @@
 #include "Player/PlayerActorBase.h"
 
 PlayerActorBase::PlayerActorBase(const char* name) : LiveActor(name) {}
+
 void PlayerActorBase::init(const al::ActorInitInfo&) {}
+
 void PlayerActorBase::initPlayer(const al::ActorInitInfo&, const PlayerInitInfo&) {}
+
 IUsePlayerCollision* PlayerActorBase::getPlayerCollision() const {
     return nullptr;
 }
+
 al::PlayerHackKeeper* PlayerActorBase::getPlayerHackKeeper() const {
     return nullptr;
 }
+
 bool PlayerActorBase::isEnableDemo() {
     return false;
 }
+
 void PlayerActorBase::startDemo() {}
+
 void PlayerActorBase::endDemo() {}
+
 void PlayerActorBase::startDemoPuppetable() {}
+
 void PlayerActorBase::endDemoPuppetable() {}
+
 void PlayerActorBase::startDemoShineGet() {}
+
 void PlayerActorBase::endDemoShineGet() {}
+
 void PlayerActorBase::startDemoMainShineGet() {}
+
 void PlayerActorBase::endDemoMainShineGet() {}
+
 void PlayerActorBase::startDemoHack() {}
+
 void PlayerActorBase::endDemoHack() {}
+
 void PlayerActorBase::startDemoKeepBind() {}
+
 void PlayerActorBase::noticeDemoKeepBindExecute() {}
+
 void PlayerActorBase::endDemoKeepBind() {}
+
 void PlayerActorBase::startDemoKeepCarry() {}
+
 void PlayerActorBase::endDemoKeepCarry() {}
+
 void PlayerActorBase::getDemoActor() {}
+
 void* PlayerActorBase::getDemoAnimator() {
     return nullptr;
 }
+
 bool PlayerActorBase::isDamageStopDemo() const {
     return false;
 }
+
 void* PlayerActorBase::getPlayerPuppet() {
     return nullptr;
 }
+
 PlayerInfo* PlayerActorBase::getPlayerInfo() const {
     return nullptr;
 }
@@ -44,6 +69,7 @@ PlayerInfo* PlayerActorBase::getPlayerInfo() const {
 u32 PlayerActorBase::getPortNo() const {
     return mPortNo;
 }
+
 void* PlayerActorBase::getViewMtx() const {
     return mViewMtx;
 }

--- a/src/Player/PlayerConst.cpp
+++ b/src/Player/PlayerConst.cpp
@@ -617,6 +617,7 @@ PlayerConst::PlayerConst() {
     mCoinDashSpeedLimit = 6.0;
     mAdditionalSpeedLimit = 30.0;
 }
+
 PlayerConst::PlayerConst(const al::ByamlIter& byaml) {
     mGravity = 3.0;
     byaml.tryGetFloatByKey(&mGravity, "Gravity");
@@ -1853,1845 +1854,2459 @@ PlayerConst::PlayerConst(const al::ByamlIter& byaml) {
 f32 PlayerConst::getGravity() const {
     return mGravity;
 }
+
 f32 PlayerConst::getFrictionAttack() const {
     return mFrictionAttack;
 }
+
 f32 PlayerConst::getPushPower() const {
     return mPushPower;
 }
+
 f32 PlayerConst::getWaitPoseDegreeMax() const {
     return mWaitPoseDegreeMax;
 }
+
 f32 PlayerConst::getHillPoseDegreeMax() const {
     return mHillPoseDegreeMax;
 }
+
 f32 PlayerConst::getTiltPoseDegreeMax() const {
     return mTiltPoseDegreeMax;
 }
+
 f32 PlayerConst::getSlerpQuatRate() const {
     return mSlerpQuatRate;
 }
+
 f32 PlayerConst::getSlerpQuatRateWait() const {
     return mSlerpQuatRateWait;
 }
+
 f32 PlayerConst::getSlerpQuatGrav() const {
     return mSlerpQuatGrav;
 }
+
 s32 PlayerConst::getPreInputFrameCapThrow() const {
     return mPreInputFrameCapThrow;
 }
+
 s32 PlayerConst::getEnableActionFrameCapCatch() const {
     return mEnableActionFrameCapCatch;
 }
+
 f32 PlayerConst::getJumpPowerCapCatch() const {
     return mJumpPowerCapCatch;
 }
+
 f32 PlayerConst::getJumpGravityCapCatch() const {
     return mJumpGravityCapCatch;
 }
+
 s32 PlayerConst::getRunTimeContinuousThrow() const {
     return mRunTimeContinuousThrow;
 }
+
 f32 PlayerConst::getRunSpeedMaxContinuousThrow() const {
     return mRunSpeedMaxContinuousThrow;
 }
+
 s32 PlayerConst::getRunAccelFrameContinuousThrow() const {
     return mRunAccelFrameContinuousThrow;
 }
+
 f32 PlayerConst::getSeparateCheckHeight() const {
     return mSeparateCheckHeight;
 }
+
 f32 PlayerConst::getSeparateOffsetLerpRate() const {
     return mSeparateOffsetLerpRate;
 }
+
 f32 PlayerConst::getSeparateEnableThrowHeight() const {
     return mSeparateEnableThrowHeight;
 }
+
 f32 PlayerConst::getTall() const {
     return mTall;
 }
+
 f32 PlayerConst::getCollisionRadius() const {
     return mCollisionRadius;
 }
+
 f32 PlayerConst::getCollisionRadiusSquat() const {
     return mCollisionRadiusSquat;
 }
+
 f32 PlayerConst::getCollisionRadiusStand() const {
     return mCollisionRadiusStand;
 }
+
 f32 PlayerConst::getCollisionSmallStepHeight() const {
     return mCollisionSmallStepHeight;
 }
+
 f32 PlayerConst::getCollisionResetLimit() const {
     return mCollisionResetLimit;
 }
+
 f32 PlayerConst::getReflectCeilingPower() const {
     return mReflectCeilingPower;
 }
+
 f32 PlayerConst::getReflectTossPower() const {
     return mReflectTossPower;
 }
+
 f32 PlayerConst::getReflectUpperPunchScaleH() const {
     return mReflectUpperPunchScaleH;
 }
+
 f32 PlayerConst::getCollisionHitDownAngleH() const {
     return mCollisionHitDownAngleH;
 }
+
 f32 PlayerConst::getCollisionHitDownEscapeAngleV() const {
     return mCollisionHitDownEscapeAngleV;
 }
+
 f32 PlayerConst::getShadowDropHeightScale() const {
     return mShadowDropHeightScale;
 }
+
 f32 PlayerConst::getShadowDropNormalAdd() const {
     return mShadowDropNormalAdd;
 }
+
 f32 PlayerConst::getShadowDropLengthMin() const {
     return mShadowDropLengthMin;
 }
+
 f32 PlayerConst::getShadowDropLengthMax() const {
     return mShadowDropLengthMax;
 }
+
 f32 PlayerConst::getShadowDropLengthExtend() const {
     return mShadowDropLengthExtend;
 }
+
 f32 PlayerConst::getGravityDamage() const {
     return mGravityDamage;
 }
+
 f32 PlayerConst::getHopPowerDamage() const {
     return mHopPowerDamage;
 }
+
 f32 PlayerConst::getPushPowerDamage() const {
     return mPushPowerDamage;
 }
+
 s32 PlayerConst::getDamageCancelFrame() const {
     return mDamageCancelFrame;
 }
+
 s32 PlayerConst::getDamageInvalidCount() const {
     return mDamageInvalidCount;
 }
+
 s32 PlayerConst::getDamageInvalidCountRecovery() const {
     return mDamageInvalidCountRecovery;
 }
+
 s32 PlayerConst::getDamageInvalidCountAbyss() const {
     return mDamageInvalidCountAbyss;
 }
+
 f32 PlayerConst::getNormalMinSpeed2D() const {
     return mNormalMinSpeed2D;
 }
+
 f32 PlayerConst::getNormalMaxSpeed2D() const {
     return mNormalMaxSpeed2D;
 }
+
 f32 PlayerConst::getDashMaxSpeed2D() const {
     return mDashMaxSpeed2D;
 }
+
 s32 PlayerConst::getNormalAccelFrame2D() const {
     return mNormalAccelFrame2D;
 }
+
 s32 PlayerConst::getDashAccelFrame2D() const {
     return mDashAccelFrame2D;
 }
+
 s32 PlayerConst::getNormalDashAnimFrame2D() const {
     return mNormalDashAnimFrame2D;
 }
+
 s32 PlayerConst::getNormalBrakeFrame2D() const {
     return mNormalBrakeFrame2D;
 }
+
 s32 PlayerConst::getStickOnBrakeFrame2D() const {
     return mStickOnBrakeFrame2D;
 }
+
 s32 PlayerConst::getBrakeTurnStartFrame2D() const {
     return mBrakeTurnStartFrame2D;
 }
+
 f32 PlayerConst::getTurnEndSpeedRate2D() const {
     return mTurnEndSpeedRate2D;
 }
+
 f32 PlayerConst::getJumpPowerMin2DArea() const {
     return mJumpPowerMin2DArea;
 }
+
 f32 PlayerConst::getJumpPowerMax2DArea() const {
     return mJumpPowerMax2DArea;
 }
+
 f32 PlayerConst::getJumpPowerMinBorder2D() const {
     return mJumpPowerMinBorder2D;
 }
+
 f32 PlayerConst::getJumpPowerMaxBorder2D() const {
     return mJumpPowerMaxBorder2D;
 }
+
 f32 PlayerConst::getGravityMove() const {
     return mGravityMove;
 }
+
 f32 PlayerConst::getNormalMaxSpeed() const {
     return mNormalMaxSpeed;
 }
+
 f32 PlayerConst::getNormalMinSpeed() const {
     return mNormalMinSpeed;
 }
+
 s32 PlayerConst::getNormalAccelFrame() const {
     return mNormalAccelFrame;
 }
+
 f32 PlayerConst::getRunAccelAverageScale() const {
     return mRunAccelAverageScale;
 }
+
 s32 PlayerConst::getNormalBrakeFrame() const {
     return mNormalBrakeFrame;
 }
+
 f32 PlayerConst::getDashJudgeSpeed() const {
     return mDashJudgeSpeed;
 }
+
 s32 PlayerConst::getStickOnBrakeFrame() const {
     return mStickOnBrakeFrame;
 }
+
 s32 PlayerConst::getNormalDashAnimFrame() const {
     return mNormalDashAnimFrame;
 }
+
 f32 PlayerConst::getRunAfterTurnSpeedMax() const {
     return mRunAfterTurnSpeedMax;
 }
+
 f32 PlayerConst::getRunAfterTurnScale() const {
     return mRunAfterTurnScale;
 }
+
 s32 PlayerConst::getRunAfterTurnFrame() const {
     return mRunAfterTurnFrame;
 }
+
 s32 PlayerConst::getBrakeTurnStartFrame() const {
     return mBrakeTurnStartFrame;
 }
+
 f32 PlayerConst::getBrakeOnSpeedRate() const {
     return mBrakeOnSpeedRate;
 }
+
 s32 PlayerConst::getBrakeOnCounterBorder() const {
     return mBrakeOnCounterBorder;
 }
+
 s32 PlayerConst::getWallPushFrame() const {
     return mWallPushFrame;
 }
+
 s32 PlayerConst::getRunDeepDownFrame() const {
     return mRunDeepDownFrame;
 }
+
 s32 PlayerConst::getRunDeepDownMargine() const {
     return mRunDeepDownMargine;
 }
+
 s32 PlayerConst::getQuickTurnJumpFrame() const {
     return mQuickTurnJumpFrame;
 }
+
 s32 PlayerConst::getRoundAccelFrame() const {
     return mRoundAccelFrame;
 }
+
 s32 PlayerConst::getRoundBrakeFrame() const {
     return mRoundBrakeFrame;
 }
+
 f32 PlayerConst::getRoundFastDegree() const {
     return mRoundFastDegree;
 }
+
 s32 PlayerConst::getRoundAccelFrameFast() const {
     return mRoundAccelFrameFast;
 }
+
 f32 PlayerConst::getRoundMinDegree() const {
     return mRoundMinDegree;
 }
+
 s32 PlayerConst::getRoundBrakeFrameForce() const {
     return mRoundBrakeFrameForce;
 }
+
 f32 PlayerConst::getRoundFastDegreeForce() const {
     return mRoundFastDegreeForce;
 }
+
 f32 PlayerConst::getRoundLimitDegreeForce() const {
     return mRoundLimitDegreeForce;
 }
+
 f32 PlayerConst::getRoundLimitDegreeForceFast() const {
     return mRoundLimitDegreeForceFast;
 }
+
 s32 PlayerConst::getRoundAccelFrameForceFast() const {
     return mRoundAccelFrameForceFast;
 }
+
 f32 PlayerConst::getRoundLimitDegreeMin() const {
     return mRoundLimitDegreeMin;
 }
+
 f32 PlayerConst::getRoundLimitDegree() const {
     return mRoundLimitDegree;
 }
+
 s32 PlayerConst::getIceAccelFrame() const {
     return mIceAccelFrame;
 }
+
 s32 PlayerConst::getIceBrakeFrame() const {
     return mIceBrakeFrame;
 }
+
 s32 PlayerConst::getIceBrakeFrameHigh() const {
     return mIceBrakeFrameHigh;
 }
+
 s32 PlayerConst::getIceBrakeFrameWall() const {
     return mIceBrakeFrameWall;
 }
+
 s32 PlayerConst::getIceRoundAccelFrame() const {
     return mIceRoundAccelFrame;
 }
+
 s32 PlayerConst::getIceRoundAccelFrameFast() const {
     return mIceRoundAccelFrameFast;
 }
+
 s32 PlayerConst::getIceRoundBrakeFrame() const {
     return mIceRoundBrakeFrame;
 }
+
 f32 PlayerConst::getIceRoundFastDegree() const {
     return mIceRoundFastDegree;
 }
+
 f32 PlayerConst::getIceRoundMinDegree() const {
     return mIceRoundMinDegree;
 }
+
 f32 PlayerConst::getIceRoundLimitDegree() const {
     return mIceRoundLimitDegree;
 }
+
 f32 PlayerConst::getHillAddSpeed() const {
     return mHillAddSpeed;
 }
+
 f32 PlayerConst::getHillSubSpeed() const {
     return mHillSubSpeed;
 }
+
 s32 PlayerConst::getHillAccelAddFrame() const {
     return mHillAccelAddFrame;
 }
+
 s32 PlayerConst::getHillAccelSubFrame() const {
     return mHillAccelSubFrame;
 }
+
 f32 PlayerConst::getHillAccelSubAngleMin() const {
     return mHillAccelSubAngleMin;
 }
+
 f32 PlayerConst::getHillAccelSubAngleMax() const {
     return mHillAccelSubAngleMax;
 }
+
 f32 PlayerConst::getStandAngleMin() const {
     return mStandAngleMin;
 }
+
 f32 PlayerConst::getStandAngleMax() const {
     return mStandAngleMax;
 }
+
 f32 PlayerConst::getHillAngleSpeedMin() const {
     return mHillAngleSpeedMin;
 }
+
 f32 PlayerConst::getHillAngleSpeedMax() const {
     return mHillAngleSpeedMax;
 }
+
 s32 PlayerConst::getSpinCapThrowFrame() const {
     return mSpinCapThrowFrame;
 }
+
 s32 PlayerConst::getSpinCapThrowFrameAir() const {
     return mSpinCapThrowFrameAir;
 }
+
 s32 PlayerConst::getSpinCapThrowFrameSwim() const {
     return mSpinCapThrowFrameSwim;
 }
+
 s32 PlayerConst::getSpinCapThrowFrameSwing() const {
     return mSpinCapThrowFrameSwing;
 }
+
 s32 PlayerConst::getSpinCapThrowFrameContinuous() const {
     return mSpinCapThrowFrameContinuous;
 }
+
 s32 PlayerConst::getSpinAttackFrame() const {
     return mSpinAttackFrame;
 }
+
 s32 PlayerConst::getSpinBrakeFrame() const {
     return mSpinBrakeFrame;
 }
+
 f32 PlayerConst::getSpinAirJumpPower() const {
     return mSpinAirJumpPower;
 }
+
 f32 PlayerConst::getSpinAirSpeedMax() const {
     return mSpinAirSpeedMax;
 }
+
 f32 PlayerConst::getGravitySpinAir() const {
     return mGravitySpinAir;
 }
+
 f32 PlayerConst::getSlerpQuatRateSpinAir() const {
     return mSlerpQuatRateSpinAir;
 }
+
 f32 PlayerConst::getSpinBrakeRate() const {
     return mSpinBrakeRate;
 }
+
 f32 PlayerConst::getSpinBrakeSideAccel() const {
     return mSpinBrakeSideAccel;
 }
+
 f32 PlayerConst::getSpinBrakeSideBrakeRate() const {
     return mSpinBrakeSideBrakeRate;
 }
+
 f32 PlayerConst::getSpinBrakeSideMaxSpeedRate() const {
     return mSpinBrakeSideMaxSpeedRate;
 }
+
 f32 PlayerConst::getSpinRoundLimitDegree() const {
     return mSpinRoundLimitDegree;
 }
+
 f32 PlayerConst::getDamageFireJumpPower1st() const {
     return mDamageFireJumpPower1st;
 }
+
 f32 PlayerConst::getDamageFireJumpPower2nd() const {
     return mDamageFireJumpPower2nd;
 }
+
 f32 PlayerConst::getDamageFireJumpMoveSpeed() const {
     return mDamageFireJumpMoveSpeed;
 }
+
 f32 PlayerConst::getDamageFireCeilHitSpeed() const {
     return mDamageFireCeilHitSpeed;
 }
+
 f32 PlayerConst::getDamageFireGravity() const {
     return mDamageFireGravity;
 }
+
 s32 PlayerConst::getDamageFireNoGravityFrame() const {
     return mDamageFireNoGravityFrame;
 }
+
 s32 PlayerConst::getDamageFireRunTime() const {
     return mDamageFireRunTime;
 }
+
 f32 PlayerConst::getDamageFireRunSpeed() const {
     return mDamageFireRunSpeed;
 }
+
 f32 PlayerConst::getDamageFireRunBrakeFrame() const {
     return mDamageFireRunBrakeFrame;
 }
+
 s32 PlayerConst::getSandSinkDeadTime() const {
     return mSandSinkDeadTime;
 }
+
 s32 PlayerConst::getSandSinkBrakeHeightH() const {
     return mSandSinkBrakeHeightH;
 }
+
 s32 PlayerConst::getSandSinkBrakeHeightV() const {
     return mSandSinkBrakeHeightV;
 }
+
 f32 PlayerConst::getSandSinkHeight() const {
     return mSandSinkHeight;
 }
+
 f32 PlayerConst::getSandSinkCapThrow() const {
     return mSandSinkCapThrow;
 }
+
 f32 PlayerConst::getSandSinkBrakeMinH() const {
     return mSandSinkBrakeMinH;
 }
+
 f32 PlayerConst::getSandSinkBrakeMaxH() const {
     return mSandSinkBrakeMaxH;
 }
+
 f32 PlayerConst::getSandSinkBrakeMinV() const {
     return mSandSinkBrakeMinV;
 }
+
 f32 PlayerConst::getSandSinkBrakeMaxV() const {
     return mSandSinkBrakeMaxV;
 }
+
 f32 PlayerConst::getSlopeSlideAngleStart() const {
     return mSlopeSlideAngleStart;
 }
+
 f32 PlayerConst::getSlopeSlideAngleEnd() const {
     return mSlopeSlideAngleEnd;
 }
+
 f32 PlayerConst::getSlopeSlideAccel() const {
     return mSlopeSlideAccel;
 }
+
 f32 PlayerConst::getSlopeSlideBrake() const {
     return mSlopeSlideBrake;
 }
+
 f32 PlayerConst::getSlopeSlideMaxSpeed() const {
     return mSlopeSlideMaxSpeed;
 }
+
 f32 PlayerConst::getSlopeSlideSpeedEnd() const {
     return mSlopeSlideSpeedEnd;
 }
+
 f32 PlayerConst::getSlopeSlideSideAccel() const {
     return mSlopeSlideSideAccel;
 }
+
 f32 PlayerConst::getSlopeSlideSideBrake() const {
     return mSlopeSlideSideBrake;
 }
+
 f32 PlayerConst::getSlopeSlideSideMaxSpeed() const {
     return mSlopeSlideSideMaxSpeed;
 }
+
 f32 PlayerConst::getSlopeTurnDegree() const {
     return mSlopeTurnDegree;
 }
+
 s32 PlayerConst::getSlideInvalidFrame() const {
     return mSlideInvalidFrame;
 }
+
 s32 PlayerConst::getSlopeForceFrame() const {
     return mSlopeForceFrame;
 }
+
 f32 PlayerConst::getSlopeSlideForceSideAccel() const {
     return mSlopeSlideForceSideAccel;
 }
+
 f32 PlayerConst::getSlopeSlideForceSideBrake() const {
     return mSlopeSlideForceSideBrake;
 }
+
 f32 PlayerConst::getSlopeSlideForceSideMaxSpeed() const {
     return mSlopeSlideForceSideMaxSpeed;
 }
+
 f32 PlayerConst::getSlopeSlideForceTurnDegree() const {
     return mSlopeSlideForceTurnDegree;
 }
+
 f32 PlayerConst::getSlopeRollingSpeedStart() const {
     return mSlopeRollingSpeedStart;
 }
+
 f32 PlayerConst::getSlopeRollingSpeedBoost() const {
     return mSlopeRollingSpeedBoost;
 }
+
 f32 PlayerConst::getSlopeRollingMaxSpeed() const {
     return mSlopeRollingMaxSpeed;
 }
+
 s32 PlayerConst::getSlopeRollingFrameMinBoost() const {
     return mSlopeRollingFrameMinBoost;
 }
+
 s32 PlayerConst::getSlopeRollingFrameMin() const {
     return mSlopeRollingFrameMin;
 }
+
 f32 PlayerConst::getSlopeRollingStartJumpPower() const {
     return mSlopeRollingStartJumpPower;
 }
+
 f32 PlayerConst::getSlopeRollingStartSlideSpeed() const {
     return mSlopeRollingStartSlideSpeed;
 }
+
 f32 PlayerConst::getSlopeRollingAccel() const {
     return mSlopeRollingAccel;
 }
+
 f32 PlayerConst::getSlopeRollingBrake() const {
     return mSlopeRollingBrake;
 }
+
 f32 PlayerConst::getSlopeRollingAgainst() const {
     return mSlopeRollingAgainst;
 }
+
 f32 PlayerConst::getSlopeRollingAnglePowerMax() const {
     return mSlopeRollingAnglePowerMax;
 }
+
 f32 PlayerConst::getSlopeRollingSpeedEnd() const {
     return mSlopeRollingSpeedEnd;
 }
+
 f32 PlayerConst::getSlopeRollingSideAccel() const {
     return mSlopeRollingSideAccel;
 }
+
 f32 PlayerConst::getSlopeRollingSideBrake() const {
     return mSlopeRollingSideBrake;
 }
+
 f32 PlayerConst::getSlopeRollingSideMaxSpeed() const {
     return mSlopeRollingSideMaxSpeed;
 }
+
 s32 PlayerConst::getSlopeRollingUnRollFrame() const {
     return mSlopeRollingUnRollFrame;
 }
+
 f32 PlayerConst::getSlopeRollingEndBrake() const {
     return mSlopeRollingEndBrake;
 }
+
 f32 PlayerConst::getSlopeRollingEndBrakeEndSpeed() const {
     return mSlopeRollingEndBrakeEndSpeed;
 }
+
 f32 PlayerConst::getSlopeRollingReStartAccel() const {
     return mSlopeRollingReStartAccel;
 }
+
 f32 PlayerConst::getSlopeRollingReStartMaxAdd() const {
     return mSlopeRollingReStartMaxAdd;
 }
+
 s32 PlayerConst::getSlopeRollingReStartInterval() const {
     return mSlopeRollingReStartinterval;
 }
+
 s32 PlayerConst::getSlopeRollingReStartSwing() const {
     return mSlopeRollingReStartSwing;
 }
+
 s32 PlayerConst::getSlopeRollingReStartCharge() const {
     return mSlopeRollingReStartCharge;
 }
+
 s32 PlayerConst::getSlopeRollingReStartForce() const {
     return mSlopeRollingReStartForce;
 }
+
 f32 PlayerConst::getSlopeRollingAccelOnSkate() const {
     return mSlopeRollingAccelOnSkate;
 }
+
 f32 PlayerConst::getSlopeRollingSideAccelOnSkate() const {
     return mSlopeRollingSideAccelOnSkate;
 }
+
 f32 PlayerConst::getSlopeRollingBrakeOnSkate() const {
     return mSlopeRollingBrakeOnSkate;
 }
+
 s32 PlayerConst::getExtendFrame() const {
     return mExtendFrame;
 }
+
 f32 PlayerConst::getJumpInertiaRate() const {
     return mJumpInertiaRate;
 }
+
 f32 PlayerConst::getJumpPowerMin() const {
     return mJumpPowerMin;
 }
+
 f32 PlayerConst::getJumpPowerMax() const {
     return mJumpPowerMax;
 }
+
 f32 PlayerConst::getJumpGravity() const {
     return mJumpGravity;
 }
+
 f32 PlayerConst::getJumpBaseSpeedMax() const {
     return mJumpBaseSpeedMax;
 }
+
 f32 PlayerConst::getJumpMoveSpeedMin() const {
     return mJumpMoveSpeedMin;
 }
+
 f32 PlayerConst::getJumpMoveSpeedMax() const {
     return mJumpMoveSpeedMax;
 }
+
 f32 PlayerConst::getJumpAccelFront() const {
     return mJumpAccelFront;
 }
+
 f32 PlayerConst::getJumpAccelBack() const {
     return mJumpAccelBack;
 }
+
 f32 PlayerConst::getJumpAccelTurn() const {
     return mJumpAccelTurn;
 }
+
 f32 PlayerConst::getJumpTurnAngleStart() const {
     return mJumpTurnAngleStart;
 }
+
 f32 PlayerConst::getJumpTurnAngleLimit() const {
     return mJumpTurnAngleLimit;
 }
+
 f32 PlayerConst::getJumpTurnAngleFast() const {
     return mJumpTurnAngleFast;
 }
+
 f32 PlayerConst::getJumpTurnAngleFastLimit() const {
     return mJumpTurnAngleFastLimit;
 }
+
 s32 PlayerConst::getJumpTurnAccelFrame() const {
     return mJumpTurnAccelFrame;
 }
+
 s32 PlayerConst::getJumpTurnAccelFrameFast() const {
     return mJumpTurnAccelFrameFast;
 }
+
 s32 PlayerConst::getJumpTurnBrakeFrame() const {
     return mJumpTurnBrakeFrame;
 }
+
 f32 PlayerConst::getTrampleGravity() const {
     return mTrampleGravity;
 }
+
 f32 PlayerConst::getTrampleJumpPower() const {
     return mTrampleJumpPower;
 }
+
 f32 PlayerConst::getTrampleHighGravity() const {
     return mTrampleHighGravity;
 }
+
 f32 PlayerConst::getTrampleHighJumpPower() const {
     return mTrampleHighJumpPower;
 }
+
 f32 PlayerConst::getTrampleGravity2D() const {
     return mTrampleGravity2D;
 }
+
 f32 PlayerConst::getTrampleJumpPower2D() const {
     return mTrampleJumpPower2D;
 }
+
 f32 PlayerConst::getTrampleHighGravity2D() const {
     return mTrampleHighGravity2D;
 }
+
 f32 PlayerConst::getTrampleHighJumpPower2D() const {
     return mTrampleHighJumpPower2D;
 }
+
 f32 PlayerConst::getTrampleHipDropGravity() const {
     return mTrampleHipDropGravity;
 }
+
 f32 PlayerConst::getTrampleHipDropJumpPower() const {
     return mTrampleHipDropJumpPower;
 }
+
 f32 PlayerConst::getTrampleRisingBrakeVelH() const {
     return mTrampleRisingBrakeVelH;
 }
+
 f32 PlayerConst::getTrampleJumpCodePower() const {
     return mTrampleJumpCodePower;
 }
+
 f32 PlayerConst::getTrampleJumpCodePowerSmall() const {
     return mTrampleJumpCodePowerSmall;
 }
+
 f32 PlayerConst::getCapLeapFrogJumpGravity() const {
     return mCapLeapFrogJumpGravity;
 }
+
 f32 PlayerConst::getCapLeapFrogJumpPower() const {
     return mCapLeapFrogJumpPower;
 }
+
 f32 PlayerConst::getCapLeapFrogJumpPowerAir() const {
     return mCapLeapFrogJumpPowerAir;
 }
+
 f32 PlayerConst::getObjLeapFrogJumpPower() const {
     return mObjLeapFrogJumpPower;
 }
+
 f32 PlayerConst::getObjLeapFrogJumpPowerHigh() const {
     return mObjLeapFrogJumpPowerHigh;
 }
+
 f32 PlayerConst::getCapHeadSpringJumpGravity() const {
     return mCapHeadSpringJumpGravity;
 }
+
 f32 PlayerConst::getCapHeadSpringJumpPower() const {
     return mCapHeadSpringJumpPower;
 }
+
 f32 PlayerConst::getCapHeadSpringJumpGravityHigh() const {
     return mCapHeadSpringJumpGravityHigh;
 }
+
 f32 PlayerConst::getCapHeadSpringJumpPowerHigh() const {
     return mCapHeadSpringJumpPowerHigh;
 }
+
 f32 PlayerConst::getCapHeadSpringSpeedMax() const {
     return mCapHeadSpringSpeedMax;
 }
+
 s32 PlayerConst::getContinuousJumpPreInputFrame() const {
     return mContinuousJumpPreInputFrame;
 }
+
 s32 PlayerConst::getContinuousJumpCount() const {
     return mContinuousJumpCount;
 }
+
 s32 PlayerConst::getContinuousJumpTimer() const {
     return mContinuousJumpTimer;
 }
+
 f32 PlayerConst::getContinuousJumpPowerMin() const {
     return mContinuousJumpPowerMin;
 }
+
 f32 PlayerConst::getJumpPowerMax2nd() const {
     return mJumpPowerMax2nd;
 }
+
 f32 PlayerConst::getJumpGravity2nd() const {
     return mJumpGravity2nd;
 }
+
 f32 PlayerConst::getJumpPowerMax3rd() const {
     return mJumpPowerMax3rd;
 }
+
 f32 PlayerConst::getJumpGravity3rd() const {
     return mJumpGravity3rd;
 }
+
 f32 PlayerConst::getSpinFlowerJumpGravity() const {
     return mSpinFlowerJumpGravity;
 }
+
 f32 PlayerConst::getSpinFlowerJumpFallSpeedMax() const {
     return mSpinFlowerJumpFallSpeedMax;
 }
+
 f32 PlayerConst::getSpinFlowerJumpMovePower() const {
     return mSpinFlowerJumpMovePower;
 }
+
 f32 PlayerConst::getSpinFlowerJumpVelMax() const {
     return mSpinFlowerJumpVelMax;
 }
+
 s32 PlayerConst::getSpinFlowerJumpStayFrame() const {
     return mSpinFlowerJumpStayFrame;
 }
+
 f32 PlayerConst::getSpinFlowerJumpStaySpeedMax() const {
     return mSpinFlowerJumpStaySpeedMax;
 }
+
 f32 PlayerConst::getSpinFlowerJumpNoInputBrake() const {
     return mSpinFlowerJumpNoInputBrake;
 }
+
 f32 PlayerConst::getSpinFlowerJumpDownFallInitSpeed() const {
     return mSpinFlowerJumpDownFallInitSpeed;
 }
+
 f32 PlayerConst::getSpinFlowerJumpDownFallPower() const {
     return mSpinFlowerJumpDownFallPower;
 }
+
 f32 PlayerConst::getSpinFlowerJumpDownFallSpeedMax() const {
     return mSpinFlowerJumpDownFallSpeedMax;
 }
+
 f32 PlayerConst::getJumpGravityForceRun() const {
     return mJumpGravityForceRun;
 }
+
 f32 PlayerConst::getJumpPowerForceRun() const {
     return mJumpPowerForceRun;
 }
+
 f32 PlayerConst::getCapCatchPopPower() const {
     return mCapCatchPopPower;
 }
+
 f32 PlayerConst::getCapCatchPopGravity() const {
     return mCapCatchPopGravity;
 }
+
 f32 PlayerConst::getSquatJumpGravity() const {
     return mSquatJumpGravity;
 }
+
 f32 PlayerConst::getSquatJumpPower() const {
     return mSquatJumpPower;
 }
+
 f32 PlayerConst::getSquatJumpBackPower() const {
     return mSquatJumpBackPower;
 }
+
 f32 PlayerConst::getSquatJumpMovePowerFront() const {
     return mSquatJumpMovePowerFront;
 }
+
 f32 PlayerConst::getSquatJumpMovePowerSide() const {
     return mSquatJumpMovePowerSide;
 }
+
 f32 PlayerConst::getSquatJumpMoveSpeedMax() const {
     return mSquatJumpMoveSpeedMax;
 }
+
 f32 PlayerConst::getTurnJumpGravity() const {
     return mTurnJumpGravity;
 }
+
 f32 PlayerConst::getTurnJumpPower() const {
     return mTurnJumpPower;
 }
+
 f32 PlayerConst::getTurnJumpVelH() const {
     return mTurnJumpVelH;
 }
+
 f32 PlayerConst::getTurnJumpBrake() const {
     return mTurnJumpBrake;
 }
+
 f32 PlayerConst::getTurnJumpAccel() const {
     return mTurnJumpAccel;
 }
+
 f32 PlayerConst::getTurnJumpSideAccel() const {
     return mTurnJumpSideAccel;
 }
+
 f32 PlayerConst::getLongJumpAccel() const {
     return mLongJumpAccel;
 }
+
 f32 PlayerConst::getLongJumpBrake() const {
     return mLongJumpBrake;
 }
+
 f32 PlayerConst::getLongJumpSideAccel() const {
     return mLongJumpSideAccel;
 }
+
 f32 PlayerConst::getLongJumpGravity() const {
     return mLongJumpGravity;
 }
+
 f32 PlayerConst::getLongJumpJumpPow() const {
     return mLongJumpJumpPow;
 }
+
 f32 PlayerConst::getLongJumpMovePow() const {
     return mLongJumpMovePow;
 }
+
 f32 PlayerConst::getLongJumpInitSpeed() const {
     return mLongJumpInitSpeed;
 }
+
 f32 PlayerConst::getLongJumpSpeed() const {
     return mLongJumpSpeed;
 }
+
 f32 PlayerConst::getLongJumpSpeedMin() const {
     return mLongJumpSpeedMin;
 }
+
 s32 PlayerConst::getContinuousLongJumpCount() const {
     return mContinuousLongJumpCount;
 }
+
 s32 PlayerConst::getContinuousLongJumpTimer() const {
     return mContinuousLongJumpTimer;
 }
+
 f32 PlayerConst::getGravityAir() const {
     return mGravityAir;
 }
+
 f32 PlayerConst::getFrictionAir() const {
     return mFrictionAir;
 }
+
 f32 PlayerConst::getFallSpeedMax() const {
     return mFallSpeedMax;
 }
+
 f32 PlayerConst::getLongFallDistance() const {
     return mLongFallDistance;
 }
+
 f32 PlayerConst::getFallWallScaleVelocity() const {
     return mFallWallScaleVelocity;
 }
+
 s32 PlayerConst::getDownFallFrameMin() const {
     return mDownFallFrameMin;
 }
+
 f32 PlayerConst::getGravityWallSlide() const {
     return mGravityWallSlide;
 }
+
 f32 PlayerConst::getWallHeightLowLimit() const {
     return mWallHeightLowLimit;
 }
+
 f32 PlayerConst::getWallKeepDegree() const {
     return mWallKeepDegree;
 }
+
 s32 PlayerConst::getWallKeepFrame() const {
     return mWallKeepFrame;
 }
+
 f32 PlayerConst::getWallJumpGravity() const {
     return mWallJumpGravity;
 }
+
 f32 PlayerConst::getWallJumpHSpeed() const {
     return mWallJumpHSpeed;
 }
+
 f32 PlayerConst::getWallJumpPower() const {
     return mWallJumpPower;
 }
+
 s32 PlayerConst::getWallJumpInvalidateInputFrame() const {
     return mWallJumpInvalidateInputFrame;
 }
+
 s32 PlayerConst::getWallInhibitAfterPunch() const {
     return mWallInhibitAfterPunch;
 }
+
 f32 PlayerConst::getWallFollowAngleH() const {
     return mWallFollowAngleH;
 }
+
 f32 PlayerConst::getWallFollowAngleV() const {
     return mWallFollowAngleV;
 }
+
 f32 PlayerConst::getWallCatchDegree() const {
     return mWallCatchDegree;
 }
+
 f32 PlayerConst::getWallCatchHeightEdgeTop() const {
     return mWallCatchHeightEdgeTop;
 }
+
 f32 PlayerConst::getWallCatchHeightBottom() const {
     return mWallCatchHeightBottom;
 }
+
 f32 PlayerConst::getWallCatchKeepDegree() const {
     return mWallCatchKeepDegree;
 }
+
 f32 PlayerConst::getWallCatchMoveDegree() const {
     return mWallCatchMoveDegree;
 }
+
 f32 PlayerConst::getWallCatchMoveSpeed() const {
     return mWallCatchMoveSpeed;
 }
+
 f32 PlayerConst::getWallCatchMoveHeightRange() const {
     return mWallCatchMoveHeightRange;
 }
+
 s32 PlayerConst::getWallCatchMoveInterpolate() const {
     return mWallCatchMoveinterpolate;
 }
+
 s32 PlayerConst::getWallCatchMoveFrame() const {
     return mWallCatchMoveFrame;
 }
+
 s32 PlayerConst::getWallCatchMoveFrameFast() const {
     return mWallCatchMoveFrameFast;
 }
+
 s32 PlayerConst::getWallCatchMoveFrameSwing() const {
     return mWallCatchMoveFrameSwing;
 }
+
 f32 PlayerConst::getWallCatchInputRepeatAngle() const {
     return mWallCatchInputRepeatAngle;
 }
+
 f32 PlayerConst::getWallClimbDegree() const {
     return mWallClimbDegree;
 }
+
 s32 PlayerConst::getWallClimbJumpStartFrame() const {
     return mWallClimbJumpStartFrame;
 }
+
 s32 PlayerConst::getWallClimbJumpEndFrame() const {
     return mWallClimbJumpEndFrame;
 }
+
 s32 PlayerConst::getWallClimbStartFrame() const {
     return mWallClimbStartFrame;
 }
+
 f32 PlayerConst::getWallClimbGravity() const {
     return mWallClimbGravity;
 }
+
 f32 PlayerConst::getWallFallJumpSpeed() const {
     return mWallFallJumpSpeed;
 }
+
 f32 PlayerConst::getWallClimbJumpSpeedV() const {
     return mWallClimbJumpSpeedV;
 }
+
 f32 PlayerConst::getWallClimbJumpSpeedH() const {
     return mWallClimbJumpSpeedH;
 }
+
 f32 PlayerConst::getWallClimbJumpGravity() const {
     return mWallClimbJumpGravity;
 }
+
 s32 PlayerConst::getWallClimbJumpInvalidFrame() const {
     return mWallClimbJumpInvalidFrame;
 }
+
 f32 PlayerConst::getWallCatchHipLocalOffset() const {
     return mWallCatchHipLocalOffset;
 }
+
 f32 PlayerConst::getWallCatchHipStability() const {
     return mWallCatchHipStability;
 }
+
 f32 PlayerConst::getWallCatchHipFriction() const {
     return mWallCatchHipFriction;
 }
+
 f32 PlayerConst::getWallCatchHipLimitDegree() const {
     return mWallCatchHipLimitDegree;
 }
+
 f32 PlayerConst::getWallCatchStainAreaOffset() const {
     return mWallCatchStainAreaOffset;
 }
+
 f32 PlayerConst::getGrabCeilRange() const {
     return mGrabCeilRange;
 }
+
 f32 PlayerConst::getGrabCeilBodyRadius() const {
     return mGrabCeilBodyRadius;
 }
+
 f32 PlayerConst::getGrabCeilLeaveSpeedMin() const {
     return mGrabCeilLeaveSpeedMin;
 }
+
 f32 PlayerConst::getGrabCeilLeavePopPower() const {
     return mGrabCeilLeavePopPower;
 }
+
 f32 PlayerConst::getGrabCeilLeavePopGravity() const {
     return mGrabCeilLeavePopGravity;
 }
+
 f32 PlayerConst::getGrabCeilSwingStartOffset() const {
     return mGrabCeilSwingStartOffset;
 }
+
 f32 PlayerConst::getGrabCeilReverseInputBorder() const {
     return mGrabCeilReverseInputBorder;
 }
+
 f32 PlayerConst::getGrabCeilInputPowerBorder() const {
     return mGrabCeilInputPowerBorder;
 }
+
 f32 PlayerConst::getGrabCeilSwingWaitEnergy() const {
     return mGrabCeilSwingWaitEnergy;
 }
+
 f32 PlayerConst::getGrabCeilEnableJumpEnergy() const {
     return mGrabCeilEnableJumpEnergy;
 }
+
 f32 PlayerConst::getGrabCeilEnableJumpEnergyMax() const {
     return mGrabCeilEnableJumpEnergyMax;
 }
+
 f32 PlayerConst::getGrabCeilJumpForceAngle() const {
     return mGrabCeilJumpForceAngle;
 }
+
 f32 PlayerConst::getGrabCeilJumpPower() const {
     return mGrabCeilJumpPower;
 }
+
 f32 PlayerConst::getGrabCeilJumpMoveMin() const {
     return mGrabCeilJumpMoveMin;
 }
+
 f32 PlayerConst::getGrabCeilJumpMoveMax() const {
     return mGrabCeilJumpMoveMax;
 }
+
 f32 PlayerConst::getGrabCeilJumpGravity() const {
     return mGrabCeilJumpGravity;
 }
+
 s32 PlayerConst::getGrabCeilJumpInvalidFrame() const {
     return mGrabCeilJumpInvalidFrame;
 }
+
 s32 PlayerConst::getGrabCeilEnableNextFrame() const {
     return mGrabCeilEnableNextFrame;
 }
+
 s32 PlayerConst::getGrabCeilEnableFallSnapFrame() const {
     return mGrabCeilEnableFallSnapFrame;
 }
+
 s32 PlayerConst::getPoleClimbPreInputSwing() const {
     return mPoleClimbPreInputSwing;
 }
+
 f32 PlayerConst::getPoleClimbInputRepeatAngle() const {
     return mPoleClimbInputRepeatAngle;
 }
+
 f32 PlayerConst::getPoleClimbInputDegreeMove() const {
     return mPoleClimbInputDegreeMove;
 }
+
 f32 PlayerConst::getPoleClimbCatchRange() const {
     return mPoleClimbCatchRange;
 }
+
 f32 PlayerConst::getPoleClimbCatchRangeMin() const {
     return mPoleClimbCatchRangeMin;
 }
+
 f32 PlayerConst::getPoleClimbCatchRangeMax() const {
     return mPoleClimbCatchRangeMax;
 }
+
 f32 PlayerConst::getPoleClimbJointAngleMin() const {
     return mPoleClimbJointAngleMin;
 }
+
 f32 PlayerConst::getPoleClimbJointAngleMax() const {
     return mPoleClimbJointAngleMax;
 }
+
 f32 PlayerConst::getPoleClimbJointRangeMin() const {
     return mPoleClimbJointRangeMin;
 }
+
 f32 PlayerConst::getPoleClimbJointRangeMax() const {
     return mPoleClimbJointRangeMax;
 }
+
 f32 PlayerConst::getPoleClimbMoveWallDegree() const {
     return mPoleClimbMoveWallDegree;
 }
+
 f32 PlayerConst::getPoleClimbUpMargine() const {
     return mPoleClimbUpMargine;
 }
+
 f32 PlayerConst::getPoleClimbUpSpeed() const {
     return mPoleClimbUpSpeed;
 }
+
 s32 PlayerConst::getPoleClimbUpFrame() const {
     return mPoleClimbUpFrame;
 }
+
 s32 PlayerConst::getPoleClimbUpFrameFast() const {
     return mPoleClimbUpFrameFast;
 }
+
 s32 PlayerConst::getPoleClimbUpFrameSwing() const {
     return mPoleClimbUpFrameSwing;
 }
+
 f32 PlayerConst::getPoleClimbDownSpeed() const {
     return mPoleClimbDownSpeed;
 }
+
 f32 PlayerConst::getPoleClimbDownSpeedFast() const {
     return mPoleClimbDownSpeedFast;
 }
+
 f32 PlayerConst::getPoleClimbDownSpeedSwing() const {
     return mPoleClimbDownSpeedSwing;
 }
+
 s32 PlayerConst::getPoleClimbDownFrame() const {
     return mPoleClimbDownFrame;
 }
+
 s32 PlayerConst::getPoleClimbDownKeepTime() const {
     return mPoleClimbDownKeepTime;
 }
+
 f32 PlayerConst::getPoleClimbTurnDist() const {
     return mPoleClimbTurnDist;
 }
+
 s32 PlayerConst::getPoleClimbTurnFrame() const {
     return mPoleClimbTurnFrame;
 }
+
 s32 PlayerConst::getPoleClimbTurnStopFrame() const {
     return mPoleClimbTurnStopFrame;
 }
+
 s32 PlayerConst::getPoleTopStartFrame() const {
     return mPoleTopStartFrame;
 }
+
 s32 PlayerConst::getPoleTopEndFrame() const {
     return mPoleTopEndFrame;
 }
+
 f32 PlayerConst::getPoleTopTurnSpeed() const {
     return mPoleTopTurnSpeed;
 }
+
 f32 PlayerConst::getPoleTopEndUnderOffsetY() const {
     return mPoleTopEndUnderOffsetY;
 }
+
 s32 PlayerConst::getGroundSpinFrame() const {
     return mGroundSpinFrame;
 }
+
 f32 PlayerConst::getGroundSpinMoveSpeedMax() const {
     return mGroundSpinMoveSpeedMax;
 }
+
 f32 PlayerConst::getGroundSpinAccelRate() const {
     return mGroundSpinAccelRate;
 }
+
 f32 PlayerConst::getGroundSpinBrakeRate() const {
     return mGroundSpinBrakeRate;
 }
+
 f32 PlayerConst::getSpinJumpGravity() const {
     return mSpinJumpGravity;
 }
+
 f32 PlayerConst::getSpinJumpPower() const {
     return mSpinJumpPower;
 }
+
 f32 PlayerConst::getSpinJumpMoveSpeedMax() const {
     return mSpinJumpMoveSpeedMax;
 }
+
 f32 PlayerConst::getSpinJumpDownFallInitSpeed() const {
     return mSpinJumpDownFallInitSpeed;
 }
+
 f32 PlayerConst::getSpinJumpDownFallPower() const {
     return mSpinJumpDownFallPower;
 }
+
 f32 PlayerConst::getSpinJumpDownFallSpeedMax() const {
     return mSpinJumpDownFallSpeedMax;
 }
+
 f32 PlayerConst::getSquatBrakeEndSpeed() const {
     return mSquatBrakeEndSpeed;
 }
+
 f32 PlayerConst::getSquatAccelRate() const {
     return mSquatAccelRate;
 }
+
 f32 PlayerConst::getSquatBrakeRate() const {
     return mSquatBrakeRate;
 }
+
 f32 PlayerConst::getSquatBrakeRateOnSkate() const {
     return mSquatBrakeRateOnSkate;
 }
+
 f32 PlayerConst::getSquatBrakeSideAccel() const {
     return mSquatBrakeSideAccel;
 }
+
 f32 PlayerConst::getSquatBrakeSideRate() const {
     return mSquatBrakeSideRate;
 }
+
 f32 PlayerConst::getSquatBrakeSideAccelOnSkate() const {
     return mSquatBrakeSideAccelOnSkate;
 }
+
 f32 PlayerConst::getSquatBrakeSideRateOnSkate() const {
     return mSquatBrakeSideRateOnSkate;
 }
+
 f32 PlayerConst::getSquatBrakeSideMaxSpeedRate() const {
     return mSquatBrakeSideMaxSpeedRate;
 }
+
 f32 PlayerConst::getSquatWalkSpeed() const {
     return mSquatWalkSpeed;
 }
+
 f32 PlayerConst::getSquatWalkTurnSpeed() const {
     return mSquatWalkTurnSpeed;
 }
+
 s32 PlayerConst::getSquatWalkTurnFrame() const {
     return mSquatWalkTurnFrame;
 }
+
 f32 PlayerConst::getSquatJumpCeilSlideSpeed2D() const {
     return mSquatJumpCeilSlideSpeed2D;
 }
+
 f32 PlayerConst::getHipDropSpeed() const {
     return mHipDropSpeed;
 }
+
 f32 PlayerConst::getHipDropGravity() const {
     return mHipDropGravity;
 }
+
 f32 PlayerConst::getHipDropSpeedMax() const {
     return mHipDropSpeedMax;
 }
+
 s32 PlayerConst::getHipDropLandCancelFrame() const {
     return mHipDropLandCancelFrame;
 }
+
 f32 PlayerConst::getHipDropHeight() const {
     return mHipDropHeight;
 }
+
 s32 PlayerConst::getHipDropMsgInterval() const {
     return mHipDropMsginterval;
 }
+
 f32 PlayerConst::getJumpHipDropPower() const {
     return mJumpHipDropPower;
 }
+
 s32 PlayerConst::getJumpHipDropPermitBeginFrame() const {
     return mJumpHipDropPermitBeginFrame;
 }
+
 s32 PlayerConst::getJumpHipDropPermitEndFrame() const {
     return mJumpHipDropPermitEndFrame;
 }
+
 f32 PlayerConst::getHeadSlidingSpeed() const {
     return mHeadSlidingSpeed;
 }
+
 f32 PlayerConst::getHeadSlidingSpeedMin() const {
     return mHeadSlidingSpeedMin;
 }
+
 f32 PlayerConst::getHeadSlidingBrake() const {
     return mHeadSlidingBrake;
 }
+
 f32 PlayerConst::getHeadSlidingSideAccel() const {
     return mHeadSlidingSideAccel;
 }
+
 f32 PlayerConst::getHeadSlidingJump() const {
     return mHeadSlidingJump;
 }
+
 f32 PlayerConst::getHeadSlidingGravityAir() const {
     return mHeadSlidingGravityAir;
 }
+
 f32 PlayerConst::getSwimCenterOffset() const {
     return mSwimCenterOffset;
 }
+
 f32 PlayerConst::getSwimWallCatchOffset() const {
     return mSwimWallCatchOffset;
 }
+
 f32 PlayerConst::getSwimRisePower() const {
     return mSwimRisePower;
 }
+
 f32 PlayerConst::getSwimRiseSpeedMax() const {
     return mSwimRiseSpeedMax;
 }
+
 s32 PlayerConst::getSwimRiseFrame() const {
     return mSwimRiseFrame;
 }
+
 f32 PlayerConst::getSwimGravity() const {
     return mSwimGravity;
 }
+
 f32 PlayerConst::getSwimGravityWalk() const {
     return mSwimGravityWalk;
 }
+
 f32 PlayerConst::getSwimFallSpeedMax() const {
     return mSwimFallSpeedMax;
 }
+
 f32 PlayerConst::getSwimFloorAccelH() const {
     return mSwimFloorAccelH;
 }
+
 f32 PlayerConst::getSwimFloorSpeedMaxH() const {
     return mSwimFloorSpeedMaxH;
 }
+
 f32 PlayerConst::getSwimHighAccelH() const {
     return mSwimHighAccelH;
 }
+
 f32 PlayerConst::getSwimHighSpeedMaxH() const {
     return mSwimHighSpeedMaxH;
 }
+
 f32 PlayerConst::getSwimLowAccelH() const {
     return mSwimLowAccelH;
 }
+
 f32 PlayerConst::getSwimLowSpeedMaxH() const {
     return mSwimLowSpeedMaxH;
 }
+
 f32 PlayerConst::getSwimBrakeRateH() const {
     return mSwimBrakeRateH;
 }
+
 f32 PlayerConst::getSwimWallHitSpeedMinH() const {
     return mSwimWallHitSpeedMinH;
 }
+
 s32 PlayerConst::getSwimHighAccelPermitFrame() const {
     return mSwimHighAccelPermitFrame;
 }
+
 f32 PlayerConst::getSwimFlowFieldBlend() const {
     return mSwimFlowFieldBlend;
 }
+
 f32 PlayerConst::getSwimWalkAnimMinRate() const {
     return mSwimWalkAnimMinRate;
 }
+
 f32 PlayerConst::getSwimWalkAnimMaxRate() const {
     return mSwimWalkAnimMaxRate;
 }
+
 f32 PlayerConst::getSwimWalkMaxSpeed() const {
     return mSwimWalkMaxSpeed;
 }
+
 f32 PlayerConst::getSwimSpinCapUpPower() const {
     return mSwimSpinCapUpPower;
 }
+
 f32 PlayerConst::getSwimSpinCapUpSpeedMax() const {
     return mSwimSpinCapUpSpeedMax;
 }
+
 f32 PlayerConst::getSwimRotStartAngle() const {
     return mSwimRotStartAngle;
 }
+
 f32 PlayerConst::getSwimRotFastAngle() const {
     return mSwimRotFastAngle;
 }
+
 s32 PlayerConst::getSwimRotAccelFrame() const {
     return mSwimRotAccelFrame;
 }
+
 s32 PlayerConst::getSwimRotAccelFrameFast() const {
     return mSwimRotAccelFrameFast;
 }
+
 s32 PlayerConst::getSwimRotBrakeFrame() const {
     return mSwimRotBrakeFrame;
 }
+
 f32 PlayerConst::getSwimRotSpeedChangeStart() const {
     return mSwimRotSpeedChangeStart;
 }
+
 f32 PlayerConst::getSwimRotSpeedForward() const {
     return mSwimRotSpeedForward;
 }
+
 f32 PlayerConst::getSwimRotSpeedMax() const {
     return mSwimRotSpeedMax;
 }
+
 f32 PlayerConst::getSwimSurfaceAccelH() const {
     return mSwimSurfaceAccelH;
 }
+
 f32 PlayerConst::getSwimSurfaceSpeedMaxH() const {
     return mSwimSurfaceSpeedMaxH;
 }
+
 s32 PlayerConst::getSwimSurfaceSpinCapFrame() const {
     return mSwimSurfaceSpinCapFrame;
 }
+
 f32 PlayerConst::getSwimSurfaceSpinCapSpeedMaxH() const {
     return mSwimSurfaceSpinCapSpeedMaxH;
 }
+
 f32 PlayerConst::getSwimSurfaceStartDist() const {
     return mSwimSurfaceStartDist;
 }
+
 f32 PlayerConst::getSwimSurfaceEndDist() const {
     return mSwimSurfaceEndDist;
 }
+
 f32 PlayerConst::getSwimSurfaceGravity() const {
     return mSwimSurfaceGravity;
 }
+
 f32 PlayerConst::getSwimSurfaceBaseHeight() const {
     return mSwimSurfaceBaseHeight;
 }
+
 f32 PlayerConst::getSwimSurfaceSpring() const {
     return mSwimSurfaceSpring;
 }
+
 f32 PlayerConst::getSwimSurfaceDamper() const {
     return mSwimSurfaceDamper;
 }
+
 s32 PlayerConst::getSwimSurfaceDamperStart() const {
     return mSwimSurfaceDamperStart;
 }
+
 s32 PlayerConst::getSwimSurfaceDamperFrame() const {
     return mSwimSurfaceDamperFrame;
 }
+
 f32 PlayerConst::getSwimSurfaceEnableJumpHeight() const {
     return mSwimSurfaceEnableJumpHeight;
 }
+
 s32 PlayerConst::getSwimSurfacePreInputJumpFrame() const {
     return mSwimSurfacePreInputJumpFrame;
 }
+
 f32 PlayerConst::getSwimSurfaceMoveSpring() const {
     return mSwimSurfaceMoveSpring;
 }
+
 f32 PlayerConst::getSwimSurfaceMoveDamper() const {
     return mSwimSurfaceMoveDamper;
 }
+
 f32 PlayerConst::getSwimSurfaceMoveBaseHeight() const {
     return mSwimSurfaceMoveBaseHeight;
 }
+
 f32 PlayerConst::getSwimRunSurfaceBaseHeight() const {
     return mSwimRunSurfaceBaseHeight;
 }
+
 f32 PlayerConst::getSwimRunSurfaceApproachRate() const {
     return mSwimRunSurfaceApproachRate;
 }
+
 f32 PlayerConst::getSwimRunSurfaceApproachLimit() const {
     return mSwimRunSurfaceApproachLimit;
 }
+
 f32 PlayerConst::getSwimRunSurfaceBrakeBorder() const {
     return mSwimRunSurfaceBrakeBorder;
 }
+
 f32 PlayerConst::getSwimRunSurfaceBrakeH() const {
     return mSwimRunSurfaceBrakeH;
 }
+
 f32 PlayerConst::getSwimRunSurfaceApproachBorderMax() const {
     return mSwimRunSurfaceApproachBorderMax;
 }
+
 f32 PlayerConst::getSwimRunSurfaceApproachBorderMin() const {
     return mSwimRunSurfaceApproachBorderMin;
 }
+
 f32 PlayerConst::getSwimRunSurfaceApproachRateMin() const {
     return mSwimRunSurfaceApproachRateMin;
 }
+
 f32 PlayerConst::getSwimFallInSpeed() const {
     return mSwimFallInSpeed;
 }
+
 f32 PlayerConst::getSwimFallInBrakeH() const {
     return mSwimFallInBrakeH;
 }
+
 f32 PlayerConst::getSwimFallInBrakeV() const {
     return mSwimFallInBrakeV;
 }
+
 f32 PlayerConst::getSwimHeadInBrakeH() const {
     return mSwimHeadInBrakeH;
 }
+
 f32 PlayerConst::getSwimHeadInBrakeV() const {
     return mSwimHeadInBrakeV;
 }
+
 f32 PlayerConst::getSwimHeadInRisePower() const {
     return mSwimHeadInRisePower;
 }
+
 f32 PlayerConst::getSwimHeadInRiseSpeedMax() const {
     return mSwimHeadInRiseSpeedMax;
 }
+
 f32 PlayerConst::getSwimHeadInSurfaceHeight() const {
     return mSwimHeadInSurfaceHeight;
 }
+
 s32 PlayerConst::getSwimFallInForceSurfaceFrame() const {
     return mSwimFallInForceSurfaceFrame;
 }
+
 s32 PlayerConst::getSwimFallInvalidJumpFrame() const {
     return mSwimFallInvalidJumpFrame;
 }
+
 f32 PlayerConst::getSwimDiveStartSpeed() const {
     return mSwimDiveStartSpeed;
 }
+
 f32 PlayerConst::getSwimDiveBrake() const {
     return mSwimDiveBrake;
 }
+
 f32 PlayerConst::getSwimDiveEndSpeed() const {
     return mSwimDiveEndSpeed;
 }
+
 s32 PlayerConst::getSwimDiveLandCount() const {
     return mSwimDiveLandCount;
 }
+
 s32 PlayerConst::getSwimDiveLandCancelFrame() const {
     return mSwimDiveLandCancelFrame;
 }
+
 s32 PlayerConst::getSwimDiveNoBrakeFrame() const {
     return mSwimDiveNoBrakeFrame;
 }
+
 s32 PlayerConst::getSwimDiveButtonValidFrame() const {
     return mSwimDiveButtonValidFrame;
 }
+
 s32 PlayerConst::getSwimDiveEndFrame() const {
     return mSwimDiveEndFrame;
 }
+
 f32 PlayerConst::getSwimDiveInBrakeH() const {
     return mSwimDiveInBrakeH;
 }
+
 f32 PlayerConst::getSwimDiveInBrakeV() const {
     return mSwimDiveInBrakeV;
 }
+
 f32 PlayerConst::getSwimDiveInRisePower() const {
     return mSwimDiveInRisePower;
 }
+
 f32 PlayerConst::getSwimDiveInRiseSpeedMax() const {
     return mSwimDiveInRiseSpeedMax;
 }
+
 f32 PlayerConst::getSwimDiveInSurfaceHeight() const {
     return mSwimDiveInSurfaceHeight;
 }
+
 s32 PlayerConst::getSwimDiveInKeepFrame() const {
     return mSwimDiveInKeepFrame;
 }
+
 s32 PlayerConst::getSwimHeadSlidingFrame() const {
     return mSwimHeadSlidingFrame;
 }
+
 s32 PlayerConst::getSwimHeadSlidingBrakeFrame() const {
     return mSwimHeadSlidingBrakeFrame;
 }
+
 f32 PlayerConst::getSwimHeadSlidingSpeed() const {
     return mSwimHeadSlidingSpeed;
 }
+
 f32 PlayerConst::getSwimHeadSlidingSpeedEnd() const {
     return mSwimHeadSlidingSpeedEnd;
 }
+
 f32 PlayerConst::getSwimHeadSlidingBrake() const {
     return mSwimHeadSlidingBrake;
 }
+
 f32 PlayerConst::getSwimHeadSlidingSideAccel() const {
     return mSwimHeadSlidingSideAccel;
 }
+
 f32 PlayerConst::getSwimHeadSlidingJump() const {
     return mSwimHeadSlidingJump;
 }
+
 f32 PlayerConst::getSwimHeadSlidingGravity() const {
     return mSwimHeadSlidingGravity;
 }
+
 s32 PlayerConst::getSwimHeadSlidingEndBrakeFrame() const {
     return mSwimHeadSlidingEndBrakeFrame;
 }
+
 s32 PlayerConst::getSwimHeadSlidingEndSpeedMin() const {
     return mSwimHeadSlidingEndSpeedMin;
 }
+
 f32 PlayerConst::getSwimJumpHipDropSpeed() const {
     return mSwimJumpHipDropSpeed;
 }
+
 f32 PlayerConst::getSwimJumpHipDropBrakeV() const {
     return mSwimJumpHipDropBrakeV;
 }
+
 f32 PlayerConst::getSwimJumpHipDropBrakeVCeiling() const {
     return mSwimJumpHipDropBrakeVCeiling;
 }
+
 f32 PlayerConst::getSwimJumpHipDropGravity() const {
     return mSwimJumpHipDropGravity;
 }
+
 f32 PlayerConst::getSwimJumpHipDropCancelSpeed() const {
     return mSwimJumpHipDropCancelSpeed;
 }
+
 f32 PlayerConst::getSwimJumpHipDropAccelH() const {
     return mSwimJumpHipDropAccelH;
 }
+
 f32 PlayerConst::getSwimJumpHipDropMoveSpeedH() const {
     return mSwimJumpHipDropMoveSpeedH;
 }
+
 f32 PlayerConst::getSwimJumpHipDropPopSpeed() const {
     return mSwimJumpHipDropPopSpeed;
 }
+
 f32 PlayerConst::getSwimJumpHipDropPopJumpAdd() const {
     return mSwimJumpHipDropPopJumpAdd;
 }
+
 f32 PlayerConst::getSwimTramplePower() const {
     return mSwimTramplePower;
 }
+
 f32 PlayerConst::getDiveTramplePower() const {
     return mDiveTramplePower;
 }
+
 s32 PlayerConst::getDiveTrampleCancelFrame() const {
     return mDiveTrampleCancelFrame;
 }
+
 f32 PlayerConst::getDamageSwimPushPower() const {
     return mDamageSwimPushPower;
 }
+
 f32 PlayerConst::getDamageSwimGravity() const {
     return mDamageSwimGravity;
 }
+
 s32 PlayerConst::getDamageSwimCancelFrame() const {
     return mDamageSwimCancelFrame;
 }
+
 f32 PlayerConst::getDamageSwimSurfaceGravity() const {
     return mDamageSwimSurfaceGravity;
 }
+
 f32 PlayerConst::getDamageSwimSurfaceHopPower() const {
     return mDamageSwimSurfaceHopPower;
 }
+
 f32 PlayerConst::getDamageSwimSurfacePushPower() const {
     return mDamageSwimSurfacePushPower;
 }
+
 f32 PlayerConst::getDamageSwimSurfaceLandSpeed() const {
     return mDamageSwimSurfaceLandSpeed;
 }
+
 f32 PlayerConst::getDamageSwimSurfaceLandBrake() const {
     return mDamageSwimSurfaceLandBrake;
 }
+
 f32 PlayerConst::getDamageSwimSurfaceLandEndSpeed() const {
     return mDamageSwimSurfaceLandEndSpeed;
 }
+
 s32 PlayerConst::getDamageSwimSurfaceCancelFrame() const {
     return mDamageSwimSurfaceCancelFrame;
 }
+
 f32 PlayerConst::getDamageSwimBrakeRateGround() const {
     return mDamageSwimBrakeRateGround;
 }
+
 s32 PlayerConst::getOxygenReduceFrame() const {
     return mOxygenReduceFrame;
 }
+
 s32 PlayerConst::getOxygenNoReduceFrame() const {
     return mOxygenNoReduceFrame;
 }
+
 s32 PlayerConst::getOxygenRecoveryFrame() const {
     return mOxygenRecoveryFrame;
 }
+
 s32 PlayerConst::getOxygenDamageInterval() const {
     return mOxygenDamageinterval;
 }
+
 s32 PlayerConst::getIceWaterDamageInterval() const {
     return mIceWaterDamageinterval;
 }
+
 s32 PlayerConst::getIceWaterRecoveryFrame() const {
     return mIceWaterRecoveryFrame;
 }
+
 f32 PlayerConst::getMoveAnimSpeedMax() const {
     return mMoveAnimSpeedMax;
 }
+
 f32 PlayerConst::getAnimFrameRateSpeedMin() const {
     return mAnimFrameRateSpeedMin;
 }
+
 f32 PlayerConst::getRunBorderSpeed() const {
     return mRunBorderSpeed;
 }
+
 f32 PlayerConst::getRunBlendRange() const {
     return mRunBlendRange;
 }
+
 f32 PlayerConst::getDashBorderSpeed() const {
     return mDashBorderSpeed;
 }
+
 f32 PlayerConst::getDashBlendRange() const {
     return mDashBlendRange;
 }
+
 f32 PlayerConst::getDashFastBorderSpeed() const {
     return mDashFastBorderSpeed;
 }
+
 f32 PlayerConst::getDashFastBlendRange() const {
     return mDashFastBlendRange;
 }
+
 f32 PlayerConst::getAnimFrameRateSpeedMax() const {
     return mAnimFrameRateSpeedMax;
 }
+
 f32 PlayerConst::getAnimFrameRateRunStart() const {
     return mAnimFrameRateRunStart;
 }
+
 f32 PlayerConst::getAnimFrameRateMinRun() const {
     return mAnimFrameRateMinRun;
 }
+
 f32 PlayerConst::getAnimFrameRateMaxRun() const {
     return mAnimFrameRateMaxRun;
 }
+
 f32 PlayerConst::getAnimFrameRateMaxDash() const {
     return mAnimFrameRateMaxDash;
 }
+
 f32 PlayerConst::getAnimFrameRateMaxDashFast() const {
     return mAnimFrameRateMaxDashFast;
 }
+
 f32 PlayerConst::getRunStartPlayFrameScale() const {
     return mRunStartPlayFrameScale;
 }
+
 s32 PlayerConst::getRunStartBlendFrame() const {
     return mRunStartBlendFrame;
 }
+
 f32 PlayerConst::getDamageFireRunAnimRate() const {
     return mDamageFireRunAnimRate;
 }
+
 f32 PlayerConst::getRunSkateAnimSpeedOffset() const {
     return mRunSkateAnimSpeedOffset;
 }
+
 f32 PlayerConst::getAnimFrameRateRange2D() const {
     return mAnimFrameRateRange2D;
 }
+
 f32 PlayerConst::getAnimFrameRateMinRun2D() const {
     return mAnimFrameRateMinRun2D;
 }
+
 f32 PlayerConst::getAnimFrameRateMaxRun2D() const {
     return mAnimFrameRateMaxRun2D;
 }
+
 s32 PlayerConst::getIKBlendFrameRun() const {
     return mIKBlendFrameRun;
 }
+
 f32 PlayerConst::getIKBlendRateRunMin() const {
     return mIKBlendRateRunMin;
 }
+
 f32 PlayerConst::getIKBlendRateRunMax() const {
     return mIKBlendRateRunMax;
 }
+
 f32 PlayerConst::getRollingAnimBorderSpeedMin() const {
     return mRollingAnimBorderSpeedMin;
 }
+
 f32 PlayerConst::getRollingAnimBorderSpeedMax() const {
     return mRollingAnimBorderSpeedMax;
 }
+
 f32 PlayerConst::getRollingAnimFrameRateMin() const {
     return mRollingAnimFrameRateMin;
 }
+
 f32 PlayerConst::getRollingAnimFrameRateMax() const {
     return mRollingAnimFrameRateMax;
 }
+
 s32 PlayerConst::getSwimPaddleAnimInterval() const {
     return mSwimPaddleAniminterval;
 }
+
 s32 PlayerConst::getSwimPaddleAnimRateIntervalMax() const {
     return mSwimPaddleAnimRateintervalMax;
 }
+
 s32 PlayerConst::getSwimPaddleAnimRateIntervalMin() const {
     return mSwimPaddleAnimRateintervalMin;
 }
+
 f32 PlayerConst::getSwimPaddleAnimMaxRate() const {
     return mSwimPaddleAnimMaxRate;
 }
+
 f32 PlayerConst::getSwimBentForwardMax() const {
     return mSwimBentForwardMax;
 }
+
 f32 PlayerConst::getSwimBentForwardBlendRate() const {
     return mSwimBentForwardBlendRate;
 }
+
 f32 PlayerConst::getSwimBentSideMax() const {
     return mSwimBentSideMax;
 }
+
 f32 PlayerConst::getSwimBentSpineMax() const {
     return mSwimBentSpineMax;
 }
+
 f32 PlayerConst::getSwimBentSideBlendRate() const {
     return mSwimBentSideBlendRate;
 }
+
 f32 PlayerConst::getSwimBentFrontMax() const {
     return mSwimBentFrontMax;
 }
+
 f32 PlayerConst::getSwimBentFrontBlendRate() const {
     return mSwimBentFrontBlendRate;
 }
+
 f32 PlayerConst::getSwimWalkAnimSpeedMax() const {
     return mSwimWalkAnimSpeedMax;
 }
+
 f32 PlayerConst::getSwimWalkAnimSpeedMin() const {
     return mSwimWalkAnimSpeedMin;
 }
+
 f32 PlayerConst::getSwimWalkAnimFrameRateMax() const {
     return mSwimWalkAnimFrameRateMax;
 }
+
 f32 PlayerConst::getSwimWalkAnimFrameRateMin() const {
     return mSwimWalkAnimFrameRateMin;
 }
+
 f32 PlayerConst::getSandSinkBorderMin() const {
     return mSandSinkBorderMin;
 }
+
 f32 PlayerConst::getSandSinkBorderMax() const {
     return mSandSinkBorderMax;
 }
+
 f32 PlayerConst::getSandSinkBorderRateMin() const {
     return mSandSinkBorderRateMin;
 }
+
 f32 PlayerConst::getSandSinkBorderRateMax() const {
     return mSandSinkBorderRateMax;
 }
+
 f32 PlayerConst::getSandSinkFrameRateMin() const {
     return mSandSinkFrameRateMin;
 }
+
 f32 PlayerConst::getSandSinkFrameRateMax() const {
     return mSandSinkFrameRateMax;
 }
+
 s32 PlayerConst::getLookAtEyeKeepFrame() const {
     return mLookAtEyeKeepFrame;
 }
+
 s32 PlayerConst::getLookAtEyeKeepFrameInSight() const {
     return mLookAtEyeKeepFrameInSight;
 }
+
 s32 PlayerConst::getLookAtEyeKeepFrameWait() const {
     return mLookAtEyeKeepFrameWait;
 }
+
 f32 PlayerConst::getLookAtEyeDistance() const {
     return mLookAtEyeDistance;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMinH() const {
     return mLookAtEyeAngleMinH;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMinInSightH() const {
     return mLookAtEyeAngleMinInSightH;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMaxH() const {
     return mLookAtEyeAngleMaxH;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMinV() const {
     return mLookAtEyeAngleMinV;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMinInSightV() const {
     return mLookAtEyeAngleMinInSightV;
 }
+
 f32 PlayerConst::getLookAtEyeAngleMaxV() const {
     return mLookAtEyeAngleMaxV;
 }
+
 f32 PlayerConst::getTiltEyeBorderStart() const {
     return mTiltEyeBorderStart;
 }
+
 f32 PlayerConst::getTiltEyeBorderEnd() const {
     return mTiltEyeBorderEnd;
 }
+
 f32 PlayerConst::getTiltEyeAngleScale() const {
     return mTiltEyeAngleScale;
 }
+
 f32 PlayerConst::getCenterTiltRateMax() const {
     return mCenterTiltRateMax;
 }
+
 f32 PlayerConst::getNoseChildLocalOffset() const {
     return mNoseChildLocalOffset;
 }
+
 f32 PlayerConst::getNoseStability() const {
     return mNoseStability;
 }
+
 f32 PlayerConst::getNoseFriction() const {
     return mNoseFriction;
 }
+
 f32 PlayerConst::getNoseLimitDegree() const {
     return mNoseLimitDegree;
 }
+
 f32 PlayerConst::getMustacheChildLocalOffset() const {
     return mMustacheChildLocalOffset;
 }
+
 f32 PlayerConst::getMustacheStability() const {
     return mMustacheStability;
 }
+
 f32 PlayerConst::getMustacheFriction() const {
     return mMustacheFriction;
 }
+
 f32 PlayerConst::getMustacheLimitDegree() const {
     return mMustacheLimitDegree;
 }
+
 s32 PlayerConst::getCapInterpolateFrame() const {
     return mCapinterpolateFrame;
 }
+
 f32 PlayerConst::getCapChildLocalOffset() const {
     return mCapChildLocalOffset;
 }
+
 f32 PlayerConst::getCapStability() const {
     return mCapStability;
 }
+
 f32 PlayerConst::getCapFriction() const {
     return mCapFriction;
 }
+
 f32 PlayerConst::getCapLimitDegree() const {
     return mCapLimitDegree;
 }
+
 f32 PlayerConst::getCapTransStability() const {
     return mCapTransStability;
 }
+
 f32 PlayerConst::getCapTransFriction() const {
     return mCapTransFriction;
 }
+
 f32 PlayerConst::getCapTransLimit() const {
     return mCapTransLimit;
 }
+
 s32 PlayerConst::getCapManHeroEyesWaitAppearFrame() const {
     return mCapManHeroEyesWaitAppearFrame;
 }
+
 s32 PlayerConst::getDeadWipeStartDamage() const {
     return mDeadWipeStartDamage;
 }
+
 s32 PlayerConst::getDeadWipeWaitDamage() const {
     return mDeadWipeWaitDamage;
 }
+
 s32 PlayerConst::getDeadWipeStartAbyss() const {
     return mDeadWipeStartAbyss;
 }
+
 s32 PlayerConst::getDeadWipeWaitAbyss() const {
     return mDeadWipeWaitAbyss;
 }
+
 s32 PlayerConst::getDeadWipeStartAbyssWithCapMsg() const {
     return mDeadWipeStartAbyssWithCapMsg;
 }
+
 s32 PlayerConst::getDeadWipeWaitAbyssWithCapMsg() const {
     return mDeadWipeWaitAbyssWithCapMsg;
 }
+
 s32 PlayerConst::getDeadWipeStartPress() const {
     return mDeadWipeStartPress;
 }
+
 s32 PlayerConst::getDeadWipeWaitPress() const {
     return mDeadWipeWaitPress;
 }
+
 s32 PlayerConst::getDeadWipeStartSandSink() const {
     return mDeadWipeStartSandSink;
 }
+
 s32 PlayerConst::getDeadWipeWaitSandSink() const {
     return mDeadWipeWaitSandSink;
 }
+
 s32 PlayerConst::getDeadWipeStartNoOxygen() const {
     return mDeadWipeStartNoOxygen;
 }
+
 s32 PlayerConst::getDeadWipeWaitNoOxygen() const {
     return mDeadWipeWaitNoOxygen;
 }
+
 s32 PlayerConst::getDeadWipeStartIceWater() const {
     return mDeadWipeStartIceWater;
 }
+
 s32 PlayerConst::getDeadWipeWaitIceWater() const {
     return mDeadWipeWaitIceWater;
 }
+
 f32 PlayerConst::getCoinDashSpeed() const {
     return mCoinDashSpeed;
 }
+
 f32 PlayerConst::getCoinDashSpeedLimit() const {
     return mCoinDashSpeedLimit;
 }
+
 f32 PlayerConst::getAdditionalSpeedLimit() const {
     return mAdditionalSpeedLimit;
 }

--- a/src/Player/PlayerCostumeInfo.cpp
+++ b/src/Player/PlayerCostumeInfo.cpp
@@ -6,6 +6,7 @@
 PlayerHeadCostumeInfo::PlayerHeadCostumeInfo(const char* a1) {
     _0 = a1;
 }
+
 PlayerBodyCostumeInfo::PlayerBodyCostumeInfo(const char* a1) {
     _0 = a1;
 }

--- a/src/Player/PlayerCounterAfterUpperPunch.h
+++ b/src/Player/PlayerCounterAfterUpperPunch.h
@@ -13,4 +13,5 @@ private:
     // yes, this is an u32, bounded by a signed s32
     u32 mCounter = sead::Mathi::maxNumber();
 };
+
 static_assert(sizeof(PlayerCounterAfterUpperPunch) == 0x4);

--- a/src/Player/PlayerCounterForceRun.h
+++ b/src/Player/PlayerCounterForceRun.h
@@ -10,7 +10,9 @@ public:
     void update();
 
     bool isForceRun() const { return mCounter > 0; }
+
     s32 getCounter() const { return mCounter; }
+
     f32 getSpeed() const { return mSpeed; }
 
 private:

--- a/src/Player/PlayerHackKeeper.h
+++ b/src/Player/PlayerHackKeeper.h
@@ -22,6 +22,7 @@ public:
                      const IUsePlayerHeightCheck* heightCheck);
 
     al::LiveActor* getCurrentHackActor() const { return mCurrentHackActor; }
+
     al::HitSensor* getUnkHitSensor() const { return mUnkHitSensor; }
 
 private:

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -93,4 +93,5 @@ private:
     bool mIsDisableInput;
     void* gap3[20];
 };
+
 static_assert(sizeof(PlayerInput) == 0x140);

--- a/src/Player/PlayerJudgeDrawForward.cpp
+++ b/src/Player/PlayerJudgeDrawForward.cpp
@@ -15,4 +15,5 @@ bool PlayerJudgeDrawForward::judge() const {
 }
 
 void PlayerJudgeDrawForward::reset() {}
+
 void PlayerJudgeDrawForward::update() {}

--- a/src/Player/PlayerJudgeForceLand.h
+++ b/src/Player/PlayerJudgeForceLand.h
@@ -15,4 +15,5 @@ private:
     const IJudge* mJudgeLongFall;
     const PlayerTrigger* mTrigger;
 };
+
 static_assert(sizeof(PlayerJudgeForceLand) == 0x18);

--- a/src/Player/PlayerJudgeForceRolling.cpp
+++ b/src/Player/PlayerJudgeForceRolling.cpp
@@ -11,4 +11,5 @@ bool PlayerJudgeForceRolling::judge() const {
 }
 
 void PlayerJudgeForceRolling::reset() {}
+
 void PlayerJudgeForceRolling::update() {}

--- a/src/Player/PlayerJudgeSameNerve.h
+++ b/src/Player/PlayerJudgeSameNerve.h
@@ -18,4 +18,5 @@ private:
     const al::IUseNerve* mNerveUser;
     const al::Nerve* mNerve;
 };
+
 static_assert(sizeof(PlayerJudgeSameNerve) == 0x18);

--- a/src/Player/PlayerJudgeSandSink.h
+++ b/src/Player/PlayerJudgeSandSink.h
@@ -20,4 +20,5 @@ private:
     const IUsePlayerCollision* mCollider;
     const PlayerSandSinkAffect* mSandSinkAffect;
 };
+
 static_assert(sizeof(PlayerJudgeSandSink) == 0x18);

--- a/src/Player/PlayerJudgeStartGroundSpin.h
+++ b/src/Player/PlayerJudgeStartGroundSpin.h
@@ -21,4 +21,5 @@ private:
     const IUsePlayerCollision* mCollider;
     const PlayerInput* mInput;
 };
+
 static_assert(sizeof(PlayerJudgeStartGroundSpin) == 0x20);

--- a/src/Player/PlayerJudgeStartHipDrop.h
+++ b/src/Player/PlayerJudgeStartHipDrop.h
@@ -23,4 +23,5 @@ private:
     const IUsePlayerHeightCheck* mHeightCheck;
     const IPlayerModelChanger* mModelChanger;
 };
+
 static_assert(sizeof(PlayerJudgeStartHipDrop) == 0x28);

--- a/src/Player/PlayerJudgeStartRolling.cpp
+++ b/src/Player/PlayerJudgeStartRolling.cpp
@@ -30,7 +30,9 @@ bool PlayerJudgeStartRolling::isTriggerRestartSwing() const {
 }
 
 void PlayerJudgeStartRolling::reset() {}
+
 void PlayerJudgeStartRolling::update() {}
+
 bool PlayerJudgeStartRolling::judge() const {
     return isEnableTriggerRolling() &&
            mInput->isTriggerRolling(rs::isOnGroundForceRollingCode(mPlayer, mCollider));

--- a/src/Player/PlayerJudgeStartRolling.h
+++ b/src/Player/PlayerJudgeStartRolling.h
@@ -33,4 +33,5 @@ private:
     const IPlayerModelChanger* mModelChanger;
     const PlayerCarryKeeper* mCarryKeeper;
 };
+
 static_assert(sizeof(PlayerJudgeStartRolling) == 0x38);

--- a/src/Player/PlayerJudgeStartSquat.h
+++ b/src/Player/PlayerJudgeStartSquat.h
@@ -21,4 +21,5 @@ private:
     const PlayerCounterForceRun* mCounterForceRun;
     const PlayerCarryKeeper* mCarryKeeper;
 };
+
 static_assert(sizeof(PlayerJudgeStartSquat) == 0x20);

--- a/src/Player/PlayerJudgeWallCatch.h
+++ b/src/Player/PlayerJudgeWallCatch.h
@@ -49,4 +49,5 @@ private:
     sead::Vector3f mCollidedWallNormal = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mNormalAtPos = {0.0f, 0.0f, 0.0f};
 };
+
 static_assert(sizeof(PlayerJudgeWallCatch) == 0x88);

--- a/src/Player/PlayerSandSinkAffect.h
+++ b/src/Player/PlayerSandSinkAffect.h
@@ -32,4 +32,5 @@ private:
     f32 mSinkAmount;
     bool mIsSafe;
 };
+
 static_assert(sizeof(PlayerSandSinkAffect) == 0x38);

--- a/src/Player/PlayerTrigger.cpp
+++ b/src/Player/PlayerTrigger.cpp
@@ -5,24 +5,31 @@ PlayerTrigger::PlayerTrigger() = default;
 void PlayerTrigger::set(ECollisionTrigger flag) {
     mCollisionTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EAttackSensorTrigger flag) {
     mAttackSensorTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EActionTrigger flag) {
     mActionTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EReceiveSensorTrigger flag) {
     mReceiveSensorTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EPreMovementTrigger flag) {
     mPreMovementTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EDemoEndTrigger flag) {
     mDemoEndTrigger.setBit(flag);
 }
+
 void PlayerTrigger::set(EMaterialChangeTrigger flag) {
     mMaterialChangeTrigger.setBit(flag);
 }
+
 void PlayerTrigger::setRecMaterialTrigger(const char* materialTrigger) {
     mRecMaterialTrigger = materialTrigger;
 }
@@ -30,22 +37,28 @@ void PlayerTrigger::setRecMaterialTrigger(const char* materialTrigger) {
 void PlayerTrigger::clearCollisionTrigger() {
     mCollisionTrigger = 0;
 }
+
 void PlayerTrigger::clearAttackSensorTrigger() {
     mAttackSensorTrigger = 0;
 }
+
 void PlayerTrigger::clearActionTrigger() {
     mActionTrigger = 0;
 }
+
 void PlayerTrigger::clearReceiveSensorTrigger() {
     mReceiveSensorTrigger = 0;
     mRecMaterialTrigger = nullptr;
 }
+
 void PlayerTrigger::clearPreMovementTrigger() {
     mPreMovementTrigger = 0;
 }
+
 void PlayerTrigger::clearDemoEndTrigger() {
     mDemoEndTrigger = 0;
 }
+
 void PlayerTrigger::clearMaterialChangeTrigger() {
     mMaterialChangeTrigger = 0;
 }
@@ -53,21 +66,27 @@ void PlayerTrigger::clearMaterialChangeTrigger() {
 bool PlayerTrigger::isOn(ECollisionTrigger flag) const {
     return mCollisionTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EAttackSensorTrigger flag) const {
     return mAttackSensorTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EActionTrigger flag) const {
     return mActionTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EReceiveSensorTrigger flag) const {
     return mReceiveSensorTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EPreMovementTrigger flag) const {
     return mPreMovementTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EDemoEndTrigger flag) const {
     return mDemoEndTrigger.isOnBit(flag);
 }
+
 bool PlayerTrigger::isOn(EMaterialChangeTrigger flag) const {
     return mMaterialChangeTrigger.isOnBit(flag);
 }

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -6,10 +6,12 @@
 class PlayerTrigger {
 public:
     enum ECollisionTrigger : u32 {};
+
     enum EAttackSensorTrigger : u32 {
         // used in PlayerCounterAfterCapCatch
         EAttackSensorTrigger_val0 = 0,
     };
+
     enum EActionTrigger : u32 {
         // used in PlayerJudgeForceLand
         EActionTrigger_val11 = 11,
@@ -17,9 +19,13 @@ public:
         EActionTrigger_val30 = 30,
         EActionTrigger_QuickTurn = 34,
     };
+
     enum EReceiveSensorTrigger : u32 {};
+
     enum EPreMovementTrigger : u32 {};
+
     enum EDemoEndTrigger : u32 {};
+
     enum EMaterialChangeTrigger : u32 {};
 
     PlayerTrigger();
@@ -67,4 +73,5 @@ private:
     sead::BitFlag32 mMaterialChangeTrigger = 0;
     const char* mRecMaterialTrigger = nullptr;
 };
+
 static_assert(sizeof(PlayerTrigger) == 0x28);

--- a/src/Player/PlayerWallActionHistory.cpp
+++ b/src/Player/PlayerWallActionHistory.cpp
@@ -3,26 +3,31 @@
 #include "Util/PlayerCollisionUtil.h"
 
 PlayerWallActionHistory::PlayerWallActionHistory() {}
+
 void PlayerWallActionHistory::update(const IUsePlayerCollision* collider) {
     if (rs::isCollidedGround(collider))
         reset();
 }
+
 void PlayerWallActionHistory::reset() {
     mIsJumpStored = false;
     mIsLeaveStored = false;
 }
+
 void PlayerWallActionHistory::recordWallJump(const IUsePlayerCollision* collider,
                                              const sead::Vector3f& position) {
     mIsJumpStored = true;
     mJumpWallPosition = position;
     mJumpWallNormal = rs::getCollidedWallNormal(collider);
 }
+
 void PlayerWallActionHistory::recordWallJump(const sead::Vector3f& position,
                                              const sead::Vector3f& normal) {
     mIsJumpStored = true;
     mJumpWallPosition = position;
     mJumpWallNormal = normal;
 }
+
 void PlayerWallActionHistory::recordWallLeave(const sead::Vector3f& position,
                                               const sead::Vector3f& normal) {
     mIsLeaveStored = true;

--- a/src/Player/PlayerWallActionHistory.h
+++ b/src/Player/PlayerWallActionHistory.h
@@ -21,4 +21,5 @@ private:
     sead::Vector3f mLeaveWallPosition = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mLeaveWallNormal = {0.0f, 0.0f, 0.0f};
 };
+
 static_assert(sizeof(PlayerWallActionHistory) == 0x38);

--- a/src/Scene/StageSceneStateWorldMap.cpp
+++ b/src/Scene/StageSceneStateWorldMap.cpp
@@ -18,25 +18,43 @@ StageSceneStateWorldMap::StageSceneStateWorldMap(const char* name, al::Scene* ho
 StageSceneStateWorldMap::~StageSceneStateWorldMap() {}
 
 void StageSceneStateWorldMap::control() {}
+
 void StageSceneStateWorldMap::appear() {}
+
 void StageSceneStateWorldMap::kill() {}
 
 void StageSceneStateWorldMap::exeInit() {}
+
 void StageSceneStateWorldMap::exeDemoPrep() {}
+
 void StageSceneStateWorldMap::exeDemoStart() {}
+
 void StageSceneStateWorldMap::appearWorldSelectLayout() {}
+
 void StageSceneStateWorldMap::exeDemoWorldOpen() {}
+
 void StageSceneStateWorldMap::exeDemoWorldUnlock() {}
+
 void StageSceneStateWorldMap::exeDemoWorldSelect() {}
+
 void StageSceneStateWorldMap::exeDemoWorldComment() {}
+
 void StageSceneStateWorldMap::exeWait() {}
+
 void StageSceneStateWorldMap::exeIgnoreMessage() {}
+
 void StageSceneStateWorldMap::exeCollectionListMain() {}
+
 void StageSceneStateWorldMap::exeCollectionListExit() {}
+
 void StageSceneStateWorldMap::exeExit() {}
+
 void StageSceneStateWorldMap::exeEnd() {}
 
 void StageSceneStateWorldMap::tryOpenWorldMap() {}
+
 void StageSceneStateWorldMap::isCloseEndWipe() {}
+
 void StageSceneStateWorldMap::isOpenEndWipe() {}
+
 void StageSceneStateWorldMap::isOpenCollectionList() {}

--- a/src/Sequence/WorldResourceLoader.cpp
+++ b/src/Sequence/WorldResourceLoader.cpp
@@ -21,6 +21,7 @@ WorldResourceLoader::WorldResourceLoader(GameDataHolder* dataHolder) {
     mWorldResourceLoader = new al::AsyncFunctorThread("WorldResourceLoader", functor, priority,
                                                       0x100000, sead::CoreId::cMain);
 }
+
 WorldResourceLoader::~WorldResourceLoader() {
     mIsCancelled = true;
     mCurLoadCount = 0;
@@ -133,6 +134,7 @@ bool WorldResourceLoader::requestLoadWorldResource(s32 loadWorldId) {
     requestLoadWorldResourceCommon(loadWorldId);
     return true;
 }
+
 // unused func
 void WorldResourceLoader::createResourcePlayer() {}
 

--- a/src/System/Application.h
+++ b/src/System/Application.h
@@ -19,9 +19,13 @@ public:
     void init(s32 argc, char** argv);
     void run();
     RootTask* getRootTask() const;
+
     al::SystemKit* getSystemKit() const { return mSystemKit; }
+
     al::GameFrameworkNx* getGameFramework() const { return mGameFramework; }
+
     al::AccountHolder* getAccountHolder() const { return mAccountHolder; }
+
     al::DrawSystemInfo* getDrawSystemInfo() const { return mDrawSystemInfo; }
 
 protected:

--- a/src/System/GameDataHolderAccessor.cpp
+++ b/src/System/GameDataHolderAccessor.cpp
@@ -7,6 +7,7 @@
 GameDataHolderAccessor::GameDataHolderAccessor(const al::IUseSceneObjHolder* holder) {
     mSceneObj = al::getSceneObj(holder, 18);
 }
+
 GameDataHolderAccessor::GameDataHolderAccessor(const al::SceneObjHolder* holder) {
     mSceneObj = holder->getObj(18);
 }

--- a/src/System/RootTask.cpp
+++ b/src/System/RootTask.cpp
@@ -8,9 +8,11 @@
 
 RootTask::RootTask(const sead::TaskConstructArg& constructArg)
     : sead::Task(constructArg, "RootTask") {}
+
 RootTask::~RootTask() = default;
 
 void RootTask::enter() {}
+
 void RootTask::calc() {
     if (!mGameSystem) {
         sead::ScopedCurrentHeapSetter heapSetter(al::getStationedHeap());
@@ -19,6 +21,7 @@ void RootTask::calc() {
     }
     mGameSystem->movement();
 }
+
 void RootTask::draw() {
     if (mGameSystem)
         mGameSystem->drawMain();

--- a/src/System/WorldList.h
+++ b/src/System/WorldList.h
@@ -52,4 +52,5 @@ private:
     sead::StrTreeMap<128, StagePosInfo*> mStagePosList;
     sead::PtrArrayImpl field_30;
 };
+
 static_assert(sizeof(WorldList) == 0x40, "WorldList Size");

--- a/src/Util/ActorDimensionKeeper.h
+++ b/src/Util/ActorDimensionKeeper.h
@@ -18,9 +18,13 @@ public:
     bool update();
 
     bool getIs2D() const { return mIs2D; }
+
     bool getIsIn2DArea() const { return mIsIn2DArea; }
+
     bool getIsCurrently2D() const { return mIsCurrently2D; }
+
     bool getIsCanChange2D() const { return mIsCanChange2D; }
+
     bool getIsCanChange3D() const { return mIsCanChange3D; }
 
 private:
@@ -33,6 +37,7 @@ private:
     bool mIsCanChange3D = false;
     In2DAreaMoveControl* mIn2DAreaMoveControl = nullptr;
 };
+
 static_assert(sizeof(ActorDimensionKeeper) == 0x18);
 
 namespace rs {


### PR DESCRIPTION
As discussed, we want to apply an additional setting for `clang-format`, separating definition blocks by one empty line. This PR adds the linter option, and applies it to all files.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/96)
<!-- Reviewable:end -->
