### PR TITLE
`System`: fix styling of `GameSystemInfo` member variables

### DIFF
--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -5,10 +5,10 @@
 #include "Library/Audio/IUseAudioKeeper.h"
 #include "Library/Nerve/NerveExecutor.h"
 #include "Library/Sequence/IUseSceneCreator.h"
-#include "Library/System/GameSystemInfo.h"
 
 namespace al {
 struct GameSystemInfo;
+struct DrawSystemInfo;
 struct SequenceInitInfo;
 struct AudioSystemInfo;
 class AudioDirector;

--- a/lib/al/Library/System/GameSystemInfo.h
+++ b/lib/al/Library/System/GameSystemInfo.h
@@ -17,26 +17,26 @@ class ApplicationMessageReceiver;
 class FontHolder;
 
 struct DrawSystemInfo {
-    agl::RenderBuffer* dockedRenderBuffer;
-    agl::RenderBuffer* handheldRenderBuffer;
-    bool isDocked;
-    agl::DrawContext* drawContext;
+    agl::RenderBuffer* mDockedRenderBuffer;
+    agl::RenderBuffer* mHandheldRenderBuffer;
+    bool mIsDocked;
+    agl::DrawContext* mDrawContext;
 };
 
 struct GameSystemInfo {
-    AudioSystem* audioSystem;
-    EffectSystem* effectSystem;
-    LayoutSystem* layoutSystem;
-    MessageSystem* messageSystem;
-    NetworkSystem* networkSystem;
+    AudioSystem* mAudioSystem;
+    EffectSystem* mEffectSystem;
+    LayoutSystem* mLayoutSystem;
+    MessageSystem* mMessageSystem;
+    NetworkSystem* mNetworkSystem;
     void* field_28;
-    GamePadSystem* gamePadSystem;
-    DrawSystemInfo* drawSystemInfo;
+    GamePadSystem* mGamePadSystem;
+    DrawSystemInfo* mDrawSystemInfo;
     FontHolder* mFontHolder;
-    NfpDirector* nfpDirector;
-    HtmlViewer* htmlViewer;
-    ApplicationMessageReceiver* applicationMessageReciever;
-    WaveVibrationHolder* waveVibrationHolder;
+    NfpDirector* mNfpDirector;
+    HtmlViewer* mHtmlViewer;
+    ApplicationMessageReceiver* mApplicationMessageReciever;
+    WaveVibrationHolder* mWaveVibrationHolder;
 };
 
 }  // namespace al

--- a/lib/al/Library/System/GameSystemInfo.h
+++ b/lib/al/Library/System/GameSystemInfo.h
@@ -17,26 +17,26 @@ class ApplicationMessageReceiver;
 class FontHolder;
 
 struct DrawSystemInfo {
-    agl::RenderBuffer* mDockedRenderBuffer;
-    agl::RenderBuffer* mHandheldRenderBuffer;
-    bool mIsDocked;
-    agl::DrawContext* mDrawContext;
+    agl::RenderBuffer* dockedRenderBuffer;
+    agl::RenderBuffer* handheldRenderBuffer;
+    bool isDocked;
+    agl::DrawContext* drawContext;
 };
 
 struct GameSystemInfo {
-    AudioSystem* mAudioSystem;
-    EffectSystem* mEffectSystem;
-    LayoutSystem* mLayoutSystem;
-    MessageSystem* mMessageSystem;
-    NetworkSystem* mNetworkSystem;
+    AudioSystem* audioSystem;
+    EffectSystem* effectSystem;
+    LayoutSystem* layoutSystem;
+    MessageSystem* messageSystem;
+    NetworkSystem* networkSystem;
     void* field_28;
-    GamePadSystem* mGamePadSystem;
-    DrawSystemInfo* mDrawSystemInfo;
-    FontHolder* mFontHolder;
-    NfpDirector* mNfpDirector;
-    HtmlViewer* mHtmlViewer;
-    ApplicationMessageReceiver* mApplicationMessageReciever;
-    WaveVibrationHolder* mWaveVibrationHolder;
+    GamePadSystem* gamePadSystem;
+    DrawSystemInfo* drawSystemInfo;
+    FontHolder* fontHolder;
+    NfpDirector* nfpDirector;
+    HtmlViewer* htmlViewer;
+    ApplicationMessageReceiver* applicationMessageReciever;
+    WaveVibrationHolder* waveVibrationHolder;
 };
 
 }  // namespace al

--- a/src/Sequence/HakoniwaSequence.cpp
+++ b/src/Sequence/HakoniwaSequence.cpp
@@ -12,10 +12,10 @@
 void HakoniwaSequence::drawMain() const {
     al::Sequence::drawMain();
     al::DrawSystemInfo* info = getDrawInfo();
-    agl::DrawContext* context = info->drawContext;
-    const agl::RenderBuffer* buffer = info->dockedRenderBuffer;
-    if (!info->isDocked)
-        buffer = info->handheldRenderBuffer;
+    agl::DrawContext* context = info->mDrawContext;
+    const agl::RenderBuffer* buffer = info->mDockedRenderBuffer;
+    if (!info->mIsDocked)
+        buffer = info->mHandheldRenderBuffer;
 
     mScreenCaptureExecutor->tryCaptureAndDraw(context, buffer, 0);
     sead::Viewport viewport = sead::Viewport(*buffer);

--- a/src/Sequence/HakoniwaSequence.cpp
+++ b/src/Sequence/HakoniwaSequence.cpp
@@ -12,10 +12,10 @@
 void HakoniwaSequence::drawMain() const {
     al::Sequence::drawMain();
     al::DrawSystemInfo* info = getDrawInfo();
-    agl::DrawContext* context = info->mDrawContext;
-    const agl::RenderBuffer* buffer = info->mDockedRenderBuffer;
-    if (!info->mIsDocked)
-        buffer = info->mHandheldRenderBuffer;
+    agl::DrawContext* context = info->drawContext;
+    const agl::RenderBuffer* buffer = info->dockedRenderBuffer;
+    if (!info->isDocked)
+        buffer = info->handheldRenderBuffer;
 
     mScreenCaptureExecutor->tryCaptureAndDraw(context, buffer, 0);
     sead::Viewport viewport = sead::Viewport(*buffer);

--- a/src/Sequence/HakoniwaSequence.h
+++ b/src/Sequence/HakoniwaSequence.h
@@ -31,6 +31,8 @@ class SeadAudioPlayer;
 class AudioBusSendFader;
 class SimpleAudioUser;
 class ScreenCaptureExecutor;
+class GamePadSystem;
+class EffectSystem;
 
 }  // namespace al
 

--- a/src/System/GameSystem.h
+++ b/src/System/GameSystem.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Library/Nerve/NerveExecutor.h"
-#include "Library/System/GameSystemInfo.h"
 
 namespace al {
 class Sequence;
@@ -13,6 +12,7 @@ class NetworkSystem;
 class HtmlViewer;
 class GamePadSystem;
 class ApplicationMessageReceiver;
+class WaveVibrationHolder;
 }  // namespace al
 
 class GameConfigData;


### PR DESCRIPTION
also forward declared some classes instead of unnecessarily including their headers

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/382)
<!-- Reviewable:end -->
