### PR TITLE
nix: Pin `clang` and `libclang` to llvm 18

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
         buildInputs = with pkgs; [
           cmake
           ninja
-          llvmPackages_14.clang
+          llvmPackages_18.clang
           ccache
           pkg-config
 
@@ -37,7 +37,7 @@
             python-pkgs.toml
           ]))
           openssl
-          llvmPackages_14.libclang
+          llvmPackages_18.libclang
           ncurses5
           ncurses6
         ];


### PR DESCRIPTION
As discussed in the comments of #393, this PR simply pins `clang-format` to version 18 for the nix devshell. The correct way to pin that would be by using `clang-tools18`, but until #348 is finished and merged, the project requires clang, so that is pinned instead. This PR should be merged ASAP after that PR is merged (and not before)