### PR TITLE
dev: Pin `clang`-versions to `14`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         buildInputs = with pkgs; [
           cmake
           ninja
-          clang
+          llvmPackages_14.clang
           ccache
           pkg-config
 
@@ -37,7 +37,7 @@
             python-pkgs.toml
           ]))
           openssl
-          libclang
+          llvmPackages_14.libclang
           ncurses5
           ncurses6
         ];


### PR DESCRIPTION
As @LynxDev2 reported, `clang-format` is currently broken/inconsistent on NixOS - this is because some update changed some default option, which we currently do not want to change. Thus, the easiest option is just keeping all `clang`-versions on version `14`, which is also the max version on Ubuntu `22.04`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/262)
<!-- Reviewable:end -->
