### PR TITLE
Player: Implement PlayerJudgeWallCatch

### DIFF
--- a/lib/al/Library/Collision/CollisionParts.h
+++ b/lib/al/Library/Collision/CollisionParts.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+
+class CollisionParts {
+public:
+    void calcForceMovePower(sead::Vector3f*, const sead::Vector3f&) const;
+};
+
+}  // namespace al

--- a/src/Player/PlayerCounterForceRun.h
+++ b/src/Player/PlayerCounterForceRun.h
@@ -9,6 +9,7 @@ public:
     void setupForceRun(s32 frames, f32 speed);
     void update();
 
+    bool isForceRun() const { return mCounter > 0; }
     s32 getCounter() const { return mCounter; }
     f32 getSpeed() const { return mSpeed; }
 

--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -1,0 +1,6 @@
+#pragma once
+
+class PlayerExternalVelocity {
+public:
+    bool isExistForce() const;
+};

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -63,6 +63,7 @@ public:
     bool isHoldPoleClimbFast() const;
     bool isHoldWallCatchMoveFast() const;
     bool isMove() const;
+    bool isMoveDeepDown() const;
     bool isHoldHackAction() const;
     bool isHoldHackJump() const;
     bool isSpinInput() const;
@@ -76,6 +77,8 @@ public:
 
     bool isThrowTypeSpiral(const sead::Vector2f&) const;
     bool isThrowTypeRolling(const sead::Vector2f&) const;
+
+    void calcMoveInput(sead::Vector3f*, const sead::Vector3f&) const;
 
 private:
     const al::LiveActor* mLiveActor;

--- a/src/Player/PlayerJudgeStartSquat.cpp
+++ b/src/Player/PlayerJudgeStartSquat.cpp
@@ -10,7 +10,7 @@ PlayerJudgeStartSquat::PlayerJudgeStartSquat(const PlayerInput* input,
     : mInput(input), mCounterForceRun(counterForceRun), mCarryKeeper(carryKeeper) {}
 
 bool PlayerJudgeStartSquat::judge() const {
-    return !mCarryKeeper->isCarry() && mInput->isHoldSquat() && mCounterForceRun->getCounter() < 1;
+    return !mCarryKeeper->isCarry() && mInput->isHoldSquat() && !mCounterForceRun->isForceRun();
 }
 
 void PlayerJudgeStartSquat::reset() {}

--- a/src/Player/PlayerJudgeWallCatch.cpp
+++ b/src/Player/PlayerJudgeWallCatch.cpp
@@ -1,0 +1,68 @@
+#include "Player/PlayerJudgeWallCatch.h"
+
+#include "Library/Collision/CollisionParts.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Math/MathAngleUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerCounterForceRun.h"
+#include "Player/PlayerExternalVelocity.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeWallCatch::PlayerJudgeWallCatch(const al::LiveActor* player, const PlayerConst* pConst,
+                                           const IUsePlayerCollision* collider,
+                                           const IPlayerModelChanger* modelChanger,
+                                           const PlayerCarryKeeper* carryKeeper,
+                                           const PlayerExternalVelocity* externalVelocity,
+                                           const PlayerInput* input, const PlayerTrigger* trigger,
+                                           const PlayerCounterForceRun* counterForceRun)
+    : mPlayer(player), mConst(pConst), mCollision(collider), mModelChanger(modelChanger),
+      mCarryKeeper(carryKeeper), mExternalVelocity(externalVelocity), mInput(input),
+      mTrigger(trigger), mCounterForceRun(counterForceRun) {}
+
+void PlayerJudgeWallCatch::reset() {
+    mIsJudge = false;
+    mPosition = {0.0f, 0.0f, 0.0f};
+    mCollidedWallNormal = {0.0f, 0.0f, 0.0f};
+    mNormalAtPos = {0.0f, 0.0f, 0.0f};
+}
+
+void PlayerJudgeWallCatch::update() {
+    mIsJudge = false;
+    if (mCarryKeeper->isCarry() || mModelChanger->is2DModel() || mCounterForceRun->isForceRun() ||
+        mExternalVelocity->isExistForce() || !rs::isCollidedWall(mCollision) ||
+        rs::isCollidedGround(mCollision) || rs::isActionCodeNoWallGrab(mCollision))
+        return;
+
+    sead::Vector3f facingDir = {0.0f, 0.0f, 0.0f};
+    if (mTrigger->isOn(PlayerTrigger::EActionTrigger_val30)) {
+        if (!mInput->isMoveDeepDown())
+            return;
+        sead::Vector3f moveDir = {0.0f, 0.0f, 0.0f};
+        mInput->calcMoveInput(&moveDir, -al::getGravity(mPlayer));
+        al::normalize(&facingDir, moveDir);
+    } else {
+        al::calcFrontDir(&facingDir, mPlayer);
+    }
+
+    mCollidedWallPart = rs::getCollidedWallCollisionParts(mCollision);
+    sead::Vector3f movePower = {0.0f, 0.0f, 0.0f};
+    mCollidedWallPart->calcForceMovePower(&movePower, rs::getCollidedWallPos(mCollision));
+    sead::Vector3f finalWallPos = rs::getCollidedWallPos(mCollision) + movePower;
+    mCollidedWallNormal.set(rs::getCollidedWallNormal(mCollision));
+
+    mIsJudge = rs::findWallCatchPos(
+        &mCollidedWallPart, &mPosition, &mNormalAtPos, mPlayer, facingDir, finalWallPos,
+        mCollidedWallNormal, mConst->getWallKeepDegree(), mConst->getWallCatchDegree(),
+        mConst->getWallCatchHeightEdgeTop(), 0.0f, mConst->getWallCatchHeightBottom(),
+        mConst->getCollisionRadius(), mConst->getCollisionRadiusStand());
+}
+
+bool PlayerJudgeWallCatch::judge() const {
+    return mIsJudge;
+}

--- a/src/Player/PlayerJudgeWallCatch.h
+++ b/src/Player/PlayerJudgeWallCatch.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+class CollisionParts;
+}  // namespace al
+class PlayerConst;
+class IUsePlayerCollision;
+class IPlayerModelChanger;
+class PlayerCarryKeeper;
+class PlayerExternalVelocity;
+class PlayerInput;
+class PlayerTrigger;
+class PlayerCounterForceRun;
+
+class PlayerJudgeWallCatch : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeWallCatch(const al::LiveActor* player, const PlayerConst* pConst,
+                         const IUsePlayerCollision* collider,
+                         const IPlayerModelChanger* modelChanger,
+                         const PlayerCarryKeeper* carryKeeper,
+                         const PlayerExternalVelocity* externalVelocity, const PlayerInput* input,
+                         const PlayerTrigger* trigger,
+                         const PlayerCounterForceRun* counterForceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const IUsePlayerCollision* mCollision;
+    const IPlayerModelChanger* mModelChanger;
+    const PlayerCarryKeeper* mCarryKeeper;
+    const PlayerExternalVelocity* mExternalVelocity;
+    const PlayerInput* mInput;
+    const PlayerTrigger* mTrigger;
+    const PlayerCounterForceRun* mCounterForceRun;
+    bool mIsJudge = false;
+    const al::CollisionParts* mCollidedWallPart = nullptr;
+    sead::Vector3f mPosition = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mCollidedWallNormal = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mNormalAtPos = {0.0f, 0.0f, 0.0f};
+};
+static_assert(sizeof(PlayerJudgeWallCatch) == 0x88);

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -13,6 +13,8 @@ public:
     enum EActionTrigger : u32 {
         // used in PlayerJudgeForceLand
         EActionTrigger_val11 = 11,
+        // used in PlayerJudgeWallCatch
+        EActionTrigger_val30 = 30,
         EActionTrigger_QuickTurn = 34,
     };
     enum EReceiveSensorTrigger : u32 {};

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class CollisionParts;
+class LiveActor;
+}  // namespace al
+
+namespace rs {
+
+bool findWallCatchPos(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
+                      const al::LiveActor*, const sead::Vector3f&, const sead::Vector3f&,
+                      const sead::Vector3f&, f32, f32, f32, f32, f32, f32, f32);
+
+}

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -4,7 +4,8 @@
 
 namespace al {
 class LiveActor;
-}
+class CollisionParts;
+}  // namespace al
 class IUsePlayerCollision;
 class IUsePlayerHeightCheck;
 class PlayerConst;
@@ -24,5 +25,10 @@ bool isJustLand(const IUsePlayerCollision*);
 void calcGroundNormalOrGravityDir(sead::Vector3f*, const al::LiveActor*,
                                   const IUsePlayerCollision*);
 bool isCollisionCodeSandSink(const IUsePlayerCollision*);
+bool isCollidedWall(const IUsePlayerCollision*);
+const sead::Vector3f& getCollidedWallPos(const IUsePlayerCollision*);
+const sead::Vector3f& getCollidedWallNormal(const IUsePlayerCollision*);
+const al::CollisionParts* getCollidedWallCollisionParts(const IUsePlayerCollision*);
+bool isActionCodeNoWallGrab(const IUsePlayerCollision*);
 
 }  // namespace rs


### PR DESCRIPTION
The first Judge with a bit more logic to it! To grab onto a wall (start wall slide), the following criteria have to be true:
1. Do not carry anything
2. Not in 2D-section
3. Not forced to run (RocketFlower)
4. No external force applied to Mario (for example moving ground, but might be more?)
5. Currently colliding with a wall
6. Currently not colliding with the ground
7. The wall does not have any `NoWallGrab` code (`NoAction, NoWallGrab, ReflectStickNoWallGrab, OnlyWallHitDown, GrabCeil, Pole, Needle, DamageFire`)
8. If currently in `PlayerTrigger::Action_val30` (as far as I can tell enabled when doing a backflip and sideflip), have the stick pressed more than 41% (`length^2 > 0.64`)
9. Finally, succeed in finding a `WallCatchPos`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/103)
<!-- Reviewable:end -->
