### PR TITLE
MapObj: Implement `CitySignal`

### DIFF
--- a/src/MapObj/CitySignal.cpp
+++ b/src/MapObj/CitySignal.cpp
@@ -1,0 +1,67 @@
+#include "MapObj/CitySignal.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+
+#include "System/GameDataFunction.h"
+
+namespace {
+NERVE_IMPL(CitySignal, WaitRed);
+NERVE_IMPL(CitySignal, WaitBlue);
+NERVE_IMPL(CitySignal, WaitOff);
+
+NERVES_MAKE_STRUCT(CitySignal, WaitRed, WaitBlue, WaitOff);
+}  // namespace
+
+CitySignal::CitySignal(const char* name) : al::LiveActor(name) {}
+
+void CitySignal::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+
+    s32 scenarioNo = GameDataFunction::getScenarioNo(this);
+    al::tryStartAction(this, al::StringTmp<64>("Scenario%d", scenarioNo).cstr());
+
+    if (scenarioNo == 1)
+        al::initNerve(this, &NrvCitySignal.WaitRed, 0);
+    else
+        al::initNerve(this, &NrvCitySignal.WaitBlue, 0);
+
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+void CitySignal::movement() {
+    // this being empty results in the animation not playing (blinking for Red)
+    // and the signal not turning off when hit by an explosion
+}
+
+void CitySignal::calcAnim() {
+    if (al::isNerve(this, &NrvCitySignal.WaitRed) || al::isNerve(this, &NrvCitySignal.WaitOff))
+        al::LiveActor::calcAnim();
+    else
+        al::calcViewModel(this);
+}
+
+bool CitySignal::receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
+                            al::HitSensor* target) {
+    if (al::isMsgExplosion(message) && al::isSensorMapObj(target) &&
+        (al::isNerve(this, &NrvCitySignal.WaitRed) || al::isNerve(this, &NrvCitySignal.WaitBlue))) {
+        al::setNerve(this, &NrvCitySignal.WaitOff);
+        return true;
+    }
+
+    return false;
+}
+
+void CitySignal::exeWaitRed() {}
+
+void CitySignal::exeWaitBlue() {}
+
+void CitySignal::exeWaitOff() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "LightOff");
+}

--- a/src/MapObj/CitySignal.h
+++ b/src/MapObj/CitySignal.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CitySignal : public al::LiveActor {
+public:
+    CitySignal(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void movement() override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
+                    al::HitSensor* target) override;
+
+    void exeWaitRed();
+    void exeWaitBlue();
+    void exeWaitOff();
+};
+
+static_assert(sizeof(CitySignal) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -7,6 +7,7 @@
 #include "Library/Obj/AllDeadWatcher.h"
 
 #include "MapObj/AnagramAlphabet.h"
+#include "MapObj/CitySignal.h"
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/WorldMapEarth.h"
 
@@ -117,7 +118,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"CityWorldSign", nullptr},
     {"CityWorldUndergroundMachine", nullptr},
     {"CitySign", nullptr},
-    {"CitySignal", nullptr},
+    {"CitySignal", al::createActorFunction<CitySignal>},
     {"CityWorldTable", nullptr},
     {"Closet", nullptr},
     {"CloudStep", nullptr},

--- a/src/System/GameDataFunction.h
+++ b/src/System/GameDataFunction.h
@@ -149,7 +149,7 @@ public:
     static bool isFirstTimeNextWorld(GameDataHolderAccessor);
     static void checkIsNewWorldInAlreadyGoWorld(GameDataHolderAccessor);
     static void getCurrentWorldIdNoDevelop(GameDataHolderAccessor);
-    static void getScenarioNo(const al::LiveActor*);
+    static s32 getScenarioNo(const al::LiveActor*);
     static void getScenarioNo(const al::LayoutActor*);
     static void getScenarioNoPlacement(GameDataHolderAccessor);
     static bool isEqualScenario(const RiseMapPartsHolder*, s32);


### PR DESCRIPTION
Today, I felt like doing something useful and implementing *something*. Scrolling around the list of functions randomly resulted in me picking this. Great!

Just as a short note beforehand - `WaitBlue` means `Green`. The other namings are straight-foward.

A bit of investigation later, it seems like the signal is supposed to do more than it actually ends up doing in the game.

https://twitter.com/MDruide1/status/1828218798719066407
(includes videos of fixed and actually observed behaviour ^)

Explanation:
- `CitySignal` contains three nerves (states): `WaitRed`, `WaitBlue` and `WaitOff`, which all don't really show different behavior, except the animation associated with each of them: `WaitRed` blinks red, `WaitBlue` shows constantly green and `WaitOff` is ... off.
- Usually, `LiveActor::movement` has to be called, which updates animations and calls the nerve code
- However, `CitySignal` overrides `movement` with an empty function, resulting in animations being stuck and nerves not being called
- The former results in the blinking not being observed in-game, just constantly showing the first frame of its animation
- The latter results in the interaction between explosive and signal being detected, but the animation not being updated to `Off`
=> the signal constantly shows red, without blinking, and without being able to affect it.
=> similarly, Day Metro just constantly shows green. This one is not supposed to blink, but would be able to get "exploded" to `Off` as well, but ... doesn't.

This behavior can be fixed to work correctly on `1.0` using the following patch (exlaunch):
```cpp
p.Seek(0x24C644);
p.BranchInst(0x90D808);
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/146)
<!-- Reviewable:end -->
