### PR TITLE
Rebase workflow: Quick fix

### DIFF
--- a/.github/workflows/rebase-requirement.yml
+++ b/.github/workflows/rebase-requirement.yml
@@ -17,7 +17,7 @@ jobs:
         fetch-depth: 0
     - name: Check out required PRs list to master
       run: |
-        git checkout master -- .github/files/rebase-requirement-prs.txt
+        git checkout origin/master -- .github/files/rebase-requirement-prs.txt || true
     - name: Run rebase requirement check
       run: |
         glog_out="$(git log --pretty=format:"%s")"


### PR DESCRIPTION
In the last PR, I put `master` as the branch to checkout to for the list file without knowing that would cause problems. Hopefully changing that to `origin/master` fixes that and if it doesn't the `|| true` should prevent the workflow from failing because of that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/381)
<!-- Reviewable:end -->
