### PR TITLE
Library/Camera: Implement `CameraParamMoveLimit`

### DIFF
--- a/lib/al/Library/Camera/CameraParamMoveLimit.cpp
+++ b/lib/al/Library/Camera/CameraParamMoveLimit.cpp
@@ -1,0 +1,84 @@
+#include "Library/Camera/CameraParamMoveLimit.h"
+
+#include <gfx/seadCamera.h>
+
+#include "Library/Camera/CameraPoser.h"
+#include "Library/Matrix/MatrixUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/ByamlUtil.h"
+
+namespace al {
+
+CameraParamMoveLimit* CameraParamMoveLimit::create(const CameraPoser* poser) {
+    CameraParamMoveLimit* result = new CameraParamMoveLimit();
+    result->mViewMtx = poser->getViewMtx();
+    result->mInvViewMtx.setInverse(poser->getViewMtx());
+    return result;
+}
+
+CameraParamMoveLimit::CameraParamMoveLimit() {}
+
+void CameraParamMoveLimit::load(const ByamlIter& iter) {
+    ByamlIter moveLimitIter;
+    if (!iter.tryGetIterByKey(&moveLimitIter, "MoveLimit"))
+        return;
+
+    if (tryGetByamlF32(&mPlus.x, moveLimitIter, "PlusX"))
+        mHasPlusX = true;
+    if (tryGetByamlF32(&mMinus.x, moveLimitIter, "MinusX"))
+        mHasMinusX = true;
+    if (tryGetByamlF32(&mPlus.y, moveLimitIter, "PlusY"))
+        mHasPlusY = true;
+    if (tryGetByamlF32(&mMinus.y, moveLimitIter, "MinusY"))
+        mHasMinusY = true;
+    if (tryGetByamlF32(&mPlus.z, moveLimitIter, "PlusZ"))
+        mHasPlusZ = true;
+    if (tryGetByamlF32(&mMinus.z, moveLimitIter, "MinusZ"))
+        mHasMinusZ = true;
+}
+
+void CameraParamMoveLimit::apply(sead::LookAtCamera* camera) const {
+    sead::Vector3f constrainedViewAt;
+
+    // required to enforce lifetimes of variables
+    {
+        f32 preRotYDegree = -mRotYDegree;
+        sead::Vector3f inverseViewAt;
+        inverseViewAt.setMul(mInvViewMtx, camera->getAt());
+        sead::Matrix34f mtxRotateY = sead::Matrix34f::ident;
+        rotateMtxYDirDegree(&mtxRotateY, mtxRotateY, preRotYDegree);
+
+        constrainedViewAt.setMul(mtxRotateY, inverseViewAt);
+
+        if (mHasPlusX)
+            constrainedViewAt.x = constrainedViewAt.x > mPlus.x ? mPlus.x : constrainedViewAt.x;
+        if (mHasPlusY)
+            constrainedViewAt.y = constrainedViewAt.y > mPlus.y ? mPlus.y : constrainedViewAt.y;
+        if (mHasPlusZ)
+            constrainedViewAt.z = constrainedViewAt.z > mPlus.z ? mPlus.z : constrainedViewAt.z;
+
+        if (mHasMinusX)
+            constrainedViewAt.x = constrainedViewAt.x < mMinus.x ? mMinus.x : constrainedViewAt.x;
+        if (mHasMinusY)
+            constrainedViewAt.y = constrainedViewAt.y < mMinus.y ? mMinus.y : constrainedViewAt.y;
+        if (mHasMinusZ)
+            constrainedViewAt.z = constrainedViewAt.z < mMinus.z ? mMinus.z : constrainedViewAt.z;
+    }
+
+    f32 rotYDegree = mRotYDegree;
+    sead::Matrix34f mtxRotateY = sead::Matrix34f::ident;
+    rotateMtxYDirDegree(&mtxRotateY, mtxRotateY, rotYDegree);
+
+    sead::Vector3f finalInverseViewAt;
+    finalInverseViewAt.setMul(mtxRotateY, constrainedViewAt);
+
+    sead::Vector3f finalViewAt;
+    finalViewAt.setMul(mViewMtx, finalInverseViewAt);
+
+    sead::Vector3f constraintAdjustment = finalViewAt - camera->getAt();
+
+    camera->getAt() = constraintAdjustment + camera->getAt();
+    camera->getPos() = constraintAdjustment + camera->getPos();
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraParamMoveLimit.h
+++ b/lib/al/Library/Camera/CameraParamMoveLimit.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <gfx/seadCamera.h>
+
+namespace al {
+class ByamlIter;
+class CameraPoser;
+
+class CameraParamMoveLimit {
+public:
+    static CameraParamMoveLimit* create(const CameraPoser* poser);
+
+    CameraParamMoveLimit();
+
+    void load(const ByamlIter& iter);
+    void apply(sead::LookAtCamera* camera) const;
+
+private:
+    sead::Vector3f mPlus = {100000.0f, 100000.0f, 100000.0f};
+    sead::Vector3f mMinus = {-100000.0f, -100000.0f, -100000.0f};
+    bool mHasPlusX = false;
+    bool mHasMinusX = false;
+    bool mHasPlusY = false;
+    bool mHasMinusY = false;
+    bool mHasPlusZ = false;
+    bool mHasMinusZ = false;
+    sead::Matrix34f mViewMtx = sead::Matrix34f::ident;
+    sead::Matrix34f mInvViewMtx = sead::Matrix34f::ident;
+    f32 mRotYDegree = 0;
+};
+
+static_assert(sizeof(CameraParamMoveLimit) == 0x84);
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -108,6 +108,8 @@ public:
 
     sead::Vector3f getCameraUp() const { return mCameraUp; };
 
+    const sead::Matrix34f& getViewMtx() const { return mViewMtx; };
+
 private:
     const char* mPoserName;
     f32 field_38;


### PR DESCRIPTION
This class somehow restricts camera movement to a certain area given by `MoveLimit`, listing `PlusX-Z` and `MinusX-Z` - at least that's what I'm guessing. It is specific to each individual `CameraPoser`, so multiple camera setups in the same stage could use different restricted movement areas.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/154)
<!-- Reviewable:end -->
