### PR TITLE
Library/Camera: Implement `CameraTicketHolder`

### DIFF
--- a/lib/al/Library/Camera/CameraTicket.h
+++ b/lib/al/Library/Camera/CameraTicket.h
@@ -9,7 +9,8 @@ class CameraTicketId;
 class CameraTicket {
 public:
     enum Priority {
-        // Priority_EntranceAll = 2,
+        Priority_Default = 0,
+        Priority_Entrance = 2,
         Priority_BossField = 3,
         Priority_Capture = 4,
         Priority_Object = 5,
@@ -24,6 +25,12 @@ public:
 
     CameraTicket(CameraPoser* poser, const CameraTicketId* ticketId, s32 priority);
     void setPriority(s32 priority);
+
+    CameraPoser* getPoser() const { return mPoser; }
+
+    const CameraTicketId* getTicketId() const { return mTicketId; }
+
+    s32 getPriority() const { return mPriority; }
 
 private:
     CameraPoser* mPoser;

--- a/lib/al/Library/Camera/CameraTicketHolder.cpp
+++ b/lib/al/Library/Camera/CameraTicketHolder.cpp
@@ -1,0 +1,49 @@
+#include "Library/Camera/CameraTicketHolder.h"
+
+#include "Library/Camera/CameraPoser.h"
+#include "Library/Camera/CameraTicket.h"
+#include "Library/Camera/CameraTicketId.h"
+
+namespace al {
+
+CameraTicketHolder::CameraTicketHolder(s32 maxTickets) : mMaxTickets(maxTickets) {
+    mTickets = new CameraTicket*[maxTickets];
+    for (s32 i = 0; i < mMaxTickets; i++)
+        mTickets[i] = nullptr;
+}
+
+void CameraTicketHolder::endInit() {
+    for (s32 i = 0; i < mNumTickets; i++)
+        mTickets[i]->getPoser()->endInit();
+
+    if (mDefaultTicket)
+        mDefaultTicket->getPoser()->endInit();
+}
+
+void CameraTicketHolder::registerTicket(CameraTicket* ticket) {
+    if (ticket->getPriority() == CameraTicket::Priority_Default) {
+        registerDefaultTicket(ticket);
+        return;
+    }
+
+    mTickets[mNumTickets] = ticket;
+    mNumTickets++;
+}
+
+void CameraTicketHolder::registerDefaultTicket(CameraTicket* ticket) {
+    mDefaultTicket = ticket;
+}
+
+CameraTicket* CameraTicketHolder::tryFindEntranceTicket(const PlacementId* placementId,
+                                                        const char* suffix) const {
+    CameraTicketId searchTicketId = {placementId, suffix};
+
+    for (s32 i = 0; i < mNumTickets; i++)
+        if (mTickets[i]->getPriority() == CameraTicket::Priority_Entrance &&
+            mTickets[i]->getTicketId()->isEqual(searchTicketId))
+            return mTickets[i];
+
+    return nullptr;
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraTicketHolder.h
+++ b/lib/al/Library/Camera/CameraTicketHolder.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class CameraTicket;
+class PlacementId;
+
+class CameraTicketHolder {
+public:
+    CameraTicketHolder(s32 maxTickets);
+
+    void endInit();
+    void registerTicket(CameraTicket* ticket);
+    void registerDefaultTicket(CameraTicket* ticket);
+    CameraTicket* tryFindEntranceTicket(const PlacementId* placementId, const char* suffix) const;
+
+private:
+    CameraTicket** mTickets;
+    s32 mNumTickets = 0;
+    s32 mMaxTickets;
+    CameraTicket* mDefaultTicket = nullptr;
+};
+
+}  // namespace al


### PR DESCRIPTION
A short class that can hold all `CameraTicket`s that are currently loaded in the stage. It also provides a small function for fetching the camera ticket belonging to a specific entrance by just comparing the `PlacementId` and `Suffix` to all currently held `Ticket`s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/159)
<!-- Reviewable:end -->
