### PR TITLE
workflow: update `clang-format` to version 18

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -56,6 +56,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
+ReferenceAlignment: Left
 ReflowComments:  true
 RemoveBracesLLVM: true
 SeparateDefinitionBlocks: Always

--- a/.clang-format
+++ b/.clang-format
@@ -56,7 +56,6 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
-ReferenceAlignment: Left
 ReflowComments:  true
 RemoveBracesLLVM: true
 SeparateDefinitionBlocks: Always

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         source: 'src lib'
         exclude: 'lib/NintendoSDK lib/aarch64 lib/agl lib/eui lib/sead'
-        clangFormatVersion: 19
+        clangFormatVersion: 18
   custom-lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
       with:
         source: 'src lib'
         exclude: 'lib/NintendoSDK lib/aarch64 lib/agl lib/eui lib/sead'
-        clangFormatVersion: 14
+        clangFormatVersion: 19
   custom-lint:
     runs-on: ubuntu-latest
     steps:

--- a/Contributing.md
+++ b/Contributing.md
@@ -98,13 +98,13 @@ CLion interacts with CMake directly, so you need to make sure CLion's build prof
 9. Before opening a PR, reformat the code with clang-format and run `tools/check`.
     * You can use clang-format via your editor – VSCode and CLion have built-in clang-format support — or by calling `git clang-format` (for files you have `git add`ed and not yet committed).
     * If your editor does not have built-in support for clang-format, or if you need to invoke clang-format in a terminal, you'll need to install it manually.
-        * If your Linux distro or system (e.g. macOS) does not package clang-format 12, you can download it from [the LLVM project website here](https://releases.llvm.org/download.html)
+        * If your Linux distro or system (e.g. macOS) does not package clang-format, you can download it from [the LLVM project website here](https://releases.llvm.org/download.html)
 
 ## Code style
 
 Super Mario Odyssey has 31MB of code and contributors *need* to read and modify existing parts of the codebase very often: inconsistencies lead to a loss of efficiency, and we literally cannot afford that considering our small number of contributors. To avoid wasting time on formatting issues, we use clang-format to automatically enforce a consistent coding style.
 
-Before opening a PR, please format your code with clang-format 12 and ensure the following guidelines are followed. This will allow your contributions to be reviewed more quickly.
+Before opening a PR, please format your code with clang-format and ensure the following guidelines are followed. This will allow your contributions to be reviewed more quickly.
 
 ### General
 

--- a/lib/al/Library/Collision/CollisionPartsTriangle.h
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.h
@@ -48,8 +48,10 @@ public:
     const sead::Matrix34f& getBaseInvMtx() const;
     const sead::Matrix34f& getPrevBaseMtx() const;
 
+    // clang-format off
     friend bool ::operator==(const Triangle& tri1, const Triangle& tri2);
     friend bool ::operator!=(const Triangle& tri1, const Triangle& tri2);
+    // clang-format on
 
 private:
     const CollisionParts* mCollisionParts;

--- a/lib/al/Library/Execute/ExecuteDirector.cpp
+++ b/lib/al/Library/Execute/ExecuteDirector.cpp
@@ -10,7 +10,7 @@
 
 namespace al {
 
-ExecuteDirector::ExecuteDirector(s32 count) : mRequestCount(count){};
+ExecuteDirector::ExecuteDirector(s32 count) : mRequestCount(count) {}
 
 ExecuteDirector::~ExecuteDirector() {
     for (s32 i = 0; i < mDrawTableCount; i++)

--- a/lib/al/Library/Nerve/NerveSetupUtil.h
+++ b/lib/al/Library/Nerve/NerveSetupUtil.h
@@ -91,7 +91,9 @@ al::initNerveAction(this, "Hide", &NrvExampleUseCase.mCollector, 0);
             (keeper->getParent<Class>())->exe##ActionFunc();                                       \
         }                                                                                          \
                                                                                                    \
-        const char* getActionName() const override { return #Action; }                             \
+        const char* getActionName() const override {                                               \
+            return #Action;                                                                        \
+        }                                                                                          \
     };
 
 #define NERVE_ACTION_IMPL(Class, Action) NERVE_ACTION_IMPL_(Class, Action, Action)
@@ -106,5 +108,7 @@ al::initNerveAction(this, "Hide", &NrvExampleUseCase.mCollector, 0);
                                                                                                    \
         alNerveFunction::NerveActionCollector mCollector;                                          \
                                                                                                    \
-        NrvStruct##Class() { FOR_EACH(NERVE_ACTION_CONSTRUCT, Class, __VA_ARGS__) }                \
+        NrvStruct##Class() {                                                                       \
+            FOR_EACH(NERVE_ACTION_CONSTRUCT, Class, __VA_ARGS__)                                   \
+        }                                                                                          \
     } Nrv##Class;


### PR DESCRIPTION
Ubuntu 24.04 supports up to version 19 at the moment, but the `clang-format-lint-action` workflow only supports version 18, so i updated it to that. 

in `CollisionPartsTriangle.h`, `clang-format` wants to make the references align to the middle (i.e. with a space on either side of the `&`). this is fixed if the `::` is removed from the start of each of the `operator` functions, but this causes a compile error, so i've just disabled `clang-format` for those two lines. would it be better to just accept the middle alignment there? i tried using the `ReferenceAlignment: Left` rule but it made no difference, and no other rule seems like it would be of any help.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/393)
<!-- Reviewable:end -->
