### PR TITLE
Enemy: Implement `PackunTrace`

### DIFF
--- a/src/Enemy/PackunTrace.cpp
+++ b/src/Enemy/PackunTrace.cpp
@@ -1,0 +1,41 @@
+#include "Enemy/PackunTrace.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Collision/PartsConnector.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/Placement/PlacementFunction.h"
+
+PackunTrace::PackunTrace(al::LiveActor* parentActor) : al::LiveActor("パックンの茎") {}
+
+void PackunTrace::init(const al::ActorInitInfo& info) {
+    const char* objectName;
+    al::getObjectName(&objectName, info);
+
+    const char* archiveName;
+    if (!al::isEqualString("PackunFlowerBig", objectName) &&
+        !al::isEqualString("PackunPoisonBig", objectName))
+        archiveName = "PackunTraceBig";
+    else
+        archiveName = "PackunTrace";
+
+    al::initActorWithArchiveName(this, info, archiveName, nullptr);
+
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+
+    makeActorDead();
+}
+
+void PackunTrace::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+void PackunTrace::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void PackunTrace::appear() {
+    al::LiveActor::appear();
+    al::startHitReaction(this, "出現");
+}

--- a/src/Enemy/PackunTrace.h
+++ b/src/Enemy/PackunTrace.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class MtxConnector;
+}
+
+class PackunTrace : public al::LiveActor {
+public:
+    PackunTrace(al::LiveActor* parentActor);
+
+    void init(const al::ActorInitInfo& info);
+    void initAfterPlacement();
+    void control();
+    void appear();
+
+private:
+    al::MtxConnector* mMtxConnector = nullptr;
+};


### PR DESCRIPTION
Some small class used by the piranha plants. Maybe we can work toward decomping them?

`PackunTrace::init` is messy, but I can't find another matching solution. If anyone wants a go at it: https://decomp.me/scratch/wNi4A