### PR TITLE
Library/MapObj: Implement `RailMoveMapParts`

### DIFF
--- a/lib/al/Library/MapObj/RailMoveMapParts.cpp
+++ b/lib/al/Library/MapObj/RailMoveMapParts.cpp
@@ -1,0 +1,110 @@
+#include "Library/MapObj/RailMoveMapParts.h"
+
+#include "Library/Area/SwitchKeepOnAreaGroup.h"
+#include "Library/Area/SwitchOnAreaGroup.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Movement/RailMoveMovement.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveStateCtrl.h"
+#include "Library/Rail/RailUtil.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace al {
+namespace {
+NERVE_ACTION_IMPL(RailMoveMapParts, StandBy)
+NERVE_ACTION_IMPL(RailMoveMapParts, MoveSign)
+NERVE_ACTION_IMPL(RailMoveMapParts, Move)
+
+NERVE_ACTIONS_MAKE_STRUCT(RailMoveMapParts, StandBy, MoveSign, Move)
+}  // namespace
+
+RailMoveMapParts::RailMoveMapParts(const char* name) : LiveActor(name) {}
+
+void RailMoveMapParts::init(const ActorInitInfo& info) {
+    using RailMoveMapPartsFunctor = FunctorV0M<RailMoveMapParts*, void (RailMoveMapParts::*)()>;
+
+    initNerveAction(this, "StandBy", &NrvRailMoveMapParts.mCollector, 1);
+    initMapPartsActor(this, info, nullptr);
+    registerAreaHostMtx(this, info);
+
+    if (isExistRail(this)) {
+        f32 radius = getClippingRadius(this);
+        setSyncRailToNearestPos(this);
+        mRailCoord = getRailCoord(this);
+        setRailClippingInfo(&mRailPos, this, 100.0f, radius);
+    }
+
+    RailMoveMovement* railMoveMovement = new RailMoveMovement(this, info);
+    initNerveState(this, railMoveMovement, NrvRailMoveMapParts.Move.data(), "レール移動");
+    initMaterialCode(this, info);
+
+    if (!listenStageSwitchOnStart(this, RailMoveMapPartsFunctor(this, &RailMoveMapParts::start)))
+        start();
+
+    if (listenStageSwitchOnStop(this, RailMoveMapPartsFunctor(this, &RailMoveMapParts::stop)))
+        stop();
+
+    mSwitchKeepOnAreaGroup = tryCreateSwitchKeepOnAreaGroup(this, info);
+    mSwitchOnAreaGroup = tryCreateSwitchOnAreaGroup(this, info);
+
+    trySyncStageSwitchAppear(this);
+    tryListenStageSwitchKill(this);
+}
+
+void RailMoveMapParts::start() {
+    if (isNerve(this, NrvRailMoveMapParts.StandBy.data()))
+        startNerveAction(this, "MoveSign");
+}
+
+void RailMoveMapParts::stop() {
+    if (isNerve(this, NrvRailMoveMapParts.Move.data()))
+        startNerveAction(this, "StandBy");
+}
+
+bool RailMoveMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
+    if (isMsgShowModel(message)) {
+        showModelIfHide(this);
+
+        return true;
+    }
+
+    if (isMsgHideModel(message)) {
+        hideModelIfShow(this);
+
+        return true;
+    }
+
+    return false;
+}
+
+void RailMoveMapParts::control() {
+    if (mSwitchKeepOnAreaGroup != nullptr)
+        mSwitchKeepOnAreaGroup->update(getTrans(this));
+
+    if (mSwitchOnAreaGroup != nullptr)
+        mSwitchOnAreaGroup->update(getTrans(this));
+}
+
+void RailMoveMapParts::appearAndSetStart() {
+    setSyncRailToCoord(this, mRailCoord);
+    startNerveAction(this, "MoveSign");
+}
+
+void RailMoveMapParts::exeStandBy() {}
+
+void RailMoveMapParts::exeMoveSign() {
+    if ((isFirstStep(this) && !tryStartAction(this, "MoveSign")) || isActionEnd(this))
+        startNerveAction(this, "Move");
+}
+
+void RailMoveMapParts::exeMove() {
+    updateNerveState(this);
+}
+}  // namespace al

--- a/lib/al/Library/MapObj/RailMoveMapParts.h
+++ b/lib/al/Library/MapObj/RailMoveMapParts.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class SwitchKeepOnAreaGroup;
+class SwitchOnAreaGroup;
+
+class RailMoveMapParts : public LiveActor {
+public:
+    RailMoveMapParts(const char* name);
+
+    void init(const ActorInitInfo& info) override;
+    void start();
+    void stop();
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
+    void control() override;
+    void appearAndSetStart();
+
+    void exeStandBy();
+    void exeMoveSign();
+    void exeMove();
+
+private:
+    SwitchKeepOnAreaGroup* mSwitchKeepOnAreaGroup = nullptr;
+    SwitchOnAreaGroup* mSwitchOnAreaGroup = nullptr;
+    sead::Vector3f mRailPos = {0.0f, 0.0f, 0.0f};
+    f32 mRailCoord = 0.0f;
+};
+
+static_assert(sizeof(RailMoveMapParts) == 0x128);
+}  // namespace al

--- a/lib/al/Library/Rail/RailUtil.h
+++ b/lib/al/Library/Rail/RailUtil.h
@@ -7,12 +7,14 @@ class IUseRail;
 class LiveActor;
 
 void setSyncRailToNearestPos(LiveActor* actor);
+void setSyncRailToCoord(LiveActor* actor, f32 coord);
 void setRailPosToStart(IUseRail* railHolder);
 void moveSyncRail(LiveActor* actor, f32 speed);
 void moveSyncRailLoop(LiveActor* actor, f32 speed);
 void moveSyncRailTurn(LiveActor* actor, f32 speed);
 void calcRailUp(sead::Vector3f* out, IUseRail* railHolder);
 const sead::Vector3f& getRailDir(IUseRail* railHolder);
+f32 getRailCoord(IUseRail* railHolder);
 bool isExistRail(IUseRail* railHolder);
 void setRailClippingInfo(sead::Vector3f*, LiveActor* actor, f32, f32);
 }  // namespace al

--- a/lib/al/Library/Stage/StageSwitchKeeper.h
+++ b/lib/al/Library/Stage/StageSwitchKeeper.h
@@ -60,4 +60,5 @@ bool listenStageSwitchOnKill(IUseStageSwitch* stageSwitchHolder, const FunctorBa
 bool listenStageSwitchOnOffKill(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn,
                                 const FunctorBase& actionOnOff);
 bool listenStageSwitchOnStart(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn);
+bool listenStageSwitchOnStop(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn);
 }  // namespace al

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -10,6 +10,7 @@
 #include "Library/MapObj/KeyMoveMapParts.h"
 #include "Library/MapObj/KeyMoveMapPartsGenerator.h"
 #include "Library/MapObj/OneMeshFixMapParts.h"
+#include "Library/MapObj/RailMoveMapParts.h"
 #include "Library/MapObj/RollingCubeMapParts.h"
 #include "Library/MapObj/SurfMapParts.h"
 #include "Library/Obj/AllDeadWatcher.h"
@@ -567,7 +568,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"Pukupuku", nullptr},
     {"PulseSwitch", nullptr},
     {"RailCollision", nullptr},
-    {"RailMoveMapParts", nullptr},
+    {"RailMoveMapParts", al::createActorFunction<al::RailMoveMapParts>},
     {"RiseMapParts", nullptr},
     {"ReactionMapParts", nullptr},
     {"RiseMapPartsHolder", nullptr},


### PR DESCRIPTION
This PR adds `RailMoveMapParts` functions.

According to the function map, it seems that `KeyMoveMapParts` and `ChildStep`'s nerves need to be defined in `al`.
I will make another PR to correct my mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/209)
<!-- Reviewable:end -->
