### PR TITLE
`Library/Controller`: add `ReplayController`-related headers

### DIFF
--- a/lib/al/Library/Controller/InputFunction.cpp
+++ b/lib/al/Library/Controller/InputFunction.cpp
@@ -2,8 +2,8 @@
 
 #include <controller/seadControllerMgr.h>
 
-#include "al/Library/Controller/PadReplayFunction.h"
-#include "al/Library/Controller/ReplayController.h"
+#include "Library/Controller/PadReplayFunction.h"
+#include "Library/Controller/ReplayController.h"
 
 namespace al {
 

--- a/lib/al/Library/Controller/InputFunction.cpp
+++ b/lib/al/Library/Controller/InputFunction.cpp
@@ -3,6 +3,7 @@
 #include <controller/seadControllerMgr.h>
 
 #include "al/Library/Controller/PadReplayFunction.h"
+#include "al/Library/Controller/ReplayController.h"
 
 namespace al {
 
@@ -10,8 +11,10 @@ inline sead::ControllerBase* getController(s32 port) {
     if (port == -1)
         port = getMainControllerPort();
 
-    return isValidReplayController(port) ? getReplayController(port) :
-                                           sead::ControllerMgr::instance()->getController(port);
+    if (isValidReplayController(port))
+        return getReplayController(port);
+
+    return sead::ControllerMgr::instance()->getController(port);
 }
 
 bool isPadTrigger(s32 port, s32 button) {

--- a/lib/al/Library/Controller/InputFunction.cpp
+++ b/lib/al/Library/Controller/InputFunction.cpp
@@ -2,6 +2,8 @@
 
 #include <controller/seadControllerMgr.h>
 
+#include "al/Library/Controller/PadReplayFunction.h"
+
 namespace al {
 
 inline sead::ControllerBase* getController(s32 port) {

--- a/lib/al/Library/Controller/InputFunction.h
+++ b/lib/al/Library/Controller/InputFunction.h
@@ -9,9 +9,6 @@ class ControllerBase;
 namespace al {
 class IUseCamera;
 
-bool isValidReplayController(u32);
-sead::ControllerBase* getReplayController(u32);  // return type might be wrong
-
 bool isPadTypeJoySingle(s32 port);
 
 bool isPadTrigger(s32 port, s32 button);

--- a/lib/al/Library/Controller/PadReplayFunction.h
+++ b/lib/al/Library/Controller/PadReplayFunction.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ReplayController;
+class IUsePadDataReader;
+class IUsePadDataWriter;
+
+ReplayController* createReplayController(u32 port);
+void unregistReplayController(u32 port);
+ReplayController* getReplayController(u32 port);
+void setPadDataReader(IUsePadDataReader* reader, u32 port);
+void createAndSetPadDataArcReader(const char* path, const char* stageName, u32 port);
+void startPadReplay(u32 port);
+void pausePadReplay(u32 port);
+void endPadReplay(u32 port);
+void setPadDataWriter(IUsePadDataWriter* writer, u32 port);
+void startPadRecording(u32 port);
+void endPadRecording(u32 port);
+bool isPadReplaying(u32 port);
+s32 getPadReplayRemainFrame(u32 port);
+bool isPadRecording(u32 port);
+void invalidatePadReplay(u32 port);
+void validatePadReplay(u32 port);
+bool isValidReplayController(u32 port);
+bool isReadPadReplayData(u32 port);
+}  // namespace al

--- a/lib/al/Library/Controller/ReplayController.h
+++ b/lib/al/Library/Controller/ReplayController.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <controller/seadControllerWrapper.h>
+
+namespace al {
+class IUsePadDataReader;
+class IUsePadDataWriter;
+
+class ReplayController : public sead::ControllerWrapper {
+    SEAD_RTTI_OVERRIDE(ReplayController, sead::ControllerWrapper);
+
+public:
+    ReplayController(sead::Controller* controller);
+    ~ReplayController();
+    void unregist();
+    void startReplay();
+    void pauseReplay();
+    void endReplay();
+    bool isReplaying() const;
+    bool isRecording() const;
+    s32 getReplayRemainFrame() const;
+    void calc(u32 prevHold, bool prevPointerOn) override;
+    void startRecord();
+    void endRecord();
+
+    void setPadDataReader(IUsePadDataReader* reader) { mPadDataReader = reader; }
+
+private:
+    IUsePadDataReader* mPadDataReader = nullptr;
+    bool mIsReplaying = false;
+    IUsePadDataWriter* mPadDataWriter = nullptr;
+    bool mIsRecording = false;
+    bool mIsValidController = true;
+    bool mIsReadPadReplayData = false;
+};
+}  // namespace al

--- a/lib/al/Library/Controller/ReplayController.h
+++ b/lib/al/Library/Controller/ReplayController.h
@@ -25,6 +25,8 @@ public:
 
     void setPadDataReader(IUsePadDataReader* reader) { mPadDataReader = reader; }
 
+    void setPadDataWriter(IUsePadDataWriter* writer) { mPadDataWriter = writer; }
+
 private:
     IUsePadDataReader* mPadDataReader = nullptr;
     bool mIsReplaying = false;


### PR DESCRIPTION
the `stageName` param of `al::createAndSetPadDataArcReader` is based on 3d world, where the `.bin` files that the game reads with `al::PadDataArcReader` are named e.g. `TitleDemo00Stage_port1.bin`.

`al::ReplayController` has two setters because they have to be used in `al::setPadDataReader`/`Writer` functions.