### PR TITLE
Player: Implement PlayerJudgeStartGroundSpin

### DIFF
--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -65,6 +65,7 @@ public:
     bool isMove() const;
     bool isHoldHackAction() const;
     bool isHoldHackJump() const;
+    bool isSpinInput() const;
 
     bool isTriggerChange2D() const;
     bool isTriggerChange3D() const;

--- a/src/Player/PlayerJudgeStartGroundSpin.cpp
+++ b/src/Player/PlayerJudgeStartGroundSpin.cpp
@@ -1,0 +1,17 @@
+#include "Player/PlayerJudgeStartGroundSpin.h"
+
+#include "Player/PlayerInput.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeStartGroundSpin::PlayerJudgeStartGroundSpin(const al::LiveActor* player,
+                                                       const IUsePlayerCollision* collider,
+                                                       const PlayerInput* input)
+    : mPlayer(player), mCollider(collider), mInput(input) {}
+
+void PlayerJudgeStartGroundSpin::reset() {}
+
+void PlayerJudgeStartGroundSpin::update() {}
+
+bool PlayerJudgeStartGroundSpin::judge() const {
+    return mInput->isSpinInput() && rs::isOnGround(mPlayer, mCollider);
+}

--- a/src/Player/PlayerJudgeStartGroundSpin.h
+++ b/src/Player/PlayerJudgeStartGroundSpin.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+class IUsePlayerCollision;
+class PlayerInput;
+
+class PlayerJudgeStartGroundSpin : public IJudge {
+public:
+    PlayerJudgeStartGroundSpin(const al::LiveActor* player, const IUsePlayerCollision* collider,
+                               const PlayerInput* input);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const IUsePlayerCollision* mCollider;
+    const PlayerInput* mInput;
+};
+static_assert(sizeof(PlayerJudgeStartGroundSpin) == 0x20);


### PR DESCRIPTION
Simple judge to determine whether the Player should start spinning. To `return true`, the following two conditions have to be fulfilled:
1. Input a spin
2. Player is on the ground

... and that's it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/99)
<!-- Reviewable:end -->
