### PR TITLE
Boss/BossForest: Implement `BossForestWander`

### DIFF
--- a/src/Boss/BossForest/BossForestWander.cpp
+++ b/src/Boss/BossForest/BossForestWander.cpp
@@ -53,12 +53,9 @@ void BossForestWander::exeWait() {
             mWaitTime = waitTime;
     }
     if (al::isGreaterEqualStep(this, mWaitTime)) {
-        if (al::checkIsPlayingSe(this, "PgSenario2StartMove", nullptr))
-            al::setNerve(this, &Move);
-        else {
+        if (!al::checkIsPlayingSe(this, "PgSenario2StartMove", nullptr))
             al::tryStartSe(this, "PgSenario2StartMove");
-            al::setNerve(this, &Move);
-        }
+        al::setNerve(this, &Move);
     }
 }
 

--- a/src/Boss/BossForest/BossForestWander.cpp
+++ b/src/Boss/BossForest/BossForestWander.cpp
@@ -1,0 +1,84 @@
+#include "Boss/BossForest/BossForestWander.h"
+
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/SubActorKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+namespace {
+NERVE_HOST_TYPE_IMPL(BossForestWander, WaitSwitchStart)
+NERVE_HOST_TYPE_IMPL(BossForestWander, Wait)
+NERVE_HOST_TYPE_IMPL(BossForestWander, Move)
+NERVE_HOST_TYPE_IMPL(BossForestWander, End)
+
+NERVES_MAKE_NOSTRUCT(HostType, WaitSwitchStart, Move)
+NERVES_MAKE_STRUCT(HostType, Wait, End)
+}  // namespace
+
+BossForestWander::BossForestWander(const char* name) : LiveActor(name) {}
+
+void BossForestWander::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "BossForest", "Wander");
+    al::initNerve(this, &WaitSwitchStart, 0);
+
+    al::tryGetQuatPtr(this);
+
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    mKeyPoseKeeper->setMoveTypeStop();
+    al::setKeyMoveClippingInfo(this, &mClippingRadius, mKeyPoseKeeper);
+
+    al::startActionSubActor(this, "ライフパーツ00", "WaitOn");
+    al::startActionSubActor(this, "ライフパーツ01", "WaitOn");
+    al::startActionSubActor(this, "ライフパーツ02", "WaitOn");
+
+    al::trySyncStageSwitchAppear(this);
+}
+
+void BossForestWander::exeWaitSwitchStart() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+    if (!al::isValidSwitchStart(this) || al::isOnSwitchStart(this))
+        al::setNerve(this, &NrvHostType.Wait);
+}
+
+void BossForestWander::exeWait() {
+    if (al::isFirstStep(this)) {
+        s32 waitTime = al::calcKeyMoveWaitTime(mKeyPoseKeeper);
+        if (waitTime >= 0)
+            mWaitTime = waitTime;
+    }
+    if (al::isGreaterEqualStep(this, mWaitTime)) {
+        if (al::checkIsPlayingSe(this, "PgSenario2StartMove", nullptr))
+            al::setNerve(this, &Move);
+        else {
+            al::tryStartSe(this, "PgSenario2StartMove");
+            al::setNerve(this, &Move);
+        }
+    }
+}
+
+void BossForestWander::exeMove() {
+    if (al::isFirstStep(this))
+        mMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+
+    f32 rate = al::calcNerveRate(this, mMoveTime);
+    al::calcLerpKeyTrans(al::getTransPtr(this), mKeyPoseKeeper, rate);
+    al::calcSlerpKeyQuat(al::getQuatPtr(this), mKeyPoseKeeper, rate);
+
+    if (al::isGreaterEqualStep(this, mMoveTime)) {
+        al::nextKeyPose(mKeyPoseKeeper);
+        if (al::isStop(mKeyPoseKeeper))
+            al::setNerve(this, &NrvHostType.End);
+        else
+            al::setNerve(this, &NrvHostType.Wait);
+    }
+}
+
+void BossForestWander::exeEnd() {
+    kill();
+}

--- a/src/Boss/BossForest/BossForestWander.h
+++ b/src/Boss/BossForest/BossForestWander.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class KeyPoseKeeper;
+}
+
+class BossForestWander : public al::LiveActor {
+public:
+    BossForestWander(const char* name);
+    void init(const al::ActorInitInfo& info);
+
+    void exeWaitSwitchStart();
+    void exeWait();
+    void exeMove();
+    void exeEnd();
+
+private:
+    al::KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    s32 mMoveTime = -1;
+    s32 mWaitTime = -1;
+    sead::Vector3f mClippingRadius = sead::Vector3f::zero;
+};

--- a/src/Boss/BossForest/BossForestWander.h
+++ b/src/Boss/BossForest/BossForestWander.h
@@ -9,7 +9,7 @@ class KeyPoseKeeper;
 class BossForestWander : public al::LiveActor {
 public:
     BossForestWander(const char* name);
-    void init(const al::ActorInitInfo& info);
+    void init(const al::ActorInitInfo& info) override;
 
     void exeWaitSwitchStart();
     void exeWait();


### PR DESCRIPTION
Implements `BossForestWander`. Because the nerves are HostType, there's a mismatching `HostTypeNrvMove` function until `BossForestBlock` is decompiled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/315)
<!-- Reviewable:end -->
