### PR TITLE
Player: Implement PlayerJudgeStartRolling

### DIFF
--- a/src/Player/PlayerJudgeStartRolling.cpp
+++ b/src/Player/PlayerJudgeStartRolling.cpp
@@ -1,0 +1,37 @@
+#include "Player/PlayerJudgeStartRolling.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerInput.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeStartRolling::PlayerJudgeStartRolling(const al::LiveActor* player,
+                                                 const PlayerConst* pConst,
+                                                 const PlayerInput* input,
+                                                 const IUsePlayerCollision* collider,
+                                                 const IPlayerModelChanger* modelChanger,
+                                                 const PlayerCarryKeeper* carryKeeper)
+    : mPlayer(player), mConst(pConst), mInput(input), mCollider(collider),
+      mModelChanger(modelChanger), mCarryKeeper(carryKeeper) {}
+
+bool PlayerJudgeStartRolling::isEnableTriggerRolling() const {
+    return !mCarryKeeper->isCarry() && !mModelChanger->is2DModel() &&
+           rs::isCollidedGround(mCollider) &&
+           !rs::isOnGroundForceSlideCode(mPlayer, mCollider, mConst);
+}
+
+bool PlayerJudgeStartRolling::judgeCancelHipDrop() const {
+    return isEnableTriggerRolling() && mInput->isTriggerRollingCancelHipDrop(
+                                           rs::isOnGroundForceRollingCode(mPlayer, mCollider));
+}
+
+bool PlayerJudgeStartRolling::isTriggerRestartSwing() const {
+    return isEnableTriggerRolling() && mInput->isTriggerRollingRestartSwing();
+}
+
+void PlayerJudgeStartRolling::reset() {}
+void PlayerJudgeStartRolling::update() {}
+bool PlayerJudgeStartRolling::judge() const {
+    return isEnableTriggerRolling() &&
+           mInput->isTriggerRolling(rs::isOnGroundForceRollingCode(mPlayer, mCollider));
+}

--- a/src/Player/PlayerJudgeStartRolling.h
+++ b/src/Player/PlayerJudgeStartRolling.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class IPlayerModelChanger;
+class PlayerCarryKeeper;
+
+class PlayerJudgeStartRolling : public IJudge {
+public:
+    PlayerJudgeStartRolling(const al::LiveActor* player, const PlayerConst* pConst,
+                            const PlayerInput* input, const IUsePlayerCollision* collider,
+                            const IPlayerModelChanger* modelChanger,
+                            const PlayerCarryKeeper* carryKeeper);
+    bool isEnableTriggerRolling() const;
+    bool judgeCancelHipDrop() const;
+    bool isTriggerRestartSwing() const;
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollider;
+    const IPlayerModelChanger* mModelChanger;
+    const PlayerCarryKeeper* mCarryKeeper;
+};
+static_assert(sizeof(PlayerJudgeStartRolling) == 0x38);


### PR DESCRIPTION
Another quick judge. This one checks a bunch of pre-conditions for switching to the `Rolling` state from various previous states. The base checks are always:
1. Do not carry anything
2. Not currently 2D
3. Player is on ground
4. Ground does not have `ForceSlide` code

Finally, for triggering a roll, each respective `PlayerInput` function has to return true, for example `isTriggerRollingCancelHipDrop` to roll from a ground pound.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/98)
<!-- Reviewable:end -->
