### PR TITLE
System: Adjust return type of `tryChangeNextStage*`

### DIFF
--- a/src/System/GameDataFunction.h
+++ b/src/System/GameDataFunction.h
@@ -119,12 +119,12 @@ public:
     static void getPlayTimeAcrossFile(GameDataHolderAccessor);
     static void getSaveDataIdForPrepo(GameDataHolderAccessor);
     static void startDemoStage(GameDataHolderWriter, const char*);
-    static void tryChangeNextStage(GameDataHolderWriter, const ChangeStageInfo*);
-    static void tryChangeNextStageWithStartRaceFlag(GameDataHolderWriter, const ChangeStageInfo*);
-    static void tryChangeNextStageWithStartRaceYukimaru(GameDataHolderWriter,
+    static bool tryChangeNextStage(GameDataHolderWriter, const ChangeStageInfo*);
+    static bool tryChangeNextStageWithStartRaceFlag(GameDataHolderWriter, const ChangeStageInfo*);
+    static bool tryChangeNextStageWithStartRaceYukimaru(GameDataHolderWriter,
                                                         const ChangeStageInfo*);
-    static void tryChangeNextStageWithDemoWorldWarp(GameDataHolderWriter, const char*);
-    static void tryChangeNextStageWithWorldWarpHole(GameDataHolderWriter, const char*);
+    static bool tryChangeNextStageWithDemoWorldWarp(GameDataHolderWriter, const char*);
+    static bool tryChangeNextStageWithWorldWarpHole(GameDataHolderWriter, const char*);
     static void changeNextStageWithStartTimeBalloon(GameDataHolderWriter, s32);
     static void changeNextStageWithEndTimeBalloon(GameDataHolderWriter);
     static void changeNextStageWithCloset(GameDataHolderWriter);


### PR DESCRIPTION
Those should return `bool`eans, which often just tell whether the `ChangeStageInfo.mChangeStageName` is non-empty. Nontheless, the current declaration is wrong and the return type should be adjusted. Thanks to @LynxDev2 for letting me know!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/193)
<!-- Reviewable:end -->
