### PR TITLE
MapObj: Implement `ChurchDoor`

### DIFF
--- a/lib/al/Library/Bgm/BgmLineFunction.h
+++ b/lib/al/Library/Bgm/BgmLineFunction.h
@@ -2,6 +2,7 @@
 
 namespace al {
 class Resource;
+class IUseAudioKeeper;
 
 class BgmDataBase {
 public:
@@ -9,4 +10,6 @@ public:
 
     BgmDataBase(const Resource*, const Resource*);
 };
+
+void startBgmSituation(const IUseAudioKeeper*, const char*, bool, bool);
 }  // namespace al

--- a/src/MapObj/ChurchDoor.cpp
+++ b/src/MapObj/ChurchDoor.cpp
@@ -1,0 +1,150 @@
+#include "MapObj/ChurchDoor.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "System/GameDataFunction.h"
+#include "Util/Sensor.h"
+#include "Util/StageSensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(ChurchDoor, DemoEnterChurch);
+NERVE_IMPL(ChurchDoor, CloseWait1);
+NERVE_IMPL(ChurchDoor, OpenWait);
+NERVE_IMPL(ChurchDoor, Open1);
+NERVE_IMPL(ChurchDoor, Open2);
+NERVE_IMPL(ChurchDoor, CloseWait2);
+NERVE_IMPL(ChurchDoor, CloseWait3);
+NERVE_IMPL(ChurchDoor, Open3);
+
+NERVES_MAKE_NOSTRUCT(ChurchDoor, DemoEnterChurch, CloseWait1, OpenWait, Open1, Open2, CloseWait2,
+                     CloseWait3, Open3);
+}  // namespace
+
+inline bool isCurrentStageMoonWeddingRoom(const al::LiveActor* actor) {
+    return al::isEqualString("MoonWorldWeddingRoomStage",
+                             GameDataFunction::getCurrentStageName(actor));
+}
+
+ChurchDoor::ChurchDoor(const char* name) : al::LiveActor(name) {}
+
+void ChurchDoor::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &CloseWait1, 0);
+
+    if (isCurrentStageMoonWeddingRoom(this)) {
+        mSaveObjInfo = rs::createSaveObjInfoWriteSaveData(info);
+        if (rs::isOnSaveObjInfo(mSaveObjInfo)) {
+            al::invalidateCollisionParts(this);
+            al::setNerve(this, &OpenWait);
+            makeActorAlive();
+            return;
+        }
+    }
+
+    al::startBgmSituation(this, "CloseChurchDoor", true, true);
+    makeActorAlive();
+}
+
+bool ChurchDoor::receiveMsg(const al::SensorMsg* msg, al::HitSensor* source,
+                            al::HitSensor* target) {
+    if (rs::isMsgPlayerDisregardTargetMarker(msg))
+        return true;
+
+    if (rs::isMsgCapTouchWall(msg)) {
+        if ((al::isNerve(this, &Open1) || al::isNerve(this, &Open2)) &&
+            al::isLessEqualStep(this, 10))
+            return true;
+
+        rs::requestHitReactionToAttacker(msg, source, al::getSensorPos(source));
+
+        if (al::isNerve(this, &CloseWait1)) {
+            al::startHitReaction(this, "ヒット1回目");
+            al::setNerve(this, &Open1);
+        } else if (al::isNerve(this, &CloseWait2) || al::isNerve(this, &Open1)) {
+            al::startHitReaction(this, "ヒット2回目");
+            al::setNerve(this, &Open2);
+        } else if (al::isNerve(this, &CloseWait3) || al::isNerve(this, &Open2)) {
+            al::startHitReaction(this, "ヒット3回目");
+            al::setNerve(this, &Open3);
+        }
+        return true;
+    }
+
+    return false;
+}
+
+bool ChurchDoor::isOpenWait() const {
+    return al::isNerve(this, &OpenWait);
+}
+
+bool ChurchDoor::isDemoEnterChurch() const {
+    return al::isNerve(this, &DemoEnterChurch);
+}
+
+void ChurchDoor::startDemoEnterChurch() {
+    al::setNerve(this, &DemoEnterChurch);
+}
+
+void ChurchDoor::endDemoEnterChurch() {
+    al::setNerve(this, &OpenWait);
+}
+
+void ChurchDoor::exeCloseWait1() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "CloseWait1");
+}
+
+void ChurchDoor::exeOpen1() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Open1");
+
+    al::setNerveAtActionEnd(this, &CloseWait2);
+}
+
+void ChurchDoor::exeCloseWait2() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "CloseWait2");
+}
+
+void ChurchDoor::exeOpen2() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Open2");
+
+    al::setNerveAtActionEnd(this, &CloseWait3);
+}
+
+void ChurchDoor::exeCloseWait3() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "CloseWait3");
+}
+
+void ChurchDoor::exeOpen3() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Open3");
+        al::invalidateCollisionParts(this);
+    }
+
+    al::setNerveAtActionEnd(this, &OpenWait);
+}
+
+void ChurchDoor::exeOpenWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "OpenWait");
+
+        if (isCurrentStageMoonWeddingRoom(this))
+            rs::onSaveObjInfo(mSaveObjInfo);
+    }
+}
+
+void ChurchDoor::exeDemoEnterChurch() {
+    if (al::isFirstStep(this)) {
+    }
+}

--- a/src/MapObj/ChurchDoor.h
+++ b/src/MapObj/ChurchDoor.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class SaveObjInfo;
+
+class ChurchDoor : public al::LiveActor {
+public:
+    ChurchDoor(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* source,
+                    al::HitSensor* target) override;
+
+    bool isOpenWait() const;
+    bool isDemoEnterChurch() const;
+    void startDemoEnterChurch();
+    void endDemoEnterChurch();
+
+    void exeCloseWait1();
+    void exeOpen1();
+    void exeCloseWait2();
+    void exeOpen2();
+    void exeCloseWait3();
+    void exeOpen3();
+    void exeOpenWait();
+    void exeDemoEnterChurch();
+
+private:
+    SaveObjInfo* mSaveObjInfo = nullptr;
+};

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -9,6 +9,7 @@
 #include "Library/Obj/AllDeadWatcher.h"
 
 #include "MapObj/AnagramAlphabet.h"
+#include "MapObj/ChurchDoor.h"
 #include "MapObj/CitySignal.h"
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/WorldMapEarth.h"
@@ -114,7 +115,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"Chair", nullptr},
     {"CheckpointFlag", nullptr},
     {"ChorobonHolder", nullptr},
-    {"ChurchDoor", nullptr},
+    {"ChurchDoor", al::createActorFunction<ChurchDoor>},
     {"CityBuilding", nullptr},
     {"CityStreetlight", nullptr},
     {"CityWorldSign", nullptr},

--- a/src/System/GameDataHolderAccessor.h
+++ b/src/System/GameDataHolderAccessor.h
@@ -7,7 +7,9 @@ class IUseSceneObjHolder;
 class SceneObjHolder;
 class ISceneObj;
 class LiveActor;
+class ActorInitInfo;
 }  // namespace al
+class SaveObjInfo;
 
 class GameDataHolderAccessor : public GameDataHolderWriter {  // maybe extends GameDataHolderWriter?
 public:
@@ -18,4 +20,8 @@ public:
 namespace rs {
 bool isInvalidChangeStage(const al::LiveActor* actor);
 bool isKidsMode(const al::LiveActor* actor);
+
+SaveObjInfo* createSaveObjInfoWriteSaveData(const al::ActorInitInfo&);
+void onSaveObjInfo(SaveObjInfo*);
+bool isOnSaveObjInfo(const SaveObjInfo*);
 }  // namespace rs

--- a/src/Util/StageSensorMsgFunction.h
+++ b/src/Util/StageSensorMsgFunction.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+namespace rs {
+
+bool isMsgPlayerDisregardTargetMarker(const al::SensorMsg* msg);
+
+void requestHitReactionToAttacker(const al::SensorMsg*, const al::HitSensor*,
+                                  const sead::Vector3f&);
+
+}  // namespace rs


### PR DESCRIPTION
I wanted to do another actor today, so my "randomly scroll around and select one" strategy landed on this one.

Notable things about the actor itself:
- It only saves whether the door is open or not in "binary" form, there is no intermediate (amount of hits). It is considered "open" after the animation of the third hit has finished playing.
- This state is only persisted for `MoonWorldWeddingRoomStage`, meaning the church on the moon itself - not the rematch.
- Attacks are only counted when the type is "Cappy hits the wall of the door". After the first and second hit, the first 10 frames the door is "immune" to another attack.

Notable things from the programmer's side:
- The amount of hits (3) and each individual animation is hardcoded, presenting a nerve for both "open" and "close" for every number of hits. The "open" nerve is active while the "hit" action plays, then "close" is entered again.

For other decompilers:
This PR is fully matching. However, one line occurs twice that I'm not quite happy with:
`this ? this : nullptr`
=> this pattern usually happens when a `LiveActor` is casted to some of its supertypes using just `this`. However, in this case, it seems to be required to explicitly write `this ? this : nullptr`, causing a compiler warning (`this` should never be null, so this check is "useless"). If anyone finds an alternative, I'm happy to change the two occurences of this!

https://decomp.me/scratch/O4tVr

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/164)
<!-- Reviewable:end -->
