### PR TITLE
Change parameter names of `HitSensor`s to `self`/`other`

### DIFF
--- a/lib/al/Library/LiveActor/LiveActor.cpp
+++ b/lib/al/Library/LiveActor/LiveActor.cpp
@@ -60,9 +60,9 @@ StageSwitchKeeper* LiveActor::getStageSwitchKeeper() const {
 
 void LiveActor::init(const ActorInitInfo& info) {}
 
-void LiveActor::attackSensor(HitSensor* target, HitSensor* source) {}
+void LiveActor::attackSensor(HitSensor* self, HitSensor* other) {}
 
-bool LiveActor::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
+bool LiveActor::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
     return false;
 }
 

--- a/lib/al/Library/LiveActor/LiveActor.h
+++ b/lib/al/Library/LiveActor/LiveActor.h
@@ -68,8 +68,8 @@ public:
     virtual void draw() const;
     virtual void startClipped();
     virtual void endClipped();
-    virtual void attackSensor(HitSensor* target, HitSensor* source);
-    virtual bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target);
+    virtual void attackSensor(HitSensor* self, HitSensor* other);
+    virtual bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self);
     virtual bool receiveMsgScreenPoint(const SensorMsg* message, ScreenPointer* source,
                                        ScreenPointTarget* target);
     virtual const char* getName() const override;

--- a/lib/al/Library/MapObj/BreakMapPartsBase.cpp
+++ b/lib/al/Library/MapObj/BreakMapPartsBase.cpp
@@ -151,8 +151,8 @@ void BreakMapPartsBase::startBreakByProgram() {
     setNerve(this, &NrvBreakMapPartsBase.Break);
 }
 
-bool BreakMapPartsBase::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
-    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && mJudgeFunction(message, source, target)) {
+bool BreakMapPartsBase::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
+    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && mJudgeFunction(message, other, self)) {
         startBreakByProgram();
 
         return true;

--- a/lib/al/Library/MapObj/BreakMapPartsBase.h
+++ b/lib/al/Library/MapObj/BreakMapPartsBase.h
@@ -5,7 +5,7 @@
 namespace al {
 class MtxConnector;
 
-using JudgeFuncPtr = bool (*)(const SensorMsg* message, HitSensor* source, HitSensor* target);
+using JudgeFuncPtr = bool (*)(const SensorMsg* message, HitSensor* other, HitSensor* self);
 
 class BreakMapPartsBase : public LiveActor {
 public:
@@ -19,7 +19,7 @@ public:
     void exeWait();
     void exeBreak();
     void startBreakByProgram();
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
     virtual JudgeFuncPtr getJudgeFunction(const char* name) const;
 
 private:

--- a/lib/al/Library/MapObj/ChildStep.cpp
+++ b/lib/al/Library/MapObj/ChildStep.cpp
@@ -27,8 +27,8 @@ void ChildStep::init(const ActorInitInfo& info) {
     makeActorAlive();
 }
 
-bool ChildStep::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
-    return mParent->receiveMsg(message, source, target);
+bool ChildStep::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
+    return mParent->receiveMsg(message, other, self);
 }
 
 void ChildStep::exeWait() {

--- a/lib/al/Library/MapObj/ChildStep.h
+++ b/lib/al/Library/MapObj/ChildStep.h
@@ -8,7 +8,7 @@ public:
     ChildStep(const char* name, LiveActor* parent);
 
     void init(const ActorInitInfo& info) override;
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
     void exeWait();
 
 private:

--- a/lib/al/Library/MapObj/FallMapParts.cpp
+++ b/lib/al/Library/MapObj/FallMapParts.cpp
@@ -40,7 +40,7 @@ void FallMapParts::init(const ActorInitInfo& info) {
     trySyncStageSwitchAppear(this);
 }
 
-bool FallMapParts::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
+bool FallMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
     if (isMsgFloorTouch(message) && isNerve(this, NrvFallMapParts.Wait.data())) {
         startNerveAction(this, "FallSign");
         invalidateClipping(this);

--- a/lib/al/Library/MapObj/FallMapParts.h
+++ b/lib/al/Library/MapObj/FallMapParts.h
@@ -8,7 +8,7 @@ public:
     FallMapParts(const char* name);
 
     void init(const ActorInitInfo& info) override;
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
     void appearAndSetStart();
     void exeAppear();
     void exeWait();

--- a/lib/al/Library/MapObj/FixMapParts.cpp
+++ b/lib/al/Library/MapObj/FixMapParts.cpp
@@ -40,7 +40,7 @@ void FixMapParts::calcAnim() {
         calcViewModel(this);
 }
 
-bool FixMapParts::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
+bool FixMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
     if (isMsgAskSafetyPoint(message))
         return !isValidSwitchAppear(this) && !isValidSwitchKill(this);
 

--- a/lib/al/Library/MapObj/FixMapParts.h
+++ b/lib/al/Library/MapObj/FixMapParts.h
@@ -10,7 +10,7 @@ public:
     void appear() override;
     void movement() override;
     void calcAnim() override;
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
 
 private:
     bool mIsStatic = false;

--- a/lib/al/Library/MapObj/FloaterMapParts.cpp
+++ b/lib/al/Library/MapObj/FloaterMapParts.cpp
@@ -53,7 +53,7 @@ void FloaterMapParts::init(const ActorInitInfo& info) {
     trySyncStageSwitchAppear(this);
 }
 
-bool FloaterMapParts::receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) {
+bool FloaterMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
     if (isMsgFloorTouch(message)) {
         mMoveType = FloaterMoveType::Sink;
 

--- a/lib/al/Library/MapObj/FloaterMapParts.h
+++ b/lib/al/Library/MapObj/FloaterMapParts.h
@@ -12,7 +12,7 @@ public:
     FloaterMapParts(const char* name);
 
     void init(const ActorInitInfo& info) override;
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
     void appearAndSetStart();
     void control() override;
     void exeWait();

--- a/lib/al/Library/MapObj/RollingCubeMapParts.cpp
+++ b/lib/al/Library/MapObj/RollingCubeMapParts.cpp
@@ -92,8 +92,7 @@ void RollingCubeMapParts::kill() {
     LiveActor::kill();
 }
 
-bool RollingCubeMapParts::receiveMsg(const SensorMsg* message, HitSensor* source,
-                                     HitSensor* target) {
+bool RollingCubeMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
     if (isMsgPlayerFloorTouch(message) && isNerve(this, NrvRollingCubeMapParts.Wait.data())) {
         startNerveAction(this, "Start");
 

--- a/lib/al/Library/MapObj/RollingCubeMapParts.h
+++ b/lib/al/Library/MapObj/RollingCubeMapParts.h
@@ -12,7 +12,7 @@ public:
 
     void init(const ActorInitInfo& info) override;
     void kill() override;
-    bool receiveMsg(const SensorMsg* message, HitSensor* source, HitSensor* target) override;
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
     void control() override;
     void appearAndSetStart();
     void setNerveNextMovement(bool isNextFallKey);

--- a/src/Amiibo/ItemAmiiboKoopa.cpp
+++ b/src/Amiibo/ItemAmiiboKoopa.cpp
@@ -49,6 +49,6 @@ void ItemAmiiboKoopa::exeWait() {
     al::setTrans(this, rs::getPlayerPos(this));
 }
 
-void ItemAmiiboKoopa::attackSensor(al::HitSensor* target, al::HitSensor* source) {
-    rs::sendMsgItemAmiiboKoopa(source, target);
+void ItemAmiiboKoopa::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    rs::sendMsgItemAmiiboKoopa(other, self);
 }

--- a/src/Amiibo/ItemAmiiboKoopa.h
+++ b/src/Amiibo/ItemAmiiboKoopa.h
@@ -11,5 +11,5 @@ public:
     void exeExpand();
     void exeWait();
 
-    void attackSensor(al::HitSensor* target, al::HitSensor* source);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other);
 };

--- a/src/Enemy/EnemyStateDamageCap.cpp
+++ b/src/Enemy/EnemyStateDamageCap.cpp
@@ -33,12 +33,12 @@ void EnemyStateDamageCap::createEnemyCap(const al::ActorInitInfo& info, const ch
     mEnemyCap = rs::tryCreateEnemyCap(mActor, info, name);
 }
 
-bool EnemyStateDamageCap::tryReceiveMsgCapBlow(const al::SensorMsg* msg, al::HitSensor* source,
-                                               al::HitSensor* target) {
+bool EnemyStateDamageCap::tryReceiveMsgCapBlow(const al::SensorMsg* msg, al::HitSensor* other,
+                                               al::HitSensor* self) {
     if (!isCapOn() || !rs::isMsgCapAttack(msg))
         return false;
-    rs::requestHitReactionToAttacker(msg, target, source);
-    mEnemyCap->startBlowDown(source);
+    rs::requestHitReactionToAttacker(msg, self, other);
+    mEnemyCap->startBlowDown(other);
     al::setNerve(this, &NrvEnemyStateDamageCap.Wait);
     return true;
 }

--- a/src/Enemy/EnemyStateHackStart.cpp
+++ b/src/Enemy/EnemyStateHackStart.cpp
@@ -39,12 +39,12 @@ EnemyStateHackStart::EnemyStateHackStart(al::LiveActor* rootActor,
     mPlayerHackStartShaderCtrl = new PlayerHackStartShaderCtrl(rootActor, shaderParam);
 }
 
-IUsePlayerHack* EnemyStateHackStart::tryStart(const al::SensorMsg* sensor, al::HitSensor* source,
-                                              al::HitSensor* target) {
-    if (!rs::isMsgStartHack(sensor))
+IUsePlayerHack* EnemyStateHackStart::tryStart(const al::SensorMsg* msg, al::HitSensor* other,
+                                              al::HitSensor* self) {
+    if (!rs::isMsgStartHack(msg))
         return nullptr;
     al::setVelocityZero(mActor);
-    mHackActor = rs::startHack(target, source, 0);
+    mHackActor = rs::startHack(self, other, 0);
     rs::startHackStartDemo(mHackActor, mActor);
     al::setNerve(this, &DiveIn);
     return mHackActor;

--- a/src/MapObj/AnagramAlphabetCharacter.h
+++ b/src/MapObj/AnagramAlphabetCharacter.h
@@ -15,8 +15,8 @@ public:
     AnagramAlphabetCharacter(const char* name);
 
     void init(const al::ActorInitInfo& info);
-    void attackSensor(al::HitSensor* source, al::HitSensor* target);
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* target, al::HitSensor* source);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other);
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
     void setComplete();
     void killCapTarget();
 

--- a/src/MapObj/ChurchDoor.cpp
+++ b/src/MapObj/ChurchDoor.cpp
@@ -53,8 +53,7 @@ void ChurchDoor::init(const al::ActorInitInfo& info) {
     makeActorAlive();
 }
 
-bool ChurchDoor::receiveMsg(const al::SensorMsg* msg, al::HitSensor* source,
-                            al::HitSensor* target) {
+bool ChurchDoor::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
     if (rs::isMsgPlayerDisregardTargetMarker(msg))
         return true;
 
@@ -63,7 +62,7 @@ bool ChurchDoor::receiveMsg(const al::SensorMsg* msg, al::HitSensor* source,
             al::isLessEqualStep(this, 10))
             return true;
 
-        rs::requestHitReactionToAttacker(msg, source, al::getSensorPos(source));
+        rs::requestHitReactionToAttacker(msg, other, al::getSensorPos(other));
 
         if (al::isNerve(this, &CloseWait1)) {
             al::startHitReaction(this, "ヒット1回目");

--- a/src/MapObj/ChurchDoor.h
+++ b/src/MapObj/ChurchDoor.h
@@ -9,8 +9,7 @@ public:
     ChurchDoor(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* source,
-                    al::HitSensor* target) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
 
     bool isOpenWait() const;
     bool isDemoEnterChurch() const;

--- a/src/MapObj/CitySignal.cpp
+++ b/src/MapObj/CitySignal.cpp
@@ -46,9 +46,9 @@ void CitySignal::calcAnim() {
         al::calcViewModel(this);
 }
 
-bool CitySignal::receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                            al::HitSensor* target) {
-    if (al::isMsgExplosion(message) && al::isSensorMapObj(target) &&
+bool CitySignal::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                            al::HitSensor* self) {
+    if (al::isMsgExplosion(message) && al::isSensorMapObj(self) &&
         (al::isNerve(this, &NrvCitySignal.WaitRed) || al::isNerve(this, &NrvCitySignal.WaitBlue))) {
         al::setNerve(this, &NrvCitySignal.WaitOff);
         return true;

--- a/src/MapObj/CitySignal.h
+++ b/src/MapObj/CitySignal.h
@@ -9,8 +9,8 @@ public:
     void init(const al::ActorInitInfo& info) override;
     void movement() override;
     void calcAnim() override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                    al::HitSensor* target) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void exeWaitRed();
     void exeWaitBlue();

--- a/src/MapObj/FireDrum2D.cpp
+++ b/src/MapObj/FireDrum2D.cpp
@@ -49,12 +49,12 @@ void FireDrum2D::exeBurn() {
         al::setNerve(this, &Wait);
 }
 
-void FireDrum2D::attackSensor(al::HitSensor* source, al::HitSensor* target) {
-    if (rs::sendMsgTouchFireDrum2D(target, source) || rs::sendMsgEnemyAttack2D(target, source))
+void FireDrum2D::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (rs::sendMsgTouchFireDrum2D(other, self) || rs::sendMsgEnemyAttack2D(other, self))
         al::setNerve(this, &Burn);
 }
 
-bool FireDrum2D::receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                            al::HitSensor* target) {
+bool FireDrum2D::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                            al::HitSensor* self) {
     return al::isMsgPlayerDisregard(message);
 }

--- a/src/MapObj/FireDrum2D.h
+++ b/src/MapObj/FireDrum2D.h
@@ -14,9 +14,9 @@ class FireDrum2D : public al::LiveActor, public IUseDimension {
 public:
     FireDrum2D(const char* name);
     void init(const al::ActorInitInfo& info) override;
-    void attackSensor(al::HitSensor* target, al::HitSensor* source) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                    al::HitSensor* target) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void exeWait();
     void exeBurn();

--- a/src/Player/Player.cpp
+++ b/src/Player/Player.cpp
@@ -145,25 +145,24 @@ void Player::control() {
 }
 
 // NON_MATCHING: issue with getting actorTrans
-void Player::attackSensor(al::HitSensor* target, al::HitSensor* source) {
-    const sead::Vector3f& actorTransRef = al::getActorTrans(source);
+void Player::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    const sead::Vector3f& actorTransRef = al::getActorTrans(other);
     const sead::Vector3f& transRef = al::getTrans(this);
     sead::Vector3f actorTrans = actorTransRef;
     sead::Vector3f trans = transRef;
 
     if ((al::isNerve(this, &NrvPlayer.Jump) || al::isNerve(this, &NrvPlayer.Fall)) &&
-        (al::isSensorEnemy(source) || al::isSensorPlayer(source)) &&
+        (al::isSensorEnemy(other) || al::isSensorPlayer(other)) &&
         (al::getVelocity(this).dot(al::getGravity(this)) > 0.0f) &&
         ((actorTrans - trans).dot(al::getGravity(this)) > 0.0f) &&
-        al::sendMsgPlayerAttackTrample(source, target, nullptr))
+        al::sendMsgPlayerAttackTrample(other, self, nullptr))
         al::setVelocityJump(this, 23.0f);
 }
 
-bool Player::receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                        al::HitSensor* target) {
+bool Player::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
     if (al::isMsgPlayerTrample(message) || al::isMsgEnemyAttack(message)) {
         if (!al::isNerve(this, &Damage)) {
-            sead::Vector3f offset = al::getTrans(this) - al::getSensorPos(source);
+            sead::Vector3f offset = al::getTrans(this) - al::getSensorPos(other);
             al::verticalizeVec(&offset, al::getGravity(this), offset);
             al::tryNormalizeOrZero(&offset);
 

--- a/src/Player/Player.h
+++ b/src/Player/Player.h
@@ -15,9 +15,9 @@ public:
     void exeDamage();
 
     void control() override;
-    void attackSensor(al::HitSensor* target, al::HitSensor* source) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* source,
-                    al::HitSensor* target) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
 private:
     const char* mArchiveName = nullptr;


### PR DESCRIPTION
According to the poll from October 14th, `self` and `other` are the "best names" for `HitSensor`s in `receiveMsg` and `attackSensor` functions that we decided upon, for clarification and consistency across the repo. In this PR, all existing usages of `HitSensor`s have been adjusted to use the new names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/196)
<!-- Reviewable:end -->
