### PR TITLE
dev: Update `nixpkgs` to `nixos-unstable`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,7 +13,7 @@ RUN apt install -y git
 # install dependencies for building and running the project
 RUN apt install -y ccache clang cmake curl less libncurses6 libssl-dev ninja-build pip pkg-config python3-full xdelta3
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN pip install --break-system-packages ansiwrap capstone colorama cxxfilt pyelftools python-Levenshtein toml watchdog
+RUN pip install --break-system-packages capstone colorama cxxfilt pyelftools python-Levenshtein toml watchdog
 
 # install dependencies for code environment
 RUN apt install -y clangd clang-format clang-tidy

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -40,7 +40,7 @@ jobs:
         python-version: '3.9'
         cache: 'pip'
     - name: Set up python package dependencies
-      run: pip install capstone colorama cxxfilt pyelftools ansiwrap watchdog python-Levenshtein toml
+      run: pip install capstone colorama cxxfilt pyelftools watchdog python-Levenshtein toml
     - name: Set up rust toolchain
       uses: actions-rust-lang/setup-rust-toolchain@v1.10.1
       with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,6 +22,6 @@ jobs:
         python-version: '3.9'
         cache: 'pip'
     - name: Set up python package dependencies
-      run: pip install capstone colorama cxxfilt pyelftools ansiwrap watchdog python-Levenshtein toml
+      run: pip install capstone colorama cxxfilt pyelftools watchdog python-Levenshtein toml
     - name: Run custom code styling checks
       run: tools/check-format.py

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ example [ncurses5-compat-libs](https://aur.archlinux.org/packages/ncurses5-compa
 Additionally, you'll also need:
 
 * A Rust toolchain ([follow the instructions here](https://www.rust-lang.org/tools/install))
-* The following Python modules: `capstone colorama cxxfilt pyelftools ansiwrap watchdog python-Levenshtein toml` (
+* The following Python modules: `capstone colorama cxxfilt pyelftools watchdog python-Levenshtein toml` (
   install them with `pip install ...`)
 
 ## 2. Set up the project

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1722555600,
-        "narHash": "sha256-XOQkdLafnb/p9ij77byFQjDf5m5QYl9b2REiVClC+x4=",
+        "lastModified": 1736143030,
+        "narHash": "sha256-+hu54pAoLDEZT9pjHlqL9DNzWz0NbUn8NEAHP7PQPzU=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "8471fe90ad337a8074e957b69ca4d0089218391d",
+        "rev": "b905f6fc23a9051a6e1b741e1438dbfc0634c6de",
         "type": "github"
       },
       "original": {
@@ -20,39 +20,39 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1722869614,
-        "narHash": "sha256-7ojM1KSk3mzutD7SkrdSflHXEujPvW1u7QuqWoTLXQU=",
+        "lastModified": 1736320768,
+        "narHash": "sha256-nIYdTAiKIGnFNugbomgBJR+Xv5F1ZQU+HfaBqJKroC0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "883180e6550c1723395a3a342f830bfc5c371f6b",
+        "rev": "4bc9c909d9ac828a039f288cf872d16d38185db8",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-24.05",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1722555339,
-        "narHash": "sha256-uFf2QeW7eAHlYXuDktm9c25OxOyCoUOQmh5SZ9amE5Q=",
+        "lastModified": 1735774519,
+        "narHash": "sha256-CewEm1o2eVAnoqb6Ml+Qi9Gg/EfNAxbRx1lANGVyoLI=",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/a5d394176e64ab29c852d03346c1fc9b0b7d33eb.tar.gz"
+        "url": "https://github.com/NixOS/nixpkgs/archive/e9b51731911566bbf7e4895475a87fe06961de0b.tar.gz"
       }
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1718428119,
-        "narHash": "sha256-WdWDpNaq6u1IPtxtYHHWpl5BmabtpmLnMAx0RdJ/vo8=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e6cea36f83499eb4e9cd184c8a8e823296b50ad5",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {
@@ -75,11 +75,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1722910815,
-        "narHash": "sha256-v6Vk/xlABhw2QzOa6xh3Jx/IvmlbKbOazFM+bDFQlWU=",
+        "lastModified": 1736476219,
+        "narHash": "sha256-+qyv3QqdZCdZ3cSO/cbpEY6tntyYjfe1bB12mdpNFaY=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "7df2ac544c203d21b63aac23bfaec7f9b919a733",
+        "rev": "de30cc5963da22e9742bbbbb9a3344570ed237b9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-parts.url = "github:hercules-ci/flake-parts";
     systems.url = "github:nix-systems/default";
     rust-overlay.url = "github:oxalica/rust-overlay";
@@ -32,7 +32,6 @@
             python-pkgs.colorama
             python-pkgs.cxxfilt
             python-pkgs.pyelftools
-            python-pkgs.ansiwrap
             python-pkgs.watchdog
             python-pkgs.python-Levenshtein
             python-pkgs.toml


### PR DESCRIPTION
Updating some of the underlying packages for all NixOS users. In the process, also disable `ansiwrap` from the python packages, because it is now marked as `broken` (after 7 years not being maintained) - it's still listed in the [`pyproject.toml` of asm-differ](https://github.com/simonlindholm/asm-differ/blob/89e9c7044039ed18117ea45b6e1f551da49172cc/pyproject.toml#L13), but I'll ask if that's even still required - or if this package has been long unused and can just be removed from here as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/237)
<!-- Reviewable:end -->
