### PR TITLE
Workflow: Add CMakeLists to headers repo job

### DIFF
--- a/.github/files/HeadersCMakeLists.txt
+++ b/.github/files/HeadersCMakeLists.txt
@@ -1,0 +1,11 @@
+add_library(OdysseyHeaders INTERFACE)
+target_include_directories(OdysseyHeaders INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}
+    ${CMAKE_CURRENT_LIST_DIR}/game
+    ${CMAKE_CURRENT_LIST_DIR}/al
+    ${CMAKE_CURRENT_LIST_DIR}/agl
+    ${CMAKE_CURRENT_LIST_DIR}/eui
+    ${CMAKE_CURRENT_LIST_DIR}/sead
+    ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK
+    ${CMAKE_CURRENT_LIST_DIR}/aarch64
+)

--- a/.github/scripts/copy-headers.sh
+++ b/.github/scripts/copy-headers.sh
@@ -24,6 +24,9 @@ cp -r ./lib/sead/include/* $DESTINATION_PATH/sead
 mkdir $DESTINATION_PATH/game
 rsync -a --prune-empty-dirs --include '*/' --include '*.h' --exclude '*' src/ $DESTINATION_PATH/game
 
+# Copy CMakeLists.txt for header only library
+cp ./.github/files/HeadersCMakeLists.txt $DESTINATION_PATH/CMakeLists.txt
+
 # Make all contents of every class public
 grep -rli 'private:' * | xargs -i@ sed -i 's/private:/public:/g' @
 grep -rli 'protected:' * | xargs -i@ sed -i 's/protected:/public:/g' @


### PR DESCRIPTION
This makes it so that the workflow that deploys the headers to `OdysseyHeaders` also adds a `CMakeLists.txt` that has a header only library. This way projects that use the headers repo can just "link" the library instead of having to include each directory manually.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/332)
<!-- Reviewable:end -->
