### PR TITLE
Player: Implement PlayerJudgeGrabCeil

### DIFF
--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -3,4 +3,5 @@
 class PlayerExternalVelocity {
 public:
     bool isExistForce() const;
+    bool isExistSnapForce() const;
 };

--- a/src/Player/PlayerJudgeGrabCeil.cpp
+++ b/src/Player/PlayerJudgeGrabCeil.cpp
@@ -1,0 +1,106 @@
+#include "Player/PlayerJudgeGrabCeil.h"
+
+#include "Library/Collision/CollisionParts.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Math/MathAngleUtil.h"
+#include "Library/Math/MathUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerExternalVelocity.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeGrabCeil::PlayerJudgeGrabCeil(const al::LiveActor* player, const PlayerConst* pConst,
+                                         const IUsePlayerCollision* collider,
+                                         const IPlayerModelChanger* modelChanger,
+                                         const PlayerCarryKeeper* carryKeeper,
+                                         const PlayerExternalVelocity* externalVelocity)
+    : mPlayer(player), mConst(pConst), mCollision(collider), mModelChanger(modelChanger),
+      mCarryKeeper(carryKeeper), mExternalVelocity(externalVelocity) {}
+
+void PlayerJudgeGrabCeil::reset() {
+    mIsJudge = false;
+    _48 = {0.0f, 0.0f, 0.0f};
+    _54 = {0.0f, 0.0f, 0.0f};
+    _60 = {0.0f, 0.0f, 0.0f};
+}
+
+void PlayerJudgeGrabCeil::update() {
+    mIsJudge = false;
+
+    if (mCarryKeeper->isCarry() || mModelChanger->is2DModel() ||
+        mExternalVelocity->isExistForce() || !rs::isCollisionCodeGrabCeilAny(mCollision))
+        return;
+
+    if (rs::isCollisionCodeGrabCeilWall(mCollision)) {
+        sead::Vector3f pos = rs::getCollidedWallPos(mCollision);
+        sead::Vector3f normal = rs::getCollidedWallNormal(mCollision);
+
+        if (!mExternalVelocity->isExistSnapForce()) {
+            sead::Vector3f verticalVelocity = al::getVelocity(mPlayer);
+            al::verticalizeVec(&verticalVelocity, al::getGravity(mPlayer), verticalVelocity);
+            if (al::tryNormalizeOrZero(&verticalVelocity) && normal.dot(verticalVelocity) > 0.0f)
+                return;
+        }
+
+        sead::Vector3f forceMovePower = {0.0f, 0.0f, 0.0f};
+        rs::getCollidedWallCollisionParts(mCollision)->calcForceMovePower(&forceMovePower, pos);
+
+        mIsJudge = rs::findGrabCeilPosWallHit(
+            &mCollidedParts, &_48, &_54, &_60, mPlayer, -normal, pos + forceMovePower,
+            mConst->getTall(), mConst->getGrabCeilRange(), mConst->getGrabCeilBodyRadius());
+
+        return;
+    }
+
+    sead::Vector3f collidedNormal = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f collidedPos = {0.0f, 0.0f, 0.0f};
+    const al::CollisionParts* collidedParts = nullptr;
+
+    if (rs::isCollisionCodeGrabCeilCeiling(mCollision)) {
+        collidedNormal = rs::getCollidedCeilingNormal(mCollision);
+        collidedPos = rs::getCollidedCeilingPos(mCollision);
+        collidedParts = rs::getCollidedCeilingCollisionParts(mCollision);
+    } else if (rs::isCollisionCodeGrabCeilGrround(mCollision)) {
+        collidedNormal = rs::getCollidedGroundNormal(mCollision);
+        collidedPos = rs::getCollidedGroundPos(mCollision);
+        collidedParts = rs::getCollidedGroundCollisionParts(mCollision);
+        if (!mExternalVelocity->isExistSnapForce()) {
+            sead::Vector3f velocity = al::getVelocity(mPlayer);
+            if (al::tryNormalizeOrZero(&velocity) && velocity.dot(collidedNormal) > 0.0f)
+                return;
+        }
+    }
+
+    sead::Vector3f forceMovePower = {0.0f, 0.0f, 0.0f};
+    collidedParts->calcForceMovePower(&forceMovePower, collidedPos);
+
+    mIsJudge = rs::findGrabCeilPosNoWallHit(
+        &mCollidedParts, &_48, &_54, &_60, mPlayer, collidedNormal, collidedPos + forceMovePower,
+        mConst->getTall(), mConst->getGrabCeilRange(), mConst->getGrabCeilBodyRadius());
+
+    if (!mIsJudge)
+        return;
+
+    f32 dot = _54.dot(al::getVelocity(mPlayer));
+    if (sead::Mathf::abs(dot) > mConst->getNormalMinSpeed()) {
+        if (dot < 0.0f) {
+            _54 *= -1;
+            al::normalize(&_54);
+        }
+    } else {
+        sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+        al::calcFrontDir(&front, mPlayer);
+        if (front.dot(_54) < 0.0f) {
+            _54 *= -1;
+            al::normalize(&_54);
+        }
+    }
+}
+
+bool PlayerJudgeGrabCeil::judge() const {
+    return mIsJudge;
+}

--- a/src/Player/PlayerJudgeGrabCeil.h
+++ b/src/Player/PlayerJudgeGrabCeil.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+class CollisionParts;
+}  // namespace al
+class PlayerConst;
+class IUsePlayerCollision;
+class IPlayerModelChanger;
+class PlayerCarryKeeper;
+class PlayerExternalVelocity;
+
+class PlayerJudgeGrabCeil : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeGrabCeil(const al::LiveActor* player, const PlayerConst* pConst,
+                        const IUsePlayerCollision* collider,
+                        const IPlayerModelChanger* modelChanger,
+                        const PlayerCarryKeeper* carryKeeper,
+                        const PlayerExternalVelocity* externalVelocity);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const IUsePlayerCollision* mCollision;
+    const IPlayerModelChanger* mModelChanger;
+    const PlayerCarryKeeper* mCarryKeeper;
+    const PlayerExternalVelocity* mExternalVelocity;
+    bool mIsJudge = false;
+    const al::CollisionParts* mCollidedParts = nullptr;
+    sead::Vector3f _48 = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f _54 = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f _60 = {0.0f, 0.0f, 0.0f};
+};

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -13,4 +13,12 @@ bool findWallCatchPos(const al::CollisionParts**, sead::Vector3f*, sead::Vector3
                       const al::LiveActor*, const sead::Vector3f&, const sead::Vector3f&,
                       const sead::Vector3f&, f32, f32, f32, f32, f32, f32, f32);
 
-}
+bool findGrabCeilPosNoWallHit(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
+                              sead::Vector3f*, const al::LiveActor*, const sead::Vector3f&,
+                              const sead::Vector3f&, f32, f32, f32);
+
+bool findGrabCeilPosWallHit(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
+                            sead::Vector3f*, const al::LiveActor*, const sead::Vector3f&,
+                            const sead::Vector3f&, f32, f32, f32);
+
+}  // namespace rs

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -13,8 +13,19 @@ class PlayerConst;
 namespace rs {
 
 f32 getGroundHeight(const IUsePlayerHeightCheck*);
+
+const sead::Vector3f& getCollidedWallPos(const IUsePlayerCollision*);
 const sead::Vector3f& getCollidedWallNormal(const IUsePlayerCollision*);
+const al::CollisionParts* getCollidedWallCollisionParts(const IUsePlayerCollision*);
+
+const sead::Vector3f& getCollidedGroundPos(const IUsePlayerCollision*);
 const sead::Vector3f& getCollidedGroundNormal(const IUsePlayerCollision*);
+const al::CollisionParts* getCollidedGroundCollisionParts(const IUsePlayerCollision*);
+
+const sead::Vector3f& getCollidedCeilingPos(const IUsePlayerCollision*);
+const sead::Vector3f& getCollidedCeilingNormal(const IUsePlayerCollision*);
+const al::CollisionParts* getCollidedCeilingCollisionParts(const IUsePlayerCollision*);
+
 bool isCollidedGround(const IUsePlayerCollision*);
 bool isCollidedGroundRunAngle(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 bool isOnGroundForceSlideCode(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
@@ -27,9 +38,11 @@ void calcGroundNormalOrGravityDir(sead::Vector3f*, const al::LiveActor*,
                                   const IUsePlayerCollision*);
 bool isCollisionCodeSandSink(const IUsePlayerCollision*);
 bool isCollidedWall(const IUsePlayerCollision*);
-const sead::Vector3f& getCollidedWallPos(const IUsePlayerCollision*);
-const sead::Vector3f& getCollidedWallNormal(const IUsePlayerCollision*);
-const al::CollisionParts* getCollidedWallCollisionParts(const IUsePlayerCollision*);
 bool isActionCodeNoWallGrab(const IUsePlayerCollision*);
+
+bool isCollisionCodeGrabCeilAny(const IUsePlayerCollision*);
+bool isCollisionCodeGrabCeilWall(const IUsePlayerCollision*);
+bool isCollisionCodeGrabCeilCeiling(const IUsePlayerCollision*);
+bool isCollisionCodeGrabCeilGrround(const IUsePlayerCollision*);
 
 }  // namespace rs


### PR DESCRIPTION
Another judge with a bit more logic to it. To grab onto a `Ceil`, the following basic conditions have to be fulfilled:
1. Do not carry anything
2. Not in 2D-Mode
3. No external force applied
4. Must be touching any surface with `GrabCeil` collision code (floor, wall or ceiling are all fine)

When those checks are okay and the surface is either `Ground` or `Wall`, there has to be either a `SnapForce` on the player, his velocity must be zero or he must be moving away from the surface with the mentioned collision code.

Finally, some code is invoked to calculate a position to grab onto. This might still fail, so this is another option to have the judge return `false`.


Here is a list of all objects across the entire game that have the `GrabCeil` code:
```
CityWorldHomeSignal000Attribute.byml
PoleGrabCeilAttribute.byml
PoleGrabCeilKeyMovePartsAttribute.byml
```

... yeah, that's it. From those examples I would conclude that `GrabCeil` means swinging from a horizontal bar/pole.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/108)
<!-- Reviewable:end -->
