### PR TITLE
Library/LiveActor: Split `ActorSensorFunction`

### DIFF
--- a/lib/al/Library/LiveActor/ActorSensorController.cpp
+++ b/lib/al/Library/LiveActor/ActorSensorController.cpp
@@ -1,6 +1,6 @@
 #include "Library/LiveActor/ActorSensorController.h"
 
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Project/HitSensor/HitSensor.h"
 
 namespace al {

--- a/lib/al/Library/LiveActor/ActorSensorFunction.h
+++ b/lib/al/Library/LiveActor/ActorSensorFunction.h
@@ -1,154 +1,16 @@
 #pragma once
 
-#include <math/seadBoundBox.h>
-#include <math/seadMatrix.h>
-#include <math/seadVector.h>
-
 namespace al {
-
 class LiveActor;
 class HitSensor;
 class SensorMsg;
-class ActorInitInfo;
-class SensorSortCmpFuncBase;
-class ActorSensorController;
-
-void addHitSensorPlayer(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                        const sead::Vector3f&);
-void addHitSensor(LiveActor*, const ActorInitInfo&, const char*, u32, f32, u16,
-                  const sead::Vector3f&);
-void addHitSensorPlayerAttack(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                              const sead::Vector3f&);
-void addHitSensorPlayerEye(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                           const sead::Vector3f&);
-void addHitSensorEnemy(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                       const sead::Vector3f&);
-void addHitSensorEnemyBody(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                           const sead::Vector3f&);
-void addHitSensorEnemyAttack(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                             const sead::Vector3f&);
-HitSensor* addHitSensorMapObj(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                              const sead::Vector3f&);
-void addHitSensorBindable(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                          const sead::Vector3f&);
-void addHitSensorBindableGoal(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                              const sead::Vector3f&);
-void addHitSensorBindableAllPlayer(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                                   const sead::Vector3f&);
-void addHitSensorBindableBubbleOutScreen(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                                         const sead::Vector3f&);
-void addHitSensorBindableKoura(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                               const sead::Vector3f&);
-void addHitSensorBindableRouteDokan(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                                    const sead::Vector3f&);
-void addHitSensorBindableBubblePadInput(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                                        const sead::Vector3f&);
-void addHitSensorCollisionParts(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                                const sead::Vector3f&);
-void addHitSensorEye(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
-                     const sead::Vector3f&);
-void setHitSensorSort(LiveActor*, const char*, const SensorSortCmpFuncBase*);
-void setHitSensorPosPtr(LiveActor*, const char*, const sead::Vector3f*);
-HitSensor* getHitSensor(const LiveActor*, const char*);
-void setHitSensorMtxPtr(LiveActor*, const char*, const sead::Matrix34f*);
-void setHitSensorJointMtx(LiveActor*, const char*, const char*);
-void setSensorRadius(LiveActor*, const char*, f32);
-void setSensorRadius(LiveActor*, f32);
-f32 getSensorRadius(const LiveActor*, const char*);
-f32 getSensorRadius(const LiveActor*);
-sead::Vector3f& getSensorPos(const LiveActor*, const char*);
-sead::Vector3f& getSensorPos(const LiveActor*);
-void setSensorFollowPosOffset(LiveActor*, const char*, const sead::Vector3f&);
-void setSensorFollowPosOffset(LiveActor*, const sead::Vector3f&);
-sead::Vector3f& getSensorFollowPosOffset(const LiveActor*, const char*);
-sead::Vector3f& getSensorFollowPosOffset(const LiveActor*);
-void createActorSensorController(LiveActor*, const char*);
-void setSensorRadius(ActorSensorController*, f32);
-void setSensorScale(ActorSensorController*, f32);
-void setSensorFollowPosOffset(ActorSensorController*, const sead::Vector3f&);
-f32 getOriginalSensorRadius(const ActorSensorController*);
-sead::Vector3f& getOriginalSensorFollowPosOffset(const ActorSensorController*);
-void resetActorSensorController(ActorSensorController*);
-void calcPosBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*, f32);
-f32 calcDistance(const HitSensor*, const HitSensor*);
-sead::Vector3f& getSensorPos(const HitSensor*);
-f32 calcDistanceV(const sead::Vector3f&, const HitSensor*, const HitSensor*);
-f32 calcDistanceH(const sead::Vector3f&, const HitSensor*, const HitSensor*);
-void calcDirBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*);
-void calcDirBetweenSensorsH(sead::Vector3f*, const HitSensor*, const HitSensor*);
-void calcDirBetweenSensorsNormal(sead::Vector3f*, const HitSensor*, const HitSensor*,
-                                 sead::Vector3f);
-void calcVecBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*);
-void calcVecBetweenSensorsH(sead::Vector3f*, const HitSensor*, const HitSensor*);
-void calcVecBetweenSensorsNormal(sead::Vector3f*, const HitSensor*, const HitSensor*,
-                                 sead::Vector3f);
-void calcStrikeArrowCollideWallAndCeilingBetweenAttackSensor(const LiveActor*, const HitSensor*,
-                                                             const HitSensor*,
-                                                             const sead::Vector3f&, f32);
-LiveActor* getSensorHost(const HitSensor*);
-bool isFaceBetweenSensors(const sead::Vector3f&, const HitSensor*, const HitSensor*);
-bool isFaceBetweenSensorsH(const sead::Vector3f&, const HitSensor*, const HitSensor*);
-bool isEnableLookAtTargetSensor(const HitSensor*, const sead::Vector3f&, f32);
-bool isSensorValid(const HitSensor*);
-bool isHitBoxSensor(const HitSensor*, const sead::Vector3f&, const sead::BoundBox3f&);
-f32 getSensorRadius(const HitSensor*);
-bool isHitBoxSensor(const HitSensor*, const sead::Matrix34f&, const sead::BoundBox3f&);
-bool isHitCylinderSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32);
-bool isHitCylinderSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32);
-bool isHitCylinderSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const sead::Vector3f&,
-                         const sead::Vector3f&, f32);
-bool isHitCylinderSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const HitSensor*,
-                         const sead::Vector3f&, f32);
-bool isHitCylinderSensorHeight(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32, f32);
-bool isHitCircleSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const sead::Vector3f&,
-                       const sead::Vector3f&, f32, f32);
-bool isHitCircleSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const HitSensor*,
-                       const sead::Vector3f&, f32, f32);
-bool isHitCircleSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32, f32);
-bool isHitCircleSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32, f32);
-bool isHitPlaneSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32);
-bool isHitPlaneSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32);
-sead::Vector3f& getActorTrans(const HitSensor*);
-sead::Vector3f& getActorVelocity(const HitSensor*);
-sead::Vector3f& getActorGravity(const HitSensor*);
-bool isSensorName(const HitSensor*, const char*);
-bool isSensorHostName(const HitSensor*, const char*);
-bool isSensorHost(const HitSensor*, const LiveActor*);
-void validateHitSensors(LiveActor*);
-void invalidateHitSensors(LiveActor*);
-bool isSensorValid(const LiveActor*, const char*);
-void validateHitSensor(LiveActor*, const char*);
-void invalidateHitSensor(LiveActor*, const char*);
-void validateHitSensorBindableAll(LiveActor*);
-bool isSensorBindableAll(const HitSensor*);
-void validateHitSensorEnemyAll(LiveActor*);
-bool isSensorEnemy(const HitSensor*);
-void validateHitSensorEnemyAttackAll(LiveActor*);
-bool isSensorEnemyAttack(const HitSensor*);
-void validateHitSensorEnemyBodyAll(LiveActor*);
-bool isSensorEnemyBody(const HitSensor*);
-void validateHitSensorEyeAll(LiveActor*);
-bool isSensorEye(const HitSensor*);
-void validateHitSensorMapObjAll(LiveActor*);
-bool isSensorMapObj(const HitSensor*);
-void validateHitSensorNpcAll(LiveActor*);
-bool isSensorNpc(const HitSensor*);
-void validateHitSensorPlayerAll(LiveActor*);
-bool isSensorPlayer(const HitSensor*);
-bool isSensorPlayerAll(const HitSensor*);
-void validateHitSensorRideAll(LiveActor*);
-bool isSensorRide(const HitSensor*);
-bool isSensorSimple(const HitSensor*);
-bool isSensorLookAt(const HitSensor*);
-void invalidateHitSensorEyeAll(LiveActor*);
-void invalidateHitSensorPlayerAll(LiveActor*);
-void invalidateHitSensorPlayerAttackAll(LiveActor*);
-bool isSensorPlayerAttack(const HitSensor*);
-bool isSensorPlayerEye(const HitSensor*);
+class HitSensorKeeper;
 }  // namespace al
 
 namespace alActorSensorFunction {
-void getSensorKeeper(const al::LiveActor*);
-void sendMsgSensorToSensor(const al::SensorMsg&, al::HitSensor*, al::HitSensor*);
-void sendMsgToActorUnusedSensor(const al::SensorMsg&, al::LiveActor*);
+al::HitSensorKeeper* getSensorKeeper(const al::LiveActor* actor);
+// NOTE: The order of sensors here is the opposite of sendMsg functions
+bool sendMsgSensorToSensor(const al::SensorMsg& message, al::HitSensor* sender,
+                           al::HitSensor* receiver);
+bool sendMsgToActorUnusedSensor(const al::SensorMsg& message, al::LiveActor* receiverActor);
 }  // namespace alActorSensorFunction

--- a/lib/al/Library/LiveActor/ActorSensorUtil.h
+++ b/lib/al/Library/LiveActor/ActorSensorUtil.h
@@ -1,0 +1,161 @@
+#pragma once
+
+#include <math/seadBoundBox.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+
+class LiveActor;
+class HitSensor;
+class SensorMsg;
+class ActorInitInfo;
+class SensorSortCmpFuncBase;
+class ActorSensorController;
+
+HitSensor* addHitSensor(LiveActor*, const ActorInitInfo&, const char*, u32, f32, u16,
+                        const sead::Vector3f&);
+
+HitSensor* addHitSensorPlayer(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                              const sead::Vector3f&);
+
+HitSensor* addHitSensorPlayerAttack(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                    const sead::Vector3f&);
+HitSensor* addHitSensorPlayerEye(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                 const sead::Vector3f&);
+HitSensor* addHitSensorEnemy(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                             const sead::Vector3f&);
+HitSensor* addHitSensorEnemyBody(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                 const sead::Vector3f&);
+HitSensor* addHitSensorEnemyAttack(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                   const sead::Vector3f&);
+HitSensor* addHitSensorMapObj(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                              const sead::Vector3f&);
+HitSensor* addHitSensorBindable(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                const sead::Vector3f&);
+HitSensor* addHitSensorBindableGoal(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                    const sead::Vector3f&);
+HitSensor* addHitSensorBindableAllPlayer(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                         const sead::Vector3f&);
+HitSensor* addHitSensorBindableBubbleOutScreen(LiveActor*, const ActorInitInfo&, const char*, f32,
+                                               u16, const sead::Vector3f&);
+HitSensor* addHitSensorBindableKoura(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                     const sead::Vector3f&);
+HitSensor* addHitSensorBindableRouteDokan(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                          const sead::Vector3f&);
+HitSensor* addHitSensorBindableBubblePadInput(LiveActor*, const ActorInitInfo&, const char*, f32,
+                                              u16, const sead::Vector3f&);
+HitSensor* addHitSensorCollisionParts(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                                      const sead::Vector3f&);
+HitSensor* addHitSensorEye(LiveActor*, const ActorInitInfo&, const char*, f32, u16,
+                           const sead::Vector3f&);
+void setHitSensorSort(LiveActor*, const char*, const SensorSortCmpFuncBase*);
+void setHitSensorPosPtr(LiveActor*, const char*, const sead::Vector3f*);
+HitSensor* getHitSensor(const LiveActor*, const char*);
+void setHitSensorMtxPtr(LiveActor*, const char*, const sead::Matrix34f*);
+void setHitSensorJointMtx(LiveActor*, const char*, const char*);
+void setSensorRadius(LiveActor*, const char*, f32);
+void setSensorRadius(LiveActor*, f32);
+f32 getSensorRadius(const LiveActor*, const char*);
+f32 getSensorRadius(const LiveActor*);
+const sead::Vector3f& getSensorPos(const LiveActor*, const char*);
+const sead::Vector3f& getSensorPos(const LiveActor*);
+void setSensorFollowPosOffset(LiveActor*, const char*, const sead::Vector3f&);
+void setSensorFollowPosOffset(LiveActor*, const sead::Vector3f&);
+const sead::Vector3f& getSensorFollowPosOffset(const LiveActor*, const char*);
+const sead::Vector3f& getSensorFollowPosOffset(const LiveActor*);
+ActorSensorController* createActorSensorController(LiveActor*, const char*);
+void setSensorRadius(ActorSensorController*, f32);
+void setSensorScale(ActorSensorController*, f32);
+void setSensorFollowPosOffset(ActorSensorController*, const sead::Vector3f&);
+f32 getOriginalSensorRadius(const ActorSensorController*);
+const sead::Vector3f& getOriginalSensorFollowPosOffset(const ActorSensorController*);
+void resetActorSensorController(ActorSensorController*);
+void calcPosBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*, f32);
+f32 calcDistance(const HitSensor*, const HitSensor*);
+const sead::Vector3f& getSensorPos(const HitSensor*);
+f32 calcDistanceV(const sead::Vector3f&, const HitSensor*, const HitSensor*);
+f32 calcDistanceH(const sead::Vector3f&, const HitSensor*, const HitSensor*);
+void calcDirBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*);
+void calcDirBetweenSensorsH(sead::Vector3f*, const HitSensor*, const HitSensor*);
+void calcDirBetweenSensorsNormal(sead::Vector3f*, const HitSensor*, const HitSensor*,
+                                 sead::Vector3f);
+void calcVecBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*);
+void calcVecBetweenSensorsH(sead::Vector3f*, const HitSensor*, const HitSensor*);
+void calcVecBetweenSensorsNormal(sead::Vector3f*, const HitSensor*, const HitSensor*,
+                                 sead::Vector3f);
+void calcStrikeArrowCollideWallAndCeilingBetweenAttackSensor(const LiveActor*, const HitSensor*,
+                                                             const HitSensor*,
+                                                             const sead::Vector3f&, f32);
+LiveActor* getSensorHost(const HitSensor*);
+bool isFaceBetweenSensors(const sead::Vector3f&, const HitSensor*, const HitSensor*);
+bool isFaceBetweenSensorsH(const sead::Vector3f&, const HitSensor*, const HitSensor*);
+bool isEnableLookAtTargetSensor(const HitSensor*, const sead::Vector3f&, f32);
+bool isSensorValid(const HitSensor*);
+bool isHitBoxSensor(const HitSensor*, const sead::Vector3f&, const sead::BoundBox3f&);
+f32 getSensorRadius(const HitSensor*);
+bool isHitBoxSensor(const HitSensor*, const sead::Matrix34f&, const sead::BoundBox3f&);
+bool isHitCylinderSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32);
+bool isHitCylinderSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32);
+bool isHitCylinderSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const sead::Vector3f&,
+                         const sead::Vector3f&, f32);
+bool isHitCylinderSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const HitSensor*,
+                         const sead::Vector3f&, f32);
+bool isHitCylinderSensorHeight(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32, f32);
+bool isHitCircleSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const sead::Vector3f&,
+                       const sead::Vector3f&, f32, f32);
+bool isHitCircleSensor(sead::Vector3f*, sead::Vector3f*, const HitSensor*, const HitSensor*,
+                       const sead::Vector3f&, f32, f32);
+bool isHitCircleSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32, f32);
+bool isHitCircleSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32, f32);
+bool isHitPlaneSensor(const HitSensor*, const sead::Vector3f&, const sead::Vector3f&, f32);
+bool isHitPlaneSensor(const HitSensor*, const HitSensor*, const sead::Vector3f&, f32);
+/* ------------------- */
+
+const sead::Vector3f& getActorTrans(const HitSensor*);
+const sead::Vector3f& getActorVelocity(const HitSensor*);
+const sead::Vector3f& getActorGravity(const HitSensor*);
+bool isSensorName(const HitSensor*, const char*);
+bool isSensorHostName(const HitSensor*, const char*);
+bool isSensorHost(const HitSensor*, const LiveActor*);
+void validateHitSensors(LiveActor*);
+void invalidateHitSensors(LiveActor*);
+bool isSensorValid(const LiveActor*, const char*);
+void validateHitSensor(LiveActor*, const char*);
+void invalidateHitSensor(LiveActor*, const char*);
+void validateHitSensorBindableAll(LiveActor*);
+bool isSensorBindableAll(const HitSensor*);
+void validateHitSensorEnemyAll(LiveActor*);
+bool isSensorEnemy(const HitSensor*);
+void validateHitSensorEnemyAttackAll(LiveActor*);
+bool isSensorEnemyAttack(const HitSensor*);
+void validateHitSensorEnemyBodyAll(LiveActor*);
+bool isSensorEnemyBody(const HitSensor*);
+void validateHitSensorEyeAll(LiveActor*);
+bool isSensorEye(const HitSensor*);
+void validateHitSensorMapObjAll(LiveActor*);
+bool isSensorMapObj(const HitSensor*);
+void validateHitSensorNpcAll(LiveActor*);
+bool isSensorNpc(const HitSensor*);
+void validateHitSensorPlayerAll(LiveActor*);
+bool isSensorPlayer(const HitSensor*);
+bool isSensorPlayerAll(const HitSensor*);
+void validateHitSensorRideAll(LiveActor*);
+bool isSensorRide(const HitSensor*);
+bool isSensorSimple(const HitSensor*);
+bool isSensorLookAt(const HitSensor*);
+void invalidateHitSensorEyeAll(LiveActor*);
+void invalidateHitSensorPlayerAll(LiveActor*);
+void invalidateHitSensorPlayerAttackAll(LiveActor*);
+bool isSensorPlayerAttack(const HitSensor*);
+bool isSensorPlayerEye(const HitSensor*);
+
+bool isSensorBindableGoal(const HitSensor*);
+bool isSensorBindableAllPlayer(const HitSensor*);
+bool isSensorBindableBubbleOutScreen(const HitSensor*);
+bool isSensorBindableKoura(const HitSensor*);
+bool isSensorBindableRouteDokan(const HitSensor*);
+bool isSensorBindableBubblePadInput(const HitSensor*);
+bool isSensorBindable(const HitSensor*);
+
+}  // namespace al

--- a/lib/al/Library/LiveActor/SubActorKeeper.cpp
+++ b/lib/al/Library/LiveActor/SubActorKeeper.cpp
@@ -4,7 +4,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorResourceFunction.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Obj/BreakModel.h"
 #include "Library/Obj/CollisionObj.h"
 #include "Library/Obj/DepthShadowModel.h"

--- a/lib/al/Library/MapObj/SeesawMapParts.cpp
+++ b/lib/al/Library/MapObj/SeesawMapParts.cpp
@@ -4,7 +4,7 @@
 #include "Library/LiveActor/ActorInitFunction.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/MapObj/ChildStep.h"
 #include "Library/Math/MathUtil.h"

--- a/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
+++ b/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
@@ -1,7 +1,7 @@
 #include "Library/MapObj/SupportFreezeSyncGroupHolder.h"
 
 #include "Library/LiveActor/ActorInitFunction.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Project/LiveActor/SupportFreezeSyncGroup.h"
 
 namespace al {

--- a/lib/al/Library/Movement/EnemyStateBlowDown.cpp
+++ b/lib/al/Library/Movement/EnemyStateBlowDown.cpp
@@ -6,7 +6,7 @@
 #include "Library/LiveActor/ActorFlagFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Math/MathUtil.h"
 
 const al::EnemyStateBlowDownParam sEnemyStateBlowDownParam = al::EnemyStateBlowDownParam();

--- a/lib/al/Project/HitSensor/HitSensorDirector.cpp
+++ b/lib/al/Project/HitSensor/HitSensorDirector.cpp
@@ -2,7 +2,7 @@
 
 #include "Library/Execute/ExecuteDirector.h"
 #include "Library/Execute/ExecuteTableHolderUpdate.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Project/HitSensor/HitSensor.h"
 #include "Project/HitSensor/SensorHitGroup.h"
 

--- a/src/Amiibo/ItemAmiiboKoopa.cpp
+++ b/src/Amiibo/ItemAmiiboKoopa.cpp
@@ -3,7 +3,7 @@
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/LiveActor.h"
 #include "Library/LiveActor/LiveActorUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"

--- a/src/Boss/Mofumofu/MofumofuScrap.cpp
+++ b/src/Boss/Mofumofu/MofumofuScrap.cpp
@@ -2,7 +2,7 @@
 
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorInitInfo.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
 #include "Library/Obj/CollisionObj.h"

--- a/src/Enemy/EnemyStateReset.cpp
+++ b/src/Enemy/EnemyStateReset.cpp
@@ -5,7 +5,7 @@
 #include "Library/LiveActor/ActorClippingFunction.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
 #include "Library/Placement/PlacementFunction.h"

--- a/src/Enemy/KuromadoMagicBall.cpp
+++ b/src/Enemy/KuromadoMagicBall.cpp
@@ -7,7 +7,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 
 #include "Util/SensorMsgFunction.h"

--- a/src/Enemy/Popn.cpp
+++ b/src/Enemy/Popn.cpp
@@ -14,7 +14,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/LiveActor/LiveActorUtil.h"
 #include "Library/Math/MathUtil.h"

--- a/src/Enemy/Togezo.cpp
+++ b/src/Enemy/Togezo.cpp
@@ -10,7 +10,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nature/NatureUtil.h"

--- a/src/Item/CoinChameleon.cpp
+++ b/src/Item/CoinChameleon.cpp
@@ -6,7 +6,7 @@
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/LiveActorUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/Item/CoinCollect.cpp
+++ b/src/Item/CoinCollect.cpp
@@ -13,7 +13,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Nature/NatureUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/MapObj/AnagramAlphabetCharacter.cpp
+++ b/src/MapObj/AnagramAlphabetCharacter.cpp
@@ -7,7 +7,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/LiveActor/SubActorKeeper.h"
 #include "Library/Math/MathUtil.h"

--- a/src/MapObj/CapBomb.cpp
+++ b/src/MapObj/CapBomb.cpp
@@ -7,7 +7,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/MapObj/CapSwitch.cpp
+++ b/src/MapObj/CapSwitch.cpp
@@ -6,7 +6,7 @@
 #include "Library/LiveActor/ActorInitFunction.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/MapObj/ChurchDoor.cpp
+++ b/src/MapObj/ChurchDoor.cpp
@@ -5,7 +5,7 @@
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorCollisionFunction.h"
 #include "Library/LiveActor/ActorInitInfo.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/MapObj/CitySignal.cpp
+++ b/src/MapObj/CitySignal.cpp
@@ -4,7 +4,7 @@
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorModelFunction.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/MapObj/MoonBasementSlideObj.cpp
+++ b/src/MapObj/MoonBasementSlideObj.cpp
@@ -6,7 +6,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"

--- a/src/Npc/FukuwaraiFaceParts.cpp
+++ b/src/Npc/FukuwaraiFaceParts.cpp
@@ -12,7 +12,7 @@
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"

--- a/src/Player/HackerStateWingFly.cpp
+++ b/src/Player/HackerStateWingFly.cpp
@@ -5,7 +5,7 @@
 #include "Library/LiveActor/ActorCollisionFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"

--- a/src/Player/Player.cpp
+++ b/src/Player/Player.cpp
@@ -10,7 +10,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseKeeper.h"
-#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"


### PR DESCRIPTION
This PR splits `ActorSensorFunction` since their functions being in the same TU would cause mismatches do to inlining. As discussed in DMs, the `ActorSensorFunction.h` file now holds the `alActorSensorFunction` namespace and everything that was previously in `ActorSensorFunction.h` is now in `ActorSensorUtil.h`, with a few additions. I've also changed each include of `ActorSensorFunction.h` to include `ActorSensorUtil.h`

This PR is mainly prep for my future PRs