### PR TITLE
Library/Camera: Implement `CameraShaker`

### DIFF
--- a/lib/al/Library/Camera/CameraShaker.cpp
+++ b/lib/al/Library/Camera/CameraShaker.cpp
@@ -1,0 +1,153 @@
+#include "Library/Camera/CameraShaker.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+using namespace al;
+
+NERVE_IMPL(CameraShaker, Shake);
+NERVE_IMPL(CameraShaker, Wait);
+NERVE_IMPL(CameraShaker, ShakeLoop);
+
+NERVES_MAKE_NOSTRUCT(CameraShaker, Shake);
+NERVES_MAKE_STRUCT(CameraShaker, Wait, ShakeLoop);
+}  // namespace
+
+namespace al {
+
+const CameraShaker::ShakeInfo WeakShakeLoop = {"弱", -1, 7.5f, 0.0007f,
+                                               CameraShaker::ShakeDirection::Both};
+
+const CameraShaker::ShakeInfo ShakeInfos[11] = {
+    {"微弱", 15, 2.5f, 0.0015f, CameraShaker::ShakeDirection::Both},
+    {"微弱[短]", 10, 2.0f, 0.0008f, CameraShaker::ShakeDirection::Both},
+    {"弱", 25, 2.5f, 0.0025f, CameraShaker::ShakeDirection::Both},
+    {"中", 25, 2.5f, 0.004f, CameraShaker::ShakeDirection::Both},
+    {"強", 30, 3.0f, 0.008f, CameraShaker::ShakeDirection::Both},
+    {"最強", 45, 3.5f, 0.015f, CameraShaker::ShakeDirection::Both},
+    {"超最強", 45, 3.5f, 0.05f, CameraShaker::ShakeDirection::Both},
+    {"長い微弱", 60, 6.0f, 0.0025f, CameraShaker::ShakeDirection::Both},
+    {"長い弱", 60, 6.0f, 0.004f, CameraShaker::ShakeDirection::Both},
+    {"船内振動", 100, 6.0f, 0.0005f, CameraShaker::ShakeDirection::Both},
+    {"弱[縦]", 25, 2.5f, 0.004f, CameraShaker::ShakeDirection::Vertical},
+};
+
+CameraShaker::CameraShaker() : NerveExecutor("カメラ振動") {
+    initNerve(&NrvCameraShaker.Wait, 0);
+    mEditedShake = {"NULL", 0, 0.0f, 0.0f, ShakeDirection::Both};
+}
+
+void CameraShaker::update(const char* shakeLoop) {
+    if (shakeLoop) {
+        mShakeLoop = isEqualString(shakeLoop, "弱") ? &WeakShakeLoop : nullptr;
+        if (isNerve(this, &NrvCameraShaker.Wait))
+            setNerve(this, &NrvCameraShaker.ShakeLoop);
+    } else {
+        mShakeLoop = nullptr;
+        if (isNerve(this, &NrvCameraShaker.ShakeLoop))
+            setNerve(this, &NrvCameraShaker.Wait);
+    }
+
+    updateNerve();
+}
+
+void CameraShaker::startShakeByAction(const char* name, const char* unused1, const char* unused2,
+                                      s32 steps) {
+    startShakeByName(name, steps);
+}
+
+void CameraShaker::startShakeByName(const char* name, s32 steps) {
+    s32 index = -1;
+    if (isEqualString(name, "微弱"))
+        index = 0;
+    else if (isEqualString(name, "微弱[短]"))
+        index = 1;
+    else if (isEqualString(name, "弱"))
+        index = 2;
+    else if (isEqualString(name, "中"))
+        index = 3;
+    else if (isEqualString(name, "強"))
+        index = 4;
+    else if (isEqualString(name, "最強"))
+        index = 5;
+    else if (isEqualString(name, "超最強"))
+        index = 6;
+    else if (isEqualString(name, "長い微弱"))
+        index = 7;
+    else if (isEqualString(name, "長い弱"))
+        index = 8;
+    else if (isEqualString(name, "船内振動"))
+        index = 9;
+    else if (isEqualString(name, "弱[縦]"))
+        index = 10;
+
+    startShakeByIndex(index, steps);
+}
+
+void CameraShaker::startShakeByHitReaction(const char* name, const char* unused1,
+                                           const char* unused2, s32 steps) {
+    startShakeByName(name, steps);
+}
+
+void CameraShaker::exeWait() {
+    if (isFirstStep(this)) {
+        mActiveShake = nullptr;
+        mShakeLoop = nullptr;
+    }
+    mOffset = {0.0f, 0.0f};
+}
+
+void CameraShaker::exeShake() {
+    if (isGreaterEqualStep(this, mActiveShake->mSteps)) {
+        if (mShakeLoop) {
+            setNerve(this, &NrvCameraShaker.ShakeLoop);
+        } else {
+            mOffset = {0.0f, 0.0f};
+            mActiveShake = nullptr;
+            setNerve(this, &NrvCameraShaker.Wait);
+        }
+        return;
+    }
+
+    f32 shakeSpeed = (mActiveShake->mSpeed * 360.0f) / mActiveShake->mSteps;
+    f32 currentShakeStrength =
+        sead::Mathf::cos(sead::Mathf::deg2rad(shakeSpeed * getNerveStep(this)));
+    f32 shakeOffset =
+        currentShakeStrength * (mActiveShake->mStrength *
+                                (mActiveShake->mSteps - getNerveStep(this)) / mActiveShake->mSteps);
+    mOffset = {shakeOffset, shakeOffset};
+    if (mActiveShake->mDirection == ShakeDirection::Vertical)
+        mOffset.x = 0.0f;
+}
+
+void CameraShaker::exeShakeLoop() {
+    s32 nerveStep = getNerveStep(this);
+    f32 shakeStep = nerveStep <= 0 ? 0.0f : nerveStep / mShakeLoop->mSpeed * sead::Mathf::pi2();
+    f32 shakeOffset = mShakeLoop->mStrength * sead::Mathf::cos(shakeStep);
+    mOffset = {shakeOffset, shakeOffset};
+    if (mShakeLoop->mDirection == ShakeDirection::Vertical)
+        mOffset.x = 0.0f;
+}
+
+void CameraShaker::startShakeByIndex(s32 index, s32 steps) {
+    const ShakeInfo& shake = ShakeInfos[index];
+    if (mActiveShake && (*mActiveShake > shake))
+        return;
+
+    mActiveShake = &shake;
+
+    if (steps >= 1) {
+        // requires doing this copy to match
+        // https://decomp.me/scratch/asjPP
+        ShakeInfo shake2 = shake;
+        mEditedShake = {shake.mName, steps, shake.mSpeed, shake.mStrength, shake.mDirection};
+        mActiveShake = &mEditedShake;
+        mEditedShake.mSpeed = ((f32)steps / (f32)shake2.mSteps) * shake.mSpeed;
+    }
+
+    setNerve(this, &Shake);
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraShaker.h
+++ b/lib/al/Library/Camera/CameraShaker.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+
+class CameraShaker : public NerveExecutor {
+public:
+    enum class ShakeDirection : s32 { Both, Vertical };
+
+    struct ShakeInfo {
+        const char* mName = nullptr;
+        s32 mSteps = 0;
+        f32 mSpeed = 0.0f;
+        f32 mStrength = 0.0f;
+        ShakeDirection mDirection = ShakeDirection::Both;
+
+        bool operator>(const ShakeInfo& other) const {
+            if (mStrength < other.mStrength)
+                return false;
+            if (other.mStrength < mStrength)
+                return true;
+
+            if (other.mSteps > 0 && mSteps < 0)
+                return false;
+            if (other.mSteps < 0 && mSteps > 0)
+                return true;
+
+            if (mSteps < other.mSteps)
+                return false;
+            if (other.mSteps < mSteps)
+                return true;
+
+            s32 otherDirection = (s32)other.mDirection;
+            s32 direction = (s32)mDirection;
+            if (otherDirection < direction)
+                return false;
+            if (direction < otherDirection)
+                return true;
+
+            if (mSpeed < other.mSpeed)
+                return true;
+            return false;
+        }
+    };
+
+    CameraShaker();
+
+    void update(const char* shakeLoop);
+    void startShakeByAction(const char* name, const char* unused1, const char* unused2, s32 steps);
+    void startShakeByName(const char* name, s32 steps);
+    void startShakeByHitReaction(const char* name, const char* unused1, const char* unused2,
+                                 s32 steps);
+
+    void exeWait();
+    void exeShake();
+    void exeShakeLoop();
+
+    void startShakeByIndex(s32 index, s32 steps);
+
+private:
+    sead::Vector2f mOffset = {0.0f, 0.0f};
+    const ShakeInfo* mActiveShake = nullptr;
+    const ShakeInfo* mShakeLoop = nullptr;
+    ShakeInfo mEditedShake = {};
+};
+
+static_assert(sizeof(CameraShaker) == 0x40);
+
+}  // namespace al


### PR DESCRIPTION
Another camera-related class.

Within `CameraShaker::startShakeByIndex`, I feel like it's not quite intended to create a copy of `ShakeInfo shake2 = shake;`, but I found that the best way to get it matching. Feel free to test around/try other things as well:
https://decomp.me/scratch/asjPP

Either way, interesting fact from the code: If the currently running CameraShake is considered "greater than" the one that should be started now, the new one will be ignored. For the comparison, the following criteria are considered, in-order:
- `mStrength`
- a shake with no determined "runtime" (steps/frames/seconds) is considered "less than" one with defined length, probably to rank one-off shakes more important than constant background shakes
- `mSteps`
- `mDirection`: Shaking in both directions is "greater than" only vertical
- `mSpeed`

If one still hasn't "won" the comparison by this point, both shakes are identical, except their `mName` - which is not used/shown in-game either way.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/219)
<!-- Reviewable:end -->
