### PR TITLE
dev: Add `flake.nix`-devshell and `direnv` setup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,8 @@
+ENV_PRIVATE=.envrc.private
+if [ -f $ENV_PRIVATE ]; then
+    source_env $ENV_PRIVATE
+fi
+
+if [[ "$USE_NIX" = "true" ]]; then
+	use flake
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ compile_commands.json
 *.gpr
 *.rep/
 *.lock
+!flake.lock
 
 # Debugging
 perf.data
@@ -49,3 +50,7 @@ perf.data.old
 tools/check
 tools/listsym
 tools/decompme
+
+# direnv
+.direnv/
+.envrc.private

--- a/README.md
+++ b/README.md
@@ -3,17 +3,31 @@ Decompilation of all Super Mario Odyssey versions, from 1.0.0 to 1.3.0.
 
 # Building
 
-Reminder: **this will not produce a playable game.** This project will not allow you to play the game if you don't already own it on a Switch.
+> [!IMPORTANT]
+> Reminder: **this will not produce a playable game.** This project will not allow you to play the game if you don't already own it on a Switch.
 
 ## For Windows users
 
-While Linux is not a hard requirement, it is strongly advised to [set up WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to simplify the setup process. Ubuntu 20.04 is usually a good choice.
+While Linux is not a hard requirement, it is strongly advised to [set up WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to simplify the setup process. Ubuntu 22.04 is usually a good choice.
 
 The instructions below assume that you are using Linux (native or WSL) or macOS.
 
 ## 1. Set up dependencies
 
-You can either set up all dependencies on your standard installation, or use a Visual Studio Code Dev Container. If you choose to do the latter, you can skip this section, just clone and open the folder in VS-Code, press F1 and select `Dev Containers: Rebuild and Reopen in Container`. You can copy the NSO executable into the container using `docker cp /path/to/main.nso [container-id]:/workspaces/main.nso`, where `[container-id]` is the ID listed in `docker container ls`.
+Depending on your system and preferences, the required programs and libraries can be setup differently.
+
+Across all platforms, using the included Visual Studio Code Dev Container should work fine. In this case, just clone and open the folder in VS-Code, press F1 and select `Dev Containers: Rebuild and Reopen in Container`. You can copy the NSO executable into the container using `docker cp /path/to/main.nso [container-id]:/workspaces/main.nso`, where `[container-id]` is the ID listed in `docker container ls`.
+
+> [!WARNING]
+> As Dev Containers add another layer of complexity to your system, compiling the project and working with the differ will be slower. If possible, prefer to install the dependencies on your system and use this project natively instead of through the container.
+
+When working with NixOS or any other system with the Nix package manager, `flake.nix` should be properly set up to use on your system. Make sure that `direnv` is installed in your system or shell. Then create a file called `.envrc.private` with the following content:
+```bash
+export USE_NIX=true
+```
+Finally, run `direnv allow` to setup all dependencies. The remainder of this section can be skipped.
+
+All other systems have to manually install the required packages and programs. We will need:
 
 * Python 3.6 or newer with [pip](https://pip.pypa.io/en/stable/installation/)
 * Ninja

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,109 @@
+{
+  "nodes": {
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib"
+      },
+      "locked": {
+        "lastModified": 1722555600,
+        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1722869614,
+        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-24.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib": {
+      "locked": {
+        "lastModified": 1722555339,
+        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1718428119,
+        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay",
+        "systems": "systems"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1722910815,
+        "narHash": "sha256-v6Vk/xlABhw2QzOa6xh3Jx/IvmlbKbOazFM+bDFQlWU=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "7df2ac544c203d21b63aac23bfaec7f9b919a733",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,50 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    flake-parts.url = "github:hercules-ci/flake-parts";
+    systems.url = "github:nix-systems/default";
+    rust-overlay.url = "github:oxalica/rust-overlay";
+  };
+
+  outputs = inputs: inputs.flake-parts.lib.mkFlake { inherit inputs; } {
+    systems = import inputs.systems;
+    perSystem = { config, self', inputs', pkgs, system, ... }: let
+      overlays = [ (import inputs.rust-overlay) ];
+      pkgs = import inputs.nixpkgs {
+        inherit system overlays;
+      };
+      rustToolchain = pkgs.pkgsBuildHost.rust-bin.stable.latest.default;
+    in {
+      _module.args.pkgs = import inputs.nixpkgs {
+        config.allowUnfree = true;
+      };
+      devShells.default = pkgs.mkShell rec {
+        buildInputs = with pkgs; [
+          cmake
+          ninja
+          clang
+          ccache
+          pkg-config
+
+          rustToolchain
+          (python3.withPackages (python-pkgs: [
+            python-pkgs.capstone
+            python-pkgs.colorama
+            python-pkgs.cxxfilt
+            python-pkgs.pyelftools
+            python-pkgs.ansiwrap
+            python-pkgs.watchdog
+            python-pkgs.python-Levenshtein
+            python-pkgs.toml
+          ]))
+          openssl
+          libclang
+          ncurses5
+          ncurses6
+        ];
+        LD_LIBRARY_PATH = "${pkgs.lib.makeLibraryPath buildInputs}";
+        LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+      };
+    };
+  };
+}


### PR DESCRIPTION
To support an easier setup for Nix-based systems, we should distribute a `flake.nix` with the right dependencies. The setup is done with `direnv allow` then. However, as non-Nix-systems do not know the command `use flake` and will throw an error when direnv is attempted to be used, it is guarded behind a `USE_NIX` variable. This can be set in `.envrc.private`, which is `.gitignore`d and cannot be added as "template" here.

The "Setup"-section of `README` has been adjusted accordingly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/140)
<!-- Reviewable:end -->
