### PR TITLE
Library/Collision: Format `KCollisionServer`

### DIFF
--- a/lib/al/Library/Collision/KCollisionServer.h
+++ b/lib/al/Library/Collision/KCollisionServer.h
@@ -20,6 +20,7 @@ struct KCPrismHeader {
     sead::Vector3u mWidthShift;
     f32 mHitboxRadiusCap;
 };
+
 struct KCPrismData {
     f32 mLength;
     u16 mPosIndex;
@@ -28,6 +29,7 @@ struct KCPrismData {
     u16 mCollisionType;
     u32 mTriIndex;
 };
+
 struct KCHitInfo {
     const KCPrismHeader* mHeader;
     const KCPrismData* mData;


### PR DESCRIPTION
I broke the CI by merging a too-old-PR without rebasing first, which means it only conformed old formatting standards, not the newly introduced ones. This should get the CI back to green again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/142)
<!-- Reviewable:end -->
