### PR TITLE
Library/Obj: Refactor `AllDeadWatcher`

### DIFF
--- a/lib/al/Library/Obj/AllDeadWatcher.cpp
+++ b/lib/al/Library/Obj/AllDeadWatcher.cpp
@@ -3,9 +3,19 @@
 #include "Library/LiveActor/ActorDrawFunction.h"
 #include "Library/LiveActor/ActorInitFunction.h"
 #include "Library/LiveActor/LiveActorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
 #include "Library/Placement/PlacementFunction.h"
 #include "Library/Stage/StageSwitchKeeper.h"
+
+namespace {
+using namespace al;
+
+NERVE_IMPL(AllDeadWatcher, Watch)
+NERVE_IMPL(AllDeadWatcher, Wait)
+
+NERVES_MAKE_STRUCT(AllDeadWatcher, Watch, Wait)
+}  // namespace
 
 namespace al {
 AllDeadWatcher::AllDeadWatcher(const char* name) : LiveActor(name) {}

--- a/lib/al/Library/Obj/AllDeadWatcher.h
+++ b/lib/al/Library/Obj/AllDeadWatcher.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Library/LiveActor/LiveActor.h"
-#include "Library/Nerve/NerveSetupUtil.h"
 
 namespace al {
 class AllDeadWatcher : public LiveActor {
@@ -23,11 +22,4 @@ private:
 };
 
 static_assert(sizeof(AllDeadWatcher) == 0x120);
-
-namespace {
-NERVE_IMPL(AllDeadWatcher, Watch);
-NERVE_IMPL(AllDeadWatcher, Wait);
-
-NERVES_MAKE_STRUCT(AllDeadWatcher, Watch, Wait);
-}  // namespace
 }  // namespace al


### PR DESCRIPTION
This PR move Nerve definitions out of the header in order to follow decomp's code style.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/171)
<!-- Reviewable:end -->
