### PR TITLE
Project/Camera: Implement `CameraAngleSwingInfo`

### DIFF
--- a/lib/al/Library/Math/MathUtil.h
+++ b/lib/al/Library/Math/MathUtil.h
@@ -56,6 +56,8 @@ void lerpVec(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&, f32)
 void lerpVecHV(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&,
                f32, f32);
 
+void rotateVectorDegree(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&, f32);
+
 f32 calcRate01(f32, f32, f32);
 
 f32 slerpQuat(sead::Quatf*, const sead::Quatf&, const sead::Quatf&, f32);

--- a/lib/al/Project/Camera/CameraAngleSwingInfo.cpp
+++ b/lib/al/Project/Camera/CameraAngleSwingInfo.cpp
@@ -1,0 +1,58 @@
+#include "Project/Camera/CameraAngleSwingInfo.h"
+
+#include "Library/Math/MathAngleUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Yaml/ByamlUtil.h"
+
+namespace al {
+
+CameraAngleSwingInfo::CameraAngleSwingInfo() {
+    // these need to be explicit in this constructor, otherwise mismatch
+    mCurrentAngle = {0.0f, 0.0f};
+    _14 = 0.3f;
+    _18 = 0.1f;
+}
+
+void CameraAngleSwingInfo::load(const ByamlIter& iter) {
+    tryGetByamlBool(&mIsInvalidSwing, iter, "IsInvalidString");
+    if (mIsInvalidSwing)
+        return;
+
+    tryGetByamlF32(&mMaxSwingDegreeH, iter, "MaxSwingDegreeH");
+    tryGetByamlF32(&mMaxSwingDegreeV, iter, "MaxSwingDegreeV");
+}
+
+void CameraAngleSwingInfo::update(const sead::Vector2f& stickInput, f32 stickSensitivity) {
+    if (mIsInvalidSwing) {
+        mCurrentAngle = {0.0f, 0.0f};
+        return;
+    }
+
+    sead::Vector2f swingDegrees = {
+        -stickInput.x * mMaxSwingDegreeH,
+        stickInput.y * mMaxSwingDegreeV,
+    };
+
+    lerpVec(&swingDegrees, mCurrentAngle, swingDegrees, _14 * stickSensitivity);
+    lerpVec(&mCurrentAngle, mCurrentAngle, swingDegrees, _18);
+}
+
+void CameraAngleSwingInfo::makeLookAtCamera(sead::LookAtCamera* camera) const {
+    sead::Vector3f cameraLookDirection = camera->getAt() - camera->getPos();
+    f32 cameraLookDistance = cameraLookDirection.length();
+    normalize(&cameraLookDirection);
+    sead::Vector3f cameraLookHDir = sead::Vector3f::ey;
+    verticalizeVec(&cameraLookHDir, cameraLookDirection, cameraLookHDir);
+    if (!tryNormalizeOrZero(&cameraLookHDir))
+        return;
+
+    rotateVectorDegree(&cameraLookDirection, cameraLookDirection, cameraLookHDir, mCurrentAngle.x);
+    normalize(&cameraLookDirection);
+    sead::Vector3f cameraSideDir;
+    cameraSideDir.setCross(cameraLookDirection, cameraLookHDir);
+    normalize(&cameraSideDir);
+    rotateVectorDegree(&cameraLookDirection, cameraLookDirection, cameraSideDir, mCurrentAngle.y);
+    camera->getAt() = (cameraLookDistance * cameraLookDirection) + camera->getPos();
+}
+
+}  // namespace al

--- a/lib/al/Project/Camera/CameraAngleSwingInfo.h
+++ b/lib/al/Project/Camera/CameraAngleSwingInfo.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <gfx/seadCamera.h>
+
+namespace al {
+class ByamlIter;
+
+class CameraAngleSwingInfo {
+public:
+    CameraAngleSwingInfo();
+
+    void load(const ByamlIter& iter);
+    void update(const sead::Vector2f& stickInput, f32 stickSensitivity);
+    void makeLookAtCamera(sead::LookAtCamera* camera) const;
+
+    // all of them are default-initialized in the constructor, but some can't be inlined here
+private:
+    bool mIsInvalidSwing = false;
+    sead::Vector2f mCurrentAngle;
+    f32 mMaxSwingDegreeH = 15.0f;
+    f32 mMaxSwingDegreeV = 15.0f;
+    // unknown purpose at the moment, only seem to be read
+    f32 _14;
+    f32 _18;
+};
+
+}  // namespace al


### PR DESCRIPTION
More camera stuff! This class is responsible for managing the slight swing movements up/down/left/right when dealing with a fixed camera. It allows slightly changing the camera direction by (default = 15°), to make it feel less static, but moves the camera back when the stick is stopped being held.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/155)
<!-- Reviewable:end -->
