### PR TITLE
Library/Camera: Implement `CameraResourceHolder`

### DIFF
--- a/lib/al/Library/Camera/CameraResourceHolder.cpp
+++ b/lib/al/Library/Camera/CameraResourceHolder.cpp
@@ -1,0 +1,134 @@
+#include "Library/Camera/CameraResourceHolder.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Camera/CameraTicketId.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Resource/Resource.h"
+#include "Library/Yaml/ByamlIter.h"
+
+namespace al {
+
+CameraResourceHolder::CameraResourceHolder(const char* stageName, s32 maxResources)
+    : mStageName(stageName), mMaxEntries(maxResources) {
+    mEntries = new Entry*[maxResources];
+    for (s32 i = 0; i < mMaxEntries; i++)
+        mEntries[i] = nullptr;
+}
+
+// too large to inline with heuristic, but needs to be explicit function (or inline lambda) for
+// stack ordering to match original assembly
+__attribute__((always_inline)) void getStageName(StringTmp<128>& stageName,
+                                                 const char* archiveName) {
+    sead::FixedSafeString<256> safeArchiveName;
+    safeArchiveName.format("%s", archiveName);
+    if (safeArchiveName.endsWith("Map"))
+        stageName.copy(safeArchiveName, safeArchiveName.calcLength() - 3);
+}
+
+bool CameraResourceHolder::tryInitCameraResource(const Resource* resource, s32 unused) {
+    StringTmp<128> stageName = "";
+    getStageName(stageName, resource->getArchiveName());
+
+    for (s32 i = 0; i < mNumEntries; i++)
+        if (isEqualString(stageName.cstr(), mEntries[i]->mStageName))
+            return false;
+
+    Entry* entry = new Entry;
+
+    if (resource->isExistFile(StringTmp<64>{"%s.byml", "CameraParam"}))
+        entry->mCameraParam = new ByamlIter(resource->getByml("CameraParam"));
+
+    if (resource->isExistFile(StringTmp<64>{"%s.byml", "InterpoleParam"}))
+        entry->mInterpoleParam = new ByamlIter(resource->getByml("InterpoleParam"));
+
+    entry->mStageName = stageName;
+
+    mEntries[mNumEntries] = entry;
+    mNumEntries++;
+    return true;
+}
+
+bool CameraResourceHolder::tryFindParamResource(ByamlIter* ticket, const CameraTicketId* ticketId,
+                                                s32 paramType) const {
+    ByamlIter paramList;
+    const PlacementId* placementId = ticketId->getPlacementId();
+    const char* paramName;
+    if (paramType == 2)
+        paramName = "StartTickets";
+    else if (paramType == 0)
+        paramName = "DefaultTickets";
+    else
+        paramName = "Tickets";
+
+    if (!tryFindCameraParamList(&paramList, placementId, paramName))
+        return false;
+
+    for (s32 i = 0; i < paramList.getSize(); i++) {
+        if (paramList.tryGetIterByIndex(ticket, i)) {
+            ByamlIter id;
+            ticket->tryGetIterByKey(&id, "Id");
+            if (ticketId->isEqual(id))
+                return true;
+        }
+    }
+    return false;
+}
+
+bool CameraResourceHolder::tryFindCameraParamList(ByamlIter* paramList,
+                                                  const PlacementId* placementId,
+                                                  const char* paramName) const {
+    if (placementId && placementId->getUnitConfigName())
+        return tryFindCameraParamList(paramList, placementId->getUnitConfigName(), paramName);
+    else
+        return tryFindCameraParamList(paramList, mStageName, paramName);
+}
+
+s32 CameraResourceHolder::calcEntranceCameraParamNum() const {
+    ByamlIter startTickets;
+    if (!tryFindCameraParamList(&startTickets, mStageName, "StartTickets"))
+        return 0;
+    return startTickets.getSize();
+}
+
+bool CameraResourceHolder::tryFindCameraParamList(ByamlIter* paramList, const char* stageName,
+                                                  const char* paramName) const {
+    CameraResourceHolder::Entry* entry = findCameraResource(stageName);
+    if (!entry || !entry->mCameraParam)
+        return false;
+    return entry->mCameraParam->tryGetIterByKey(paramList, paramName);
+}
+
+void CameraResourceHolder::getEntranceCameraParamResource(ByamlIter* ticket, s32 index) const {
+    ByamlIter startTickets;
+    tryFindCameraParamList(&startTickets, mStageName, "StartTickets");
+    startTickets.tryGetIterByIndex(ticket, index);
+}
+
+CameraResourceHolder::Entry* CameraResourceHolder::findCameraResource(const char* stageName) const {
+    for (s32 i = 0; i < mNumEntries; i++)
+        if (isEqualString(stageName, mEntries[i]->mStageName))
+            return mEntries[i];
+
+    return nullptr;
+}
+
+CameraResourceHolder::Entry*
+CameraResourceHolder::tryFindCameraResource(const char* stageName) const {
+    return findCameraResource(stageName);
+}
+
+CameraResourceHolder::Entry*
+CameraResourceHolder::tryFindCameraResource(const PlacementId* placementId) const {
+    if (placementId) {
+        const char* name = placementId->getUnitConfigName();
+        if (!name)
+            name = mStageName;
+        return findCameraResource(name);
+    } else {
+        return findCameraResource(mStageName);
+    }
+}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraResourceHolder.h
+++ b/lib/al/Library/Camera/CameraResourceHolder.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+
+namespace al {
+class Resource;
+class ByamlIter;
+class CameraTicketId;
+class PlacementId;
+
+class CameraResourceHolder {
+public:
+    struct Entry {
+        ByamlIter* mCameraParam = nullptr;
+        ByamlIter* mInterpoleParam = nullptr;
+        sead::FixedSafeString<128> mStageName = {""};
+    };
+
+    enum ParamType : s32 {
+        DefaultTickets = 0,
+        StartTickets = 2,
+        Tickets  // any other value
+    };
+
+    CameraResourceHolder(const char* stageName, s32 maxResources);
+
+    bool tryInitCameraResource(const Resource* resource, s32 unused);
+    bool tryFindParamResource(ByamlIter* ticket, const CameraTicketId* ticketId,
+                              s32 paramType) const;
+    bool tryFindCameraParamList(ByamlIter* paramList, const PlacementId* placementId,
+                                const char* paramName) const;
+    s32 calcEntranceCameraParamNum() const;
+    bool tryFindCameraParamList(ByamlIter* paramList, const char* stageName,
+                                const char* paramName) const;
+    void getEntranceCameraParamResource(ByamlIter* ticket, s32 index) const;
+    Entry* findCameraResource(const char* stageName) const;
+    Entry* tryFindCameraResource(const char* stageName) const;
+    Entry* tryFindCameraResource(const PlacementId* placementId) const;
+
+private:
+    const char* mStageName;
+    s32 mMaxEntries;
+    s32 mNumEntries = 0;
+    Entry** mEntries;
+};
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraTicketId.h
+++ b/lib/al/Library/Camera/CameraTicketId.h
@@ -15,6 +15,8 @@ public:
     const char* tryGetObjId() const;
     const char* getObjId() const;
 
+    const PlacementId* getPlacementId() const { return mPlacementId; }
+
     const char* getSuffix() const { return mSuffix; }
 
 private:

--- a/lib/al/Library/Placement/PlacementId.h
+++ b/lib/al/Library/Placement/PlacementId.h
@@ -19,6 +19,8 @@ public:
 
     const char* getId() const { return mId; }
 
+    const char* getUnitConfigName() const { return mUnitConfigName; }
+
 private:
     const char* mId;
     const char* mUnitConfigName;


### PR DESCRIPTION
"Hey! Let's implement a simple class before sleeping." - I thought. Which was a mistake.

This class is responsible for caching `CameraParam.byml`s and `InterpoleParam.byml`s, although only the former is exposed. As `[try]FindCameraResource`, the functions with more detailed return type, are not used outside of this class itself, it seems like `InterpoleParam.byml` is not fetched from this class again.

Most of this file was straight-forward to implement, with the exception of `SafeString`-magic. Here, this is capsuled into `getStageName`: `endsWith` is being inlined here, meaning that in total 4 `calcLength`s end up in this file, which was ... not easy to map to one of the existing functions again. The `paramType` attribute of `tryFindParamResource` seems a bit weird (`0`, `2`, `anything else`), but ... that's just how it behaves there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/259)
<!-- Reviewable:end -->
