### PR TITLE
Player: Implement `PlayerStateHipDrop`

### DIFF
--- a/src/Player/PlayerAnimator.h
+++ b/src/Player/PlayerAnimator.h
@@ -45,7 +45,7 @@ public:
     void setPartsAnimRate(f32, const char*);
     void setPartsAnimFrame(f32, const char*);
 
-    bool get_1a2() const { return _1a2; }
+    bool isSubAnimPlaying() const { return mIsSubAnimPlaying; }
 
 private:
     PlayerModelHolder* mModelHolder;
@@ -57,5 +57,5 @@ private:
     sead::FixedSafeString<64> mCurUpperBodyAnim;
     sead::FixedSafeString<64> _128;
     char padding_180[0x1A2 - 0x180];
-    bool _1a2;
+    bool mIsSubAnimPlaying;
 };

--- a/src/Player/PlayerAnimator.h
+++ b/src/Player/PlayerAnimator.h
@@ -22,6 +22,7 @@ public:
     void clearUpperBodyAnim();
 
     bool isAnim(const sead::SafeString& animName) const;
+    bool isAnimEnd() const;
     bool isSubAnim(const sead::SafeString& subAnimName) const;
     bool isSubAnimEnd() const;
     bool isUpperBodyAnimAttached() const;
@@ -44,12 +45,17 @@ public:
     void setPartsAnimRate(f32, const char*);
     void setPartsAnimFrame(f32, const char*);
 
+    bool get_1a2() const { return _1a2; }
+
 private:
     PlayerModelHolder* mModelHolder;
     al::LiveActor* mPlayerDeco;
     void* _10;
     PlayerAnimFrameCtrl* mAnimFrameCtrl;
-    sead::SafeString mCurAnim;
-    unsigned char padding_78[0x78 - 0x30];
-    sead::SafeString mCurSubAnim;
+    sead::FixedSafeString<64> mCurAnim;
+    sead::FixedSafeString<64> mCurSubAnim;
+    sead::FixedSafeString<64> mCurUpperBodyAnim;
+    sead::FixedSafeString<64> _128;
+    char padding_180[0x1A2 - 0x180];
+    bool _1a2;
 };

--- a/src/Player/PlayerStateHipDrop.cpp
+++ b/src/Player/PlayerStateHipDrop.cpp
@@ -33,7 +33,7 @@ PlayerStateHipDrop::PlayerStateHipDrop(al::LiveActor* player, const PlayerConst*
 
 void PlayerStateHipDrop::appear() {
     setDead(false);
-    if (mPlayerAnimator->get_1a2())
+    if (mPlayerAnimator->isSubAnimPlaying())
         mPlayerAnimator->endSubAnim();
     mIsLandGround = false;
     mLandPos = {0.0f, 0.0f, 0.0f};

--- a/src/Player/PlayerStateHipDrop.cpp
+++ b/src/Player/PlayerStateHipDrop.cpp
@@ -130,8 +130,7 @@ void PlayerStateHipDrop::exeFall() {
 
     al::addVelocityToGravityLimit(mActor, mConst->getHipDropGravity(),
                                   mConst->getHipDropSpeedMax());
-    if (mTrigger->isOn(PlayerTrigger::ECollisionTrigger_val1) &&
-        mInput->isHoldHipDrop()) {
+    if (mTrigger->isOn(PlayerTrigger::ECollisionTrigger_val1) && mInput->isHoldHipDrop()) {
         mHipDropMsgIntervalCounter = mConst->getHipDropMsgInterval();
         mAnimator->startAnim("HipDropReaction");
         mIsLandGround = false;
@@ -169,9 +168,8 @@ void PlayerStateHipDrop::exeLand() {
     }
 
     if (rs::isOnGroundRunAngle(mActor, mCollision, mConst)) {
-        rs::waitGround(mActor, mCollision, mConst->getGravityMove(),
-                       mConst->getFallSpeedMax(), mConst->getSlerpQuatRateWait(),
-                       mConst->getWaitPoseDegreeMax());
+        rs::waitGround(mActor, mCollision, mConst->getGravityMove(), mConst->getFallSpeedMax(),
+                       mConst->getSlerpQuatRateWait(), mConst->getWaitPoseDegreeMax());
     } else {
         kill();
     }

--- a/src/Player/PlayerStateHipDrop.cpp
+++ b/src/Player/PlayerStateHipDrop.cpp
@@ -1,0 +1,181 @@
+#include "Player/PlayerStateHipDrop.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorSensorMsgFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateHipDrop, Land);
+NERVE_IMPL(PlayerStateHipDrop, Start);
+NERVE_IMPL(PlayerStateHipDrop, Fall);
+
+NERVES_MAKE_NOSTRUCT(PlayerStateHipDrop, Land, Start, Fall);
+}  // namespace
+
+PlayerStateHipDrop::PlayerStateHipDrop(al::LiveActor* player, const PlayerConst* pConst,
+                                       const PlayerInput* input,
+                                       const IUsePlayerCollision* collider,
+                                       PlayerAnimator* animator, PlayerTrigger* trigger)
+    : al::ActorStateBase("ヒップドロップ", player), mPlayerConst(pConst), mPlayerInput(input),
+      mPlayerCollision(collider), mPlayerAnimator(animator), mPlayerTrigger(trigger) {
+    initNerve(&Start, 0);
+}
+
+void PlayerStateHipDrop::appear() {
+    setDead(false);
+    if (mPlayerAnimator->get_1a2())
+        mPlayerAnimator->endSubAnim();
+    mIsLandGround = false;
+    mLandPos = {0.0f, 0.0f, 0.0f};
+    al::setNerve(this, &Start);
+}
+
+bool PlayerStateHipDrop::attackHipDropKnockDown(al::HitSensor* sender, al::HitSensor* receiver) {
+    if (isDead())
+        return false;
+    if (!al::isNerve(this, &Land) || !al::isFirstStep(this))
+        return false;
+    return al::sendMsgPlayerHipDropKnockDown(receiver, sender);
+}
+
+bool PlayerStateHipDrop::isEnableHeadSliding() const {
+    if (isDead())
+        return false;
+    return al::isNerve(this, &Start) || al::isNerve(this, &Fall);
+}
+
+bool PlayerStateHipDrop::isEnableHipDropAttack() const {
+    if (isDead())
+        return false;
+    return al::isNerve(this, &Fall) && mHipDropMsgIntervalCounter == 0;
+}
+
+bool PlayerStateHipDrop::isEnableLandCancel() const {
+    if (isDead())
+        return false;
+    if (!al::isNerve(this, &Land))
+        return false;
+    s32 nerveStep = al::getNerveStep(this);
+    return nerveStep >= mPlayerConst->getJumpHipDropPermitBeginFrame() &&
+           nerveStep <= mPlayerConst->getJumpHipDropPermitEndFrame();
+}
+
+bool PlayerStateHipDrop::isEnableMove() const {
+    if (isDead())
+        return false;
+    return al::isNerve(this, &Land) &&
+           al::isGreaterEqualStep(this, mPlayerConst->getHipDropLandCancelFrame());
+}
+
+bool PlayerStateHipDrop::isEnableInWater() const {
+    if (isDead())
+        return false;
+    if (al::isNerve(this, &Start))
+        return false;
+    if (al::isNerve(this, &Fall))
+        return al::isGreaterEqualStep(this, 1);
+    return true;
+}
+
+bool PlayerStateHipDrop::isEnableIK() const {
+    if (isDead())
+        return false;
+    return al::isNerve(this, &Land);
+}
+
+bool PlayerStateHipDrop::isLandTrigger() const {
+    if (mPlayerTrigger->isOn(PlayerTrigger::ECollisionTrigger_val1))
+        return true;
+    return al::isNerve(this, &Land) && al::isFirstStep(this);
+}
+
+void PlayerStateHipDrop::exeStart() {
+    if (al::isFirstStep(this)) {
+        mPlayerAnimator->startAnim("HipDropStart");
+        al::setVelocityZero(mActor);
+        sead::Vector3f negGravity = -al::getGravity(mActor);
+        sead::Vector3f up = {0.0f, 0.0f, 0.0f};
+        al::calcUpDir(&up, mActor);
+
+        if (up.dot(negGravity) <=
+            sead::Mathf::cos(sead::Mathf::deg2rad(mPlayerConst->getCollisionResetLimit())))
+            mPlayerTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+        sead::Quatf quat;
+        al::calcQuat(&quat, mActor);
+        al::turnQuatYDirRadian(&quat, quat, negGravity, sead::Mathf::deg2rad(180.0f));
+        al::updatePoseQuat(mActor, quat);
+    }
+
+    if (mPlayerAnimator->isAnimEnd())
+        al::setNerve(this, &Fall);
+}
+
+void PlayerStateHipDrop::exeFall() {
+    if (al::isFirstStep(this)) {
+        mPlayerAnimator->startAnim("HipDrop");
+        al::addVelocityToGravityLimit(mActor, mPlayerConst->getHipDropSpeed(),
+                                      mPlayerConst->getHipDropSpeedMax());
+    }
+
+    al::addVelocityToGravityLimit(mActor, mPlayerConst->getHipDropGravity(),
+                                  mPlayerConst->getHipDropSpeedMax());
+    if (mPlayerTrigger->isOn(PlayerTrigger::ECollisionTrigger_val1) &&
+        mPlayerInput->isHoldHipDrop()) {
+        mHipDropMsgIntervalCounter = mPlayerConst->getHipDropMsgInterval();
+        mPlayerAnimator->startAnim("HipDropReaction");
+        mIsLandGround = false;
+        if (rs::isCollidedGround(mPlayerCollision)) {
+            mIsLandGround = true;
+            mLandPos = rs::getCollidedGroundPos(mPlayerCollision);
+        }
+    }
+
+    if (mHipDropMsgIntervalCounter > 0) {
+        if (rs::convergeOnGroundCount(&mHipDropMsgIntervalCounter, mActor, mPlayerCollision, 0, 1))
+            return;
+        mHipDropMsgIntervalCounter = 0;
+    }
+
+    if (rs::isOnGroundRunAngle(mActor, mPlayerCollision, mPlayerConst))
+        al::setNerve(this, &Land);
+}
+
+void PlayerStateHipDrop::exeLand() {
+    if (al::isFirstStep(this)) {
+        mPlayerAnimator->startAnim("HipDropLand");
+
+        al::LiveActor* actor = mActor;
+        bool isLandingWeak = false;
+        if (mIsLandGround) {
+            const IUsePlayerCollision* collision = mPlayerCollision;
+            if (rs::isCollidedGround(collision)) {
+                const sead::Vector3f& gravity = al::getGravity(actor);
+                isLandingWeak =
+                    (rs::getCollidedGroundPos(collision) - mLandPos).dot(gravity) <= 10.0f;
+            }
+        }
+        rs::startHitReactionHipDropLand(actor, isLandingWeak);
+    }
+
+    if (rs::isOnGroundRunAngle(mActor, mPlayerCollision, mPlayerConst)) {
+        rs::waitGround(mActor, mPlayerCollision, mPlayerConst->getGravityMove(),
+                       mPlayerConst->getFallSpeedMax(), mPlayerConst->getSlerpQuatRateWait(),
+                       mPlayerConst->getWaitPoseDegreeMax());
+    } else {
+        kill();
+    }
+
+    if (mPlayerAnimator->isAnimEnd())
+        kill();
+}

--- a/src/Player/PlayerStateHipDrop.cpp
+++ b/src/Player/PlayerStateHipDrop.cpp
@@ -1,7 +1,7 @@
 #include "Player/PlayerStateHipDrop.h"
 
 #include "Library/LiveActor/ActorMovementFunction.h"
-#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/LiveActor/ActorSensorMsgFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"

--- a/src/Player/PlayerStateHipDrop.h
+++ b/src/Player/PlayerStateHipDrop.h
@@ -34,11 +34,11 @@ public:
     void exeLand();
 
 private:
-    const PlayerConst* mPlayerConst;
-    const PlayerInput* mPlayerInput;
-    const IUsePlayerCollision* mPlayerCollision;
-    PlayerAnimator* mPlayerAnimator;
-    PlayerTrigger* mPlayerTrigger;
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollision;
+    PlayerAnimator* mAnimator;
+    PlayerTrigger* mTrigger;
     s32 mHipDropMsgIntervalCounter = 0;
     bool mIsLandGround = false;
     sead::Vector3f mLandPos = {0.0f, 0.0f, 0.0f};

--- a/src/Player/PlayerStateHipDrop.h
+++ b/src/Player/PlayerStateHipDrop.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+class HitSensor;
+}  // namespace al
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class PlayerAnimator;
+class PlayerTrigger;
+
+class PlayerStateHipDrop : public al::ActorStateBase {
+public:
+    PlayerStateHipDrop(al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+                       const IUsePlayerCollision* collider, PlayerAnimator* animator,
+                       PlayerTrigger* trigger);
+    void appear() override;
+    bool attackHipDropKnockDown(al::HitSensor* sender, al::HitSensor* receiver);
+    bool isEnableHeadSliding() const;
+    bool isEnableHipDropAttack() const;
+    bool isEnableLandCancel() const;
+    bool isEnableMove() const;
+    bool isEnableInWater() const;
+    bool isEnableIK() const;
+    bool isLandTrigger() const;
+
+    void exeStart();
+    void exeFall();
+    void exeLand();
+
+private:
+    const PlayerConst* mPlayerConst;
+    const PlayerInput* mPlayerInput;
+    const IUsePlayerCollision* mPlayerCollision;
+    PlayerAnimator* mPlayerAnimator;
+    PlayerTrigger* mPlayerTrigger;
+    s32 mHipDropMsgIntervalCounter = 0;
+    bool mIsLandGround = false;
+    sead::Vector3f mLandPos = {0.0f, 0.0f, 0.0f};
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -5,7 +5,10 @@
 
 class PlayerTrigger {
 public:
-    enum ECollisionTrigger : u32 {};
+    enum ECollisionTrigger : u32 {
+        // used in PlayerStateHipDrop
+        ECollisionTrigger_val1 = 1,
+    };
 
     enum EAttackSensorTrigger : u32 {
         // used in PlayerCounterAfterCapCatch
@@ -13,6 +16,8 @@ public:
     };
 
     enum EActionTrigger : u32 {
+        // used in PlayerStateHipDrop
+        EActionTrigger_val3 = 3,
         // used in PlayerJudgeForceLand
         EActionTrigger_val11 = 11,
         // used in PlayerJudgeWallCatch

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -8,6 +8,8 @@ class HitSensor;
 class LiveActor;
 }  // namespace al
 
+class IUsePlayerCollision;
+class PlayerConst;
 class PlayerModelHolder;
 
 namespace rs {
@@ -27,5 +29,13 @@ bool findGrabCeilPosWallHit(const al::CollisionParts**, sead::Vector3f*, sead::V
                             const sead::Vector3f&, f32, f32, f32);
 
 void calcOffsetAllRoot(sead::Vector3f* offset, const PlayerModelHolder* model);
+
+bool convergeOnGroundCount(s32*, const al::LiveActor*, const IUsePlayerCollision*, s32, s32);
+
+bool isOnGroundRunAngle(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
+
+void startHitReactionHipDropLand(al::LiveActor*, bool);
+
+void waitGround(al::LiveActor*, const IUsePlayerCollision*, f32, f32, f32, f32);
 
 }  // namespace rs


### PR DESCRIPTION
The player, doing a ground pound. Pretty simple, as the player has almost no control over Mario during this action, only again after he hits the ground.

Interesting things:
- `ECollisionTrigger_val1` can trigger `HipDropReaction`-animation and causes `isLandTrigger` to return `true`, but doesn't necessarily land on the ground (depending on what triggers this collision attribute)
- If the ground is not `isOnRunAngle` (angled outside of `StandAngleMin` and `StandAngleMax` depending on velocity, so tilted by more than 60/70 degrees), the action is immediately killed instead of waiting for the ground pound animation to end, which might be faster during speedruns

Also, a thing I did a larger investigation on was the `isLandingWeak` variable: If the ground pound is interrupted by previously-mentioned `ECollisionTrigger_val1`, and the distance between the ground the player lands on and the location where `ECollisionTrigger_val1` was triggered is less than 10 units (10cm), a smaller hit reaction is triggered. I also believe that a ground pound this near to the origin would also *not* cause the large smoke cloud to appear (because the member variable holding the location of `ECollisionTrigger_val1`-location (`mLandPos`) is initialized to the origin). By modding the game to show them alternatingly during standard ground pounds, we can see how they would look in-game:

https://github.com/user-attachments/assets/ea0cd0fd-b56c-4cd6-a889-b78ceb674c1b

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/408)
<!-- Reviewable:end -->
