### PR TITLE
Copy-headers workflow: Fix pushing commits with a git username with spaces 

### DIFF
--- a/.github/scripts/push-headers.sh
+++ b/.github/scripts/push-headers.sh
@@ -12,7 +12,7 @@ cd "./OdysseyHeaders"
 echo "Open root of OdysseyHeaders repo"
 
 git add -A .
-git config user.name $AUTHOR_NAME
+git config user.name "$AUTHOR_NAME"
 git config user.email $AUTHOR_MAIL
 git commit -am "$MESSAGE"
 git push -f -u origin $HEADER_BRANCH


### PR DESCRIPTION
Earlier today I noticed that @german77's commits weren't being pushed to [OdysseyHeaders](https://github.com/MonsterDruide1/OdysseyHeaders) correctly. This is because their git name (`Narr The Reg`) has spaces which causes it to be interpreted as multiple args when setting the username. This PR fixes that by simply putting `$AUTHOR_NAME` in quotes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/420)
<!-- Reviewable:end -->
