### PR TITLE
dev: Update workflows for Ubuntu 24.04

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   compile_verify:
     if: github.repository == 'MonsterDruide1/OdysseyDecomp'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out project
       uses: actions/checkout@v4
@@ -32,7 +32,8 @@ jobs:
         fi
     - name: Set up dependencies
       run: |
-        sudo apt update && sudo apt install -y python3-pip ninja-build cmake ccache xdelta3 clang libssl-dev python-is-python3 curl libncurses5
+        sudo apt update && sudo apt install -y python3-pip ninja-build cmake ccache xdelta3 clang libssl-dev python-is-python3 curl
+        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -7,14 +7,16 @@ on:
 jobs:
   publish_progress:
     if: github.repository == 'MonsterDruide1/OdysseyDecomp'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out project
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up dependencies
-      run: sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl libncurses5
+      run: |
+        sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl
+        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -3,14 +3,16 @@ on: [push, pull_request]
 
 jobs:
   test_compile:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Check out project
       uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Set up dependencies
-      run: sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl libncurses5
+      run: |
+        sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl
+        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
https://github.com/actions/runner-images/issues/10636
> Rollout will begin on December 5th and will complete on January 17th, 2025.

`ubuntu-latest` as runner image will be upgraded from `22.04` to `24.04` gradually within this period, and it seems like the repo by @Fuzzy2319 has been affected first, causing build failures due to the removal of `libncurses5` from `apt`.

The simplest fix is to globally pin our `runs-on` version of all sensitive workflows to `24.04` to enforce that version for all forks, and download `libtinfo5` (as part of `libncurses5`) manually as `deb` from the ubuntu archive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/211)
<!-- Reviewable:end -->
