### PR TITLE
MapObj: Implement `BlinkRateCalculator`

### DIFF
--- a/src/MapObj/BlinkRateCalculator.cpp
+++ b/src/MapObj/BlinkRateCalculator.cpp
@@ -1,0 +1,39 @@
+#include "MapObj/BlinkRateCalculator.h"
+
+#include "Library/Math/MathUtil.h"
+
+BlinkRateCalculator::BlinkRateCalculator(s32 maxFrames) : mMaxFrames(maxFrames) {}
+
+BlinkRateCalculator::BlinkRateCalculator() {}
+
+void BlinkRateCalculator::reset() {
+    mCurrentFrame = 0;
+    mCurrentRate = 1.0f;
+}
+
+void BlinkRateCalculator::update() {
+    if (mCurrentFrame < mMaxFrames)
+        mCurrentFrame = ++mCurrentFrame;
+
+    if (mMaxFrames - mCurrentFrame > 150) {
+        mCurrentRate = 1.0f;
+        return;
+    }
+
+    s32 interval = mCurrentFrame % 50;
+
+    if (interval < 5) {
+        mCurrentRate = al::lerpValue(1.0f, mRateThreshold, interval / 5.0f);
+        return;
+    }
+    if (interval < 20) {
+        mCurrentRate = mRateThreshold;
+        return;
+    }
+    if (interval < 25) {
+        mCurrentRate = al::lerpValue(mRateThreshold, 1.0f, (interval - 20) / 5.0f);
+        return;
+    }
+
+    mCurrentRate = 1.0f;
+}

--- a/src/MapObj/BlinkRateCalculator.cpp
+++ b/src/MapObj/BlinkRateCalculator.cpp
@@ -13,7 +13,7 @@ void BlinkRateCalculator::reset() {
 
 void BlinkRateCalculator::update() {
     if (mCurrentFrame < mMaxFrames)
-        mCurrentFrame = ++mCurrentFrame;
+        mCurrentFrame++;
 
     if (mMaxFrames - mCurrentFrame > 150) {
         mCurrentRate = 1.0f;
@@ -22,18 +22,12 @@ void BlinkRateCalculator::update() {
 
     s32 interval = mCurrentFrame % 50;
 
-    if (interval < 5) {
+    if (interval < 5)
         mCurrentRate = al::lerpValue(1.0f, mRateThreshold, interval / 5.0f);
-        return;
-    }
-    if (interval < 20) {
+    else if (interval < 20)
         mCurrentRate = mRateThreshold;
-        return;
-    }
-    if (interval < 25) {
+    else if (interval < 25)
         mCurrentRate = al::lerpValue(mRateThreshold, 1.0f, (interval - 20) / 5.0f);
-        return;
-    }
-
-    mCurrentRate = 1.0f;
+    else
+        mCurrentRate = 1.0f;
 }

--- a/src/MapObj/BlinkRateCalculator.h
+++ b/src/MapObj/BlinkRateCalculator.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class BlinkRateCalculator {
+public:
+    BlinkRateCalculator(s32 maxFrames);
+    BlinkRateCalculator();
+    void reset();
+    void update();
+
+private:
+    s32 mMaxFrames = 50;
+    s32 mCurrentFrame = 0;
+    f32 mCurrentRate = 0.0f;
+    f32 mRateThreshold = 0.498f;
+};


### PR DESCRIPTION
Oops, I pushed this to MonsterDruide1's remote instead of my fork. Implements an unused class named `BlinkRateCalculator`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/299)
<!-- Reviewable:end -->
