### PR TITLE
Npc: Implement `TiaraEyes`

### DIFF
--- a/lib/al/Library/Nerve/NerveSetupUtil.h
+++ b/lib/al/Library/Nerve/NerveSetupUtil.h
@@ -52,6 +52,19 @@ al::initNerveAction(this, "Hide", &NrvExampleUseCase.mCollector, 0);
 
 #define NERVE_IMPL(Class, Action) NERVE_IMPL_(Class, Action, Action)
 
+#define NERVE_END_IMPL_(Class, Action, ActionFunc)                                                 \
+    class Class##Nrv##Action : public al::Nerve {                                                  \
+    public:                                                                                        \
+        void execute(al::NerveKeeper* keeper) const override {                                     \
+            (keeper->getParent<Class>())->exe##ActionFunc();                                       \
+        }                                                                                          \
+        void executeOnEnd(al::NerveKeeper* keeper) const override {                                \
+            (keeper->getParent<Class>())->end##ActionFunc();                                       \
+        }                                                                                          \
+    };
+
+#define NERVE_END_IMPL(Class, Action) NERVE_END_IMPL_(Class, Action, Action)
+
 #define NERVE_HOST_TYPE_IMPL_(Class, Action, ActionFunc)                                           \
     class HostType##Nrv##Action : public al::Nerve {                                               \
     public:                                                                                        \

--- a/src/Npc/TiaraEyes.cpp
+++ b/src/Npc/TiaraEyes.cpp
@@ -1,0 +1,131 @@
+#include "Npc/TiaraEyes.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(TiaraEyes, Appear);
+NERVE_IMPL_(TiaraEyes, WaitPanicL, Controlled);
+NERVE_IMPL_(TiaraEyes, WaitPanicR, Controlled);
+NERVE_IMPL_(TiaraEyes, MovePanicL, Controlled);
+NERVE_IMPL_(TiaraEyes, MovePanicR, Controlled);
+NERVE_IMPL_(TiaraEyes, Reaction, Controlled);
+NERVE_IMPL_(TiaraEyes, ReactionCap, Controlled);
+NERVE_IMPL(TiaraEyes, Wait);
+NERVE_IMPL(TiaraEyes, Disappear);
+NERVE_END_IMPL(TiaraEyes, Hide);
+
+NERVES_MAKE_NOSTRUCT(TiaraEyes, Appear, WaitPanicL, WaitPanicR, MovePanicL, MovePanicR, Reaction,
+                     ReactionCap, Wait, Disappear, Hide);
+}  // namespace
+
+TiaraEyes::TiaraEyes(char const* name) : al::PartsModel(name) {}
+
+void TiaraEyes::init(const al::ActorInitInfo& info) {
+    al::initNerve(this, &Appear, 0);
+    makeActorDead();
+}
+
+void TiaraEyes::appear() {
+    al::LiveActor::appear();
+    al::setNerve(this, &Appear);
+}
+
+void TiaraEyes::startWaitPanicL(float frame) {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "WaitPanicL");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "WaitPanicL"), frame));
+    al::setNerve(this, &WaitPanicL);
+}
+
+void TiaraEyes::startWaitPanicR(float frame) {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "WaitPanicR");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "WaitPanicR"), frame));
+    al::setNerve(this, &WaitPanicR);
+}
+
+void TiaraEyes::startMovePanicL(float frame) {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "MovePanicL");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "MovePanicL"), frame));
+    al::setNerve(this, &MovePanicL);
+}
+
+void TiaraEyes::startMovePanicR(float frame) {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "MovePanicR");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "MovePanicR"), frame));
+    al::setNerve(this, &MovePanicR);
+}
+
+void TiaraEyes::startReaction() {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "Reaction");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "Reaction"), 0.0f));
+    al::setNerve(this, &Reaction);
+}
+
+void TiaraEyes::startReactionCap() {
+    if (al::isDead(this))
+        appear();
+
+    al::startAction(this, "ReactionCap");
+    al::setActionFrame(this, sead::Mathf::min(al::getActionFrameMax(this, "ReactionCap"), 0.0f));
+    al::setNerve(this, &ReactionCap);
+}
+
+void TiaraEyes::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+
+    al::setNerveAtActionEnd(this, &Wait);
+}
+
+void TiaraEyes::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+
+    if (!mIsActive)
+        al::setNerve(this, &Disappear);
+}
+
+void TiaraEyes::exeDisappear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Disappear");
+
+    if (al::isActionEnd(this)) {
+        al::hideModelIfShow(this);
+        al::setNerve(this, &Hide);
+    }
+}
+
+void TiaraEyes::exeHide() {
+    if (al::isFirstStep(this))
+        mHideTimer = 0;
+
+    mHideTimer += mIsActive ? 1 : -mHideTimer;
+
+    if (mHideTimer >= 60)
+        al::setNerve(this, &Appear);
+}
+
+void TiaraEyes::endHide() {
+    al::showModelIfHide(this);
+}
+
+void TiaraEyes::exeControlled() {}

--- a/src/Npc/TiaraEyes.cpp
+++ b/src/Npc/TiaraEyes.cpp
@@ -23,7 +23,7 @@ NERVES_MAKE_NOSTRUCT(TiaraEyes, Appear, WaitPanicL, WaitPanicR, MovePanicL, Move
                      ReactionCap, Wait, Disappear, Hide);
 }  // namespace
 
-TiaraEyes::TiaraEyes(char const* name) : al::PartsModel(name) {}
+TiaraEyes::TiaraEyes(const char* name) : al::PartsModel(name) {}
 
 void TiaraEyes::init(const al::ActorInitInfo& info) {
     al::initNerve(this, &Appear, 0);
@@ -35,7 +35,7 @@ void TiaraEyes::appear() {
     al::setNerve(this, &Appear);
 }
 
-void TiaraEyes::startWaitPanicL(float frame) {
+void TiaraEyes::startWaitPanicL(f32 frame) {
     if (al::isDead(this))
         appear();
 
@@ -44,7 +44,7 @@ void TiaraEyes::startWaitPanicL(float frame) {
     al::setNerve(this, &WaitPanicL);
 }
 
-void TiaraEyes::startWaitPanicR(float frame) {
+void TiaraEyes::startWaitPanicR(f32 frame) {
     if (al::isDead(this))
         appear();
 
@@ -53,7 +53,7 @@ void TiaraEyes::startWaitPanicR(float frame) {
     al::setNerve(this, &WaitPanicR);
 }
 
-void TiaraEyes::startMovePanicL(float frame) {
+void TiaraEyes::startMovePanicL(f32 frame) {
     if (al::isDead(this))
         appear();
 
@@ -62,7 +62,7 @@ void TiaraEyes::startMovePanicL(float frame) {
     al::setNerve(this, &MovePanicL);
 }
 
-void TiaraEyes::startMovePanicR(float frame) {
+void TiaraEyes::startMovePanicR(f32 frame) {
     if (al::isDead(this))
         appear();
 

--- a/src/Npc/TiaraEyes.h
+++ b/src/Npc/TiaraEyes.h
@@ -4,14 +4,14 @@
 
 class TiaraEyes : public al::PartsModel {
 public:
-    TiaraEyes(char const* name);
+    TiaraEyes(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
     void appear() override;
-    void startWaitPanicL(float frame);
-    void startWaitPanicR(float frame);
-    void startMovePanicL(float frame);
-    void startMovePanicR(float frame);
+    void startWaitPanicL(f32 frame);
+    void startWaitPanicR(f32 frame);
+    void startMovePanicL(f32 frame);
+    void startMovePanicR(f32 frame);
     void startReaction();
     void startReactionCap();
     void exeAppear();

--- a/src/Npc/TiaraEyes.h
+++ b/src/Npc/TiaraEyes.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/Obj/PartsModel.h"
+
+class TiaraEyes : public al::PartsModel {
+public:
+    TiaraEyes(char const* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void startWaitPanicL(float frame);
+    void startWaitPanicR(float frame);
+    void startMovePanicL(float frame);
+    void startMovePanicR(float frame);
+    void startReaction();
+    void startReactionCap();
+    void exeAppear();
+    void exeWait();
+    void exeDisappear();
+    void exeHide();
+    void endHide();
+    void exeControlled();
+
+private:
+    bool mIsActive = false;
+    s32 mHideTimer = 0;
+};


### PR DESCRIPTION
`TiaraEyes` is a simple class with a bunch of repeated functions. However, this is the first class to have an implemented `executeOnEnd` nerve!
I created a `NERVE_END_IMPL_` and `NERVE_END_IMPL` to handle it. Maybe it should be renamed `NERVE_ON_END_IMPL` or `NERVE_WITH_END_IMPL`?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/272)
<!-- Reviewable:end -->
