### PR TITLE
all: Fix various mismatches

### DIFF
--- a/lib/al/Library/Camera/SnapShotCameraCtrl.cpp
+++ b/lib/al/Library/Camera/SnapShotCameraCtrl.cpp
@@ -4,15 +4,15 @@
 
 namespace al {
 
-// NON_MATCHING
 void SnapShotCameraCtrl::load(const ByamlIter& iter) {
-    ByamlIter param;
-    if (!tryGetByamlIterByKey(&param, iter, "SnapShotParam"))
+    CameraParam* param = mParam;
+    ByamlIter paramIter;
+    if (!tryGetByamlIterByKey(&paramIter, iter, "SnapShotParam"))
         return;
-    if (tryGetByamlF32(&mParam->mMinFovyDegree, param, "MinFovyDegree"))
-        mParam->mHasMin = true;
-    if (tryGetByamlF32(&mParam->mMinFovyDegree, param, "MinFovyDegree"))
-        mParam->mHasMax = true;
+    if (tryGetByamlF32(&param->mMinFovyDegree, paramIter, "MinFovyDegree"))
+        param->mHasMin = true;
+    if (tryGetByamlF32(&param->mMaxFovyDegree, paramIter, "MaxFovyDegree"))
+        param->mHasMax = true;
 }
 
 }  // namespace al

--- a/lib/al/Library/Controller/InputFunction.cpp
+++ b/lib/al/Library/Controller/InputFunction.cpp
@@ -594,29 +594,17 @@ void getPadCrossDirSideways(sead::Vector2f* vec, s32 port) {
         vec->y = 1;
 }
 
-#ifdef NON_MATCHING
 void calcTouchScreenPos(sead::Vector2f* vec) {
-    *vec = getController(getTouchPanelPort())->getPointer();  // uses w8 for storage instead and
-                                                              // inserts another write at +4 bytes
+    vec->set(getController(getTouchPanelPort())->getPointer());
 }
-#endif
 
 void calcTouchLayoutPos(sead::Vector2f*) {}
 
 bool isTouchPosInRect(const sead::Vector2f& rect_pos, const sead::Vector2f& size) {
     sead::Vector2f pos;
     calcTouchScreenPos(&pos);
-
-    if (rect_pos.x > pos.x)
-        return false;
-    if (pos.x >= (rect_pos.x + size.x))
-        return false;
-    if (rect_pos.y > pos.y)
-        return false;
-    if (pos.y > rect_pos.y + size.y)
-        return false;
-
-    return true;
+    return rect_pos.x <= pos.x && pos.x < rect_pos.x + size.x && rect_pos.y <= pos.y &&
+           pos.y < rect_pos.y + size.y;
 }
 
 void setPadRepeat(s32 a1, s32 a2, s32 a3, s32 port) {

--- a/lib/al/Library/Execute/ExecuteDirector.cpp
+++ b/lib/al/Library/Execute/ExecuteDirector.cpp
@@ -10,9 +10,15 @@
 
 namespace al {
 
-ExecuteDirector::ExecuteDirector(s32 count) : mUpdateTableCount(count){};
+ExecuteDirector::ExecuteDirector(s32 count) : mRequestCount(count){};
 
-ExecuteDirector::~ExecuteDirector() = default;
+ExecuteDirector::~ExecuteDirector() {
+    for (s32 i = 0; i < mDrawTableCount; i++)
+        delete mDrawTables[i];
+
+    for (s32 i = 0; i < mUpdateTableCount; i++)
+        delete mUpdateTables[i];
+}
 
 void ExecuteDirector::init(const ExecuteSystemInitInfo& initInfo) {
     mUpdateTableCount = UpdateTableSize;

--- a/lib/al/Library/Execute/ExecuteDirector.h
+++ b/lib/al/Library/Execute/ExecuteDirector.h
@@ -2,6 +2,8 @@
 
 #include <basis/seadTypes.h>
 
+#include "Library/HostIO/HioNode.h"
+
 namespace al {
 class ExecuteRequestKeeper;
 class ExecuteTableHolderDraw;
@@ -12,7 +14,7 @@ class IUseExecutor;
 class LayoutActor;
 class LiveActor;
 
-class ExecuteDirector {
+class ExecuteDirector : public HioNode {
 public:
     ExecuteDirector(s32 count);
     virtual ~ExecuteDirector();
@@ -33,7 +35,7 @@ public:
     bool isActiveDraw(const char* tableName) const;
 
 private:
-    s32 mRequestCount = 0;
+    s32 mRequestCount;
     s32 mUpdateTableCount = 0;
     ExecuteTableHolderUpdate** mUpdateTables = nullptr;
     s32 mDrawTableCount = 0;

--- a/lib/al/Library/LiveActor/ActorAnimFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorAnimFunction.cpp
@@ -5,6 +5,7 @@
 
 #include "Library/Anim/SklAnimRetargettingInfo.h"
 #include "Library/Base/StringUtil.h"
+#include "Library/Execute/ExecuteTableHolderUpdate.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
 #include "Library/LiveActor/LiveActor.h"
 #include "Project/Anim/AnimPlayerVisual.h"
@@ -558,6 +559,7 @@ bool isMatAnimPlaying(const LiveActor* actor, const char* animName) {
 
 void clearMatAnim(LiveActor* actor) {
     getMat(actor)->clearAnim();
+    updateModelDraw(actor);
 }
 
 bool isMatAnimExist(const LiveActor* actor) {
@@ -639,6 +641,7 @@ bool isVisAnimPlaying(const LiveActor* actor, const char* animName) {
 
 void clearVisAnim(LiveActor* actor) {
     getVis(actor)->clearAnim();
+    alActorSystemFunction::updateExecutorDraw(actor);
 }
 
 bool isVisAnimExist(const LiveActor* actor) {
@@ -731,6 +734,7 @@ bool isVisAnimPlayingForAction(const LiveActor* actor, const char* animName) {
 
 void clearVisAnimForAction(LiveActor* actor) {
     getVisForAction(actor)->clearAnim();
+    alActorSystemFunction::updateExecutorDraw(actor);
 }
 
 bool isVisAnimEndForAction(const LiveActor* actor) {

--- a/lib/al/Library/LiveActor/ActorFlagFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorFlagFunction.cpp
@@ -1,7 +1,10 @@
 #include "Library/LiveActor/ActorFlagFunction.h"
 
+#include "Library/Collision/Collider.h"
 #include "Library/LiveActor/LiveActor.h"
 #include "Library/LiveActor/LiveActorFlag.h"
+#include "Library/Shadow/ShadowKeeper.h"
+#include "Library/Shadow/ShadowMaskCtrl.h"
 
 namespace al {
 bool isAlive(const LiveActor* actor) {
@@ -17,19 +20,30 @@ bool isNoCollide(const LiveActor* actor) {
 }
 
 void onCalcAnim(LiveActor* actor) {
-    actor->getFlags()->isCalcAnim = true;
+    actor->getFlags()->isDisableCalcAnim = false;
 }
 
 void offCalcAnim(LiveActor* actor) {
-    actor->getFlags()->isCalcAnim = false;
+    actor->getFlags()->isDisableCalcAnim = true;
 }
 
-void validateShadow(LiveActor* actor) {}
+void validateShadow(LiveActor* actor) {
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    if (shadowMaskCtrl)
+        shadowMaskCtrl->validate();
+}
 
-void invalidateShadow(LiveActor* actor) {}
+void invalidateShadow(LiveActor* actor) {
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    if (shadowMaskCtrl)
+        shadowMaskCtrl->invalidate();
+}
 
 void onCollide(LiveActor* actor) {
     actor->getFlags()->isCollideOff = false;
+    Collider* collider = actor->getCollider();
+    if (collider)
+        collider->onInvalidate();
 }
 
 void offCollide(LiveActor* actor) {
@@ -61,7 +75,7 @@ void onAreaTarget(LiveActor* actor) {
 }
 
 void offAreaTarget(LiveActor* actor) {
-    actor->getFlags()->isAreaTargetOn = true;
+    actor->getFlags()->isAreaTargetOn = false;
 }
 
 bool isUpdateMovementEffectAudioCollisionSensor(const LiveActor* actor) {

--- a/lib/al/Library/LiveActor/ActorInitInfo.h
+++ b/lib/al/Library/LiveActor/ActorInitInfo.h
@@ -85,20 +85,20 @@ public:
     ExecuteDirector* getExecuteDirector() const { return mExecuteDirector; }
 
 private:
-    LiveActorGroup* mKitDrawingGroup;
-    const PlacementInfo* mPlacementInfo;
-    const LayoutInitInfo* mLayoutInitInfo;
-    ActorSceneInfo mActorSceneInfo;
-    LiveActorGroup* mAllActorsGroup;
-    const ActorFactory* mActorFactory;
-    ActorResourceHolder* mActorResourceHolder;
-    AudioDirector* mAudioDirector;
-    EffectSystemInfo* mEffectSystemInfo;
-    ExecuteDirector* mExecuteDirector;
-    HitSensorDirector* mHitSensorDirector;
-    ScreenPointDirector* mScreenPointDirector;
-    StageSwitchDirector* mStageSwitchDirector;
-    ViewIdHolder* mViewIdHolder;
+    LiveActorGroup* mKitDrawingGroup = nullptr;
+    const PlacementInfo* mPlacementInfo = nullptr;
+    const LayoutInitInfo* mLayoutInitInfo = nullptr;
+    ActorSceneInfo mActorSceneInfo = {};
+    LiveActorGroup* mAllActorsGroup = nullptr;
+    const ActorFactory* mActorFactory = nullptr;
+    ActorResourceHolder* mActorResourceHolder = nullptr;
+    AudioDirector* mAudioDirector = nullptr;
+    EffectSystemInfo* mEffectSystemInfo = nullptr;
+    ExecuteDirector* mExecuteDirector = nullptr;
+    HitSensorDirector* mHitSensorDirector = nullptr;
+    ScreenPointDirector* mScreenPointDirector = nullptr;
+    StageSwitchDirector* mStageSwitchDirector = nullptr;
+    ViewIdHolder* mViewIdHolder = nullptr;
 };
 
 void initActor(LiveActor* actor, const ActorInitInfo& initInfo);

--- a/lib/al/Library/LiveActor/ActorPoseKeeper.h
+++ b/lib/al/Library/LiveActor/ActorPoseKeeper.h
@@ -238,7 +238,7 @@ public:
 
 private:
     sead::Vector3f mRotate = {0.0, 0.0, 0.0};
-    sead::Vector3f mGravity = {0.0, -1.0, 0.0};
+    sead::Vector3f mGravity = -sead::Vector3f::ey;
     sead::Vector3f mScale = {1.0, 1.0, 1.0};
     sead::Vector3f mVelocity = {0.0, 0.0, 0.0};
     sead::Matrix34f mMtx;

--- a/lib/al/Library/LiveActor/ActorSceneInfo.h
+++ b/lib/al/Library/LiveActor/ActorSceneInfo.h
@@ -23,25 +23,27 @@ class GraphicsSystemInfo;
 class ModelDrawBufferCounter;
 
 struct ActorSceneInfo {
-    AreaObjDirector* mAreaObjDirector;
-    CameraDirector* mCameraDirector;
-    ClippingDirector* mClippingDirector;
-    CollisionDirector* mCollisionDirector;
-    DemoDirector* mDemoDirector;
-    GameDataHolderBase* mGameDataHolder;
-    GravityHolder* mGravityHolder;
-    ItemDirectorBase* mItemDirector;
-    NatureDirector* mNatureDirector;
-    const GamePadSystem* mGamePadSystem;
-    PadRumbleDirector* mPadRumbleDirector;
-    PlayerHolder* mPlayerHolder;
-    SceneObjHolder* mSceneObjHolder;
-    SceneStopCtrl* mSceneStopCtrl;
-    SceneMsgCtrl* mSceneMsgCtrl;
-    ScreenCoverCtrl* mScreenCoverCtrl;
-    ShadowDirector* mShadowDirector;
-    ModelGroup* mModelGroup;
-    GraphicsSystemInfo* mGraphicsSystemInfo;
-    ModelDrawBufferCounter* mModelDrawBufferCounter;
+    ActorSceneInfo();
+
+    AreaObjDirector* mAreaObjDirector = nullptr;
+    CameraDirector* mCameraDirector = nullptr;
+    ClippingDirector* mClippingDirector = nullptr;
+    CollisionDirector* mCollisionDirector = nullptr;
+    DemoDirector* mDemoDirector = nullptr;
+    GameDataHolderBase* mGameDataHolder = nullptr;
+    GravityHolder* mGravityHolder = nullptr;
+    ItemDirectorBase* mItemDirector = nullptr;
+    NatureDirector* mNatureDirector = nullptr;
+    const GamePadSystem* mGamePadSystem = nullptr;
+    PadRumbleDirector* mPadRumbleDirector = nullptr;
+    PlayerHolder* mPlayerHolder = nullptr;
+    SceneObjHolder* mSceneObjHolder = nullptr;
+    SceneStopCtrl* mSceneStopCtrl = nullptr;
+    SceneMsgCtrl* mSceneMsgCtrl = nullptr;
+    ScreenCoverCtrl* mScreenCoverCtrl = nullptr;
+    ShadowDirector* mShadowDirector = nullptr;
+    ModelGroup* mModelGroup = nullptr;
+    GraphicsSystemInfo* mGraphicsSystemInfo = nullptr;
+    ModelDrawBufferCounter* mModelDrawBufferCounter = nullptr;
 };
 }  // namespace al

--- a/lib/al/Library/LiveActor/LiveActorFlag.h
+++ b/lib/al/Library/LiveActor/LiveActorFlag.h
@@ -7,7 +7,7 @@ struct LiveActorFlag {
     bool isClipped = false;
     bool isClippingInvalid = true;
     bool isDrawClipped = false;
-    bool isCalcAnim = false;
+    bool isDisableCalcAnim = false;
     bool isModelVisible = false;
     bool isCollideOff = true;
     bool field_07 = false;

--- a/lib/al/Library/Math/MathRandomUtil.cpp
+++ b/lib/al/Library/Math/MathRandomUtil.cpp
@@ -44,8 +44,10 @@ void getRandomVector(sead::Vector3f* vec, f32 factor) {
 
 void getRandomDir(sead::Vector3f* vec) {
     getRandomVector(vec, 10.f);
-    while (vec->dot(*vec) > 0.000001f)
+    while (vec->dot(*vec) < 0.000001f) {
+        *vec = {0.0f, 0.0f, 0.0f};
         getRandomVector(vec, 10.f);
+    }
     vec->normalize();
 }
 

--- a/lib/al/Library/Nerve/NerveKeeper.cpp
+++ b/lib/al/Library/Nerve/NerveKeeper.cpp
@@ -5,7 +5,7 @@
 
 namespace al {
 NerveKeeper::NerveKeeper(IUseNerve* parent, const Nerve* nerve, s32 maxStates)
-    : mParent(parent), mNextNerve(nullptr) {
+    : mParent(parent), mNextNerve(nerve) {
     if (maxStates > 0)
         mStateCtrl = new NerveStateCtrl(maxStates);
 }

--- a/lib/al/Library/Nerve/NerveKeeper.h
+++ b/lib/al/Library/Nerve/NerveKeeper.h
@@ -32,9 +32,9 @@ public:
     }
 
 private:
-    IUseNerve* mParent = nullptr;
+    IUseNerve* mParent;
     const Nerve* mCurrentNerve = nullptr;
-    const Nerve* mNextNerve = nullptr;
+    const Nerve* mNextNerve;
     s32 mStep = 0;
     NerveStateCtrl* mStateCtrl = nullptr;
     NerveActionCtrl* mActionCtrl = nullptr;

--- a/lib/al/Library/Nerve/NerveUtil.cpp
+++ b/lib/al/Library/Nerve/NerveUtil.cpp
@@ -58,15 +58,11 @@ bool isInRangeStep(const IUseNerve* user, s32 startStep, s32 endStep) {
 
 bool isIntervalStep(const IUseNerve* user, s32 interval, s32 offset) {
     s32 currentStep = user->getNerveKeeper()->getCurrentStep() - offset;
-    if (currentStep < 0)
-        return false;
-    return currentStep == (interval != 0 ? currentStep / interval : 0) * interval;
+    return currentStep >= 0 && currentStep % interval == 0;
 }
 
 bool isIntervalOnOffStep(const IUseNerve* user, s32 interval, s32 offset) {
-    if (interval == 0)
-        return false;
-    return ((user->getNerveKeeper()->getCurrentStep() - offset) / interval) == 0;
+    return ((user->getNerveKeeper()->getCurrentStep() - offset) / interval) % 2 == 0;
 }
 
 bool isNerve(const IUseNerve* user, const Nerve* nerve) {
@@ -74,7 +70,7 @@ bool isNerve(const IUseNerve* user, const Nerve* nerve) {
 }
 
 bool isNewNerve(const IUseNerve* user) {
-    return user->getNerveKeeper()->isNewNerve();
+    return isLessStep(user, 0);
 }
 
 s32 calcNerveInterval(const IUseNerve* pKeeper, s32 start, s32 end) {

--- a/lib/al/Library/Rail/Rail.cpp
+++ b/lib/al/Library/Rail/Rail.cpp
@@ -43,7 +43,7 @@ void Rail::init(const PlacementInfo& info) {
     for (s32 i = 0; i < mRailPartCount; i++) {
         PlacementInfo startInfo, endInfo;
         tryGetPlacementInfoByIndex(&startInfo, railPointsInfo, i);
-        tryGetPlacementInfoByIndex(&startInfo, railPointsInfo, (i + 1) % mRailPartCount);
+        tryGetPlacementInfoByIndex(&endInfo, railPointsInfo, (i + 1) % mRailPointsCount);
 
         sead::Vector3f start = sead::Vector3f::zero;
         sead::Vector3f startHandle = sead::Vector3f::zero;

--- a/lib/al/Library/Rail/RailKeeper.h
+++ b/lib/al/Library/Rail/RailKeeper.h
@@ -13,7 +13,7 @@ public:
     RailRider* getRailRider() const override;
 
 private:
-    RailRider* mRailRider;
+    RailRider* mRailRider = nullptr;
 };
 
 RailKeeper* tryCreateRailKeeper(const PlacementInfo& info, const char* linkName);

--- a/lib/al/Library/Rail/RailRider.cpp
+++ b/lib/al/Library/Rail/RailRider.cpp
@@ -3,7 +3,8 @@
 #include "Library/Rail/Rail.h"
 
 namespace al {
-RailRider::RailRider(const Rail* rail) : mRail(rail), mCoord(rail->normalizeLength(0)) {
-    rail->calcPosDir(&mPosition, &mDirection, mCoord);
+RailRider::RailRider(const Rail* rail) : mRail(rail) {
+    mCoord = rail->normalizeLength(0);
+    mRail->calcPosDir(&mPosition, &mDirection, mCoord);
 }
 }  // namespace al

--- a/lib/al/Library/Rail/RailRider.h
+++ b/lib/al/Library/Rail/RailRider.h
@@ -30,10 +30,10 @@ public:
 
 private:
     const Rail* mRail;
-    sead::Vector3f mPosition;
-    sead::Vector3f mDirection;
-    f32 mCoord;
-    f32 mRate;
-    bool mIsMoveForwards;
+    sead::Vector3f mPosition = sead::Vector3f::zero;
+    sead::Vector3f mDirection = sead::Vector3f::zero;
+    f32 mCoord = 0.0f;
+    f32 mRate = 0.0f;
+    bool mIsMoveForwards = true;
 };
 }  // namespace al

--- a/lib/al/Library/Shadow/ShadowKeeper.h
+++ b/lib/al/Library/Shadow/ShadowKeeper.h
@@ -15,6 +15,8 @@ public:
     void hide();
     void show();
 
+    ShadowMaskCtrl* getShadowMaskCtrl() const { return mShadowMaskCtrl; }
+
 private:
     ShadowMaskCtrl* mShadowMaskCtrl = nullptr;
     DepthShadowMapCtrl* mDepthShadowMapCtrl = nullptr;

--- a/lib/al/Project/Item/ActorScoreKeeper.cpp
+++ b/lib/al/Project/Item/ActorScoreKeeper.cpp
@@ -22,7 +22,7 @@ void ActorScoreKeeper::init(const ByamlIter& iter) {
 }
 
 inline void ActorScoreKeeper::allocArray() {
-    Entry* local_array = new Entry[mSize];
+    Entry* local_array = new Entry[mSize]();
     if (mSize)
         memset(local_array, 0, sizeof(Entry) * mSize);
     mArray = local_array;

--- a/lib/al/Project/Item/ActorScoreKeeper.h
+++ b/lib/al/Project/Item/ActorScoreKeeper.h
@@ -22,7 +22,7 @@ private:
     inline void allocArray();
     inline void putEntry(s32 index, const ByamlIter& iter);
 
-    Entry* mArray;
-    s32 mSize;
+    Entry* mArray = nullptr;
+    s32 mSize = 0;
 };
 }  // namespace al

--- a/lib/al/Project/Rail/BezierCurve.cpp
+++ b/lib/al/Project/Rail/BezierCurve.cpp
@@ -96,7 +96,7 @@ f32 BezierCurve::calcCurveParam(f32 distance) const {
             return percent;
     }
 
-    if (percent > 1.0f || partLength < 0.0f)
+    if (partLength < 0.0f || percent > 1.0f)
         return sead::Mathf::clamp(percent, 0.0f, 1.0f);
     return percent;
 }

--- a/src/Npc/AchievementHolder.cpp
+++ b/src/Npc/AchievementHolder.cpp
@@ -187,12 +187,10 @@ s32 AchievementHolder::calcMoonGetTotalNum(GameDataHolderAccessor accessor) cons
     return count;
 }
 
-Achievement*
-AchievementHolder::tryGetNewAchievement(GameDataHolderAccessor accessor) const {  // TODO mismatch
-    s32 i = 0;
-    for (; i < mArray.capacity(); i++)
+Achievement* AchievementHolder::tryGetNewAchievement(GameDataHolderAccessor accessor) const {
+    for (s32 i = 0; i < mArray.capacity(); i++)
         if (!mArray[i]->isGet(accessor) &&
-            getAchievementProgressCurrent(i, accessor) >= mAchievementInfoReader->get(i)->mNum)
-            break;
-    return mArray[i];
+            getAchievementProgressCurrent(i, accessor) >= mAchievementInfoReader->unsafeAt(i)->mNum)
+            return mArray[i];
+    return nullptr;
 }

--- a/src/Npc/AchievementInfoReader.cpp
+++ b/src/Npc/AchievementInfoReader.cpp
@@ -6,34 +6,35 @@
 
 AchievementInfoReader::AchievementInfoReader() = default;
 
-void AchievementInfoReader::init() {  // TODO minor mismatches during loop
+void AchievementInfoReader::init() {
     al::Resource* achievementInfoResource =
         al::findOrCreateResource("SystemData/AchievementInfo", nullptr);
-    const char* byamlFileName = al::StringTmp<256>{"%s.byml", "AchievementInfo"}.cstr();
+    al::StringTmp<256> bymlName = {"%s.byml", "AchievementInfo"};
 
-    if (!achievementInfoResource->isExistFile(byamlFileName))
+    if (!achievementInfoResource->isExistFile(bymlName.cstr()))
         return;
 
     al::ByamlIter achievementInfo = achievementInfoResource->getByml("AchievementInfo");
     al::ByamlIter achievementInfoArray;
-    if (achievementInfo.tryGetIterByKey(&achievementInfoArray, "AchievementInfoArray")) {
-        auto size = achievementInfoArray.getSize();
-        mAchievements.allocBuffer(size, nullptr);
+    if (!achievementInfo.tryGetIterByKey(&achievementInfoArray, "AchievementInfoArray"))
+        return;
 
-        for (s32 i = 0; i < size; i++) {
-            al::ByamlIter iter;
-            if (achievementInfoArray.tryGetIterByIndex(&iter, i)) {
-                const char* name = nullptr;
-                iter.tryGetStringByKey(&name, "Name");
-                const char* note = nullptr;
-                iter.tryGetStringByKey(&note, "Note");
-                s32 num = 1;
-                iter.tryGetIntByKey(&num, "Num");
-                s32 level = -1;
-                iter.tryGetIntByKey(&level, "Level");
+    s32 size = achievementInfoArray.getSize();
+    mAchievements.allocBuffer(size, nullptr);
 
-                mAchievements.pushBack(new AchievementInfo(name, num, level, note));
-            }
+    for (s32 i = 0; i < size; i++) {
+        al::ByamlIter iter;
+        if (achievementInfoArray.tryGetIterByIndex(&iter, i)) {
+            const char* name = nullptr;
+            iter.tryGetStringByKey(&name, "Name");
+            const char* note = nullptr;
+            iter.tryGetStringByKey(&note, "Note");
+            s32 num = 1;
+            iter.tryGetIntByKey(&num, "Num");
+            s32 level = -1;
+            iter.tryGetIntByKey(&level, "Level");
+
+            mAchievements.pushBack(new AchievementInfo(name, num, level, note));
         }
     }
 }

--- a/src/Npc/AchievementInfoReader.h
+++ b/src/Npc/AchievementInfoReader.h
@@ -23,6 +23,8 @@ public:
 
     AchievementInfo* get(s32 index) { return mAchievements[index]; }
 
+    AchievementInfo* unsafeAt(s32 index) { return mAchievements.unsafeAt(index); }
+
     s32 size() { return mAchievements.size(); }
 
     s32 capacity() { return mAchievements.capacity(); }

--- a/src/Player/PlayerInput.cpp
+++ b/src/Player/PlayerInput.cpp
@@ -12,9 +12,6 @@
 #include "Player/PlayerInputFunction.h"
 #include "Util/ActorDimensionKeeper.h"
 
-PlayerInput::PlayerInput(const al::LiveActor*, const IUsePlayerCollision*, const IUseDimension*) {
-}  // FIXME remove this
-
 bool PlayerInput::isEnableCarry() const {
     if (mIsDisableInput)
         return false;

--- a/src/Player/PlayerInputFunction.cpp
+++ b/src/Player/PlayerInputFunction.cpp
@@ -5,6 +5,6 @@
 
 bool PlayerInputFunction::isTriggerAction(const al::LiveActor* actor, s32 port) {
     if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
-        return true;
+        return al::isPadTriggerY(port);
     return al::isPadTriggerX(port) || al::isPadTriggerY(port);
 }

--- a/src/Player/PlayerJudgePreInputJump.cpp
+++ b/src/Player/PlayerJudgePreInputJump.cpp
@@ -4,6 +4,7 @@
 
 #include "Player/PlayerConst.h"
 #include "Player/PlayerInput.h"
+#include "Util/JudgeUtil.h"
 
 PlayerJudgePreInputJump::PlayerJudgePreInputJump(const PlayerConst* pConst,
                                                  const PlayerInput* input,
@@ -22,5 +23,9 @@ void PlayerJudgePreInputJump::update() {
 }
 
 bool PlayerJudgePreInputJump::judge() const {
+    if (rs::updateJudgeAndResult(mJudgeForceSlopeSlide))
+        return false;
+    if (mInput->isTriggerJump())
+        return true;
     return mRemainJumpFrame > 0;
 }

--- a/src/Player/PlayerModelHolder.cpp
+++ b/src/Player/PlayerModelHolder.cpp
@@ -7,7 +7,9 @@ PlayerModelHolder::PlayerModelHolder(u32 bufferSize) {
 }
 
 void PlayerModelHolder::registerModel(al::LiveActor* liveActor, const char* name) {
-    mBuffer.pushBack(new Entry{sead::FixedSafeString<128>(name), liveActor});
+    Entry* entry = new Entry{liveActor};
+    entry->mName = name;
+    mBuffer.pushBack(entry);
 }
 
 void PlayerModelHolder::changeModel(const char* name) {

--- a/src/Player/PlayerModelHolder.h
+++ b/src/Player/PlayerModelHolder.h
@@ -10,6 +10,8 @@ class LiveActor;
 class PlayerModelHolder {
 public:
     struct Entry {
+        Entry(al::LiveActor* liveActor) : mLiveActor(liveActor) {}
+
         sead::FixedSafeString<128> mName;
         al::LiveActor* mLiveActor;
     };

--- a/src/Player/PlayerOxygen.cpp
+++ b/src/Player/PlayerOxygen.cpp
@@ -26,14 +26,11 @@ void PlayerOxygen::reduce() {
     }
 }
 
-#ifdef NON_MATCHING
 void PlayerOxygen::recovery() {
-    // different regalloc
-    mOxygenLevel = sead::Mathf::min(1.0f, mOxygenLevel + (1.0f / mOxygenRecoveryFrame));
+    mOxygenLevel = sead::Mathf::min(1.0f, (1.0f / mOxygenRecoveryFrame) + mOxygenLevel);
     mFramesReducing = 0;
     mFramesWithoutOxygen = 0;
 }
-#endif
 
 bool PlayerOxygen::isTriggerDamage() const {
     if (mFramesWithoutOxygen)

--- a/src/Player/PlayerPainPartsKeeper.cpp
+++ b/src/Player/PlayerPainPartsKeeper.cpp
@@ -54,6 +54,7 @@ bool PlayerPainPartsKeeper::isInvalidNoseDynamics() const {
     return mNeedlesActor && al::isAlive(mNeedlesActor);
 }
 
+static sead::Vector3f initialPosition = {0, 0, 0};
 static sead::Vector3f initialRotation = {0, 270, 180};
 
 void PlayerPainPartsKeeper::createNoseNeedle(const PlayerModelHolder* playerModelHolder,
@@ -63,8 +64,8 @@ void PlayerPainPartsKeeper::createNoseNeedle(const PlayerModelHolder* playerMode
     mPlayerFaceActor = playerFaceActor;
     mNeedlesActor = new al::PartsModel("鼻のトゲ");
     mNeedlesActor->initPartsDirect(playerFaceActor, actorInitInfo, "CactusMiniNeedle",
-                                   al::getJointMtxPtr(faceSubActor, "Nose"), sead::Vector3f::zero,
-                                   initialRotation, {1, 1, 1}, false);
+                                   al::getJointMtxPtr(faceSubActor, "Nose"), initialPosition,
+                                   initialRotation, {1.0f, 1.0f, 1.0f}, false);
     al::onSyncClippingSubActor(playerFaceActor, mNeedlesActor);
     al::onSyncHideSubActor(playerFaceActor, mNeedlesActor);
     al::onSyncAlphaMaskSubActor(playerFaceActor, mNeedlesActor);
@@ -78,10 +79,8 @@ void PlayerPainPartsKeeper::appearNeedle() {
         return;
 
     mNeedlesActor->makeActorAlive();
-    const char* actionName;
     if (mPlayerCostumeInfo->isHidePainNose())
-        actionName = "NoseOff";
+        al::startAction(mNeedlesActor, "NoseOff");
     else
-        actionName = "NoseOn";
-    al::startAction(mNeedlesActor, actionName);
+        al::startAction(mNeedlesActor, "NoseOn");
 }


### PR DESCRIPTION
Here, I went over a lot of the `M` and `m`-marked functions, and shortly tried to match them again - and as it turns out, a lot of them were simple to fix.

Two functions have been removed in this PR because they were only stubbed and too complex to fix here:
- `WorldResourceLoader::loadResource()`
- `PlayerInput::PlayerInput`

These will be marked with `U` (unimplemented) instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/263)
<!-- Reviewable:end -->
