### PR TITLE
Library/Camera: Implement `CameraTicket`

### DIFF
--- a/lib/al/Library/Camera/CameraTicket.cpp
+++ b/lib/al/Library/Camera/CameraTicket.cpp
@@ -1,0 +1,12 @@
+#include "Library/Camera/CameraTicket.h"
+
+namespace al {
+
+CameraTicket::CameraTicket(CameraPoser* poser, const CameraTicketId* ticketId, s32 priority)
+    : mPoser(poser), mTicketId(ticketId), mPriority(priority) {}
+
+void CameraTicket::setPriority(s32 priority) {
+    mPriority = priority;
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraTicket.h
+++ b/lib/al/Library/Camera/CameraTicket.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class CameraPoser;
+class CameraTicketId;
+
+class CameraTicket {
+public:
+    enum Priority {
+        // Priority_EntranceAll = 2,
+        Priority_BossField = 3,
+        Priority_Capture = 4,
+        Priority_Object = 5,
+        Priority_ForceArea = 6,
+        // Priority_EntranceAll = 7,
+        Priority_SafetyPointRecovery = 8,
+        Priority_Player = 9,
+        Priority_DemoTalk = 10,
+        Priority_Demo = 11,
+        Priority_Demo2 = 12,
+    };
+
+    CameraTicket(CameraPoser* poser, const CameraTicketId* ticketId, s32 priority);
+    void setPriority(s32 priority);
+
+private:
+    CameraPoser* mPoser;
+    const CameraTicketId* mTicketId;
+    s32 mPriority;
+    bool mIsActiveCamera = false;
+};
+
+}  // namespace al


### PR DESCRIPTION
Next! `CameraTicket` holds the associated `CameraPoser`, (for example `CameraPoserFix`) in pre-configured form, its ticket (from the previous PR) and a certain priority, depending on the type of camera it is used for.

The enum `Priority` holds the currently known values I could gather from a quick search. The type of `setPriority` is `s32`/`int` though, so it can't accept the enum as type. To avoid casting at all usages, this is an `enum` instead of `enum class`. Regarding the entrance priority, I only found `alCameraPoserFunction::isPrePriorityEntranceAll(al::CameraStartInfo const&)`, which checks for *both* values - so this can be adjusted later when other, proper values are found.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/153)
<!-- Reviewable:end -->
