### PR TITLE
Layout: Implement `MapTerrainLayout`

### DIFF
--- a/src/Layout/MapTerrainLayout.cpp
+++ b/src/Layout/MapTerrainLayout.cpp
@@ -1,0 +1,26 @@
+#include "Layout/MapTerrainLayout.h"
+
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+
+#include "System/MapDataHolder.h"
+
+MapTerrainLayout::MapTerrainLayout(const char* name) : al::LayoutActor(name) {}
+
+bool MapTerrainLayout::tryChangePrintWorld(s32 worldId) {
+    if (worldId < 0)
+        return false;
+
+    mMapData = rs::findMapData(this, worldId);
+    if (!mMapData)
+        return false;
+
+    al::setPaneTexture(this, "PicMap00", mMapData->mTexture2dMap);
+    al::setPaneLocalScale(this, "PicMap00", sead::Vector2f(256.0f, 256.0f));
+
+    return true;
+}
+
+f32 MapTerrainLayout::getPaneSize() const {
+    return 2048.0f;
+}

--- a/src/Layout/MapTerrainLayout.h
+++ b/src/Layout/MapTerrainLayout.h
@@ -2,13 +2,13 @@
 
 #include "Library/Layout/LayoutActor.h"
 
-#include "System/MapDataHolder.h"
+class MapData;
 
 class MapTerrainLayout : public al::LayoutActor {
 public:
-    MapTerrainLayout(const char*);
+    MapTerrainLayout(const char* name);
 
-    bool tryChangePrintWorld(s32);
+    bool tryChangePrintWorld(s32 worldId);
     f32 getPaneSize() const;
 
 private:

--- a/src/Layout/MapTerrainLayout.h
+++ b/src/Layout/MapTerrainLayout.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Library/Layout/LayoutActor.h"
+
+#include "System/MapDataHolder.h"
+
+class MapTerrainLayout : public al::LayoutActor {
+public:
+    MapTerrainLayout(const char*);
+
+    bool tryChangePrintWorld(s32);
+    f32 getPaneSize() const;
+
+private:
+    MapData* mMapData = nullptr;
+};

--- a/src/Layout/MapTerrainLayout.h
+++ b/src/Layout/MapTerrainLayout.h
@@ -2,7 +2,7 @@
 
 #include "Library/Layout/LayoutActor.h"
 
-class MapData;
+struct MapData;
 
 class MapTerrainLayout : public al::LayoutActor {
 public:

--- a/src/System/MapDataHolder.h
+++ b/src/System/MapDataHolder.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
+
+class GameDataHolder;
+
+namespace nn::ui2d {
+class TextureInfo;
+}
+
+namespace al {
+class Resource;
+class IUseSceneObjHolder;
+}  // namespace al
+
+struct MapData {
+    sead::Matrix44f mViewProjMatrix;
+    sead::Matrix34f mViewMatrix;
+    sead::Matrix44f mProjMatrix;
+    nn::ui2d::TextureInfo* mTexture2dMap;
+    void* field_B8;
+    s32 mPartsNum;
+    void** mParts;
+    s32 mWorldScenarioNum;
+    sead::PtrArray<MapData> mScenarioMapData;
+};
+
+class MapDataHolder {
+public:
+    MapDataHolder(const GameDataHolder*);
+    void loadMapData(al::Resource*, const char*, s32);
+    bool tryLoadMapData(al::Resource*, const char*, s32);
+    void findViewMtx(s32);
+    void findMapData(s32);
+
+private:
+    sead::PtrArray<MapData> mMapDatas;
+    const GameDataHolder* mGameDataHolder;
+};
+
+namespace rs {
+MapData* findMapData(al::IUseSceneObjHolder*, s32);
+}

--- a/src/System/MapDataHolder.h
+++ b/src/System/MapDataHolder.h
@@ -20,9 +20,9 @@ struct MapData {
     sead::Matrix34f mViewMatrix;
     sead::Matrix44f mProjMatrix;
     nn::ui2d::TextureInfo* mTexture2dMap;
-    void* field_B8;
+    void* field_B8;  // TODO unknown type
     s32 mPartsNum;
-    void** mParts;
+    void** mParts;  // TODO unknown type
     s32 mWorldScenarioNum;
     sead::PtrArray<MapData> mScenarioMapData;
 };
@@ -30,10 +30,10 @@ struct MapData {
 class MapDataHolder {
 public:
     MapDataHolder(const GameDataHolder*);
-    void loadMapData(al::Resource*, const char*, s32);
-    bool tryLoadMapData(al::Resource*, const char*, s32);
-    void findViewMtx(s32);
-    void findMapData(s32);
+    MapData* loadMapData(al::Resource*, const char*, s32);
+    MapData* tryLoadMapData(al::Resource*, const char*, s32);
+    const sead::Matrix34f& findViewMtx(s32);
+    const MapData& findMapData(s32);
 
 private:
     sead::PtrArray<MapData> mMapDatas;

--- a/src/System/MapDataHolder.h
+++ b/src/System/MapDataHolder.h
@@ -32,8 +32,8 @@ public:
     MapDataHolder(const GameDataHolder*);
     MapData* loadMapData(al::Resource*, const char*, s32);
     MapData* tryLoadMapData(al::Resource*, const char*, s32);
-    const sead::Matrix34f& findViewMtx(s32);
-    const MapData& findMapData(s32);
+    const sead::Matrix34f& findViewMtx(s32) const;
+    const MapData& findMapData(s32) const;
 
 private:
     sead::PtrArray<MapData> mMapDatas;


### PR DESCRIPTION
This small class contains a single pane of world's map texture. Used in `MapLayout`.

Requires `System/MapDataHolder.h`, along with a `MapData` struct for the loaded data.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/112)
<!-- Reviewable:end -->
