### PR TITLE
Enemy: Match `SenobiLeaf::registerToHost`

### DIFF
--- a/src/Enemy/SenobiLeaf.cpp
+++ b/src/Enemy/SenobiLeaf.cpp
@@ -38,12 +38,15 @@ void SenobiLeaf::updatePose() {
     al::updatePoseTrans(this, al::getTrans(this) - newFrontDir * 15.0f);
 }
 
-// NON_MATCHING: regswap when adding
 void SenobiLeaf::registerToHost(al::LiveActor* host, bool flip) {
     mHostActor = host;
     getName();  // unused
     al::invalidateClipping(this);
     al::registerSubActorSyncClipping(host, this);
     al::onSyncHideSubActor(host, this);
-    mYDegree = al::getRandom(-60.0f, 60.0f) + (flip ? -90.0f : 90.0f);
+
+    if (flip)
+        mYDegree = al::getRandom(-60.0f, 60.0f) - 90.0f;
+    else
+        mYDegree = al::getRandom(-60.0f, 60.0f) + 90.0f;
 }


### PR DESCRIPTION
Fixes a regswap in `SenobiLeaf::registerToHost` by using an if/else instead of a ternary. I can't believe I didn't try this before!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/292)
<!-- Reviewable:end -->
