### PR TITLE
Library/Nature: Fix WaterSurfaceFinder and Implement FireSurfaceFinder

### DIFF
--- a/lib/al/Library/Nature/FireSurfaceFinder.cpp
+++ b/lib/al/Library/Nature/FireSurfaceFinder.cpp
@@ -1,0 +1,32 @@
+#include "Library/Nature/FireSurfaceFinder.h"
+
+#include "Library/Nature/NatureUtil.h"
+
+namespace al {
+
+FireSurfaceFinder::FireSurfaceFinder(const LiveActor* actor) : mActor(actor) {}
+
+void FireSurfaceFinder::update(const sead::Vector3f& position, const sead::Vector3f& gravity,
+                               f32 distance) {
+    sead::Vector3f surfacePos = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f surfaceNormal = {0.0f, 0.0f, 0.0f};
+    mIsFoundSurface =
+        calcFindFireSurface(&surfacePos, &surfaceNormal, mActor, position, gravity, distance);
+
+    if (mIsFoundSurface) {
+        // requires this manual dot product calculation to match
+        mSurface.setDistance(gravity.x * (surfacePos.x - position.x) +
+                             gravity.y * (surfacePos.y - position.y) +
+                             gravity.z * (surfacePos.z - position.z));
+        mSurface.setPosition(surfacePos);
+        mSurface.setNormal(surfaceNormal);
+    } else {
+        mSurface.setDistance(0.0f);
+        mSurface.setPosition({0.0f, 0.0f, 0.0f});
+        mSurface.setNormal({0.0f, 0.0f, 0.0f});
+    }
+
+    mSurface.set1c({0.0f, 0.0f, 0.0f});
+}
+
+}  // namespace al

--- a/lib/al/Library/Nature/FireSurfaceFinder.h
+++ b/lib/al/Library/Nature/FireSurfaceFinder.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+
+struct FireSurfaceProperties {
+    f32 distance = 0.0f;
+    sead::Vector3f position = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f normal = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f _1c = {0.0f, 0.0f, 0.0f};
+
+    void setDistance(f32 value) { distance = value; }
+
+    void setPosition(const sead::Vector3f& vector) { position.set(vector); }
+
+    void setNormal(const sead::Vector3f& vector) { normal.set(vector); }
+
+    void set1c(const sead::Vector3f& vector) { _1c.set(vector); }
+};
+
+class FireSurfaceFinder {
+public:
+    FireSurfaceFinder(const LiveActor* player);
+
+    void update(const sead::Vector3f& position, const sead::Vector3f& gravity, f32 distance);
+
+private:
+    const LiveActor* mActor;
+    bool mIsFoundSurface = false;
+    FireSurfaceProperties mSurface{};
+};
+
+static_assert(sizeof(FireSurfaceFinder) == 0x38);
+
+}  // namespace al

--- a/lib/al/Library/Nature/NatureUtil.h
+++ b/lib/al/Library/Nature/NatureUtil.h
@@ -1,15 +1,34 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadBoundBox.h>
+#include <math/seadMatrix.h>
+#include <math/seadQuat.h>
 #include <math/seadVector.h>
 
 namespace al {
+class AreaObj;
+class FireSurfaceFinder;
+class IUseFluidSurface;
 class LiveActor;
+class NatureDirector;
+class WaterSurfaceFinder;
 
-bool isInWaterPos(const LiveActor* actor, const sead::Vector3f& pos);
-bool isInWater(const LiveActor* actor);
-bool isInIceWaterPos(const LiveActor* actor, const sead::Vector3f& pos);
-bool tryAddRippleMiddle(LiveActor* actor);
+void registerFluidSurfaceObj(IUseFluidSurface*, const LiveActor*);
+bool isExistFluidSurface(const LiveActor*);
+void setWaterRippleFieldScale(const LiveActor*, f32);
+bool isInWaterPos(const LiveActor*, const sead::Vector3f&);
+bool isInWater(const LiveActor*);
+bool isInWaterNoIgnore(const LiveActor*, const sead::Vector3f&);
+bool isInSodaWater(const LiveActor*, const sead::Vector3f&);
+bool isInIceWaterPos(const LiveActor*, const sead::Vector3f&);
+bool isInIceWater(const LiveActor*);
+bool isInFirePos(const LiveActor*, const sead::Vector3f&);
+bool isInFire(const LiveActor*);
+bool isInCloudPos(const LiveActor*, const sead::Vector3f&);
+bool isInCloud(const LiveActor*);
+bool isWaterAreaIgnore(const AreaObj*);
+const char* getFireMaterialCode(const LiveActor*);
 
 bool calcFindWaterSurface(sead::Vector3f*, sead::Vector3f*, const LiveActor*, const sead::Vector3f&,
                           const sead::Vector3f&, f32);
@@ -19,5 +38,50 @@ bool calcFindWaterSurfaceDisplacement(sead::Vector3f*, sead::Vector3f*, const Li
                                       const sead::Vector3f&, const sead::Vector3f&, f32);
 bool calcFindWaterSurfaceOverGround(sead::Vector3f*, sead::Vector3f*, const LiveActor*,
                                     const sead::Vector3f&, const sead::Vector3f&, f32);
+bool calcFindFireSurface(sead::Vector3f*, sead::Vector3f*, const LiveActor*, const sead::Vector3f&,
+                         const sead::Vector3f&, f32);
+bool calcFindCloudSurface(sead::Vector3f*, sead::Vector3f*, const LiveActor*, const sead::Vector3f&,
+                          const sead::Vector3f&, f32);
+
+bool tryAddRipple(const NatureDirector*, const sead::Vector3f&, f32, f32);
+bool tryAddRippleTiny(const LiveActor*);
+bool tryAddRippleSmall(const LiveActor*, const sead::Vector3f&);
+bool tryAddRippleTiny(const LiveActor*, const sead::Vector3f&);
+bool tryAddRippleSmall(const LiveActor*);
+bool tryAddRippleMiddle(const LiveActor*);
+bool tryAddRippleMiddle(const LiveActor*, const sead::Vector3f&);
+bool tryAddRippleLarge(const LiveActor*);
+bool tryAddRippleLarge(const LiveActor*, const sead::Vector3f&);
+bool tryAddRippleWithRange(const LiveActor*, const sead::Vector3f&, f32, f32, f32, f32);
+bool tryAddRipple(const LiveActor*, const sead::Vector3f&, f32, f32);
+bool tryAddRippleRandomBlur(const LiveActor*, const sead::Vector3f&, f32, f32, f32);
+bool tryAddQuadRipple(const LiveActor*, const sead::Vector3f&, const sead::Vector3f&,
+                      const sead::Vector3f&, const sead::Vector3f&, f32);
+bool tryAddQuadRipple(const LiveActor*, const sead::BoundBox3f&, const sead::Vector3f&,
+                      const sead::Quatf&, f32, f32);
+bool tryAddQuadRippleByBoxRotateY(const LiveActor*, const sead::BoundBox3f&, const sead::Vector3f&,
+                                  f32, f32, f32);
+
+void approachWaterSurfaceSpringDumper(LiveActor*, const WaterSurfaceFinder*, f32, f32, f32, f32,
+                                      f32);
+void approachFireSurfaceSpringDumper(LiveActor*, const FireSurfaceFinder*, f32, f32, f32, f32, f32);
+void approachWaterSurfaceRate(LiveActor*, const WaterSurfaceFinder*, f32, f32, f32);
+void approachFireSurfaceRate(LiveActor*, const FireSurfaceFinder*, f32, f32, f32);
+
+void keepWaterSurfaceHeight(LiveActor*, const WaterSurfaceFinder*, f32);
+void syncWaterSurfaceTrans(LiveActor*, const WaterSurfaceFinder*);
+void syncFireSurfaceTrans(LiveActor*, const FireSurfaceFinder*);
+void syncWaterSurfaceTransH(LiveActor*, const WaterSurfaceFinder*);
+void blendWaterSurfaceTransH(LiveActor*, const WaterSurfaceFinder*, f32);
+void syncWaterSurfaceUp(LiveActor*, const WaterSurfaceFinder*, f32);
+void syncFireSurfaceUp(LiveActor*, const FireSurfaceFinder*, f32);
+void calcMatrixFromActorPoseAndWaterSurfaceH(sead::Matrix34f*, const WaterSurfaceFinder*,
+                                             const LiveActor*);
 
 }  // namespace al
+
+namespace alNatureUtil {
+
+bool calcFindDistanceWaterSurfaceToGround(f32*, const al::LiveActor*, const sead::Vector3f&, f32);
+
+}  // namespace alNatureUtil

--- a/lib/al/Library/Nature/WaterSurfaceFinder.cpp
+++ b/lib/al/Library/Nature/WaterSurfaceFinder.cpp
@@ -6,7 +6,6 @@ namespace al {
 
 WaterSurfaceFinder::WaterSurfaceFinder(const LiveActor* actor) : mActor(actor) {}
 
-// NON_MATCHING: inlined updateLocal
 void WaterSurfaceFinder::update(const sead::Vector3f& position, const sead::Vector3f& gravity,
                                 f32 distance) {
     updateLocal(position, gravity, distance, false, false, false);

--- a/lib/al/Library/Nature/WaterSurfaceFinder.cpp
+++ b/lib/al/Library/Nature/WaterSurfaceFinder.cpp
@@ -12,7 +12,6 @@ void WaterSurfaceFinder::update(const sead::Vector3f& position, const sead::Vect
     updateLocal(position, gravity, distance, false, false, false);
 }
 
-// NON_MATCHING: storing {0,0,0} if no surface was found (https://decomp.me/scratch/zHEdm)
 void WaterSurfaceFinder::updateLocal(const sead::Vector3f& position, const sead::Vector3f& gravity,
                                      f32 maxDistance, bool isFlat, bool isDisplacement,
                                      bool isOverGround) {
@@ -35,41 +34,37 @@ void WaterSurfaceFinder::updateLocal(const sead::Vector3f& position, const sead:
 
     if (mIsFoundSurface) {
         // requires this manual dot product calculation to match
-        mDistance = gravity.x * (surfacePos.x - position.x) +
-                    gravity.y * (surfacePos.y - position.y) +
-                    gravity.z * (surfacePos.z - position.z);
-        // mDistance = gravity.dot(surfacePos - position);
-        mSurfacePosition.set(surfacePos);
-        mSurfaceNormal.set(surfaceNormal);
+        mSurface.setDistance(gravity.x * (surfacePos.x - position.x) +
+                             gravity.y * (surfacePos.y - position.y) +
+                             gravity.z * (surfacePos.z - position.z));
+        mSurface.setPosition(surfacePos);
+        mSurface.setNormal(surfaceNormal);
     } else {
-        mDistance = 0.0f;
-        mSurfacePosition = {0.0f, 0.0f, 0.0f};
-        mSurfaceNormal = {0.0f, 0.0f, 0.0f};
+        mSurface.setDistance(0.0f);
+        mSurface.setPosition({0.0f, 0.0f, 0.0f});
+        mSurface.setNormal({0.0f, 0.0f, 0.0f});
     }
 
-    _28 = {0.0f, 0.0f, 0.0f};
+    mSurface.set1c({0.0f, 0.0f, 0.0f});
 }
 
-// NON_MATCHING: inlined updateLocal
 void WaterSurfaceFinder::updateForSurfaceShadow(const sead::Vector3f& position,
                                                 const sead::Vector3f& gravity, f32 distance) {
     updateLocal(position, gravity, distance, true, false, false);
 }
 
-// NON_MATCHING: inlined updateLocal
 void WaterSurfaceFinder::updateForDisplacement(const sead::Vector3f& position,
                                                const sead::Vector3f& gravity, f32 distance) {
     updateLocal(position, gravity, distance, false, true, false);
 }
 
-// NON_MATCHING: inlined updateLocal
 void WaterSurfaceFinder::updateConsiderGround(const sead::Vector3f& position,
                                               const sead::Vector3f& gravity, f32 distance) {
     updateLocal(position, gravity, distance, false, false, true);
 }
 
 bool WaterSurfaceFinder::isNearSurface(f32 distance) const {
-    return mIsFoundSurface && sead::Mathf::abs(mDistance) < distance;
+    return mIsFoundSurface && sead::Mathf::abs(mSurface.distance) < distance;
 }
 
 }  // namespace al

--- a/lib/al/Library/Nature/WaterSurfaceFinder.h
+++ b/lib/al/Library/Nature/WaterSurfaceFinder.h
@@ -5,7 +5,7 @@
 namespace al {
 class LiveActor;
 
-struct SurfaceProperties {
+struct WaterSurfaceProperties {
     f32 distance = 0.0f;
     sead::Vector3f position = {0.0f, 0.0f, 0.0f};
     sead::Vector3f normal = {0.0f, 0.0f, 0.0f};
@@ -45,7 +45,7 @@ public:
 private:
     const LiveActor* mActor;
     bool mIsFoundSurface = false;
-    SurfaceProperties mSurface{};
+    WaterSurfaceProperties mSurface{};
 };
 
 static_assert(sizeof(WaterSurfaceFinder) == 0x38);

--- a/lib/al/Library/Nature/WaterSurfaceFinder.h
+++ b/lib/al/Library/Nature/WaterSurfaceFinder.h
@@ -5,6 +5,21 @@
 namespace al {
 class LiveActor;
 
+struct SurfaceProperties {
+    f32 distance = 0.0f;
+    sead::Vector3f position = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f normal = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f _1c = {0.0f, 0.0f, 0.0f};
+
+    void setDistance(f32 value) { distance = value; }
+
+    void setPosition(const sead::Vector3f& vector) { position.set(vector); }
+
+    void setNormal(const sead::Vector3f& vector) { normal.set(vector); }
+
+    void set1c(const sead::Vector3f& vector) { _1c.set(vector); }
+};
+
 class WaterSurfaceFinder {
 public:
     WaterSurfaceFinder(const LiveActor* player);
@@ -23,17 +38,14 @@ public:
 
     bool isFoundSurface() const { return mIsFoundSurface; };
 
-    f32 getDistance() const { return mDistance; };
+    f32 getDistance() const { return mSurface.distance; };
 
-    const sead::Vector3f& getSurfacePosition() const { return mSurfacePosition; };
+    const sead::Vector3f& getSurfacePosition() const { return mSurface.position; };
 
 private:
     const LiveActor* mActor;
     bool mIsFoundSurface = false;
-    f32 mDistance = 0.0f;
-    sead::Vector3f mSurfacePosition = {0.0f, 0.0f, 0.0f};
-    sead::Vector3f mSurfaceNormal = {0.0f, 0.0f, 0.0f};
-    sead::Vector3f _28 = {0.0f, 0.0f, 0.0f};
+    SurfaceProperties mSurface{};
 };
 
 static_assert(sizeof(WaterSurfaceFinder) == 0x38);


### PR DESCRIPTION
Apparently surface properties are another class. We don't have other surface objects to verify that this struct belongs to other object. But fixes mismatches of this file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/339)
<!-- Reviewable:end -->
