### PR TITLE
Enemy: Implement `Togezo2D`

### DIFF
--- a/src/Enemy/Togezo2D.cpp
+++ b/src/Enemy/Togezo2D.cpp
@@ -1,0 +1,179 @@
+#include "Enemy/Togezo2D.h"
+
+#include "Library/Item/ItemUtil.h"
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/LiveActor/LiveActorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/ActorDimensionKeeper.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(Togezo2D, Walk)
+NERVE_IMPL(Togezo2D, Damage)
+NERVE_IMPL(Togezo2D, HideWait)
+
+NERVES_MAKE_STRUCT(Togezo2D, Walk, Damage, HideWait)
+}  // namespace
+
+Togezo2D::Togezo2D(const char* name) : al::LiveActor(name) {}
+
+void Togezo2D::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &NrvTogezo2D.Walk, 0);
+    rs::createAndSetFilter2DOnly(this);
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    if (!rs::isIn2DArea(this)) {
+        makeActorDead();
+        return;
+    }
+    rs::snap2DGravity(this, this, 500.0f);
+    makeActorAlive();
+    mLocalZRotator = 0.0f;
+    al::initJointControllerKeeper(this, 1);
+    al::initJointLocalZRotator(this, &mLocalZRotator, "Center");
+    mInitTrans = al::getTrans(this);
+    mInitFront = al::getFront(this);
+}
+
+void Togezo2D::checkFacingTarget(al::HitSensor* target) {
+    if (al::isFaceToTargetDegreeH(this, al::getSensorPos(target), al::getFront(this), 5.0f)) {
+        al::turnFront(this, 180.0f);
+        al::setVelocityToFront(this, mVelocityFront);
+        al::addVelocityToGravity(this, 0.65f);
+        updateCollider();
+    }
+}
+
+bool Togezo2D::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isNerve(this, &NrvTogezo2D.Damage))
+        return false;
+    if (rs::isMsgPlayerDisregardHomingAttack(message) ||
+        rs::isMsgPlayerDisregardTargetMarker(message) || al::isMsgPlayerDisregard(message))
+        return true;
+    if (rs::isMsgPush2D(message) && al::isNerve(this, &NrvTogezo2D.Walk)) {
+        checkFacingTarget(other);
+        return true;
+    }
+    if (rs::isMsgBlockUpperPunch2D(message)) {
+        al::setNerve(this, &NrvTogezo2D.Damage);
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        al::appearItem(this);
+        return true;
+    }
+    if (rs::isMsgKouraAttack2D(message)) {
+        al::setNerve(this, &NrvTogezo2D.Damage);
+        rs::requestHitReactionToAttacker(message, self, other);
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        al::appearItem(this);
+        return true;
+    }
+    return false;
+}
+
+void Togezo2D::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorEnemyBody(self) && al::isSensorEnemyBody(other) &&
+        rs::sendMsgPush2D(other, self))
+        checkFacingTarget(other);
+    if (al::isSensorPlayer(other) && al::isSensorEnemyAttack(self))
+        rs::sendMsgEnemyAttack2D(other, self);
+}
+
+void Togezo2D::startMove() {
+    al::onCollide(this);
+    al::setNerve(this, &NrvTogezo2D.Walk);
+}
+
+void Togezo2D::control() {
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    if (al::isNerve(this, &NrvTogezo2D.HideWait))
+        return;
+    al::addVelocityToGravity(this, 0.65f);
+    al::addVelocityToDirection(this, al::getGravity(this), 0.98f);
+    if (al::isCollidedWall(this)) {
+        al::turnFront(this, 150.0f);
+        if (al::isOnGround(this, 0)) {
+            al::setVelocityToFront(this, mVelocityFront);
+            al::addVelocityToGravity(this, 0.65f);
+        } else {
+            al::addVelocityToFront(this, 2 * mVelocityFront);
+        }
+        updateCollider();
+    }
+    if (al::isNerve(this, &NrvTogezo2D.Damage))
+        return;
+    if (rs::isIn2DArea(this)) {
+        if (al::isOnGround(this, 0)) {
+            al::setVelocityToFront(this, mVelocityFront);
+            al::addVelocityToGravity(this, 0.65f);
+        }
+        rs::snap2DGravity(this, this, 500.0f);
+        return;
+    }
+    al::setNerve(this, &NrvTogezo2D.HideWait);
+}
+
+void Togezo2D::exeWalk() {
+    if (al::isFirstStep(this)) {
+        al::validateClipping(this);
+        al::showModelIfHide(this);
+        al::onCollide(this);
+        al::validateHitSensors(this);
+        mVelocityFront = 2.5f;
+        al::setVelocityToFront(this, mVelocityFront);
+        al::addVelocityToGravity(this, 0.65f);
+        al::startAction(this, "Move");
+    }
+    if (al::isOnGround(this, 0)) {
+        al::setVelocityToFront(this, mVelocityFront);
+        al::addVelocityToGravity(this, 0.65f);
+    }
+}
+
+void Togezo2D::exeDamage() {
+    if (al::isFirstStep(this)) {
+        al::offCollide(this);
+        al::invalidateHitSensors(this);
+        al::turnFront(this, 180.0f);
+        mVelocityFront = 2.5f;
+        mLocalZRotator = 180.0f;
+        al::setVelocityToFront(this, mVelocityFront);
+        sead::Vector3f gravity = al::getGravity(this);
+        sead::Vector3f velocityFromGravity;
+        sead::Vector3CalcCommon<f32>::multScalar(velocityFromGravity, gravity, -20.0f);
+        al::addVelocity(this, velocityFromGravity);
+    }
+    if (al::isGreaterStep(this, 90))
+        al::setNerve(this, &NrvTogezo2D.HideWait);
+}
+
+void Togezo2D::exeHideWait() {
+    if (!al::isFirstStep(this))
+        return;
+    al::invalidateClipping(this);
+    al::offCollide(this);
+    al::hideModelIfShow(this);
+    al::invalidateHitSensors(this);
+    al::setVelocityZero(this);
+    al::setTrans(this, mInitTrans);
+    al::setFront(this, mInitFront);
+    if (mIsAlwaysFalse)
+        mIsAlwaysFalse = false;
+    al::resetPosition(this);
+}
+
+ActorDimensionKeeper* Togezo2D::getActorDimensionKeeper() const {
+    return mDimensionKeeper;
+}

--- a/src/Enemy/Togezo2D.h
+++ b/src/Enemy/Togezo2D.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+class Togezo2D : public al::LiveActor, public IUseDimension {
+public:
+    Togezo2D(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    void control() override;
+    void startMove();
+
+    void exeWalk();
+    void exeDamage();
+    void exeHideWait();
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+
+    inline void checkFacingTarget(al::HitSensor* target);
+
+private:
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    f32 mVelocityFront = 0.0f;
+    bool mIsAlwaysFalse = false;
+    f32 mLocalZRotator = 0.0f;
+    sead::Vector3f mInitTrans = sead::Vector3f::zero;
+    sead::Vector3f mInitFront = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(Togezo2D) == 0x140);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -32,6 +32,7 @@
 #include "Enemy/Gamane.h"
 #include "Enemy/PackunTrace.h"
 #include "Enemy/Togezo.h"
+#include "Enemy/Togezo2D.h"
 #include "Item/Coin.h"
 #include "Item/Coin2D.h"
 #include "Item/CoinBlow.h"
@@ -544,7 +545,7 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"TextureReplaceScreen", nullptr},
     {"ThunderRenderRequester", nullptr},
     {"Togezo", al::createActorFunction<Togezo>},
-    {"Togezo2D", nullptr},
+    {"Togezo2D", al::createActorFunction<Togezo2D>},
     {"TokimekiMayorNpc", nullptr},
     {"TrampleBush", nullptr},
     {"TrampleSwitch", nullptr},

--- a/src/Util/ActorDimensionKeeper.h
+++ b/src/Util/ActorDimensionKeeper.h
@@ -56,5 +56,6 @@ bool isChange2D(const IUseDimension* dimension);
 bool isChange3D(const IUseDimension* dimension);
 bool is3D(const IUseDimension* dimension);
 void snap2D(const al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
+void snap2DGravity(const al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
 
 }  // namespace rs

--- a/src/Util/ActorDimensionKeeper.h
+++ b/src/Util/ActorDimensionKeeper.h
@@ -55,7 +55,7 @@ bool isIn2DArea(const IUseDimension* dimension);
 bool isChange2D(const IUseDimension* dimension);
 bool isChange3D(const IUseDimension* dimension);
 bool is3D(const IUseDimension* dimension);
-void snap2D(const al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
-void snap2DGravity(const al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
+void snap2D(al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
+void snap2DGravity(al::LiveActor* actor, const IUseDimension* dimension, f32 unk_distance);
 
 }  // namespace rs


### PR DESCRIPTION
This PR implements `Togezo2D`, the 2D version of the spiny enemy

I know the discussion about inline member functions is still in progress, but I still decided to keep `checkFacingTarget` as another example for #343, it should maybe be made private though 

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/372)
<!-- Reviewable:end -->
