### PR TITLE
Player: Implement PlayerJudgeDirectRolling

### DIFF
--- a/src/Player/PlayerJudgeDirectRolling.cpp
+++ b/src/Player/PlayerJudgeDirectRolling.cpp
@@ -1,0 +1,37 @@
+#include "Player/PlayerJudgeDirectRolling.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Math/MathAngleUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerCounterForceRun.h"
+#include "Player/PlayerInput.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeDirectRolling::PlayerJudgeDirectRolling(
+    const al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+    const IUsePlayerCollision* collider, const IPlayerModelChanger* modelChanger,
+    const PlayerCarryKeeper* carryKeeper, const PlayerCounterForceRun* counterForceRun)
+    : mPlayer(player), mConst(pConst), mInput(input), mCollider(collider),
+      mModelChanger(modelChanger), mCarryKeeper(carryKeeper), mCounterForceRun(counterForceRun) {}
+
+void PlayerJudgeDirectRolling::reset() {
+    mIsJudge = false;
+}
+
+void PlayerJudgeDirectRolling::update() {
+    mIsJudge = false;
+    if (mCounterForceRun->isForceRun() || mCarryKeeper->isCarry() ||
+        !rs::isOnGround(mPlayer, mCollider) || mModelChanger->is2DModel() || !mInput->isHoldSquat())
+        return;
+    sead::Vector3f horizontalSpeed = {0.0f, 0.0f, 0.0f};
+    al::verticalizeVec(&horizontalSpeed, al::getGravity(mPlayer), al::getVelocity(mPlayer));
+    mIsJudge = horizontalSpeed.length() >= mConst->getDashJudgeSpeed();
+}
+
+bool PlayerJudgeDirectRolling::judge() const {
+    return mIsJudge;
+}

--- a/src/Player/PlayerJudgeDirectRolling.h
+++ b/src/Player/PlayerJudgeDirectRolling.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class IPlayerModelChanger;
+class PlayerCarryKeeper;
+class PlayerCounterForceRun;
+
+class PlayerJudgeDirectRolling : public IJudge {
+public:
+    PlayerJudgeDirectRolling(const al::LiveActor* player, const PlayerConst* pConst,
+                             const PlayerInput* input, const IUsePlayerCollision* collider,
+                             const IPlayerModelChanger* modelChanger,
+                             const PlayerCarryKeeper* carryKeeper,
+                             const PlayerCounterForceRun* counterForceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollider;
+    const IPlayerModelChanger* mModelChanger;
+    const PlayerCarryKeeper* mCarryKeeper;
+    const PlayerCounterForceRun* mCounterForceRun;
+    bool mIsJudge = false;
+};


### PR DESCRIPTION
Another mostly-simple judge, this one determines whether the player can go from a dive instantly into a roll (without standing/crouching first). For it to return true, the following conditions have to be fulfilled:
1. Do not be forced to run (rocket flower)
2. Do not carry anything
3. Player must be touching the ground
4. Not in a 2D-area
5. `Squat` must be held down
6. The horizontal speed of the player must be larger than `DashJudgeSpeed` (default: `14.5`)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/124)
<!-- Reviewable:end -->
