### PR TITLE
Library/Base: Implement `WStringTmp`

### DIFF
--- a/lib/al/Library/Base/StringUtil.h
+++ b/lib/al/Library/Base/StringUtil.h
@@ -36,7 +36,7 @@ bool isEqualString(const sead::SafeString&, const sead::SafeString&);
 bool isEqualStringCase(const sead::SafeString&, const sead::SafeString&);
 
 template <s32 L>
-class StringTmp : public sead::FixedSafeString<L> {  // equal to WFormatFixedSafeString
+class StringTmp : public sead::FixedSafeString<L> {
 public:
     StringTmp(const char* format, ...) : sead::FixedSafeString<L>() {
         std::va_list args;
@@ -45,6 +45,23 @@ public:
         va_end(args);
     }
 
+    StringTmp() : sead::FixedSafeString<L>() {}
+
     ~StringTmp() = default;
+};
+
+template <s32 L>
+class WStringTmp : public sead::WFixedSafeString<L> {
+public:
+    WStringTmp(const char16* format, ...) : sead::WFixedSafeString<L>() {
+        std::va_list args;
+        va_start(args, format);
+        sead::WFixedSafeString<L>::formatV(format, args);
+        va_end(args);
+    }
+
+    WStringTmp() : sead::WFixedSafeString<L>() {}
+
+    ~WStringTmp() = default;
 };
 }  // namespace al


### PR DESCRIPTION
This PR adds in `al::WStringTmp` as well as a default constructor for `al::StringTmp`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/137)
<!-- Reviewable:end -->
