### PR TITLE
workflow: Fix error outputs for `compile-check`

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -62,10 +62,10 @@ jobs:
       run: tools/build.py
     - name: Verify function states
       run: |
-        var="$(tools/check 2>&1)"
-        if [[ "$var" == "OK" ]]; then
+        var="$(tools/check 2> errfile || true)"
+        if [[ "$(cat errfile)" == "OK" ]]; then
           exit 0
         else
-          echo $var;
+          cat errfile | tr '\n' '\f' | sed 's/Stack backtrace:.*//' | tr '\f' '\n'
           exit 1
         fi


### PR DESCRIPTION
Fixes #60 

So far, the `compile-check` workflow did not output its error messages, because `tools/check` failed with a non-zero exit code in these circumstances, so the remainder of the step would not be executed. By adding `|| true` to it, failing return codes are ignored. Additionally, by piping the error to a file and reading it back with `cat`, newlines are preserved. Rust shows its stack trace by default when using `bail!` to exit a program, so we're also cutting that and the remainder of the (multiline) message away using `sed`. `\f` (form feed symbol) is used as a temporary replacement for `\n` here, to allow multi-line replacements in `sed` without fancy commands.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/287)
<!-- Reviewable:end -->
