### PR TITLE
`Project/Controller`: implement `al::PadDataArcReader`

### DIFF
--- a/lib/al/Library/Controller/IUsePadDataReader.h
+++ b/lib/al/Library/Controller/IUsePadDataReader.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct PadDataPack;
+
+class IUsePadDataReader {
+public:
+    virtual void read(PadDataPack* frameData) = 0;
+    virtual bool isEnd() const = 0;
+    virtual u32 getCursorFrame() const = 0;
+    virtual u32 getRemainFrame() const = 0;
+    virtual void close(){};
+};
+}  // namespace al

--- a/lib/al/Library/Controller/IUsePadDataReader.h
+++ b/lib/al/Library/Controller/IUsePadDataReader.h
@@ -10,7 +10,8 @@ public:
     virtual void read(PadDataPack* frameData) = 0;
     virtual bool isEnd() const = 0;
     virtual u32 getCursorFrame() const = 0;
-    virtual u32 getRemainFrame() const = 0;
-    virtual void close(){};
+    virtual s32 getRemainFrame() const = 0;
+
+    virtual void close() {}
 };
 }  // namespace al

--- a/lib/al/Library/Controller/IUsePadDataWriter.h
+++ b/lib/al/Library/Controller/IUsePadDataWriter.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct PadDataPack;
+
+class IUsePadDataWriter {
+public:
+    virtual void write(const PadDataPack& frameData) = 0;
+    virtual void open() = 0;
+    virtual void close() = 0;
+};
+}  // namespace al

--- a/lib/al/Library/Controller/PadDataPack.h
+++ b/lib/al/Library/Controller/PadDataPack.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct PadDataPack {
+    s32 mTrig = 0;
+    s32 mHold = 0;
+    sead::Vector2f mLeftStick = sead::Vector2f::zero;
+    sead::Vector2f mPointer = sead::Vector2f::zero;
+};
+}  // namespace al

--- a/lib/al/Library/Resource/Resource.h
+++ b/lib/al/Library/Resource/Resource.h
@@ -33,12 +33,12 @@ public:
                              u32) const;
     const u8* getByml(const sead::SafeString& name) const;
     void* getFile(const sead::SafeString& name) const;
-    void tryGetByml(const sead::SafeString& name) const;
-    void getKcl(const sead::SafeString& name) const;
-    void tryGetKcl(const sead::SafeString& name) const;
-    void getPa(const sead::SafeString& name) const;
-    void tryGetPa(const sead::SafeString& name) const;
-    void getOtherFile(const sead::SafeString& name) const;
+    void* tryGetByml(const sead::SafeString& name) const;
+    void* getKcl(const sead::SafeString& name) const;
+    void* tryGetKcl(const sead::SafeString& name) const;
+    void* getPa(const sead::SafeString& name) const;
+    void* tryGetPa(const sead::SafeString& name) const;
+    void* getOtherFile(const sead::SafeString& name) const;
     const char* getArchiveName() const;
 
     ActorInitResourceData* getResData() const { return mData; }

--- a/lib/al/Project/Controller/PadDataArcReader.cpp
+++ b/lib/al/Project/Controller/PadDataArcReader.cpp
@@ -6,7 +6,7 @@
 namespace al {
 
 PadDataArcReader::PadDataArcReader(const char* path) : mPath(path) {
-    al::findOrCreateResource(path, nullptr);
+    findOrCreateResource(path, nullptr);
 }
 
 PadDataArcReader::PadDataArcReader(const char* path, const char* resourceName) : mPath(path) {
@@ -15,7 +15,7 @@ PadDataArcReader::PadDataArcReader(const char* path, const char* resourceName) :
 
 void PadDataArcReader::readResource(const char* resourceName) {
     mCursorFrame = 0;
-    al::Resource* resource = al::findOrCreateResource(mPath, nullptr);
+    Resource* resource = findOrCreateResource(mPath, nullptr);
     sead::FixedSafeString<256> filename;
     filename.format("%s.bin", resourceName);
     mDataFrames = (PadDataPack*)resource->getOtherFile(filename);

--- a/lib/al/Project/Controller/PadDataArcReader.cpp
+++ b/lib/al/Project/Controller/PadDataArcReader.cpp
@@ -35,8 +35,7 @@ void PadDataArcReader::read(PadDataPack* frameData) {
     if (mIsEnd)
         return;
 
-    const PadDataPack& curFrame = mDataFrames[mCursorFrame++];
-    *frameData = curFrame;
+    *frameData = mDataFrames[mCursorFrame++];
     checkEnd();
 }
 
@@ -48,7 +47,7 @@ u32 PadDataArcReader::getCursorFrame() const {
     return mCursorFrame;
 }
 
-u32 PadDataArcReader::getRemainFrame() const {
+s32 PadDataArcReader::getRemainFrame() const {
     return mTotalFrame - mCursorFrame;
 }
 

--- a/lib/al/Project/Controller/PadDataArcReader.cpp
+++ b/lib/al/Project/Controller/PadDataArcReader.cpp
@@ -1,0 +1,55 @@
+#include "Project/Controller/PadDataArcReader.h"
+
+#include "Library/Controller/PadDataPack.h"
+#include "Library/Resource/ResourceUtil.h"
+
+namespace al {
+
+PadDataArcReader::PadDataArcReader(const char* path) : mPath(path) {
+    al::findOrCreateResource(path, nullptr);
+}
+
+PadDataArcReader::PadDataArcReader(const char* path, const char* resourceName) : mPath(path) {
+    readResource(resourceName);
+}
+
+void PadDataArcReader::readResource(const char* resourceName) {
+    mCursorFrame = 0;
+    al::Resource* resource = al::findOrCreateResource(mPath, nullptr);
+    sead::FixedSafeString<256> filename;
+    filename.format("%s.bin", resourceName);
+    mDataFrames = (PadDataPack*)resource->getOtherFile(filename);
+    checkEnd();
+    PadDataPack* checkFrame = mDataFrames;
+    while (checkFrame->mTrig != -1)
+        checkFrame++;
+    mTotalFrame = checkFrame - mDataFrames;
+}
+
+void PadDataArcReader::checkEnd() {
+    if (mDataFrames[mCursorFrame].mTrig == -1)
+        mIsEnd = true;
+}
+
+void PadDataArcReader::read(PadDataPack* frameData) {
+    if (mIsEnd)
+        return;
+
+    const PadDataPack& curFrame = mDataFrames[mCursorFrame++];
+    *frameData = curFrame;
+    checkEnd();
+}
+
+bool PadDataArcReader::isEnd() const {
+    return mIsEnd;
+}
+
+u32 PadDataArcReader::getCursorFrame() const {
+    return mCursorFrame;
+}
+
+u32 PadDataArcReader::getRemainFrame() const {
+    return mTotalFrame - mCursorFrame;
+}
+
+}  // namespace al

--- a/lib/al/Project/Controller/PadDataArcReader.h
+++ b/lib/al/Project/Controller/PadDataArcReader.h
@@ -16,7 +16,7 @@ public:
     void read(PadDataPack* frameData) override;
     bool isEnd() const override;
     u32 getCursorFrame() const override;
-    u32 getRemainFrame() const override;
+    s32 getRemainFrame() const override;
 
 private:
     PadDataPack* mDataFrames = nullptr;

--- a/lib/al/Project/Controller/PadDataArcReader.h
+++ b/lib/al/Project/Controller/PadDataArcReader.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Controller/IUsePadDataReader.h"
+
+namespace al {
+struct PadDataPack;
+
+class PadDataArcReader : public IUsePadDataReader {
+public:
+    PadDataArcReader(const char* path);
+    PadDataArcReader(const char* path, const char* resourceName);
+    void readResource(const char* resourceName);
+    void checkEnd();
+    void read(PadDataPack* frameData) override;
+    bool isEnd() const override;
+    u32 getCursorFrame() const override;
+    u32 getRemainFrame() const override;
+
+private:
+    PadDataPack* mDataFrames = nullptr;
+    u32 mCursorFrame = 0;
+    u32 mTotalFrame = 0;
+    bool mIsEnd = false;
+    const char* mPath = nullptr;
+};
+}  // namespace al


### PR DESCRIPTION
an unused class. this reads input data from a `.bin` file as an array of 0x18-byte frames (of type `PadDataPack`), and sends it to `al::ReplayController` to be applied to the controller. this does get used in 3D world, so perhaps it's a relic from that. the `IUsePadDataReader`/`Writer` classes are almost nonexistent in the binary, but i got the `Reader`'s functions from the class in this PR, and the `Writer`'s functions i deduced from various `al::ReplayController` functions (namely `calc`, `startRecord` and `endRecord`, with the `open`/`close` copied from the `Reader` class, rather than just naming them `start`/`end` or something like that).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/391)
<!-- Reviewable:end -->
