### PR TITLE
Library/MapObj: Implement `SlideMapParts`

### DIFF
--- a/lib/al/Library/LiveActor/ActorInitInfo.h
+++ b/lib/al/Library/LiveActor/ActorInitInfo.h
@@ -158,6 +158,7 @@ void setSubActorOffSyncClipping(LiveActor*);
 void initScreenPointKeeper(LiveActor*, const Resource*, const ActorInitInfo&, const char*);
 void initScreenPointKeeperNoYaml(LiveActor*, s32);
 void initActorMaterialCategory(LiveActor*, const ActorInitInfo&, const char*);
+const char* tryGetMapPartsSuffix(const ActorInitInfo&, const char*);
 
 // TODO: move these
 void initActorSceneInfo(LiveActor*, const ActorInitInfo&);

--- a/lib/al/Library/LiveActor/ActorMovementFunction.h
+++ b/lib/al/Library/LiveActor/ActorMovementFunction.h
@@ -171,6 +171,7 @@ void calcQuatUp(sead::Vector3f*, const LiveActor* actor);
 void calcQuatUp(sead::Vector3f*, const sead::Quatf& quat);
 void calcQuatFront(sead::Vector3f*, const LiveActor* actor);
 void calcQuatLocalAxis(sead::Vector3f*, const LiveActor* actor, s32);
+void calcQuatLocalAxis(sead::Vector3f*, const sead::Quatf&, s32);
 void calcTransOffsetFront(sead::Vector3f*, const LiveActor* actor, f32);
 void calcTransOffsetUp(sead::Vector3f*, const LiveActor* actor, f32);
 void calcTransOffsetSide(sead::Vector3f*, const LiveActor* actor, f32);

--- a/lib/al/Library/MapObj/SlideMapParts.cpp
+++ b/lib/al/Library/MapObj/SlideMapParts.cpp
@@ -29,7 +29,7 @@ NERVE_ACTIONS_MAKE_STRUCT(SlideMapParts, StandBy, Delay, Wait, Move)
 namespace al {
 SlideMapParts::SlideMapParts(const char* name) : LiveActor(name) {}
 
-// NON_MATCHING
+// NON_MATCHING Uses makeQT but with different axis? https://decomp.me/scratch/Ce6nu
 void SlideMapParts::init(const ActorInitInfo& info) {
     using SlideMapPartsFunctor = FunctorV0M<SlideMapParts*, void (SlideMapParts::*)()>;
 

--- a/lib/al/Library/MapObj/SlideMapParts.cpp
+++ b/lib/al/Library/MapObj/SlideMapParts.cpp
@@ -1,0 +1,138 @@
+#include "Library/MapObj/SlideMapParts.h"
+
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+using namespace al;
+
+NERVE_ACTION_IMPL(SlideMapParts, StandBy)
+NERVE_ACTION_IMPL(SlideMapParts, Delay)
+NERVE_ACTION_IMPL(SlideMapParts, Wait)
+NERVE_ACTION_IMPL(SlideMapParts, Move)
+
+NERVE_ACTIONS_MAKE_STRUCT(SlideMapParts, StandBy, Delay, Wait, Move)
+}  // namespace
+
+namespace al {
+SlideMapParts::SlideMapParts(const char* name) : LiveActor(name) {}
+
+// looks like makeQT but with x y w instead of y z x
+inline void makeSomething(sead::BaseMtx34<f32>* o, const sead::Quatf& q, const sead::Vector3f& t) {
+    // Assuming the quaternion "q" is normalized
+
+    const f32 xx = 2 * q.x * q.x;
+    const f32 yy = 2 * q.y * q.y;
+    const f32 ww = 2 * q.w * q.w;
+    const f32 wx = 2 * q.w * q.x;
+    const f32 wy = 2 * q.w * q.y;
+    const f32 xy = 2 * q.x * q.y;
+    const f32 zx = 2 * q.z * q.x;
+    const f32 zy = 2 * q.z * q.y;
+    const f32 zw = 2 * q.z * q.w;
+
+    o->m[0][0] = 1 - xx - yy;
+    o->m[0][1] = wx - zy;
+    o->m[0][2] = wy + zx;
+
+    o->m[1][0] = wx + zy;
+    o->m[1][1] = 1 - ww - yy;
+    o->m[1][2] = xy - zw;
+
+    o->m[2][0] = wy - zx;
+    o->m[2][1] = xy + zw;
+    o->m[2][2] = 1 - ww - xx;
+
+    o->m[0][3] = t.x;
+    o->m[1][3] = t.y;
+    o->m[2][3] = t.z;
+}
+
+// NON_MATCHING
+void SlideMapParts::init(const ActorInitInfo& info) {
+    using SlideMapPartsFunctor = FunctorV0M<SlideMapParts*, void (SlideMapParts::*)()>;
+
+    initNerveAction(this, "Move", &NrvSlideMapParts.mCollector, 0);
+    initMapPartsActor(this, info, tryGetMapPartsSuffix(info, "SlideMapParts"));
+    registerAreaHostMtx(this, info);
+
+    mTrans = getTrans(this);
+    tryGetArg(&mMoveAxis, info, "MoveAxis");
+    tryGetArg(&mMoveDistance, info, "MoveDistance");
+    tryGetArg(&mMoveSpeed, info, "MoveSpeed");
+    tryGetArg(&mWaitTime, info, "WaitTime");
+    if (mWaitTime < 0)
+        mWaitTime = 0;
+    tryGetArg(&mMoveTime, info, "MoveTime");
+    tryGetArg(&mDelayTime, info, "DelayTime");
+
+    f32 surfaceHeight = 0.0f;
+    tryGetArg(&surfaceHeight, info, "SurfaceHeight");
+
+    initMaterialCode(this, info);
+
+    sead::Vector3f tmp;
+    calcQuatLocalAxis(&tmp, getQuat(this), mMoveAxis);
+    makeSomething(&mSurfaceEffectMtx, getQuat(this), tmp * surfaceHeight + mTrans);
+
+    trySetEffectNamedMtxPtr(this, "Surface", &mSurfaceEffectMtx);
+
+    if (listenStageSwitchOnStart(this, SlideMapPartsFunctor(this, &SlideMapParts::start)))
+        startNerveAction(this, "StandBy");
+    else if (mDelayTime >= 1)
+        startNerveAction(this, "Delay");
+
+    trySyncStageSwitchAppear(this);
+}
+
+void SlideMapParts::start() {
+    if (isNerve(this, NrvSlideMapParts.StandBy.data())) {
+        if (mDelayTime >= 1) {
+            startNerveAction(this, "Delay");
+
+            return;
+        }
+
+        startNerveAction(this, "Move");
+    }
+}
+
+bool SlideMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
+    if (isMsgShowModel(message)) {
+        showModelIfHide(this);
+
+        return true;
+    }
+
+    if (isMsgHideModel(message)) {
+        hideModelIfShow(this);
+
+        return true;
+    }
+
+    return false;
+}
+
+void SlideMapParts::exeStandBy() {}
+
+void SlideMapParts::exeDelay() {
+    if (isGreaterEqualStep(this, mDelayTime))
+        startNerveAction(this, "Move");
+}
+
+void SlideMapParts::exeWait() {
+    if (isGreaterStep(this, mWaitTime))
+        startNerveAction(this, "Move");
+}
+}  // namespace al

--- a/lib/al/Library/MapObj/SlideMapParts.cpp
+++ b/lib/al/Library/MapObj/SlideMapParts.cpp
@@ -99,15 +99,16 @@ void SlideMapParts::init(const ActorInitInfo& info) {
 }
 
 void SlideMapParts::start() {
-    if (isNerve(this, NrvSlideMapParts.StandBy.data())) {
-        if (mDelayTime >= 1) {
-            startNerveAction(this, "Delay");
+    if (!isNerve(this, NrvSlideMapParts.StandBy.data()))
+        return;
 
-            return;
-        }
+    if (mDelayTime >= 1) {
+        startNerveAction(this, "Delay");
 
-        startNerveAction(this, "Move");
+        return;
     }
+
+    startNerveAction(this, "Move");
 }
 
 bool SlideMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {

--- a/lib/al/Library/MapObj/SlideMapParts.cpp
+++ b/lib/al/Library/MapObj/SlideMapParts.cpp
@@ -38,7 +38,7 @@ void SlideMapParts::init(const ActorInitInfo& info) {
     registerAreaHostMtx(this, info);
 
     mTrans = getTrans(this);
-    tryGetArg(&mMoveAxis, info, "MoveAxis");
+    tryGetArg((s32*)&mMoveAxis, info, "MoveAxis");
     tryGetArg(&mMoveDistance, info, "MoveDistance");
     tryGetArg(&mMoveSpeed, info, "MoveSpeed");
     tryGetArg(&mWaitTime, info, "WaitTime");
@@ -53,7 +53,7 @@ void SlideMapParts::init(const ActorInitInfo& info) {
     initMaterialCode(this, info);
 
     sead::Vector3f t;
-    calcQuatLocalAxis(&t, getQuat(this), mMoveAxis);
+    calcQuatLocalAxis(&t, getQuat(this), (s32)mMoveAxis);
 
     f32 offsetX = surfaceHeight * t.x + mTrans.x;
     f32 offsetY = surfaceHeight * t.y;
@@ -150,7 +150,7 @@ void SlideMapParts::exeMove() {
     if (!_15c)
         rate = 1.0f - rate;
 
-    setTransOffsetLocalDir(this, getQuat(this), mTrans, mMoveDistance * rate, mMoveAxis);
+    setTransOffsetLocalDir(this, getQuat(this), mTrans, mMoveDistance * rate, (s32)mMoveAxis);
 
     if (isGreaterEqualStep(this, calcMoveTime())) {
         if (_15c)
@@ -171,10 +171,6 @@ s32 SlideMapParts::calcMoveTime() const {
     if (mMoveSpeed < 1.0f)
         return 0;
 
-    f32 moveTime = mMoveDistance / mMoveSpeed;
-    if (!(moveTime > 0.0f))
-        moveTime = -moveTime;
-
-    return (s32)moveTime;
+    return (s32)sead::Mathf::abs(mMoveDistance / mMoveSpeed);
 }
 }  // namespace al

--- a/lib/al/Library/MapObj/SlideMapParts.h
+++ b/lib/al/Library/MapObj/SlideMapParts.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/Axis.h"
 
 namespace al {
 class SlideMapParts : public LiveActor {
@@ -21,7 +22,7 @@ public:
 private:
     sead::Matrix34f mSurfaceEffectMtx = sead::Matrix34f::ident;
     sead::Vector3f mTrans = sead::Vector3f::zero;
-    s32 /*Axis*/ mMoveAxis = 0 /*Axis::None*/;
+    Axis mMoveAxis = Axis::None;
     f32 mMoveDistance = 100.0f;
     f32 mMoveSpeed = 10.0f;
     s32 mWaitTime = 60;

--- a/lib/al/Library/MapObj/SlideMapParts.h
+++ b/lib/al/Library/MapObj/SlideMapParts.h
@@ -28,7 +28,7 @@ private:
     s32 mWaitTime = 60;
     s32 mMoveTime = -1;
     s32 mDelayTime = 0;
-    bool _15c = true;
+    bool mIsMoveForwards = true;
 };
 
 static_assert(sizeof(SlideMapParts) == 0x160);

--- a/lib/al/Library/MapObj/SlideMapParts.h
+++ b/lib/al/Library/MapObj/SlideMapParts.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class SlideMapParts : public LiveActor {
+public:
+    SlideMapParts(const char* name);
+
+    void init(const ActorInitInfo& info) override;
+    void start();
+    bool receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) override;
+
+    void exeStandBy();
+    void exeDelay();
+    void exeWait();
+    void exeMove();
+
+    s32 calcMoveTime() const;
+
+private:
+    sead::Matrix34f mSurfaceEffectMtx = sead::Matrix34f::ident;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    s32 /*Axis*/ mMoveAxis = 0 /*Axis::None*/;
+    f32 mMoveDistance = 100.0f;
+    f32 mMoveSpeed = 10.0f;
+    s32 mWaitTime = 60;
+    s32 mMoveTime = -1;
+    s32 mDelayTime = 0;
+    bool _15c = true;
+};
+
+static_assert(sizeof(SlideMapParts) == 0x160);
+}  // namespace al

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -14,6 +14,7 @@
 #include "Library/MapObj/RailMoveMapParts.h"
 #include "Library/MapObj/RollingCubeMapParts.h"
 #include "Library/MapObj/RotateMapParts.h"
+#include "Library/MapObj/SlideMapParts.h"
 #include "Library/MapObj/SurfMapParts.h"
 #include "Library/Obj/AllDeadWatcher.h"
 
@@ -582,7 +583,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"RippleFixMapParts", nullptr},
     {"RotateMapParts", al::createActorFunction<al::RotateMapParts>},
     {"SeesawMapParts", nullptr},
-    {"SlideMapParts", nullptr},
+    {"SlideMapParts", al::createActorFunction<al::SlideMapParts>},
     {"SubActorLodMapParts", nullptr},
     {"SurfMapParts", al::createActorFunction<al::SurfMapParts>},
     {"SwingMapParts", nullptr},


### PR DESCRIPTION
This PR adds `SlideMapParts` functions

I didn't manage to get `SlideMapParts::init` matching. It seems that it uses `makeQT` but with different axis.

This class is a leftover from SM3DW
![image](https://github.com/user-attachments/assets/91408024-9e1a-421f-a5e6-f2a1ff34aba5)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/288)
<!-- Reviewable:end -->
