### PR TITLE
MapObj: Implement a local function in `WorldMapParts`

### DIFF
--- a/src/MapObj/WorldMapParts.cpp
+++ b/src/MapObj/WorldMapParts.cpp
@@ -10,7 +10,7 @@
 void processSubActors(al::LiveActor* actor) {
     al::invalidateOcclusionQuery(actor);
     if (al::isExistSubActorKeeper(actor))
-        for (int i = 0; i < al::getSubActorNum(actor); i++)
+        for (s32 i = 0; i < al::getSubActorNum(actor); i++)
             processSubActors(al::getSubActor(actor, i));
 }
 

--- a/src/MapObj/WorldMapParts.cpp
+++ b/src/MapObj/WorldMapParts.cpp
@@ -7,11 +7,11 @@
 #include "Library/Math/MathLengthUtil.h"
 #include "Library/Math/MathUtil.h"
 
-void processSubActors(al::LiveActor* actor) {
+void recursivelyInvalidateOcclusionQuery(al::LiveActor* actor) {
     al::invalidateOcclusionQuery(actor);
     if (al::isExistSubActorKeeper(actor))
         for (s32 i = 0; i < al::getSubActorNum(actor); i++)
-            processSubActors(al::getSubActor(actor, i));
+            recursivelyInvalidateOcclusionQuery(al::getSubActor(actor, i));
 }
 
 WorldMapParts::WorldMapParts(const char* name) : al::LiveActor(name) {}
@@ -51,7 +51,7 @@ void WorldMapParts::initParts(WorldMapParts* mapParts, const char* arcName,
     mapParts->updatePose();
 
     if (al::isExistModel(mapParts))
-        processSubActors(mapParts);
+        recursivelyInvalidateOcclusionQuery(mapParts);
 
     mapParts->makeActorDead();
 }

--- a/src/MapObj/WorldMapParts.cpp
+++ b/src/MapObj/WorldMapParts.cpp
@@ -3,14 +3,15 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/SubActorKeeper.h"
 #include "Library/Math/MathLengthUtil.h"
 #include "Library/Math/MathUtil.h"
 
-void localFunc_34B9A8(WorldMapParts* mapParts) {
-    al::invalidateOcclusionQuery(mapParts);
-    //    if(al::isExistSubActorKeeper(mapParts) && al::getSubActorNum(mapParts) >= 1) {
-    //
-    //    }
+void processSubActors(al::LiveActor* actor) {
+    al::invalidateOcclusionQuery(actor);
+    if (al::isExistSubActorKeeper(actor))
+        for (int i = 0; i < al::getSubActorNum(actor); i++)
+            processSubActors(al::getSubActor(actor, i));
 }
 
 WorldMapParts::WorldMapParts(const char* name) : al::LiveActor(name) {}
@@ -50,7 +51,7 @@ void WorldMapParts::initParts(WorldMapParts* mapParts, const char* arcName,
     mapParts->updatePose();
 
     if (al::isExistModel(mapParts))
-        localFunc_34B9A8(mapParts);
+        processSubActors(mapParts);
 
     mapParts->makeActorDead();
 }


### PR DESCRIPTION
Implements a local function I named `processSubActors` in `WorldMapParts`, which loops through an actor's sub actors and runs `al::invalidateOcclusionQuery` on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/244)
<!-- Reviewable:end -->
