### PR TITLE
Player: Implement PlayerJudgeForceLand

### DIFF
--- a/src/Player/PlayerJudgeForceLand.cpp
+++ b/src/Player/PlayerJudgeForceLand.cpp
@@ -1,0 +1,16 @@
+#include "Player/PlayerJudgeForceLand.h"
+
+#include "Player/PlayerTrigger.h"
+#include "Util/StageSceneFunction.h"
+
+PlayerJudgeForceLand::PlayerJudgeForceLand(const IJudge* judgeLongFall,
+                                           const PlayerTrigger* trigger)
+    : mJudgeLongFall(judgeLongFall), mTrigger(trigger) {}
+
+void PlayerJudgeForceLand::reset() {}
+
+void PlayerJudgeForceLand::update() {}
+
+bool PlayerJudgeForceLand::judge() const {
+    return rs::isJudge(mJudgeLongFall) || mTrigger->isOn(PlayerTrigger::EActionTrigger_val11);
+}

--- a/src/Player/PlayerJudgeForceLand.h
+++ b/src/Player/PlayerJudgeForceLand.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+class PlayerTrigger;
+
+class PlayerJudgeForceLand : public IJudge {
+public:
+    PlayerJudgeForceLand(const IJudge* judgeLongFall, const PlayerTrigger* trigger);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const IJudge* mJudgeLongFall;
+    const PlayerTrigger* mTrigger;
+};
+static_assert(sizeof(PlayerJudgeForceLand) == 0x18);

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -11,6 +11,8 @@ public:
         EAttackSensorTrigger_val0 = 0,
     };
     enum EActionTrigger : u32 {
+        // used in PlayerJudgeForceLand
+        EActionTrigger_val11 = 11,
         EActionTrigger_QuickTurn = 34,
     };
     enum EReceiveSensorTrigger : u32 {};


### PR DESCRIPTION
Another one! To trigger this judge, either the `PlayerJudgeLongFall` judge passed in the constructor has to return `true`, or the `PlayerTrigger` has to hold the value `11` in its `ActionTrigger`. As the purpose of this value is currently unknown, it only contains a placeholder name in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/101)
<!-- Reviewable:end -->
