### PR TITLE
Library/MapObj: Implement `SwitchDitherMapParts`

### DIFF
--- a/lib/al/Library/MapObj/SwitchDitherMapParts.cpp
+++ b/lib/al/Library/MapObj/SwitchDitherMapParts.cpp
@@ -1,0 +1,45 @@
+#include "Library/MapObj/SwitchDitherMapParts.h"
+
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+using namespace al;
+
+NERVE_ACTION_IMPL(SwitchDitherMapParts, Wait)
+
+NERVE_ACTIONS_MAKE_STRUCT(SwitchDitherMapParts, Wait)
+}  // namespace
+
+namespace al {
+SwitchDitherMapParts::SwitchDitherMapParts(const char* name) : LiveActor(name) {}
+
+void SwitchDitherMapParts::init(const ActorInitInfo& info) {
+    using SwitchDitherMapPartsFunctor =
+        FunctorV0M<SwitchDitherMapParts*, void (SwitchDitherMapParts::*)()>;
+
+    initNerveAction(this, "Wait", &NrvSwitchDitherMapParts.mCollector, 0);
+    initMapPartsActor(this, info, nullptr);
+
+    bool isListenStartOnOff = listenStageSwitchOnOff(
+        this, "SwitchStart", SwitchDitherMapPartsFunctor(this, &SwitchDitherMapParts::ditherOn),
+        SwitchDitherMapPartsFunctor(this, &SwitchDitherMapParts::ditherOff));
+    if (isListenStartOnOff)
+        invalidateDitherAnim(this);
+
+    makeActorAlive();
+}
+
+void SwitchDitherMapParts::ditherOn() {
+    validateDitherAnim(this);
+}
+
+void SwitchDitherMapParts::ditherOff() {
+    invalidateDitherAnim(this);
+}
+
+void SwitchDitherMapParts::exeWait() {}
+}  // namespace al

--- a/lib/al/Library/MapObj/SwitchDitherMapParts.h
+++ b/lib/al/Library/MapObj/SwitchDitherMapParts.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class SwitchDitherMapParts : public LiveActor {
+public:
+    SwitchDitherMapParts(const char* name);
+
+    void init(const ActorInitInfo& info) override;
+
+    void ditherOn();
+    void ditherOff();
+
+    void exeWait();
+};
+
+static_assert(sizeof(SwitchDitherMapParts) == 0x108);
+}  // namespace al

--- a/lib/al/Library/Model/ModelCtrl.h
+++ b/lib/al/Library/Model/ModelCtrl.h
@@ -10,6 +10,7 @@ namespace al {
 class GpuMemAllocator;
 class ModelShaderHolder;
 class Resource;
+class ActorDitherAnimator;
 
 class ModelCtrl {
 public:
@@ -23,12 +24,18 @@ public:
 
     nn::g3d::ModelObj* getModelObj() const { return mModelObj; }
 
+    ActorDitherAnimator* getActorDitherAnimator() const { return mActorDitherAnimator; }
+
 private:
     nn::g3d::ModelObj* mModelObj;
     s32 _8;
     GpuMemAllocator* mGpuMemAllocator;
     ModelShaderHolder* mShaderHolder;
     s32 mBlockBufferSize;
-    // note: member list not complete
+    unsigned char padding1[0x354];
+    ActorDitherAnimator* mActorDitherAnimator;
+    unsigned char padding2[0xc8];
 };
+
+static_assert(sizeof(ModelCtrl) == 0x448);
 }  // namespace al

--- a/lib/al/Library/Obj/ActorDitherAnimator.h
+++ b/lib/al/Library/Obj/ActorDitherAnimator.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/Anim/DitherAnimator.h"
+
+namespace al {
+class LiveActor;
+
+// TODO: Finish this
+class ActorDitherAnimator : public DitherAnimator {
+public:
+    ActorDitherAnimator(LiveActor* host);
+
+    void validateDitherAnim();
+    void invalidateDitherAnim();
+
+private:
+    unsigned char padding[0x68 - sizeof(DitherAnimator)];
+};
+
+static_assert(sizeof(ActorDitherAnimator) == 0x68);
+}  // namespace al

--- a/lib/al/Library/Thread/FunctorV0M.h
+++ b/lib/al/Library/Thread/FunctorV0M.h
@@ -15,8 +15,10 @@ template <class T, class F>
 class FunctorV0M : public FunctorBase {
 public:
     inline FunctorV0M() = default;
+
     inline FunctorV0M(T objPointer, F functPointer)
-        : mObjPointer(objPointer), mFunctPointer(functPointer) {};
+        : mObjPointer(objPointer), mFunctPointer(functPointer) {}
+
     inline FunctorV0M(const FunctorV0M<T, F>& copy) = default;
 
     void operator()() const override { (mObjPointer->*mFunctPointer)(); }

--- a/lib/al/Library/Thread/FunctorV0M.h
+++ b/lib/al/Library/Thread/FunctorV0M.h
@@ -16,15 +16,15 @@ class FunctorV0M : public FunctorBase {
 public:
     inline FunctorV0M() = default;
     inline FunctorV0M(T objPointer, F functPointer)
-        : mObjPointer(objPointer), mFunctor(functPointer){};
+        : mObjPointer(objPointer), mFunctPointer(functPointer) {};
     inline FunctorV0M(const FunctorV0M<T, F>& copy) = default;
 
-    void operator()() const override { (mObjPointer->*mFunctor)(); }
+    void operator()() const override { (mObjPointer->*mFunctPointer)(); }
 
     FunctorV0M<T, F>* clone() const override { return new FunctorV0M<T, F>(*this); }
 
 private:
     T mObjPointer = nullptr;
-    F mFunctor = nullptr;
+    F mFunctPointer = nullptr;
 };
 }  // namespace al

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -15,6 +15,7 @@
 #include "Library/MapObj/RollingCubeMapParts.h"
 #include "Library/MapObj/RotateMapParts.h"
 #include "Library/MapObj/SurfMapParts.h"
+#include "Library/MapObj/SwitchDitherMapParts.h"
 #include "Library/Obj/AllDeadWatcher.h"
 
 #include "Boss/Mofumofu/MofumofuScrap.h"
@@ -586,7 +587,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"SubActorLodMapParts", nullptr},
     {"SurfMapParts", al::createActorFunction<al::SurfMapParts>},
     {"SwingMapParts", nullptr},
-    {"SwitchDitherMapParts", nullptr},
+    {"SwitchDitherMapParts", al::createActorFunction<al::SwitchDitherMapParts>},
     {"SwitchKeepOnWatcher", nullptr},
     {"SwitchOpenMapParts", nullptr},
     {"VisibleSwitchMapParts", nullptr},


### PR DESCRIPTION
This PR:
- adds `SwitchDitherMapParts` functions.
- rename `mFunctor` by `mFunctPointer` in `FunctorV0M`
- adds padding in `ModelCtrl`
- adds an incomplete declaration for `ActorDitherAnimator`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/298)
<!-- Reviewable:end -->
