### PR TITLE
Workflow: simplify `progress.yml` and remove unusable `inline` functions from headers repo

### DIFF
--- a/.github/scripts/copy-headers.sh
+++ b/.github/scripts/copy-headers.sh
@@ -27,6 +27,4 @@ rsync -a --prune-empty-dirs --include '*/' --include '*.h' --exclude '*' src/ $D
 # Copy CMakeLists.txt for header only library
 cp ./.github/files/HeadersCMakeLists.txt $DESTINATION_PATH/CMakeLists.txt
 
-# Make all contents of every class public
-grep -rli 'private:' * | xargs -i@ sed -i 's/private:/public:/g' @
-grep -rli 'protected:' * | xargs -i@ sed -i 's/protected:/public:/g' @
+python3 ./.github/scripts/process-headers.py $DESTINATION_PATH

--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -7,7 +7,8 @@ workdir = Path(sys.argv[1])
 for root, _, files in os.walk(workdir):
     for file in files:
         file_path = os.path.join(root, file)
-        if not str(file).endswith(".h"):
+        # Only process .h and .hpp files
+        if ".h" not in str(file):
             continue
         with open(file_path, "r+") as file:
             lines = list(file)

--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -28,6 +28,7 @@ for root, _, files in os.walk(workdir):
                             break
                         if line_inner_no_newline.endswith(";"):
                             del lines[i:i+j+1]
+                            i -= 1
                             break
                 i += 1
             file.seek(0)

--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -1,0 +1,31 @@
+import os
+import sys
+from pathlib import Path
+
+workdir = Path(sys.argv[1])
+
+for root, _, files in os.walk(workdir):
+    for file in files:
+        file_path = os.path.join(root, file)
+        if not str(file).endswith(".h"):
+            continue
+        with open(file_path, "r+") as file:
+            lines = list(file)
+            for i, line in enumerate(lines):
+                if "private:" in line:
+                     lines[i] = line.replace("private:", "public:")
+                elif "protected:" in line:
+                    lines[i] = line.replace("protected:", "public:")
+                if "al/" not in file_path and "game/" not in file_path:
+                    continue
+                if "inline " in line and "(" in line and not "= default" in line:
+                    for j, line_inner in enumerate(lines[i:]):
+                        line_inner_no_newline = line_inner.strip("\n")
+                        if line_inner_no_newline.endswith("{") or line_inner_no_newline.endswith("}"):
+                            break
+                        if line_inner_no_newline.endswith(";"):
+                            del lines[i:i+j+1]
+                            break;
+            file.seek(0)
+            file.truncate(0)
+            file.writelines(lines)

--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -8,25 +8,28 @@ for root, _, files in os.walk(workdir):
     for file in files:
         file_path = os.path.join(root, file)
         # Only process .h and .hpp files
-        if ".h" not in str(file):
+        if not file.endswith(".h") and not file.endswith(".hpp"):
             continue
         with open(file_path, "r+") as file:
             lines = list(file)
-            for i, line in enumerate(lines):
-                if "private:" in line:
-                     lines[i] = line.replace("private:", "public:")
-                elif "protected:" in line:
-                    lines[i] = line.replace("protected:", "public:")
+            i = 0
+            while i < len(lines):
+                if "private:" in lines[i]:
+                     lines[i] = lines[i].replace("private:", "public:")
+                elif "protected:" in lines[i]:
+                    lines[i] = lines[i].replace("protected:", "public:")
                 if "al/" not in file_path and "game/" not in file_path:
+                    i += 1
                     continue
-                if "inline " in line and "(" in line and not "= default" in line:
+                if "inline " in lines[i] and "(" in lines[i] and not "= default" in lines[i]:
                     for j, line_inner in enumerate(lines[i:]):
                         line_inner_no_newline = line_inner.strip("\n")
                         if line_inner_no_newline.endswith("{") or line_inner_no_newline.endswith("}"):
                             break
                         if line_inner_no_newline.endswith(";"):
                             del lines[i:i+j+1]
-                            break;
+                            break
+                i += 1
             file.seek(0)
-            file.truncate(0)
             file.writelines(lines)
+            file.truncate()

--- a/.github/workflows/copy-headers.yml
+++ b/.github/workflows/copy-headers.yml
@@ -69,6 +69,8 @@ jobs:
         PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         PR_AUTHOR_MAIL: ${{ github.event.pull_request.user.email }}
         PR_TITLE: ${{ github.event.pull_request.title }}
+    - name: Install python3
+      run: sudo apt update && sudo apt install python3 -y
     - name: Move to correct branch of OdysseyHeaders and reset history
       run: |
         cd OdysseyHeaders

--- a/.github/workflows/progress.yml
+++ b/.github/workflows/progress.yml
@@ -13,10 +13,6 @@ jobs:
       uses: actions/checkout@v4
       with:
         submodules: recursive
-    - name: Set up dependencies
-      run: |
-        sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl
-        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v5
       with:
@@ -24,17 +20,6 @@ jobs:
         cache: 'pip'
     - name: Set up python package dependencies
       run: pip install toml colorama cxxfilt
-    - name: Set up cache for clang
-      uses: actions/cache@v4
-      with:
-        key: clang391-401
-        path: |
-          toolchain/clang-3.9.1
-          toolchain/clang-4.0.1
-    - name: Run simplified setup
-      run: tools/setup.py --project
-    - name: Build project
-      run: tools/build.py
     - name: Upload progress state
       run: |
         full_ansi="$(tools/file_list_progress.py)"


### PR DESCRIPTION
This PR simplifies the progress worklow by removing setting up and building the project from it. I also made it so that `copy-headers.sh` removes lines with `inline` functions from the `al` and `game` folders that don't appear in the executable since calling them would cause a crash

I have tested the `inline` function remover inside a local copy of the headers repo but not the progress workflow

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/343)
<!-- Reviewable:end -->
