### PR TITLE
Player: Implement `CollidedShapeResult`

### DIFF
--- a/lib/al/Library/Collision/CollisionPartsTriangle.cpp
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.cpp
@@ -239,21 +239,21 @@ const sead::Vector3f& HitInfo::tryGetHitEdgeNormal() const {
 
 void SphereHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
     // TODO add proper names here, once the missing names for _70 and _80 in HitInfo are found
-    if (isCollisionAtFace()) {
+    if (mHitInfo->isCollisionAtFace()) {
         calcFixVectorNormal(a1, a2);
         return;
     }
 
     sead::Vector3f v20;
-    v20.x = _80.x - mCollisionHitPos.x;
-    v20.y = _80.y - mCollisionHitPos.y;
-    v20.z = _80.z - mCollisionHitPos.z;
+    v20.x = mHitInfo->_80.x - mHitInfo->mCollisionHitPos.x;
+    v20.y = mHitInfo->_80.y - mHitInfo->mCollisionHitPos.y;
+    v20.z = mHitInfo->_80.z - mHitInfo->mCollisionHitPos.z;
     tryNormalizeOrZero(&v20);
 
     sead::Vector3f scaled_a1;
     sead::Vector3f scaled_a2;
-    f32 v13 = v20.dot(mTriangle.getFaceNormal() * _70);
-    f32 v12 = v20.dot(mTriangle.getFaceNormal());
+    f32 v13 = v20.dot(mHitInfo->mTriangle.getFaceNormal() * mHitInfo->_70);
+    f32 v12 = v20.dot(mHitInfo->mTriangle.getFaceNormal());
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a1, v20, v13);
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a2, v20, v12);
     *a1 = scaled_a1;
@@ -261,31 +261,31 @@ void SphereHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const 
 }
 
 void SphereHitInfo::calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const {
-    f32 unk = _70;
-    a1->x = mTriangle.getFaceNormal().x * unk;
-    a1->y = mTriangle.getFaceNormal().y * unk;
-    a1->z = mTriangle.getFaceNormal().z * unk;
+    f32 unk = mHitInfo->_70;
+    a1->x = mHitInfo->mTriangle.getFaceNormal().x * unk;
+    a1->y = mHitInfo->mTriangle.getFaceNormal().y * unk;
+    a1->z = mHitInfo->mTriangle.getFaceNormal().z * unk;
     if (a2)
-        a2->set(mTriangle.getFaceNormal());
+        a2->set(mHitInfo->mTriangle.getFaceNormal());
 }
 
 void DiskHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
     // TODO add proper names here, once the missing names for _70 and _80 in HitInfo are found
-    if (isCollisionAtFace()) {
+    if (mHitInfo->isCollisionAtFace()) {
         calcFixVectorNormal(a1, a2);
         return;
     }
 
     sead::Vector3f v20;
-    v20.x = _80.x - mCollisionHitPos.x;
-    v20.y = _80.y - mCollisionHitPos.y;
-    v20.z = _80.z - mCollisionHitPos.z;
+    v20.x = mHitInfo->_80.x - mHitInfo->mCollisionHitPos.x;
+    v20.y = mHitInfo->_80.y - mHitInfo->mCollisionHitPos.y;
+    v20.z = mHitInfo->_80.z - mHitInfo->mCollisionHitPos.z;
     tryNormalizeOrZero(&v20);
 
     sead::Vector3f scaled_a1;
     sead::Vector3f scaled_a2;
-    f32 v13 = v20.dot(mTriangle.getFaceNormal() * _70);
-    f32 v12 = v20.dot(mTriangle.getFaceNormal());
+    f32 v13 = v20.dot(mHitInfo->mTriangle.getFaceNormal() * mHitInfo->_70);
+    f32 v12 = v20.dot(mHitInfo->mTriangle.getFaceNormal());
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a1, v20, v13);
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a2, v20, v12);
     *a1 = scaled_a1;
@@ -293,12 +293,12 @@ void DiskHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
 }
 
 void DiskHitInfo::calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const {
-    f32 unk = _70;
-    a1->x = mTriangle.getFaceNormal().x * unk;
-    a1->y = mTriangle.getFaceNormal().y * unk;
-    a1->z = mTriangle.getFaceNormal().z * unk;
+    f32 unk = mHitInfo->_70;
+    a1->x = mHitInfo->mTriangle.getFaceNormal().x * unk;
+    a1->y = mHitInfo->mTriangle.getFaceNormal().y * unk;
+    a1->z = mHitInfo->mTriangle.getFaceNormal().z * unk;
     if (a2)
-        a2->set(mTriangle.getFaceNormal());
+        a2->set(mHitInfo->mTriangle.getFaceNormal());
 }
 
 }  // namespace al

--- a/lib/al/Library/Collision/CollisionPartsTriangle.h
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.h
@@ -2,6 +2,7 @@
 
 #include <math/seadMatrix.h>
 #include <math/seadVector.h>
+#include <prim/seadStorageFor.h>
 
 namespace al {
 class Triangle;
@@ -81,6 +82,10 @@ public:
     bool isCollisionAtCorner() const;
     const sead::Vector3f& tryGetHitEdgeNormal() const;
 
+    friend class ArrowHitInfo;
+    friend class SphereHitInfo;
+    friend class DiskHitInfo;
+
 protected:
     Triangle mTriangle;
     f32 _70 = 0.0f;
@@ -90,18 +95,49 @@ protected:
     CollisionLocation mCollisionLocation = CollisionLocation::None;
 };
 
-class ArrowHitInfo : public HitInfo {};
-
-class SphereHitInfo : public HitInfo {
+class ArrowHitInfo {
 public:
-    void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
-    void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
+    HitInfo& operator*() { return *mHitInfo; }
+
+    const HitInfo& operator*() const { return *mHitInfo; }
+
+    HitInfo& operator->() { return *mHitInfo; }
+
+    const HitInfo& operator->() const { return *mHitInfo; }
+
+    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
 };
 
-class DiskHitInfo : public HitInfo {
+class SphereHitInfo {
 public:
     void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
     void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
+
+    HitInfo& operator*() { return *mHitInfo; }
+
+    const HitInfo& operator*() const { return *mHitInfo; }
+
+    HitInfo& operator->() { return *mHitInfo; }
+
+    const HitInfo& operator->() const { return *mHitInfo; }
+
+    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
+};
+
+class DiskHitInfo {
+public:
+    void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
+    void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
+
+    HitInfo& operator*() { return *mHitInfo; }
+
+    const HitInfo& operator*() const { return *mHitInfo; }
+
+    HitInfo& operator->() { return *mHitInfo; }
+
+    const HitInfo& operator->() const { return *mHitInfo; }
+
+    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
 };
 
 }  // namespace al

--- a/lib/al/Library/Collision/CollisionPartsTriangle.h
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.h
@@ -113,9 +113,9 @@ public:
     void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
     void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
 
-    HitInfo& operator*() { return *mHitInfo; }
+    HitInfo* operator*() { return mHitInfo.data(); }
 
-    const HitInfo& operator*() const { return *mHitInfo; }
+    const HitInfo* operator*() const { return mHitInfo.data(); }
 
     HitInfo& operator->() { return *mHitInfo; }
 
@@ -129,9 +129,9 @@ public:
     void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
     void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
 
-    HitInfo& operator*() { return *mHitInfo; }
+    HitInfo* operator*() { return mHitInfo.data(); }
 
-    const HitInfo& operator*() const { return *mHitInfo; }
+    const HitInfo* operator*() const { return mHitInfo.data(); }
 
     HitInfo& operator->() { return *mHitInfo; }
 

--- a/lib/al/Library/Collision/CollisionPartsTriangle.h
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.h
@@ -97,9 +97,9 @@ protected:
 
 class ArrowHitInfo {
 public:
-    HitInfo& operator*() { return *mHitInfo; }
+    HitInfo* operator*() { return mHitInfo.data(); }
 
-    const HitInfo& operator*() const { return *mHitInfo; }
+    const HitInfo* operator*() const { return mHitInfo.data(); }
 
     HitInfo& operator->() { return *mHitInfo; }
 

--- a/src/Player/CollidedShapeResult.cpp
+++ b/src/Player/CollidedShapeResult.cpp
@@ -6,15 +6,15 @@ CollidedShapeResult::CollidedShapeResult(const CollisionShapeInfoBase* shapeInfo
     : mShapeInfo(shapeInfo) {}
 
 void CollidedShapeResult::setArrowHitInfo(const al::ArrowHitInfo& arrowHitInfo) {
-    *mArrowHitInfo = *arrowHitInfo;
+    *mArrowHitInfo.mHitInfo = *arrowHitInfo.mHitInfo;
 }
 
 void CollidedShapeResult::setSphereHitInfo(const al::SphereHitInfo& sphereHitInfo) {
-    *mSphereHitInfo = *sphereHitInfo;
+    *mSphereHitInfo.mHitInfo = *sphereHitInfo.mHitInfo;
 }
 
 void CollidedShapeResult::setDiskHitInfo(const al::DiskHitInfo& diskHitInfo) {
-    *mDiskHitInfo = *diskHitInfo;
+    *mDiskHitInfo.mHitInfo = *diskHitInfo.mHitInfo;
 }
 
 bool CollidedShapeResult::isArrow() const {

--- a/src/Player/CollidedShapeResult.cpp
+++ b/src/Player/CollidedShapeResult.cpp
@@ -6,15 +6,15 @@ CollidedShapeResult::CollidedShapeResult(const CollisionShapeInfoBase* shapeInfo
     : mShapeInfo(shapeInfo) {}
 
 void CollidedShapeResult::setArrowHitInfo(const al::ArrowHitInfo& arrowHitInfo) {
-    *mArrowHitInfo = arrowHitInfo;
+    *mArrowHitInfo = *arrowHitInfo;
 }
 
 void CollidedShapeResult::setSphereHitInfo(const al::SphereHitInfo& sphereHitInfo) {
-    *mSphereHitInfo = sphereHitInfo;
+    *mSphereHitInfo = *sphereHitInfo;
 }
 
 void CollidedShapeResult::setDiskHitInfo(const al::DiskHitInfo& diskHitInfo) {
-    *mDiskHitInfo = diskHitInfo;
+    *mDiskHitInfo = *diskHitInfo;
 }
 
 bool CollidedShapeResult::isArrow() const {
@@ -30,15 +30,15 @@ bool CollidedShapeResult::isDisk() const {
 }
 
 const al::ArrowHitInfo& CollidedShapeResult::getArrowHitInfo() const {
-    return *mArrowHitInfo;
+    return mArrowHitInfo;
 }
 
 const al::SphereHitInfo& CollidedShapeResult::getSphereHitInfo() const {
-    return *mSphereHitInfo;
+    return mSphereHitInfo;
 }
 
 const al::DiskHitInfo& CollidedShapeResult::getDiskHitInfo() const {
-    return *mDiskHitInfo;
+    return mDiskHitInfo;
 }
 
 const CollisionShapeInfoArrow* CollidedShapeResult::getShapeInfoArrow() const {
@@ -55,7 +55,7 @@ const CollisionShapeInfoDisk* CollidedShapeResult::getShapeInfoDisk() const {
 
 void CollidedShapeResult::operator=(const CollidedShapeResult& other) {
     mShapeInfo = other.mShapeInfo;
-    *mArrowHitInfo = *other.mArrowHitInfo;
-    *mSphereHitInfo = *other.mSphereHitInfo;
-    *mDiskHitInfo = *other.mDiskHitInfo;
+    setArrowHitInfo(other.mArrowHitInfo);
+    setSphereHitInfo(other.mSphereHitInfo);
+    setDiskHitInfo(other.mDiskHitInfo);
 }

--- a/src/Player/CollidedShapeResult.cpp
+++ b/src/Player/CollidedShapeResult.cpp
@@ -1,0 +1,61 @@
+#include "Player/CollidedShapeResult.h"
+
+#include "Util/CollisionShapeFunction.h"
+
+CollidedShapeResult::CollidedShapeResult(const CollisionShapeInfoBase* shapeInfo)
+    : mShapeInfo(shapeInfo) {}
+
+void CollidedShapeResult::setArrowHitInfo(const al::ArrowHitInfo& arrowHitInfo) {
+    *mArrowHitInfo = arrowHitInfo;
+}
+
+void CollidedShapeResult::setSphereHitInfo(const al::SphereHitInfo& sphereHitInfo) {
+    *mSphereHitInfo = sphereHitInfo;
+}
+
+void CollidedShapeResult::setDiskHitInfo(const al::DiskHitInfo& diskHitInfo) {
+    *mDiskHitInfo = diskHitInfo;
+}
+
+bool CollidedShapeResult::isArrow() const {
+    return CollisionShapeFunction::isShapeArrow(mShapeInfo);
+}
+
+bool CollidedShapeResult::isSphere() const {
+    return CollisionShapeFunction::isShapeSphere(mShapeInfo);
+}
+
+bool CollidedShapeResult::isDisk() const {
+    return CollisionShapeFunction::isShapeDisk(mShapeInfo);
+}
+
+const al::ArrowHitInfo& CollidedShapeResult::getArrowHitInfo() const {
+    return *mArrowHitInfo;
+}
+
+const al::SphereHitInfo& CollidedShapeResult::getSphereHitInfo() const {
+    return *mSphereHitInfo;
+}
+
+const al::DiskHitInfo& CollidedShapeResult::getDiskHitInfo() const {
+    return *mDiskHitInfo;
+}
+
+const CollisionShapeInfoArrow* CollidedShapeResult::getShapeInfoArrow() const {
+    return CollisionShapeFunction::getShapeInfoArrow(mShapeInfo);
+}
+
+const CollisionShapeInfoSphere* CollidedShapeResult::getShapeInfoSphere() const {
+    return CollisionShapeFunction::getShapeInfoSphere(mShapeInfo);
+}
+
+const CollisionShapeInfoDisk* CollidedShapeResult::getShapeInfoDisk() const {
+    return CollisionShapeFunction::getShapeInfoDisk(mShapeInfo);
+}
+
+void CollidedShapeResult::operator=(const CollidedShapeResult& other) {
+    mShapeInfo = other.mShapeInfo;
+    *mArrowHitInfo = *other.mArrowHitInfo;
+    *mSphereHitInfo = *other.mSphereHitInfo;
+    *mDiskHitInfo = *other.mDiskHitInfo;
+}

--- a/src/Player/CollidedShapeResult.h
+++ b/src/Player/CollidedShapeResult.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <prim/seadStorageFor.h>
+
+#include "Library/Collision/CollisionPartsTriangle.h"
+
+class CollisionShapeInfoBase;
+class CollisionShapeInfoArrow;
+class CollisionShapeInfoSphere;
+class CollisionShapeInfoDisk;
+
+class CollidedShapeResult {
+public:
+    CollidedShapeResult(const CollisionShapeInfoBase* shapeInfo);
+
+    void setArrowHitInfo(const al::ArrowHitInfo& arrowHitInfo);
+    void setSphereHitInfo(const al::SphereHitInfo& sphereHitInfo);
+    void setDiskHitInfo(const al::DiskHitInfo& diskHitInfo);
+
+    bool isArrow() const;
+    bool isSphere() const;
+    bool isDisk() const;
+
+    const al::ArrowHitInfo& getArrowHitInfo() const;
+    const al::SphereHitInfo& getSphereHitInfo() const;
+    const al::DiskHitInfo& getDiskHitInfo() const;
+
+    const CollisionShapeInfoArrow* getShapeInfoArrow() const;
+    const CollisionShapeInfoSphere* getShapeInfoSphere() const;
+    const CollisionShapeInfoDisk* getShapeInfoDisk() const;
+
+    void operator=(const CollidedShapeResult& other);
+
+private:
+    const CollisionShapeInfoBase* mShapeInfo;
+    sead::StorageFor<al::ArrowHitInfo> mArrowHitInfo{sead::ZeroInitializeTag{}};
+    sead::StorageFor<al::SphereHitInfo> mSphereHitInfo{sead::ZeroInitializeTag{}};
+    sead::StorageFor<al::DiskHitInfo> mDiskHitInfo{sead::ZeroInitializeTag{}};
+};
+
+static_assert(sizeof(CollidedShapeResult) == 0x1e8);

--- a/src/Player/CollidedShapeResult.h
+++ b/src/Player/CollidedShapeResult.h
@@ -33,9 +33,9 @@ public:
 
 private:
     const CollisionShapeInfoBase* mShapeInfo;
-    sead::StorageFor<al::ArrowHitInfo> mArrowHitInfo{sead::ZeroInitializeTag{}};
-    sead::StorageFor<al::SphereHitInfo> mSphereHitInfo{sead::ZeroInitializeTag{}};
-    sead::StorageFor<al::DiskHitInfo> mDiskHitInfo{sead::ZeroInitializeTag{}};
+    al::ArrowHitInfo mArrowHitInfo;
+    al::SphereHitInfo mSphereHitInfo;
+    al::DiskHitInfo mDiskHitInfo;
 };
 
 static_assert(sizeof(CollidedShapeResult) == 0x1e8);

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -307,7 +307,7 @@ def common_string_finder(c, path):
 def common_const_reference(c, path):
     for line in c.splitlines():
         if "& " in line and line[line.find("& ") - 1] != "&" and line[line.find("& ") - 1] != " " and "CLASS&" not in line:
-            if ("const" not in line or line.find("& ") < line.find("const ")) and ("for" not in line or " : " not in line):
+            if ("const" not in line or line.find("& ") < line.find("const ")) and ("for" not in line or " : " not in line) and ("operator->" not in line):
                 FAIL("References must be const!", line, path)
 
 def common_self_other(c, path, is_header):


### PR DESCRIPTION
Requires #404 to be merged first.

Also pretty simple. Note the `sead::StorageFor` being used here, due to the constructor behaving kind-of weird: Instead of calling the constructor for each `HitInfo` directly, it first calls `memset` to set the entire area to `0`, *then* calls the constructor. I was only able to re-create that using this class. Additionally, should *not* be implemented like this in the `cpp`, as it would end up linking in the wrong place - until `CollisionShapeKeeper` is implemented, it should remain like this though, to ensure this function is generated and can be checked.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/406)
<!-- Reviewable:end -->
