### PR TITLE
tools/build: Non-zero return code on build failure

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -55,7 +55,10 @@ def main():
         if paths != real_source_paths:
             touch_cmake_lists()
 
-    subprocess.run(cmake_args)
+    try:
+        subprocess.run(cmake_args, check=True)
+    except subprocess.CalledProcessError:
+        exit(1)  # silently exit with failure if build failed
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
When the build fails, it should show that it failed, not silently ignore it.

Fixes #61

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/141)
<!-- Reviewable:end -->
