### PR TITLE
Amiibo: Implement HelpAmiiboLifeMaxUpItem

### DIFF
--- a/src/Amiibo/HelpAmiiboCountUpCoin.cpp
+++ b/src/Amiibo/HelpAmiiboCountUpCoin.cpp
@@ -109,7 +109,7 @@ void HelpAmiiboCountUpCoin::activate() {
 }
 
 HelpAmiiboType HelpAmiiboCountUpCoin::getType() const {
-    return HelpAmiiboType::CountUpCoin;
+    return HelpAmiiboType::All;
 }
 
 al::NerveKeeper* HelpAmiiboCountUpCoin::getNerveKeeper() const {

--- a/src/Amiibo/HelpAmiiboDirector.h
+++ b/src/Amiibo/HelpAmiiboDirector.h
@@ -1,22 +1,83 @@
 #pragma once
 
+#include <container/seadPtrArray.h>
+
+#include "Library/Audio/IUseAudioKeeper.h"
+#include "Library/Nerve/IUseNerve.h"
+#include "Library/Scene/ISceneObj.h"
+
 namespace al {
+struct NfpInfo;
+
+class ActorInitInfo;
+class AudioDirector;
+class AudioKeeper;
 class IUseSceneObjHolder;
+class LayoutActor;
+class LayoutInitInfo;
+class NerveKeeper;
+class PlayerHolder;
+class SimpleLayoutAppearWaitEnd;
 }  // namespace al
+
+class ProjectNfpDirector;
+class HelpAmiiboCoinCollect;
+class HelpAmiiboExecutor;
+
+class HelpAmiiboDirector : public al::ISceneObj, public al::IUseAudioKeeper, public al::IUseNerve {
+public:
+    HelpAmiiboDirector();
+    void init(ProjectNfpDirector* projectNfpDirector, const al::PlayerHolder* playerHolder,
+              al::AudioDirector* audioDirector, const al::LayoutInitInfo& initInfo);
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) override;
+
+    bool isTriggerTouchAmiiboMario() const;
+    bool isTriggerTouchAmiiboPeach() const;
+    bool isTriggerTouchAmiiboKoopa() const;
+    bool isTriggerTouchAmiiboYoshi() const;
+    bool isTriggerTouchAmiiboAll() const;
+    void execute();
+    void reset();
+    bool isHelpAmiiboMode() const;
+    void appearCoinCollectEffect();
+    void killCoinCollectEffect();
+    bool tryExecute(const al::NfpInfo* nfpInfo);
+
+    const char* getSceneObjName() const override;
+    al::AudioKeeper* getAudioKeeper() const override;
+    al::NerveKeeper* getNerveKeeper() const override;
+
+    void exeWait();
+    void exeCountHold();
+    void exeActive();
+    void exeIconClose();
+
+private:
+    ProjectNfpDirector* mProjectNfpDirector = nullptr;
+    const al::PlayerHolder* mPlayerHolder = nullptr;
+    al::AudioKeeper* mAudioKeeper = nullptr;
+    sead::PtrArray<HelpAmiiboExecutor> mTouchEntries;
+
+    al::NerveKeeper* mNerveKeeper = nullptr;
+    al::SimpleLayoutAppearWaitEnd* mSimpleLayout = nullptr;
+    al::LayoutActor* mLayoutActor = nullptr;
+    bool _58 = true;
+    HelpAmiiboCoinCollect* mCoinCollect = nullptr;
+};
 
 namespace AmiiboFunction {
 
-void tryCreateHelpAmiiboDirector(const al::IUseSceneObjHolder*);
-bool isTriggerTouchAmiiboMario(const al::IUseSceneObjHolder*);
-bool isTriggerTouchAmiiboPeach(const al::IUseSceneObjHolder*);
-bool isTriggerTouchAmiiboKoopa(const al::IUseSceneObjHolder*);
-bool isTriggerTouchAmiiboAll(const al::IUseSceneObjHolder*);
+void tryCreateHelpAmiiboDirector(const al::IUseSceneObjHolder* objHolder);
+bool isTriggerTouchAmiiboMario(const al::IUseSceneObjHolder* objHolder);
+bool isTriggerTouchAmiiboPeach(const al::IUseSceneObjHolder* objHolder);
+bool isTriggerTouchAmiiboKoopa(const al::IUseSceneObjHolder* objHolder);
+bool isTriggerTouchAmiiboAll(const al::IUseSceneObjHolder* objHolder);
 
 }  // namespace AmiiboFunction
 
 namespace rs {
 
-void resetHelpAmiiboState(const al::IUseSceneObjHolder*);
-bool isHelpAmiiboMode(const al::IUseSceneObjHolder*);
+void resetHelpAmiiboState(const al::IUseSceneObjHolder* objHolder);
+bool isHelpAmiiboMode(const al::IUseSceneObjHolder* objHolder);
 
 }  // namespace rs

--- a/src/Amiibo/HelpAmiiboDirector.h
+++ b/src/Amiibo/HelpAmiiboDirector.h
@@ -3,6 +3,7 @@
 #include <container/seadPtrArray.h>
 
 #include "Library/Audio/IUseAudioKeeper.h"
+#include "Library/HostIO/HioNode.h"
 #include "Library/Nerve/IUseNerve.h"
 #include "Library/Scene/ISceneObj.h"
 
@@ -24,7 +25,10 @@ class ProjectNfpDirector;
 class HelpAmiiboCoinCollect;
 class HelpAmiiboExecutor;
 
-class HelpAmiiboDirector : public al::ISceneObj, public al::IUseAudioKeeper, public al::IUseNerve {
+class HelpAmiiboDirector : public al::IUseHioNode,
+                           public al::ISceneObj,
+                           public al::IUseAudioKeeper,
+                           public al::IUseNerve {
 public:
     HelpAmiiboDirector();
     void init(ProjectNfpDirector* projectNfpDirector, const al::PlayerHolder* playerHolder,
@@ -36,7 +40,7 @@ public:
     bool isTriggerTouchAmiiboKoopa() const;
     bool isTriggerTouchAmiiboYoshi() const;
     bool isTriggerTouchAmiiboAll() const;
-    void execute();
+    virtual void execute();
     void reset();
     bool isHelpAmiiboMode() const;
     void appearCoinCollectEffect();

--- a/src/Amiibo/HelpAmiiboExecutor.h
+++ b/src/Amiibo/HelpAmiiboExecutor.h
@@ -13,14 +13,11 @@ class ActorInitInfo;
 class HelpAmiiboDirector;
 
 enum class HelpAmiiboType : s32 {
-    PlayerInvincible = 0,
-    FallCoin = 1,
-    LifeMaxUpItem = 1,
-    CoinCollect = 2,
-    InvincibleAttack = 2,
-    NavigateCoinCollect = 2,
+    Mario = 0,
+    Peach = 1,
+    Koopa = 2,
     Yoshi = 3,
-    CountUpCoin = 4,
+    All = 4,
 };
 
 class HelpAmiiboExecutor : public al::IUseHioNode {
@@ -37,6 +34,10 @@ public:
 
     bool tryTouch(const al::NfpInfo&);
     void tryExecute();
+
+    bool isTouched() const { return mIsTouched; }
+
+    HelpAmiiboDirector* getDirector() const { return mHelpAmiiboDirector; }
 
     al::LiveActor* getActor() const { return mHelpAmiiboActor; }
 

--- a/src/Amiibo/HelpAmiiboLifeMaxUpItem.cpp
+++ b/src/Amiibo/HelpAmiiboLifeMaxUpItem.cpp
@@ -1,0 +1,73 @@
+#include "Amiibo/HelpAmiiboLifeMaxUpItem.h"
+
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nfp/NfpFunction.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Amiibo/HelpAmiiboDirector.h"
+#include "Amiibo/HelpAmiiboFunction.h"
+#include "Item/LifeMaxUpItem.h"
+#include "Item/LifeMaxUpItem2D.h"
+#include "Util/PlayerUtil.h"
+
+HelpAmiiboLifeMaxUpItem::HelpAmiiboLifeMaxUpItem(HelpAmiiboDirector* director, al::LiveActor* actor)
+    : HelpAmiiboExecutor(director, actor, "ライフアップアイテムお助け") {}
+
+void HelpAmiiboLifeMaxUpItem::initAfterPlacement(const al::ActorInitInfo& initInfo) {
+    HelpAmiiboExecutor::initAfterPlacement(initInfo);
+    mItem = new LifeMaxUpItem("最大ライフアップアイテム[amiibo]");
+    al::initCreateActorNoPlacementInfo(mItem, initInfo);
+    mItem->makeActorDead();
+
+    mItem2D = new LifeMaxUpItem2D("最大ライフアップアイテム2D[amiibo]");
+    al::initCreateActorNoPlacementInfo(mItem2D, initInfo);
+    mItem2D->makeActorDead();
+}
+
+bool HelpAmiiboLifeMaxUpItem::isTriggerTouch(const al::NfpInfo& nfpInfo) const {
+    return al::isCharacterIdBasePeach(nfpInfo);
+}
+
+bool HelpAmiiboLifeMaxUpItem::isEnableUse() {
+    return true;
+}
+
+bool HelpAmiiboLifeMaxUpItem::execute() {
+    bool isAlive = true;
+    if (!al::isDead(mItem) || !al::isDead(mItem2D))
+        isAlive = false;
+
+    return isAlive;
+}
+
+void HelpAmiiboLifeMaxUpItem::activate() {
+    al::LiveActor* actor = getActor();
+    const sead::Vector3f& playerPos = rs::getPlayerPos(actor);
+    HelpAmiiboExecutor::activate();
+
+    if (rs::isPlayer2D(actor)) {
+        sead::Vector3f appearOffset = sead::Vector3f::zero;
+        HelpAmiiboFunction::calcLifeUpItemAppearOffset(&appearOffset, actor);
+        sead::Vector3f frontDir = sead::Vector3f::zero;
+        rs::calcPlayerFrontDir(&frontDir, actor);
+        mItem2D->appearByAmiibo(playerPos + appearOffset, frontDir);
+        al::startSe(getDirector(), "AmiiboPeach");
+        return;
+    }
+
+    sead::Vector3f appearOffset = sead::Vector3f::zero;
+    HelpAmiiboFunction::calcLifeUpItemAppearOffset(&appearOffset, actor);
+    if (!rs::isPlayerHack(actor)) {
+        mItem->appearAmiiboTouch(playerPos + appearOffset);
+    } else {
+        sead::Vector3f basePos = sead::Vector3f::zero;
+        rs::calcPlayerAmiiboPeachAppearBasePos(&basePos, actor);
+        mItem->appearAmiiboTouch(basePos);
+    }
+    al::startSe(getDirector(), "AmiiboPeach");
+}
+
+HelpAmiiboType HelpAmiiboLifeMaxUpItem::getType() const {
+    return HelpAmiiboType::Peach;
+}

--- a/src/Amiibo/HelpAmiiboLifeMaxUpItem.h
+++ b/src/Amiibo/HelpAmiiboLifeMaxUpItem.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Amiibo/HelpAmiiboExecutor.h"
+
+namespace al {
+struct NfpInfo;
+
+class ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class LifeMaxUpItem;
+class LifeMaxUpItem2D;
+
+class HelpAmiiboLifeMaxUpItem : public HelpAmiiboExecutor {
+public:
+    HelpAmiiboLifeMaxUpItem(HelpAmiiboDirector* director, al::LiveActor* amiiboActor);
+
+    void initAfterPlacement(const al::ActorInitInfo& initInfo) override;
+    bool isTriggerTouch(const al::NfpInfo& nfpInfo) const override;
+    bool isEnableUse() override;
+    bool execute() override;
+    void activate() override;
+    HelpAmiiboType getType() const override;
+
+private:
+    LifeMaxUpItem* mItem = nullptr;
+    LifeMaxUpItem2D* mItem2D = nullptr;
+};

--- a/src/Item/LifeMaxUpItem.h
+++ b/src/Item/LifeMaxUpItem.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class ActorInitInfo;
+class HitSensor;
+}  // namespace al
+
+class LifeMaxUpItem : public al::LiveActor {
+public:
+    LifeMaxUpItem(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacement() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appear() override;
+    void control() override;
+
+    void appearAmiiboTouch(const sead::Vector3f&);
+    void appearPopUp();
+    void appearPopUpAbove();
+    void appearSlot();
+    void appearPopUpDir(const sead::Quatf&);
+
+    void exeAppeared();
+    void exeStayPlacedPos();
+    void exeWaterFallWorld();
+    void exeAutoGetDemo();
+    void exeGotWaitLifeUpDemo();
+    void exeGotAppearCoin();
+    void exeGotDeadWait();
+
+private:
+    char filler[0x48];
+};

--- a/src/Item/LifeMaxUpItem2D.h
+++ b/src/Item/LifeMaxUpItem2D.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+namespace al {
+class ActorInitInfo;
+class HitSensor;
+}  // namespace al
+
+class ActorDimensionKeeper;
+class FlashingCtrl;
+class LifeUpItemStateAutoGet;
+
+class LifeMaxUpItem2D : public al::LiveActor, public IUseDimension {
+public:
+    LifeMaxUpItem2D(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+    void appear() override;
+
+    void appearPopUp();
+    void appearByAmiibo(const sead::Vector3f&, const sead::Vector3f&);
+
+    void exeAppeared();
+    void exeSink();
+    void exeGotWaitLifeUpDemo();
+    void exeGotAppearCoin();
+    void exeVanishing();
+    void exeDeadWait();
+    void exeAutoGetDemo();
+
+private:
+    LifeUpItemStateAutoGet* mStateAutoGet = nullptr;
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    FlashingCtrl* mFlashingCtrl = nullptr;
+    s32 _128 = 0;
+};

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -38,6 +38,8 @@
 #include "Item/CoinChameleon.h"
 #include "Item/CoinCollect.h"
 #include "Item/CoinCollect2D.h"
+#include "Item/LifeMaxUpItem.h"
+#include "Item/LifeMaxUpItem2D.h"
 #include "Item/LifeUpItem.h"
 #include "Item/LifeUpItem2D.h"
 #include "MapObj/AnagramAlphabet.h"
@@ -329,8 +331,8 @@ static al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[]
     {"LavaStewVeget", nullptr},
     {"LavaPan", al::createActorFunction<LavaPan>},
     {"LavaWave", nullptr},
-    {"LifeMaxUpItem", nullptr},
-    {"LifeMaxUpItem2D", nullptr},
+    {"LifeMaxUpItem", al::createActorFunction<LifeMaxUpItem>},
+    {"LifeMaxUpItem2D", al::createActorFunction<LifeMaxUpItem2D>},
     {"LifeUpItem", al::createActorFunction<LifeUpItem>},
     {"LifeUpItem2D", al::createActorFunction<LifeUpItem2D>},
     {"LightningController", nullptr},


### PR DESCRIPTION
I couldn't implement `HelpAmiiboDirector `so I went with the next best thing. Some header dependencies. This is a relatively small class but required many headers. Including changing the `HelpAmiiboType` enum, the entries of this enum don't refer to the class type, instead they indicate which amiibos might trigger that loot when an amiibo is loaded.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/388)
<!-- Reviewable:end -->
