### PR TITLE
Player: Implement `PlayerJudgeAirForceCount`

### DIFF
--- a/src/Player/PlayerJudgeAirForceCount.cpp
+++ b/src/Player/PlayerJudgeAirForceCount.cpp
@@ -1,0 +1,28 @@
+#include "Player/PlayerJudgeAirForceCount.h"
+
+#include "Library/Math/MathUtil.h"
+
+#include "Player/PlayerExternalVelocity.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeAirForceCount::PlayerJudgeAirForceCount(const al::LiveActor* player,
+                                                   const PlayerExternalVelocity* externalVelocity,
+                                                   const IUsePlayerCollision* collider)
+    : mPlayer(player), mExternalVelocity(externalVelocity), mCollider(collider) {}
+
+void PlayerJudgeAirForceCount::reset() {
+    mCounterAirForce = 0;
+}
+
+void PlayerJudgeAirForceCount::update() {
+    if (rs::isOnGround(mPlayer, mCollider) || !mExternalVelocity->isExistForce()) {
+        reset();
+        return;
+    }
+
+    mCounterAirForce = al::converge(mCounterAirForce, 40, 1);
+}
+
+bool PlayerJudgeAirForceCount::judge() const {
+    return mCounterAirForce >= 40;
+}

--- a/src/Player/PlayerJudgeAirForceCount.h
+++ b/src/Player/PlayerJudgeAirForceCount.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerExternalVelocity;
+class IUsePlayerCollision;
+
+class PlayerJudgeAirForceCount : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeAirForceCount(const al::LiveActor* player,
+                             const PlayerExternalVelocity* externalVelocity,
+                             const IUsePlayerCollision* collider);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerExternalVelocity* mExternalVelocity;
+    const IUsePlayerCollision* mCollider;
+    s32 mCounterAirForce = 0;
+};


### PR DESCRIPTION
Another simple judge, this one counts the frames for which the player has been in the air and affected by an `ExternalVelocity/Force`. It triggers once the counter hits 40. The counter is increased when the player is in the air and an external velocity/force exists, otherwise immediately reset to zero. Once this judge returns `true`, Mario is forced into the `Fall` state.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/126)
<!-- Reviewable:end -->
