### PR TITLE
Custom linter: Remove `this->` prefix

### DIFF
--- a/lib/al/Library/Base/StringUtil.h
+++ b/lib/al/Library/Base/StringUtil.h
@@ -41,7 +41,7 @@ public:
     StringTmp(const char* format, ...) : sead::FixedSafeString<L>() {
         std::va_list args;
         va_start(args, format);
-        this->formatV(format, args);
+        sead::FixedSafeString<L>::formatV(format, args);
         va_end(args);
     }
     ~StringTmp() = default;

--- a/lib/al/Library/Layout/LayoutActor.cpp
+++ b/lib/al/Library/Layout/LayoutActor.cpp
@@ -13,7 +13,7 @@ void LayoutActor::appear() {
     if (mLayoutPartsActorKeeper)
         mLayoutPartsActorKeeper->appear();
     updateLayoutPaneRecursive(this);
-    this->calcAnim(false);
+    calcAnim(false);
 }
 void LayoutActor::initLayoutPartsActorKeeper(s32 capacity) {
     mLayoutPartsActorKeeper = new LayoutPartsActorKeeper(capacity);

--- a/lib/al/Library/LiveActor/LiveActorGroup.cpp
+++ b/lib/al/Library/LiveActor/LiveActorGroup.cpp
@@ -10,9 +10,9 @@ LiveActorGroup::LiveActorGroup(const char* groupName, s32 maxActors)
 }
 
 s32 LiveActorGroup::registerActor(LiveActor* pActor) {
-    this->mActors[this->mActorCount] = pActor;
-    auto count = this->mActorCount;
-    this->mActorCount = count + 1;
+    mActors[mActorCount] = pActor;
+    auto count = mActorCount;
+    mActorCount = count + 1;
     return count;
 }
 

--- a/src/MapObj/AnagramAlphabetCharacter.cpp
+++ b/src/MapObj/AnagramAlphabetCharacter.cpp
@@ -127,7 +127,7 @@ void AnagramAlphabetCharacter::exeHackWait() {
         al::setNerve(this, &NrvAnagramAlphabetCharacter.HackGoal);
 
     else {
-        if (!rs::updateJudgeAndResult((IJudge*)this->mHackerJudgeStartRun))
+        if (!rs::updateJudgeAndResult((IJudge*)mHackerJudgeStartRun))
             return;
         al::setNerve(this, &NrvAnagramAlphabetCharacter.HackMove);
     }
@@ -182,7 +182,7 @@ void AnagramAlphabetCharacter::exeHackGoal() {
     if (al::isGreaterEqualStep(this, 0LL))
         return;
     al::updatePoseMtx(this, unkMtx);
-    rs::endHackDir(&this->mHackerParent, rot);
+    rs::endHackDir(&mHackerParent, rot);
     al::validateClipping(this);
     al::setNerve(this, &NrvAnagramAlphabetCharacter.Wait);
     mCapTargetParts->startNormal();

--- a/src/Sequence/HakoniwaSequence.h
+++ b/src/Sequence/HakoniwaSequence.h
@@ -26,7 +26,7 @@ public:
     void update();
     bool isEnableSave();
     void drawMain();
-    al::Scene* getCurrentScene();  // {return this->curScene}
+    al::Scene* getCurrentScene();  // {return curScene}
 
     u8** field_0x0;
     u8 padding_120[120];

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -211,6 +211,11 @@ def common_const_type(c, path):
                 continue
             index += 1
 
+def common_this_prefix(c, path):
+    for line in c.splitlines():
+        if 'this->' in line:
+            FAIL("this-> is not allowed!", line, path)
+
 # Header files
 
 def header_sorted_visibility(c, path):
@@ -325,6 +330,7 @@ def check_source(c, path):
     common_sead_types(c, path)
     common_void_params(c, path)
     common_const_type(c, path)
+    common_this_prefix(c, path)
 
 def check_header(c, path):
     common_newline_eof(c, path)
@@ -335,6 +341,7 @@ def check_header(c, path):
     common_const_type(c, path)
     header_sorted_visibility(c, path)
     header_no_offset_comments(c, path)
+    common_this_prefix(c, path)
 
 def check_file(file_str):
     file = open(file_str, mode="r")


### PR DESCRIPTION
Fixes #66 by searching for `this->`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/102)
<!-- Reviewable:end -->
