### PR TITLE
Player: Implement PlayerJudgeSandSink

### DIFF
--- a/src/Player/PlayerJudgeSandSink.cpp
+++ b/src/Player/PlayerJudgeSandSink.cpp
@@ -1,0 +1,17 @@
+#include "Player/PlayerJudgeSandSink.h"
+
+#include "Player/PlayerSandSinkAffect.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeSandSink::PlayerJudgeSandSink(const IUsePlayerCollision* collider,
+                                         const PlayerSandSinkAffect* sandSinkAffect)
+    : mCollider(collider), mSandSinkAffect(sandSinkAffect) {}
+
+void PlayerJudgeSandSink::reset() {}
+
+void PlayerJudgeSandSink::update() {}
+
+bool PlayerJudgeSandSink::judge() const {
+    return mSandSinkAffect->isSink() ||
+           (rs::isCollidedGround(mCollider) && rs::isCollisionCodeSandSink(mCollider));
+}

--- a/src/Player/PlayerJudgeSandSink.h
+++ b/src/Player/PlayerJudgeSandSink.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+class IUsePlayerCollision;
+class PlayerSandSinkAffect;
+
+class PlayerJudgeSandSink : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeSandSink(const IUsePlayerCollision* collider,
+                        const PlayerSandSinkAffect* sandSinkAffect);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const IUsePlayerCollision* mCollider;
+    const PlayerSandSinkAffect* mSandSinkAffect;
+};
+static_assert(sizeof(PlayerJudgeSandSink) == 0x18);

--- a/src/Player/PlayerSandSinkAffect.h
+++ b/src/Player/PlayerSandSinkAffect.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class PlayerEffect;
+
+class PlayerSandSinkAffect {
+public:
+    PlayerSandSinkAffect(const al::LiveActor*, const PlayerConst*, const PlayerInput*,
+                         IUsePlayerCollision*, PlayerEffect*);
+    void clear();
+    bool isSink() const;
+    void update(bool);
+    bool isSinkDeathHeight() const;
+    void reduceVelocity(sead::Vector3f*);
+    bool isEnableCapThrow() const;
+    f32 calcSandSinkDeathRate() const;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    IUsePlayerCollision* mCollider;
+    PlayerEffect* mEffect;
+    f32 mSinkVelocity;
+    f32 mSinkAmount;
+    bool mIsSafe;
+};
+static_assert(sizeof(PlayerSandSinkAffect) == 0x38);

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -23,5 +23,6 @@ bool isOnGround(const al::LiveActor*, const IUsePlayerCollision*);
 bool isJustLand(const IUsePlayerCollision*);
 void calcGroundNormalOrGravityDir(sead::Vector3f*, const al::LiveActor*,
                                   const IUsePlayerCollision*);
+bool isCollisionCodeSandSink(const IUsePlayerCollision*);
 
 }  // namespace rs


### PR DESCRIPTION
Another judge? How many of these exist overall?!
... way more than we have done here already.

Alright, next-up: PlayerJudgeSandSink. Determines whether the player should be affected by sinking sand. This is true if the player is already affected by `SandSinkAffect`, or the following two conditions are true:
1. Player is on ground
2. Touched ground collision triangle has collision code `SandSink`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/100)
<!-- Reviewable:end -->
