### PR TITLE
Enemy: Implement `Togezo` (by CraftyBoss)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         buildInputs = with pkgs; [
           cmake
           ninja
-          clang
+          llvmPackages_14.clang
           ccache
           pkg-config
 
@@ -37,7 +37,7 @@
             python-pkgs.toml
           ]))
           openssl
-          libclang
+          llvmPackages_14.libclang
           ncurses5
           ncurses6
         ];

--- a/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
+++ b/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
@@ -6,10 +6,10 @@
 // TODO: This defines the class but the sead decomp doesn't have anything inside the RTTI functions,
 // causing the functions in the vtable to be exported
 #define SENSOR_MSG(Type)                                                                           \
-    class SensorMsg##Type : public al::SensorMsg {                                                 \
-        SEAD_RTTI_OVERRIDE(SensorMsg##Type, al::SensorMsg)                                         \
+    class SensorMsg##Type : public SensorMsg {                                                     \
+        SEAD_RTTI_OVERRIDE(SensorMsg##Type, SensorMsg)                                             \
     };                                                                                             \
-    bool isMsg##Type(const al::SensorMsg* msg) {                                                   \
+    bool isMsg##Type(const SensorMsg* msg) {                                                       \
         return SensorMsg##Type::checkDerivedRuntimeTypeInfoStatic(msg->getRuntimeTypeInfo());      \
     }
 
@@ -443,7 +443,9 @@ bool isMsgPlayerUpperPunchForCrossoverSensor(const SensorMsg* msg, const HitSens
 bool isMsgKickStoneTrampleForCrossoverSensor(const SensorMsg* msg, const HitSensor*,
                                              const HitSensor*);
 
-bool sendMsgPushAndKillVelocityToTarget(LiveActor*, HitSensor*, HitSensor*);
+void sendMsgPushAndKillVelocityToTarget(LiveActor*, HitSensor*, HitSensor*);
+bool tryReceiveMsgPushAndAddVelocity(LiveActor*, const SensorMsg*, const HitSensor*,
+                                     const HitSensor*, f32);
 bool tryReceiveMsgPushAndAddVelocityH(LiveActor*, const SensorMsg*, const HitSensor*,
                                       const HitSensor*, f32);
 }  // namespace al

--- a/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
+++ b/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
@@ -7,7 +7,7 @@
 // causing the functions in the vtable to be exported
 #define SENSOR_MSG(Type)                                                                           \
     class SensorMsg##Type : public al::SensorMsg {                                                 \
-        SEAD_RTTI_OVERRIDE(al::SensorMsg##Type, SensorMsg)                                         \
+        SEAD_RTTI_OVERRIDE(SensorMsg##Type, al::SensorMsg)                                         \
     };                                                                                             \
     bool isMsg##Type(const al::SensorMsg* msg) {                                                   \
         return SensorMsg##Type::checkDerivedRuntimeTypeInfoStatic(msg->getRuntimeTypeInfo());      \
@@ -443,7 +443,7 @@ bool isMsgPlayerUpperPunchForCrossoverSensor(const SensorMsg* msg, const HitSens
 bool isMsgKickStoneTrampleForCrossoverSensor(const SensorMsg* msg, const HitSensor*,
                                              const HitSensor*);
 
-void sendMsgPushAndKillVelocityToTarget(LiveActor*, HitSensor*, HitSensor*);
+bool sendMsgPushAndKillVelocityToTarget(LiveActor*, HitSensor*, HitSensor*);
 bool tryReceiveMsgPushAndAddVelocity(LiveActor*, const SensorMsg*, const HitSensor*,
                                      const HitSensor*, f32);
 bool tryReceiveMsgPushAndAddVelocityH(LiveActor*, const SensorMsg*, const HitSensor*,

--- a/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
+++ b/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
@@ -6,10 +6,10 @@
 // TODO: This defines the class but the sead decomp doesn't have anything inside the RTTI functions,
 // causing the functions in the vtable to be exported
 #define SENSOR_MSG(Type)                                                                           \
-    class SensorMsg##Type : public SensorMsg {                                                     \
+    class SensorMsg##Type : public al::SensorMsg {                                                 \
         SEAD_RTTI_OVERRIDE(SensorMsg##Type, SensorMsg)                                             \
     };                                                                                             \
-    bool isMsg##Type(const SensorMsg* msg) {                                                       \
+    bool isMsg##Type(const al::SensorMsg* msg) {                                                   \
         return SensorMsg##Type::checkDerivedRuntimeTypeInfoStatic(msg->getRuntimeTypeInfo());      \
     }
 

--- a/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
+++ b/lib/al/Library/LiveActor/ActorSensorMsgFunction.h
@@ -7,7 +7,7 @@
 // causing the functions in the vtable to be exported
 #define SENSOR_MSG(Type)                                                                           \
     class SensorMsg##Type : public al::SensorMsg {                                                 \
-        SEAD_RTTI_OVERRIDE(SensorMsg##Type, SensorMsg)                                             \
+        SEAD_RTTI_OVERRIDE(al::SensorMsg##Type, SensorMsg)                                         \
     };                                                                                             \
     bool isMsg##Type(const al::SensorMsg* msg) {                                                   \
         return SensorMsg##Type::checkDerivedRuntimeTypeInfoStatic(msg->getRuntimeTypeInfo());      \

--- a/lib/al/Library/Nature/NatureUtil.h
+++ b/lib/al/Library/Nature/NatureUtil.h
@@ -8,5 +8,6 @@ class LiveActor;
 bool isInWaterPos(const LiveActor* actor, const sead::Vector3f& pos);
 bool isInWater(const LiveActor* actor);
 bool isInIceWaterPos(const LiveActor* actor, const sead::Vector3f& pos);
+bool tryAddRippleMiddle(LiveActor* actor);
 
 }  // namespace al

--- a/lib/al/Library/Stage/StageSwitchKeeper.h
+++ b/lib/al/Library/Stage/StageSwitchKeeper.h
@@ -54,6 +54,7 @@ bool listenStageSwitchOn(IUseStageSwitch* stageSwitchHolder, const char* eventNa
                          const FunctorBase& actionOnOn);
 bool listenStageSwitchOnOff(IUseStageSwitch* stageSwitchHolder, const char* eventName,
                             const FunctorBase& actionOnOn, const FunctorBase& actionOnOff);
+bool listenStageSwitchOnAppear(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn);
 bool listenStageSwitchOnOffAppear(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn,
                                   const FunctorBase& actionOnOff);
 bool listenStageSwitchOnKill(IUseStageSwitch* stageSwitchHolder, const FunctorBase& actionOnOn);

--- a/src/Enemy/Togezo.cpp
+++ b/src/Enemy/Togezo.cpp
@@ -1,0 +1,454 @@
+#include "Enemy/Togezo.h"
+
+#include "Library/Collision/Collider.h"
+#include "Library/Item/ItemUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Math/MathAngleUtil.h"
+#include "Library/Math/MathLengthUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Math/VectorUtil.h"
+#include "Library/Nature/NatureUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Enemy/EnemyStateWander.h"
+#include "Util/ExternalForceKeeper.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(Togezo, Wait)
+NERVE_IMPL(Togezo, Wander)
+NERVE_IMPL(Togezo, CapHit)
+NERVE_IMPL(Togezo, BlowDown)
+NERVE_IMPL(Togezo, Attack)
+NERVE_IMPL(Togezo, Turn)
+NERVE_IMPL(Togezo, Fall)
+NERVE_IMPL(Togezo, Find)
+NERVE_IMPL(Togezo, Chase)
+NERVE_IMPL(Togezo, Land)
+
+NERVES_MAKE_NOSTRUCT(Togezo, Land)
+NERVES_MAKE_STRUCT(Togezo, Wait, Wander, CapHit, BlowDown, Attack, Turn, Fall, Find, Chase)
+}  // namespace
+
+Togezo::Togezo(const char* name) : al::LiveActor(name) {}
+
+void Togezo::init(const al::ActorInitInfo& info) {
+    using TogezoFunctor = al::FunctorV0M<Togezo*, void (Togezo::*)()>;
+
+    al::initActorWithArchiveName(this, info, "Togezo", nullptr);
+
+    if (al::isValidStageSwitch(this, "SwitchStart"))
+        al::initNerve(this, &NrvTogezo.Wait, 1);
+    else
+        al::initNerve(this, &NrvTogezo.Wander, 1);
+
+    mStateWander = new EnemyStateWander(this, "Walk");
+    al::initNerveState(this, mStateWander, &NrvTogezo.Wander, "徘徊");
+
+    mForceKeeper = new ExternalForceKeeper();
+
+    if (al::listenStageSwitchOnAppear(this, TogezoFunctor(this, &Togezo::listenAppear)))
+        makeActorDead();
+    else
+        makeActorAlive();
+}
+
+void Togezo::listenAppear() {
+    appear();
+}
+
+bool Togezo::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (rs::isMsgTargetMarkerPosition(message)) {
+        rs::setMsgTargetMarkerPosition(message,
+                                       al::getTrans(this) + sead::Vector3f(0.0f, 180.0f, 0.0f));
+        return true;
+    }
+
+    if (rs::isMsgKillByShineGet(message)) {
+        kill();
+        return true;
+    }
+
+    if (rs::isMsgNpcScareByEnemy(message) ||
+        al::tryReceiveMsgPushAndAddVelocity(this, message, other, self, 1.0))
+        return true;
+
+    if (rs::isMsgCapReflect(message) && !al::isNerve(this, &NrvTogezo.BlowDown) &&
+        mCapHitCooldown <= 0) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::setNerve(this, &NrvTogezo.CapHit);
+        mCapPos = al::getSensorPos(other);
+        mCapHitCooldown = 10;
+        return true;
+    }
+
+    if ((rs::isMsgBlowDown(message) || rs::isMsgDonsukeAttack(message)) &&
+        !al::isNerve(this, &NrvTogezo.BlowDown)) {
+        al::setVelocityBlowAttackAndTurnToTarget(this, al::getActorTrans(other), 15.0f, 35.0f);
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::setNerve(this, &NrvTogezo.BlowDown);
+        return true;
+    }
+
+    if ((rs::isMsgPechoSpot(message) || rs::isMsgDamageBallAttack(message) ||
+         al::isMsgPlayerFireBallAttack(message)) &&
+        al::isSensorEnemyBody(self)) {
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::startHitReaction(this, "死亡");
+
+        kill();
+        return false;
+    }
+
+    return mForceKeeper->receiveMsg(message, other, self);
+}
+
+void Togezo::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvTogezo.BlowDown))
+        return;
+
+    if (al::sendMsgEnemyAttack(other, self)) {
+        al::setNerve(this, &NrvTogezo.Attack);
+        return;
+    }
+
+    rs::sendMsgPushToPlayer(other, self);
+
+    if (al::isNerve(this, &NrvTogezo.BlowDown))
+        return;
+
+    if (!al::isNerve(this, &NrvTogezo.BlowDown) && !al::isNerve(this, &NrvTogezo.Attack) &&
+        (al::sendMsgEnemyAttackNeedle(other, self) || al::sendMsgEnemyAttack(other, self)))
+        al::setNerve(this, &NrvTogezo.Attack);
+    else
+        al::sendMsgPushAndKillVelocityToTarget(this, self, other);
+}
+
+void Togezo::control() {
+    if (al::isInDeathArea(this) || al::isCollidedFloorCode(this, "DamageFire") ||
+        al::isCollidedFloorCode(this, "Needle") || al::isCollidedFloorCode(this, "Poison") ||
+        al::isInWaterArea(this)) {
+        al::startHitReaction(this, "死亡");
+        al::tryAddRippleMiddle(this);
+        kill();
+    } else {
+        if (mCapHitCooldown > 0)
+            mCapHitCooldown--;
+
+        sead::Vector3f calculatedForce = sead::Vector3f::zero;
+        mForceKeeper->calcForce(&calculatedForce);
+
+        mFuturePos = calculatedForce * 0.64f + mFuturePos;
+        mFuturePos *= 0.955f;
+
+        mForceKeeper->reset();
+
+        if (!al::isNearZero(calculatedForce, 0.001f)) {
+            mWanderCooldown = 180;
+            al::invalidateClipping(this);
+        }
+
+        if (mWanderCooldown > 0) {
+            mWanderCooldown--;
+
+            if (mWanderCooldown == 0) {
+                if (al::isNerve(this, &NrvTogezo.Wander))
+                    al::validateClipping(this);
+            }
+        }
+    }
+}
+
+void Togezo::updateCollider() {
+    const sead::Vector3f& velocity = al::getVelocity(this);
+
+    if (al::isNoCollide(this)) {
+        *al::getTransPtr(this) += velocity;
+        al::getActorCollider(this)->onInvalidate();
+    } else {
+        if (al::isFallOrDamageCodeNextMove(this, (velocity + mFuturePos) * 1.5f, 50.0f, 200.0f)) {
+            sead::Vector3f* transPtr = al::getTransPtr(this);
+            sead::Vector3f result =
+                al::getActorCollider(this)->collide((velocity + mFuturePos) * 1.5f);
+            *transPtr += result;
+        } else {
+            sead::Vector3f result = al::getActorCollider(this)->collide(velocity + mFuturePos);
+            *al::getTransPtr(this) += result;
+        }
+    }
+}
+
+void Togezo::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Wait");
+        al::setVelocityZero(this);
+    }
+    if (al::isValidStageSwitch(this, "SwitchStart") && al::isOnStageSwitch(this, "SwitchStart"))
+        al::setNerve(this, &NrvTogezo.Wander);
+}
+
+void Togezo::exeWander() {
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(this);
+        al::startAction(this, "Walk");
+    }
+
+    al::updateNerveState(this);
+
+    bool isGrounded = al::isOnGround(this, 0);
+    bool isNearPlayer = al::isNearPlayer(this, 1000.0f);
+
+    if (isGrounded && isNearPlayer) {
+        al::setNerve(this, &NrvTogezo.Turn);
+    } else if (isGrounded) {
+        mAirTime = 0;
+        mGroundNormal = al::getOnGroundNormal(this, 0);
+    } else {
+        mAirTime++;
+
+        if (mAirTime > 4)
+            al::setNerve(this, &NrvTogezo.Fall);
+    }
+}
+
+void Togezo::exeTurn() {
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(this);
+        al::startAction(this, "Turn");
+    }
+
+    sead::Vector3f frontDir = sead::Vector3f::zero;
+    al::calcFrontDir(&frontDir, this);
+
+    al::LiveActor* player = al::tryFindNearestPlayerActor(this);
+    if (player) {
+        if (al::isFaceToTargetDegreeH(this, al::getTrans(player), frontDir, 1.0f)) {
+            al::setNerve(this, &NrvTogezo.Find);
+            return;
+        }
+        al::turnToTarget(this, al::getTrans(player), 3.5f);
+    }
+
+    if (!al::isNearPlayer(this, 1300.0f)) {
+        al::setNerve(this, &NrvTogezo.Wander);
+        return;
+    }
+
+    if (al::isOnGround(this, 0)) {
+        mAirTime = 0;
+        return;
+    }
+
+    al::addVelocityToGravity(this, 1.0f);
+    al::scaleVelocity(this, 0.98f);
+
+    if (mAirTime++ >= 4)
+        al::setNerve(this, &NrvTogezo.Fall);
+}
+
+void applyTogezoGroundVelocity(Togezo* self) {
+    if (al::isOnGround(self, 0)) {
+        const sead::Vector3f& normal = al::getOnGroundNormal(self, 0);
+        const sead::Vector3f& velocity = al::getVelocity(self);  // unused
+
+        if (al::isFallOrDamageCodeNextMove(self, al::getVelocity(self), 50.0f, 200.0f)) {
+            f32 y = al::getVelocity(self).y;
+            al::scaleVelocity(self, -1.0f);
+            al::getVelocityPtr(self)->y = y;
+        } else {
+            al::addVelocity(self, -normal);
+            al::scaleVelocity(self, 0.95f);
+            return;
+        }
+    } else {
+        al::addVelocityY(self, -2.0f);
+        al::scaleVelocity(self, 0.98f);
+    }
+}
+
+void Togezo::exeFind() {
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(this);
+        al::startAction(this, "Find");
+        mAirTime = 0;
+        al::invalidateClipping(this);
+    }
+
+    if (!al::isOnGround(this, 0) && mAirTime++ >= 4) {
+        al::setNerve(this, &NrvTogezo.Fall);
+    } else {
+        applyTogezoGroundVelocity(this);
+        if (al::isActionEnd(this))
+            al::setNerve(this, &NrvTogezo.Chase);
+    }
+}
+
+void Togezo::exeChase() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Run");
+        al::invalidateClipping(this);
+    }
+
+    if (al::isOnGround(this, 0)) {
+        sead::Vector3f normal = al::getOnGroundNormal(this, 0);
+        al::scaleVelocityDirection(this, normal, 0);
+        mAirTime = 0;
+
+        al::LiveActor* player = al::tryFindNearestPlayerActor(this);
+        if (player) {
+            al::turnToTarget(this, al::getTrans(player), 3.5f);
+
+            sead::Vector3f frontDir = sead::Vector3f::zero;
+            al::calcFrontDir(&frontDir, this);
+
+            sead::Vector3f verticalVel = sead::Vector3f::zero;
+            sead::Vector3f horizontalVel = sead::Vector3f::zero;
+            al::separateVectorHV(&horizontalVel, &verticalVel, normal, frontDir);
+            al::tryNormalizeOrDirZ(&horizontalVel, horizontalVel);
+
+            al::addVelocity(this, horizontalVel * 0.6f);
+            al::scaleVelocity(this, 0.95f);
+        }
+        if (!al::isNearPlayer(this, 1300.0f)) {
+            al::setNerve(this, &NrvTogezo.Wander);
+            return;
+        }
+    } else {
+        if (mAirTime++ >= 4) {
+            al::setNerve(this, &NrvTogezo.Fall);
+            return;
+        }
+    }
+
+    applyTogezoGroundVelocity(this);
+}
+
+void Togezo::exeFall() {
+    if (al::isFirstStep(this)) {
+        al::invalidateClipping(this);
+        al::startAction(this, "Fall");
+    }
+
+    applyTogezoGroundVelocity(this);
+
+    if (al::isOnGround(this, 0)) {
+        mAirTime = 0;
+        al::validateClipping(this);
+        al::setNerve(this, &Land);
+    }
+}
+
+void Togezo::exeLand() {
+    s32* airTimePtr;
+
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(this);
+        al::startAction(this, "Land");
+        airTimePtr = &mAirTime;
+        mAirTime = 0;
+    } else {
+        airTimePtr = &mAirTime;
+    }
+
+    applyTogezoGroundVelocity(this);
+
+    if (!al::isOnGround(this, 0) && (*airTimePtr)++ >= 4)
+        al::setNerve(this, &NrvTogezo.Fall);
+    else if (al::isActionEnd(this))
+        al::setNerve(this, &NrvTogezo.Wander);
+}
+
+void Togezo::exeAttack() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "AttackSuccess");
+        al::setVelocityZero(this);
+    }
+
+    applyTogezoGroundVelocity(this);
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvTogezo.Wander);
+}
+
+void Togezo::exeCapHit() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "CapHit");
+
+        sead::Vector3f capDirection = al::getTrans(this) - mCapPos;
+        capDirection.y = 0.0f;
+
+        al::tryNormalizeOrDirZ(&capDirection, capDirection);
+        al::setVelocity(this, capDirection * 20.0f);
+
+        sead::Quatf frontUp = sead::Quatf::unit;
+        al::makeQuatUpFront(&frontUp, capDirection, sead::Vector3f::ey);
+
+        mAirTime = 0;
+
+        al::invalidateClipping(this);
+    }
+
+    if (al::isActionEnd(this)) {
+        if (al::isNearPlayer(this, 1000.0f))
+            al::setNerve(this, &NrvTogezo.Find);
+        else
+            al::setNerve(this, &NrvTogezo.Wander);
+    } else if (al::isOnGround(this, 0)) {
+        mAirTime = 0;
+
+        al::addVelocityToGravity(this, 1.0);
+        al::scaleVelocity(this, 0.95f);
+
+        sead::Vector3f velocity = al::getVelocity(this);
+        f32 y = velocity.y;
+        velocity.y = 0.0f;
+
+        if (al::tryNormalizeOrZero(&velocity, velocity)) {
+            if (al::isFallOrDamageCodeNextMove(this, velocity * 10.0f, 50.0f, 200.0f))
+                al::setVelocity(this,
+                                sead::Vector3f(velocity * 5.0f + sead::Vector3f(0.0f, y, 0.0f)));
+        }
+
+    } else {
+        mAirTime++;
+
+        if (mAirTime > 5) {
+            al::setNerve(this, &NrvTogezo.Fall);
+        } else {
+            al::addVelocityToGravity(this, 1.0f);
+            al::scaleVelocity(this, 0.98f);
+        }
+    }
+}
+
+void Togezo::exeBlowDown() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "BlowDown");
+        al::invalidateClipping(this);
+    }
+
+    al::addVelocityToGravity(this, 2.0f);
+    al::scaleVelocity(this, 0.98f);
+
+    if (al::isActionEnd(this)) {
+        al::startHitReaction(this, "死亡");
+        al::appearItem(this);
+        kill();
+    }
+}

--- a/src/Enemy/Togezo.cpp
+++ b/src/Enemy/Togezo.cpp
@@ -185,9 +185,8 @@ void Togezo::updateCollider() {
         al::getActorCollider(this)->onInvalidate();
     } else if (al::isFallOrDamageCodeNextMove(this, (velocity + mFuturePos) * 1.5f, 50.0f,
                                               200.0f)) {
-        sead::Vector3f* transPtr = al::getTransPtr(this);
-        sead::Vector3f result = al::getActorCollider(this)->collide((velocity + mFuturePos) * 1.5f);
-        *transPtr += result;
+        *al::getTransPtr(this) +=
+            al::getActorCollider(this)->collide((velocity + mFuturePos) * 1.5f);
     } else {
         sead::Vector3f result = al::getActorCollider(this)->collide(velocity + mFuturePos);
         *al::getTransPtr(this) += result;

--- a/src/Enemy/Togezo.h
+++ b/src/Enemy/Togezo.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class ExternalForceKeeper;
+class EnemyStateWander;
+
+class Togezo : public al::LiveActor {
+public:
+    Togezo(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void listenAppear();
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    void control() override;
+    void updateCollider() override;
+
+    void exeWait();
+    void exeWander();
+    void exeTurn();
+    void exeFind();
+    void exeChase();
+    void exeFall();
+    void exeLand();
+    void exeAttack();
+    void exeCapHit();
+    void exeBlowDown();
+
+private:
+    ExternalForceKeeper* mForceKeeper = nullptr;
+    EnemyStateWander* mStateWander = nullptr;
+    sead::Vector3f mCapPos = sead::Vector3f::zero;
+    s32 mCapHitCooldown = 0;
+    s32 mAirTime = 0;
+    sead::Vector3f mFuturePos = sead::Vector3f::zero;
+    sead::Vector3f mGroundNormal = sead::Vector3f::zero;
+    s32 mWanderCooldown = 0;
+};

--- a/src/Util/SensorMsgFunction.h
+++ b/src/Util/SensorMsgFunction.h
@@ -54,6 +54,10 @@ bool isMsgFishingLineTouch(const al::SensorMsg*);
 bool isMsgItemGet2D(const al::SensorMsg*);
 bool isMsgItemGetAll(const al::SensorMsg*);
 bool isMsgCapIgnoreCancelLockOn(const al::SensorMsg*);
+bool isMsgCapReflect(const al::SensorMsg*);
+bool isMsgDonsukeAttack(const al::SensorMsg*);
+bool isMsgPechoSpot(const al::SensorMsg*);
+bool isMsgDamageBallAttack(const al::SensorMsg*);
 
 bool tryGetAirExplosionForce(sead::Vector3f* force, const al::SensorMsg*);
 bool tryGetByugoBlowForce(sead::Vector3f* force, const al::SensorMsg*);


### PR DESCRIPTION
I was searching on Discord and found a zip of @CraftyBoss's Togezo decomp. Believe it or not, people really decomped this game before the reorganization. I've went around and modernized it and now it's 100% matching (thanks everyone in discord for helping with that.)

This is the weirdest class I've dealt with in the way that Nintendo wrote this code. A Nintendo developer really struggled to implement this actor. Here's some examples on the cursed code going on:
![image](https://github.com/user-attachments/assets/b5072e57-b45a-4787-afeb-4cc9d72d66dd)
![image](https://github.com/user-attachments/assets/3ffa0af5-cddb-4122-afca-f8d1878aeb9d)
![image](https://github.com/user-attachments/assets/05a08a3f-d17f-481b-a1ae-693e37138179)
![image](https://github.com/user-attachments/assets/24ea6a1d-182c-440e-9dee-58c76751606d)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/268)
<!-- Reviewable:end -->
