### PR TITLE
Scene: Add `al::FallMapParts` to the actor factory

### DIFF
--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -2,6 +2,7 @@
 
 #include "Library/Factory/Factory.h"
 #include "Library/LiveActor/LiveActorUtil.h"
+#include "Library/MapObj/FallMapParts.h"
 #include "Library/MapObj/FixMapParts.h"
 #include "Library/Obj/AllDeadWatcher.h"
 
@@ -545,7 +546,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"CapRotateMapParts", nullptr},
     {"ClockMapParts", nullptr},
     {"ConveyerMapParts", nullptr},
-    {"FallMapParts", nullptr},
+    {"FallMapParts", al::createActorFunction<al::FallMapParts>},
     {"FixMapParts", al::createActorFunction<al::FixMapParts>},
     {"FloaterMapParts", nullptr},
     {"FlowMapParts", nullptr},


### PR DESCRIPTION
Simple change to add the `createActorFunction` for `al::FallMapParts` added in #130.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/132)
<!-- Reviewable:end -->
