### PR TITLE
Player: Implement `PlayerJudgeDiveInWater`

### DIFF
--- a/lib/al/Library/Nature/NatureUtil.h
+++ b/lib/al/Library/Nature/NatureUtil.h
@@ -13,5 +13,7 @@ bool tryAddRippleMiddle(LiveActor* actor);
 
 bool calcFindWaterSurface(sead::Vector3f*, sead::Vector3f*, const LiveActor*, const sead::Vector3f&,
                           const sead::Vector3f&, f32);
+bool calcFindWaterSurfaceFlat(sead::Vector3f*, sead::Vector3f*, const LiveActor*,
+                              const sead::Vector3f&, const sead::Vector3f&, f32);
 
 }  // namespace al

--- a/src/Player/PlayerJudgeDiveInWater.cpp
+++ b/src/Player/PlayerJudgeDiveInWater.cpp
@@ -1,0 +1,48 @@
+#include "Player/PlayerJudgeDiveInWater.h"
+
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Nature/NatureUtil.h"
+
+#include "Player/IUsePlayerFallDistanceCheck.h"
+#include "Player/IUsePlayerHeightCheck.h"
+#include "Player/PlayerConst.h"
+
+PlayerJudgeDiveInWater::PlayerJudgeDiveInWater(const al::LiveActor* player,
+                                               const PlayerConst* playerConst,
+                                               const IUsePlayerHeightCheck* heightCheck,
+                                               const IUsePlayerFallDistanceCheck* fallDistanceCheck)
+    : mPlayer(player), mConst(playerConst), mHeightCheck(heightCheck),
+      mFallDistanceCheck(fallDistanceCheck) {}
+
+bool PlayerJudgeDiveInWater::judge() const {
+    if (mFallDistanceCheck->getFallDistance() < 10.0f)
+        return false;
+    if (mHeightCheck->isAboveGround() && mHeightCheck->getGroundHeight() < 1500.0f)
+        return false;
+
+    sead::Vector3f up = -al::getGravity(mPlayer);
+    f32 findDistance = (mConst->getTall() + 1500.0f) * 0.5f;
+    sead::Vector3f findStart = al::getTrans(mPlayer) + -up * findDistance;
+
+    sead::Vector3f surfacePos = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f surfaceNormal = {0.0f, 0.0f, 0.0f};
+    if (!al::calcFindWaterSurfaceFlat(&surfacePos, &surfaceNormal, mPlayer, findStart, up,
+                                      findDistance))
+        return false;
+
+    f32 surfaceDistance = (al::getTrans(mPlayer) - surfacePos).dot(up);
+    if (surfaceDistance < 1500.0f)
+        return false;
+
+    if (mHeightCheck->isAboveGround()) {
+        f32 minHeight = (surfaceDistance + mConst->getTall());
+        if (mHeightCheck->getGroundHeight() < minHeight)
+            return false;
+    }
+
+    return true;
+}
+
+void PlayerJudgeDiveInWater::reset() {}
+
+void PlayerJudgeDiveInWater::update() {}

--- a/src/Player/PlayerJudgeDiveInWater.h
+++ b/src/Player/PlayerJudgeDiveInWater.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class IUsePlayerHeightCheck;
+class IUsePlayerFallDistanceCheck;
+
+class PlayerJudgeDiveInWater : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeDiveInWater(const al::LiveActor* player, const PlayerConst* playerConst,
+                           const IUsePlayerHeightCheck* heightCheck,
+                           const IUsePlayerFallDistanceCheck* fallDistanceCheck);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const IUsePlayerHeightCheck* mHeightCheck;
+    const IUsePlayerFallDistanceCheck* mFallDistanceCheck;
+};
+
+static_assert(sizeof(PlayerJudgeDiveInWater) == 0x28);


### PR DESCRIPTION
If this judge triggers, the player automatically enters a diving animation/state. It only seems to trigger when jumping off very high cliffs/objects, as Mario needs to have a distance of at least 1500 units (+160 for his own height) to the water surface.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/310)
<!-- Reviewable:end -->
