### PR TITLE
Player: Add IUsePlayerFallDistanceCheck

### DIFF
--- a/src/Player/IUsePlayerFallDistanceCheck.h
+++ b/src/Player/IUsePlayerFallDistanceCheck.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class IUsePlayerFallDistanceCheck {
+public:
+    virtual f32 getFallDistance() const = 0;
+};


### PR DESCRIPTION
Similar to the last PR, this is a header also used by `PlayerColliderHakoniwa`, but also the now-unused `PlayerCollider2D3D`.