### PR TITLE
Player: Implement PlayerCapActionHistory

### DIFF
--- a/src/Player/PlayerCapActionHistory.cpp
+++ b/src/Player/PlayerCapActionHistory.cpp
@@ -1,0 +1,58 @@
+#include "Player/PlayerCapActionHistory.h"
+
+#include "Library/LiveActor/ActorPoseKeeper.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerCounterAfterCapCatch.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerCapActionHistory::PlayerCapActionHistory(const al::LiveActor* player,
+                                               const PlayerConst* pConst,
+                                               const PlayerTrigger* trigger,
+                                               const IUsePlayerCollision* collider)
+    : mPlayer(player), mConst(pConst), mTrigger(trigger), mCollision(collider),
+      mCounterAfterCapCatch(new PlayerCounterAfterCapCatch(pConst, trigger)) {}
+
+void PlayerCapActionHistory::update() {
+    mCounterAfterCapCatch->update(mTrigger);
+}
+
+void PlayerCapActionHistory::clearLandLimit() {
+    clearLimitHeight();
+    clearCapJump();
+    _39 = true;
+}
+
+void PlayerCapActionHistory::clearLimitHeight() {
+    mIsLimitHeight = false;
+}
+
+void PlayerCapActionHistory::clearCapJump() {
+    mIsCapJumpPossible = true;
+}
+
+void PlayerCapActionHistory::clearLandLimitStandAngle() {
+    clearLimitHeight();
+    _39 = true;
+    if (rs::isOnGroundLessAngle(mPlayer, mCollision, mConst->getStandAngleMin()))
+        clearCapJump();
+}
+
+void PlayerCapActionHistory::clearWallAirLimit() {
+    clearLimitHeight();
+    _39 = true;
+}
+
+void PlayerCapActionHistory::recordLimitHeight() {
+    if (rs::isCollidedGround(mCollision))
+        return;
+    mIsLimitHeight = true;
+    mHeightLimit = al::getTrans(mPlayer);
+}
+
+bool PlayerCapActionHistory::isOverLimitHeight() const {
+    if (!mIsLimitHeight || rs::isCollidedGround(mCollision))
+        return false;
+
+    return (al::getTrans(mPlayer) - mHeightLimit).dot(al::getGravity(mPlayer)) < 0.0f;
+}

--- a/src/Player/PlayerCapActionHistory.h
+++ b/src/Player/PlayerCapActionHistory.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class PlayerTrigger;
+class IUsePlayerCollision;
+class PlayerCounterAfterCapCatch;
+
+class PlayerCapActionHistory {
+public:
+    PlayerCapActionHistory(const al::LiveActor* player, const PlayerConst* pConst,
+                           const PlayerTrigger* trigger, const IUsePlayerCollision* collider);
+    void update();
+    void clearLandLimit();
+    void clearLimitHeight();
+    void clearCapJump();
+    void clearLandLimitStandAngle();
+    void clearWallAirLimit();
+    void recordLimitHeight();
+    bool isOverLimitHeight() const;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const PlayerTrigger* mTrigger;
+    const IUsePlayerCollision* mCollision;
+    PlayerCounterAfterCapCatch* mCounterAfterCapCatch;
+    bool mIsLimitHeight = false;
+    sead::Vector3f mHeightLimit = sead::Vector3f::zero;
+    bool mIsCapJumpPossible = true;
+    // seems to be always set to `true`
+    bool _39 = true;
+};

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -18,6 +18,7 @@ bool isCollidedGround(const IUsePlayerCollision*);
 bool isCollidedGroundRunAngle(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 bool isOnGroundForceSlideCode(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 bool isOnGroundForceRollingCode(const al::LiveActor*, const IUsePlayerCollision*);
+bool isOnGroundLessAngle(const al::LiveActor*, const IUsePlayerCollision*, f32);
 bool isPlayerOnGround(const al::LiveActor*);
 bool isOnGround(const al::LiveActor*, const IUsePlayerCollision*);
 bool isJustLand(const IUsePlayerCollision*);


### PR DESCRIPTION
Another small helper class that keeps track of some statistics about the cap, for example whether the player has already cap-jumped once and the current `HeightLimit` (not sure where this is used). It also keeps track of its own `PlayerCounterAfterCapCatch`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/114)
<!-- Reviewable:end -->
