### PR TITLE
MapObj: Implement `MoonBasementSlideObj`

### DIFF
--- a/src/MapObj/MoonBasementSlideObj.cpp
+++ b/src/MapObj/MoonBasementSlideObj.cpp
@@ -1,0 +1,94 @@
+#include "MapObj/MoonBasementSlideObj.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/Math/MathAngleUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/Sensor.h"
+
+namespace {
+NERVE_IMPL(MoonBasementSlideObj, Wait)
+NERVE_IMPL(MoonBasementSlideObj, Slide)
+
+NERVES_MAKE_NOSTRUCT(MoonBasementSlideObj, Wait, Slide)
+}  // namespace
+
+MoonBasementSlideObj::MoonBasementSlideObj(const char* name) : al::LiveActor(name) {}
+
+void MoonBasementSlideObj::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+}
+
+bool MoonBasementSlideObj::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                      al::HitSensor* self) {
+    if (!rs::isMsgKoopaHackPunchCollide(message))
+        return false;
+
+    field_108++;
+
+    sead::Vector3f sideDir = sead::Vector3f(0, 0, 0);
+    sead::Vector3f frontDir = sead::Vector3f(0, 0, 0);
+
+    al::calcSideDir(&sideDir, this);
+    al::calcFrontDir(&frontDir, this);
+
+    sead::Vector3f dir = sead::Vector3f(0, 0, 0);
+
+    al::calcDirBetweenSensorsH(&dir, other, self);
+
+    sead::Vector3f alignedSideDir = sead::Vector3f(0, 0, 0);
+    sead::Vector3f alignedFrontDir = sead::Vector3f(0, 0, 0);
+
+    al::parallelizeVec(&alignedSideDir, sideDir, dir);
+    al::parallelizeVec(&alignedFrontDir, frontDir, dir);
+
+    sead::Vector3f* temp = &alignedSideDir;
+    if (alignedSideDir.length() < alignedFrontDir.length())
+        temp = &alignedFrontDir;
+
+    dir.set(*temp);
+
+    al::tryNormalizeOrZero(&dir);
+
+    al::addVelocity(this, dir * 45.0f);
+    al::startHitReaction(this, "命中");
+    al::setNerve(this, &Slide);
+
+    return true;
+}
+
+void MoonBasementSlideObj::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+
+    al::addVelocityToGravity(this, 2.0f);
+    al::scaleVelocityHV(this, 0.95f, 0.99f);
+    al::limitVelocityDir(this, al::getGravity(this), 5.0f);
+}
+
+void MoonBasementSlideObj::exeSlide() {
+    al::addVelocityToGravity(this, 2.0f);
+    al::scaleVelocityHV(this, 0.95f, 0.99f);
+
+    if (al::isOnGround(this, 0))
+        al::limitVelocityDir(this, al::getGravity(this), 5.0f);
+
+    if (al::isVelocitySlowH(this, 0.2f)) {
+        sead::Vector3f* velocityPtr = al::getVelocityPtr(this);
+        al::parallelizeVec(velocityPtr, al::getGravity(this), *velocityPtr);
+
+        al::startHitReaction(this, "停止");
+        al::setNerve(this, &Wait);
+    } else if (al::isInDeathArea(this))
+        kill();
+}

--- a/src/MapObj/MoonBasementSlideObj.h
+++ b/src/MapObj/MoonBasementSlideObj.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class MoonBasementSlideObj : public al::LiveActor {
+public:
+    MoonBasementSlideObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeSlide();
+
+private:
+    s32 field_108 = 0;
+};

--- a/src/Util/Sensor.h
+++ b/src/Util/Sensor.h
@@ -31,6 +31,7 @@ bool isMsgHackMarioDead(const al::SensorMsg*);
 bool isMsgHackMarioDemo(const al::SensorMsg*);
 bool isMsgHackMarioInWater(const al::SensorMsg*);
 bool isMsgHackMarioCheckpointFlagWarp(const al::SensorMsg*);
+bool isMsgKoopaHackPunchCollide(const al::SensorMsg*);
 
 bool isMsgCapAttack(const al::SensorMsg*);
 bool isMsgStartHack(const al::SensorMsg*);


### PR DESCRIPTION
A deceptively simple class used in Moon Kingdom

I'm not sure if you'd prefer `MoonBasementSlideObj::receiveMsg` to be flipped around, where the entire function's contents would be indented by an extra tab.