### PR TITLE
Library/Camera: Implement `ActorCameraTarget`

### DIFF
--- a/lib/al/Library/Camera/ActorCameraTarget.cpp
+++ b/lib/al/Library/Camera/ActorCameraTarget.cpp
@@ -1,0 +1,53 @@
+#include "Library/Camera/ActorCameraTarget.h"
+
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+
+ActorCameraTarget::ActorCameraTarget(const LiveActor* actor, f32 yOffset,
+                                     const sead::Vector3f* localOffset)
+    : mActor(actor), mLocalOffset(localOffset), mYOffset(yOffset) {}
+
+const char* ActorCameraTarget::getTargetName() const {
+    return mActor->getName();
+}
+
+void ActorCameraTarget::calcTrans(sead::Vector3f* trans) const {
+    calcTransLocalOffset(trans, mActor, mLocalOffset ? *mLocalOffset : sead::Vector3f::zero);
+    trans->y += mYOffset;
+}
+
+void ActorCameraTarget::calcSide(sead::Vector3f* side) const {
+    calcSideDir(side, mActor);
+}
+
+void ActorCameraTarget::calcUp(sead::Vector3f* up) const {
+    calcUpDir(up, mActor);
+}
+
+void ActorCameraTarget::calcFront(sead::Vector3f* front) const {
+    calcFrontDir(front, mActor);
+}
+
+void ActorCameraTarget::calcGravity(sead::Vector3f* gravity) const {
+    gravity->set(getGravity(mActor));
+}
+
+void ActorCameraTarget::calcVelocity(sead::Vector3f* velocity) const {
+    velocity->set(getVelocity(mActor));
+}
+
+bool ActorCameraTarget::isCollideGround() const {
+    return isExistActorCollider(mActor) && !isNoCollide(mActor) && isOnGround(mActor, 0);
+}
+
+bool ActorCameraTarget::isInWater() const {
+    return isInWaterArea(mActor);
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/ActorCameraTarget.h
+++ b/lib/al/Library/Camera/ActorCameraTarget.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/Camera/CameraTargetBase.h"
+
+namespace al {
+class LiveActor;
+
+class ActorCameraTarget : public CameraTargetBase {
+public:
+    ActorCameraTarget(const LiveActor* actor, f32 yOffset, const sead::Vector3f* localOffset);
+
+    const char* getTargetName() const override;
+    void calcTrans(sead::Vector3f* trans) const override;
+    void calcSide(sead::Vector3f* side) const override;
+    void calcUp(sead::Vector3f* up) const override;
+    void calcFront(sead::Vector3f* front) const override;
+    void calcGravity(sead::Vector3f* gravity) const override;
+    void calcVelocity(sead::Vector3f* velocity) const override;
+    bool isCollideGround() const override;
+    bool isInWater() const override;
+
+private:
+    const LiveActor* mActor;
+    const sead::Vector3f* mLocalOffset;
+    f32 mYOffset;
+};
+
+}  // namespace al

--- a/lib/al/Library/LiveActor/ActorAreaFunction.h
+++ b/lib/al/Library/LiveActor/ActorAreaFunction.h
@@ -7,6 +7,7 @@ class LiveActor;
 
 bool isInAreaObj(const LiveActor*, const char*);
 bool isInDeathArea(const LiveActor*);
+bool isInWaterArea(const LiveActor*);
 
 AreaObj* tryFindAreaObj(const LiveActor*, const char*);
 


### PR DESCRIPTION
Next in the category of "Camera stuff": A `CameraTarget` for following actors. It allows adding a `localOffset`, for example to place the target 150 units to the front of the actor, which gets adjusted according to the matrix of the actor (=> front relative to the actor, not globally). Additionally, the target can be moved along the global Y axis, usually placing the target above the actor itself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/157)
<!-- Reviewable:end -->
