### PR TITLE
lint: Fix typo in includes check

### DIFF
--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -188,7 +188,7 @@ def common_include_order(c, path, is_header):
                          "Wrong order for includes: Found \"game\"-include outside of expected block!", path): return
                 order = 2
             else:
-                FAIL("This file is not allowed to be included with <>!", line, path)
+                FAIL("This file is not allowed to be included with \"file\"!", line, path)
                 return
         else:
             FAIL("Unknown include format", line, path)


### PR DESCRIPTION
I wrote down that this issue exists back in March 2024 - and then forgot about it. This PR finally fixes this one wrong error message.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/283)
<!-- Reviewable:end -->
