### PR TITLE
Amiibo: Implement `HelpAmiiboCoinCollect`

### DIFF
--- a/lib/al/Library/Scene/SceneObjUtil.h
+++ b/lib/al/Library/Scene/SceneObjUtil.h
@@ -19,4 +19,9 @@ inline T* getSceneObj(const IUseSceneObjHolder* user, s32 sceneObjId) {
     return static_cast<T*>(getSceneObj(user, sceneObjId));
 }
 
+template <typename T>
+inline T* tryGetSceneObj(const IUseSceneObjHolder* user, s32 sceneObjId) {
+    return static_cast<T*>(tryGetSceneObj(user, sceneObjId));
+}
+
 }  // namespace al

--- a/src/Amiibo/HelpAmiiboCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboCoinCollect.cpp
@@ -1,0 +1,274 @@
+#include "Amiibo/HelpAmiiboCoinCollect.h"
+
+#include "Library/Area/AreaObj.h"
+#include "Library/Area/AreaObjUtil.h"
+#include "Library/Area/IUseAreaObj.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/Nfp/NfpFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Amiibo/HelpAmiiboDirector.h"
+#include "Item/CoinCollect.h"
+#include "Item/CoinCollect2D.h"
+#include "Item/CoinCollectDummy.h"
+#include "Item/CoinCollectHolder.h"
+#include "Scene/SceneObjFactory.h"
+#include "System/GameDataFunction.h"
+#include "Util/PlayerUtil.h"
+
+HelpAmiiboCoinCollect::HelpAmiiboCoinCollect(HelpAmiiboDirector* director,
+                                             al::LiveActor* amiiboActor)
+    : HelpAmiiboExecutor(director, amiiboActor, "コレクトコインお助け") {}
+
+void HelpAmiiboCoinCollect::initAfterPlacement(const al::ActorInitInfo& actorInitInfo) {
+    HelpAmiiboExecutor::initAfterPlacement(actorInitInfo);
+
+    mCoinCollectDummy = new CoinCollectDummy("コレクトコインお助け");
+    al::initCreateActorNoPlacementInfo(mCoinCollectDummy, actorInitInfo);
+}
+
+bool HelpAmiiboCoinCollect::isTriggerTouch(const al::NfpInfo& nfpInfo) const {
+    return al::isCharacterIdBaseKoopa(nfpInfo);
+}
+
+bool HelpAmiiboCoinCollect::isEnableUse() {
+    CoinCollectHolder* coinHolder = (CoinCollectHolder*)al::tryGetSceneObj(getActor(), 7);
+    if (coinHolder == nullptr)
+        return false;
+
+    if (mCoinCollect2D != nullptr && al::isAlive(mCoinCollect2D))
+        return false;
+
+    if (mCoinCollect != nullptr && al::isAlive(mCoinCollect))
+        return false;
+
+    const sead::Vector3f& playerPos = rs::getPlayerPos(getActor());
+    if (coinHolder->tryFindAliveCoinCollect(playerPos, true) != nullptr)
+        return true;
+    if (coinHolder->tryFindAliveCoinCollect2D(playerPos, true) != nullptr)
+        return true;
+    if (coinHolder->tryFindDeadButHintEnableCoinCollect() != nullptr)
+        return true;
+
+    if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
+        sead::Vector3f vector = sead::Vector3f::zero;
+        const char* text = nullptr;
+        if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
+                &vector, &text, getActor()) &&
+            (GameDataFunction::isMainStage(mCoinCollectDummy) ||
+             coinHolder->tryFindExStageHintObjTrans(&vector, text)))
+            return true;
+    }
+
+    return false;
+}
+
+bool HelpAmiiboCoinCollect::execute() {
+    const sead::Vector3f& playerPos = rs::getPlayerPos(getActor());
+
+    al::AreaObj* areaObj =
+        al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
+    if (areaObj != mAreaObj) {
+        if (mCoinCollect != nullptr) {
+            mCoinCollect->deleteHelpAmiiboEffect();
+            mCoinCollect = nullptr;
+            return true;
+        }
+
+        if (mCoinCollect2D != nullptr) {
+            mCoinCollect2D->deleteHintEffect();
+            mCoinCollect2D = nullptr;
+            return true;
+        }
+
+        if (al::isAlive(mCoinCollectDummy))
+            mCoinCollectDummy->kill();
+        return true;
+    }
+
+    if (mCoinCollect != nullptr) {
+        if (mCoinCollect->isEnableHint()) {
+            mCoinCollect = nullptr;
+            return true;
+        }
+        return false;
+    }
+
+    if (mCoinCollect2D != nullptr) {
+        if (mCoinCollect2D->isEnableHint()) {
+            mCoinCollect2D = nullptr;
+            return true;
+        }
+        return false;
+    }
+
+    return !al::isAlive(mCoinCollectDummy);
+}
+
+void HelpAmiiboCoinCollect::activate() {
+    HelpAmiiboExecutor::activate();
+
+    al::LiveActor* actor = getActor();
+    const sead::Vector3f& playerPos = rs::getPlayerPos(actor);
+    CoinCollectHolder* coinHolder =
+        (CoinCollectHolder*)al::tryGetSceneObj(actor, SceneObjID_CoinCollectHolder);
+    mAreaObj = al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
+
+    CoinCollect* aliveCoinCollect =
+        coinHolder->tryFindAliveCoinCollect(playerPos, 5000.0f, 10000.0f, true);
+    if (aliveCoinCollect != nullptr) {
+        al::startSe(getDirector(), "AmiiboKoopa");
+        if (isUseDummyModel(aliveCoinCollect)) {
+            sead::Vector3f vector2 = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&vector2, aliveCoinCollect);
+            mCoinCollectDummy->appearHint(vector2);
+            return;
+        }
+        aliveCoinCollect->appearHelpAmiiboEffect();
+        mCoinCollect = aliveCoinCollect;
+        return;
+    }
+
+    CoinCollect2D* aliveCoinCollect2D =
+        coinHolder->tryFindAliveCoinCollect2D(playerPos, 5000.0f, 10000.0f, true);
+    if (aliveCoinCollect2D != nullptr) {
+        al::startSe(getDirector(), "AmiiboKoopa");
+        if (isUseDummyModel(aliveCoinCollect2D)) {
+            sead::Vector3f vector2 = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&vector2, aliveCoinCollect2D);
+            mCoinCollectDummy->appearHint(vector2);
+            return;
+        }
+        aliveCoinCollect2D->appearHintEffect();
+        mCoinCollect2D = aliveCoinCollect2D;
+        return;
+    }
+
+    CoinCollect* coinCollect = coinHolder->tryFindAliveCoinCollect(playerPos, true);
+    if (coinCollect != nullptr) {
+        al::startSe(getDirector(), "AmiiboKoopa");
+        if (isUseDummyModel(coinCollect)) {
+            sead::Vector3f vector2 = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&vector2, coinCollect);
+            mCoinCollectDummy->appearHint(vector2);
+            return;
+        }
+        coinCollect->appearHelpAmiiboEffect();
+        mCoinCollect = coinCollect;
+
+        return;
+    }
+
+    CoinCollect2D* coinCollect2D = coinHolder->tryFindAliveCoinCollect2D(playerPos, true);
+    if (coinCollect2D != nullptr) {
+        al::startSe(getDirector(), "AmiiboKoopa");
+        if (isUseDummyModel(coinCollect2D)) {
+            sead::Vector3f vector2 = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&vector2, coinCollect2D);
+            mCoinCollectDummy->appearHint(vector2);
+            return;
+        }
+        coinCollect2D->appearHintEffect();
+        mCoinCollect2D = coinCollect2D;
+        return;
+    }
+
+    CoinCollect* deadCoinCollect = coinHolder->tryFindDeadButHintEnableCoinCollect();
+    if (deadCoinCollect != nullptr) {
+        al::startSe(getDirector(), "AmiiboKoopa");
+        if (isUseDummyModel(deadCoinCollect)) {
+            sead::Vector3f vector2 = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&vector2, deadCoinCollect);
+            mCoinCollectDummy->appearHint(vector2);
+            return;
+        }
+        deadCoinCollect->appearHelpAmiiboEffect();
+        mCoinCollect = deadCoinCollect;
+        return;
+    }
+
+    if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
+        sead::Vector3f vector = sead::Vector3f::zero;
+        const char* name = nullptr;
+        if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
+                &vector, &name, actor)) {
+            if (GameDataFunction::isMainStage(actor) ||
+                coinHolder->tryFindExStageHintObjTrans(&vector, name)) {
+                mCoinCollectDummy->appearHint(vector);
+                al::startSe(getDirector(), "AmiiboKoopa");
+            }
+        }
+    }
+}
+
+HelpAmiiboType HelpAmiiboCoinCollect::getType() const {
+    return HelpAmiiboType::Koopa;
+}
+
+void HelpAmiiboCoinCollect::deleteHintEffect() {
+    if (mCoinCollect != nullptr) {
+        mCoinCollect->deleteHelpAmiiboEffect();
+        mCoinCollect = nullptr;
+        return;
+    }
+
+    if (mCoinCollect2D != nullptr) {
+        mCoinCollect2D->deleteHintEffect();
+        mCoinCollect2D = nullptr;
+        return;
+    }
+
+    if (al::isAlive(mCoinCollectDummy))
+        mCoinCollectDummy->kill();
+}
+
+void HelpAmiiboCoinCollect::appearEffect() {
+    if (mCoinCollect != nullptr) {
+        mCoinCollect->reappearHelpAmiiboEffect();
+        return;
+    }
+
+    if (mCoinCollect2D != nullptr) {
+        mCoinCollect2D->reappearHintEffect();
+        return;
+    }
+
+    if (al::isAlive(mCoinCollectDummy))
+        mCoinCollectDummy->reappearHint();
+}
+
+void HelpAmiiboCoinCollect::killEffect() {
+    if (mCoinCollect != nullptr) {
+        mCoinCollect->deleteHelpAmiiboEffect();
+        return;
+    }
+
+    if (mCoinCollect2D != nullptr)
+        mCoinCollect2D->deleteHintEffect();
+
+    if (al::isAlive(mCoinCollectDummy))
+        mCoinCollectDummy->deleteHint();
+}
+
+bool HelpAmiiboCoinCollect::isUseDummyModel(al::LiveActor* actor) {
+    const sead::Vector3f& playerPos = rs::getPlayerPos(mCoinCollectDummy);
+    al::AreaObj* dummyAreaObj =
+        al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
+    al::AreaObj* actorAreaObj =
+        al::tryFindAreaObj(actor, "InvalidateStageMapArea", al::getTrans(actor));
+
+    return dummyAreaObj != actorAreaObj;
+}
+
+void HelpAmiiboCoinCollect::getDummyEffectEmitPos(sead::Vector3f* position, al::LiveActor* actor) {
+    al::AreaObj* areaObj = al::tryFindAreaObj(actor, "InvalidateStageMapArea", al::getTrans(actor));
+    if (areaObj != nullptr)
+        al::tryGetLinksTrans(position, *areaObj->getPlacementInfo(), "PlayerPoint");
+}

--- a/src/Amiibo/HelpAmiiboCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboCoinCollect.cpp
@@ -7,7 +7,7 @@
 #include "Library/LiveActor/ActorInitInfo.h"
 #include "Library/LiveActor/ActorInitUtil.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
-#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/Nfp/NfpFunction.h"
 #include "Library/Placement/PlacementFunction.h"
 #include "Library/Placement/PlacementInfo.h"
@@ -39,7 +39,8 @@ bool HelpAmiiboCoinCollect::isTriggerTouch(const al::NfpInfo& nfpInfo) const {
 }
 
 bool HelpAmiiboCoinCollect::isEnableUse() {
-    CoinCollectHolder* coinHolder = (CoinCollectHolder*)al::tryGetSceneObj(getActor(), 7);
+    CoinCollectHolder* coinHolder =
+        al::tryGetSceneObj<CoinCollectHolder>(getActor(), SceneObjID_CoinCollectHolder);
     if (coinHolder == nullptr)
         return false;
 
@@ -58,13 +59,14 @@ bool HelpAmiiboCoinCollect::isEnableUse() {
         return true;
 
     if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
-        sead::Vector3f vector = sead::Vector3f::zero;
-        const char* text = nullptr;
+        sead::Vector3f stagePos = sead::Vector3f::zero;
+        const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
-                &vector, &text, getActor()) &&
-            (GameDataFunction::isMainStage(mCoinCollectDummy) ||
-             coinHolder->tryFindExStageHintObjTrans(&vector, text)))
-            return true;
+                &stagePos, &stageName, getActor())) {
+            if (GameDataFunction::isMainStage(mCoinCollectDummy) ||
+                coinHolder->tryFindExStageHintObjTrans(&stagePos, stageName))
+                return true;
+        }
     }
 
     return false;
@@ -75,21 +77,8 @@ bool HelpAmiiboCoinCollect::execute() {
 
     al::AreaObj* areaObj =
         al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
-    if (areaObj != mAreaObj) {
-        if (mCoinCollect != nullptr) {
-            mCoinCollect->deleteHelpAmiiboEffect();
-            mCoinCollect = nullptr;
-            return true;
-        }
-
-        if (mCoinCollect2D != nullptr) {
-            mCoinCollect2D->deleteHintEffect();
-            mCoinCollect2D = nullptr;
-            return true;
-        }
-
-        if (al::isAlive(mCoinCollectDummy))
-            mCoinCollectDummy->kill();
+    if (areaObj != mStartInvalidateStageMapArea) {
+        deleteHintEffect();
         return true;
     }
 
@@ -118,17 +107,18 @@ void HelpAmiiboCoinCollect::activate() {
     al::LiveActor* actor = getActor();
     const sead::Vector3f& playerPos = rs::getPlayerPos(actor);
     CoinCollectHolder* coinHolder =
-        (CoinCollectHolder*)al::tryGetSceneObj(actor, SceneObjID_CoinCollectHolder);
-    mAreaObj = al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
+        al::tryGetSceneObj<CoinCollectHolder>(actor, SceneObjID_CoinCollectHolder);
+    mStartInvalidateStageMapArea =
+        al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos);
 
     CoinCollect* aliveCoinCollect =
         coinHolder->tryFindAliveCoinCollect(playerPos, 5000.0f, 10000.0f, true);
     if (aliveCoinCollect != nullptr) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect)) {
-            sead::Vector3f vector2 = sead::Vector3f::zero;
-            getDummyEffectEmitPos(&vector2, aliveCoinCollect);
-            mCoinCollectDummy->appearHint(vector2);
+            sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&dummyEffectEmitPos, aliveCoinCollect);
+            mCoinCollectDummy->appearHint(dummyEffectEmitPos);
             return;
         }
         aliveCoinCollect->appearHelpAmiiboEffect();
@@ -141,9 +131,9 @@ void HelpAmiiboCoinCollect::activate() {
     if (aliveCoinCollect2D != nullptr) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect2D)) {
-            sead::Vector3f vector2 = sead::Vector3f::zero;
-            getDummyEffectEmitPos(&vector2, aliveCoinCollect2D);
-            mCoinCollectDummy->appearHint(vector2);
+            sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&dummyEffectEmitPos, aliveCoinCollect2D);
+            mCoinCollectDummy->appearHint(dummyEffectEmitPos);
             return;
         }
         aliveCoinCollect2D->appearHintEffect();
@@ -155,14 +145,13 @@ void HelpAmiiboCoinCollect::activate() {
     if (coinCollect != nullptr) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect)) {
-            sead::Vector3f vector2 = sead::Vector3f::zero;
-            getDummyEffectEmitPos(&vector2, coinCollect);
-            mCoinCollectDummy->appearHint(vector2);
+            sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&dummyEffectEmitPos, coinCollect);
+            mCoinCollectDummy->appearHint(dummyEffectEmitPos);
             return;
         }
         coinCollect->appearHelpAmiiboEffect();
         mCoinCollect = coinCollect;
-
         return;
     }
 
@@ -170,9 +159,9 @@ void HelpAmiiboCoinCollect::activate() {
     if (coinCollect2D != nullptr) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect2D)) {
-            sead::Vector3f vector2 = sead::Vector3f::zero;
-            getDummyEffectEmitPos(&vector2, coinCollect2D);
-            mCoinCollectDummy->appearHint(vector2);
+            sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&dummyEffectEmitPos, coinCollect2D);
+            mCoinCollectDummy->appearHint(dummyEffectEmitPos);
             return;
         }
         coinCollect2D->appearHintEffect();
@@ -184,9 +173,9 @@ void HelpAmiiboCoinCollect::activate() {
     if (deadCoinCollect != nullptr) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(deadCoinCollect)) {
-            sead::Vector3f vector2 = sead::Vector3f::zero;
-            getDummyEffectEmitPos(&vector2, deadCoinCollect);
-            mCoinCollectDummy->appearHint(vector2);
+            sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
+            getDummyEffectEmitPos(&dummyEffectEmitPos, deadCoinCollect);
+            mCoinCollectDummy->appearHint(dummyEffectEmitPos);
             return;
         }
         deadCoinCollect->appearHelpAmiiboEffect();
@@ -195,13 +184,13 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
-        sead::Vector3f vector = sead::Vector3f::zero;
-        const char* name = nullptr;
+        sead::Vector3f stagePos = sead::Vector3f::zero;
+        const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
-                &vector, &name, actor)) {
+                &stagePos, &stageName, actor)) {
             if (GameDataFunction::isMainStage(actor) ||
-                coinHolder->tryFindExStageHintObjTrans(&vector, name)) {
-                mCoinCollectDummy->appearHint(vector);
+                coinHolder->tryFindExStageHintObjTrans(&stagePos, stageName)) {
+                mCoinCollectDummy->appearHint(stagePos);
                 al::startSe(getDirector(), "AmiiboKoopa");
             }
         }

--- a/src/Amiibo/HelpAmiiboCoinCollect.h
+++ b/src/Amiibo/HelpAmiiboCoinCollect.h
@@ -37,5 +37,5 @@ private:
     CoinCollect* mCoinCollect = nullptr;
     CoinCollect2D* mCoinCollect2D = nullptr;
     CoinCollectDummy* mCoinCollectDummy = nullptr;
-    al::AreaObj* mAreaObj = nullptr;
+    al::AreaObj* mStartInvalidateStageMapArea = nullptr;
 };

--- a/src/Amiibo/HelpAmiiboCoinCollect.h
+++ b/src/Amiibo/HelpAmiiboCoinCollect.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Amiibo/HelpAmiiboExecutor.h"
+
+namespace al {
+struct NfpInfo;
+class LiveActor;
+class ActorInitInfo;
+class AreaObj;
+}  // namespace al
+
+class CoinCollect;
+class CoinCollectDummy;
+class CoinCollect2D;
+class HelpAmiiboDirector;
+
+class HelpAmiiboCoinCollect : public HelpAmiiboExecutor {
+public:
+    HelpAmiiboCoinCollect(HelpAmiiboDirector* director, al::LiveActor* amiiboActor);
+
+    void initAfterPlacement(const al::ActorInitInfo& actorInitInfo) override;
+    bool isTriggerTouch(const al::NfpInfo& nfpInfo) const override;
+    bool isEnableUse() override;
+    bool execute() override;
+    void activate() override;
+    HelpAmiiboType getType() const override;
+
+    void deleteHintEffect();
+    void appearEffect();
+    void killEffect();
+    bool isUseDummyModel(al::LiveActor* actor);
+    void getDummyEffectEmitPos(sead::Vector3f* position, al::LiveActor* actor);
+
+private:
+    CoinCollect* mCoinCollect = nullptr;
+    CoinCollect2D* mCoinCollect2D = nullptr;
+    CoinCollectDummy* mCoinCollectDummy = nullptr;
+    al::AreaObj* mAreaObj = nullptr;
+};

--- a/src/Item/CoinCollectHolder.h
+++ b/src/Item/CoinCollectHolder.h
@@ -28,7 +28,7 @@ public:
     CoinCollect* tryFindDeadButHintEnableCoinCollect() const;
     CoinCollect2D* tryFindAliveCoinCollect2D(const sead::Vector3f&, bool) const;
     CoinCollect2D* tryFindAliveCoinCollect2D(const sead::Vector3f&, f32, f32, bool) const;
-    CoinCollectHintObj* tryFindExStageHintObjTrans(sead::Vector3f*, const char*);
+    bool tryFindExStageHintObjTrans(sead::Vector3f*, const char*);
 };
 
 namespace rs {


### PR DESCRIPTION
This class has been in the burner for quite a few weeks. From the start to bottom the code was harsh to implement and look at. HelpAmiiboCoinCollect::activate was very hard. It contains a lot of duplicated code that resulted in very weird branching.

This implementation feels like it can get a lot cleaner than this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/407)
<!-- Reviewable:end -->
