### PR TITLE
README: Add information about `libncurses5` on arch

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ If you are running Ubuntu 23.10 or later, the `libncurses5` package won't be ava
 wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.4-2_amd64.deb && sudo dpkg -i libtinfo5_6.4-2_amd64.deb && rm -f libtinfo5_6.4-2_amd64.deb
 ```
 
+For other systems, please check for the corresponding `libncurses5` backport, for example [ncurses5-compat-libs](https://aur.archlinux.org/packages/ncurses5-compat-libs) for Arch-based distributions.
+
 Additionally, you'll also need:
 
 * A Rust toolchain ([follow the instructions here](https://www.rust-lang.org/tools/install))


### PR DESCRIPTION
Thanks to `@Cookieso` on Discord, we now also know which package is required to add the `libtinfo.so.5` library to arch-based systems. This information should be added to the README.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/172)
<!-- Reviewable:end -->
