### PR TITLE
Libary/Camera: Add `CameraViewCtrl*`

### DIFF
--- a/lib/al/Library/Camera/CameraViewCtrlGyro.h
+++ b/lib/al/Library/Camera/CameraViewCtrlGyro.h
@@ -9,8 +9,8 @@ namespace al {
 class GyroCameraCtrl {
 public:
     GyroCameraCtrl();
-    void reset(const sead::Vector3f, const sead::Vector3f&, const sead::Vector3f&);
-    void update(const sead::Vector3f, const sead::Vector3f&, const sead::Vector3f&);
+    void reset(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&);
+    void update(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&);
     void reduceSensitivity();
 
     void setIsValidGyro(bool isValidGyro) { mIsValidGyro = isValidGyro; }

--- a/lib/al/Library/Camera/CameraViewCtrlGyro.h
+++ b/lib/al/Library/Camera/CameraViewCtrlGyro.h
@@ -50,4 +50,3 @@ private:
 static_assert(sizeof(GyroCameraCtrl) == 0xC8);
 
 }  // namespace al
-

--- a/lib/al/Library/Camera/CameraViewCtrlGyro.h
+++ b/lib/al/Library/Camera/CameraViewCtrlGyro.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+
+class GyroCameraCtrl {
+public:
+    GyroCameraCtrl();
+    void reset(const sead::Vector3f, const sead::Vector3f&, const sead::Vector3f&);
+    void update(const sead::Vector3f, const sead::Vector3f&, const sead::Vector3f&);
+    void reduceSensitivity();
+
+    void setIsValidGyro(bool isValidGyro) { mIsValidGyro = isValidGyro; }
+
+    void setSensitivityScale(f32 sensitivityScale) { mSensitivityScale = sensitivityScale; }
+
+private:
+    sead::Matrix34f _0;
+    sead::Vector3f _30;
+    sead::Vector3f _3c;
+    sead::Vector3f _48;
+    sead::Vector3f _54;
+    sead::Vector3f _60;
+    sead::Vector3f _6c;
+    f32 _78;
+    f32 _7c;
+    f32 _80;
+    f32 _84;
+    f32 _88;
+    f32 _8c;
+    f32 _90;
+    f32 _94;
+    f32 _98;
+    s32 mSensitivityLevel;
+    f32 _a0;
+    f32 _a4;
+    f32 mSensitivityScale;
+    bool mIsValidGyro;
+    f32 _b0;
+    f32 _b4;
+    f32 _b8;
+    f32 _bc;
+    f32 _c0;
+    f32 _c4;
+};
+
+static_assert(sizeof(GyroCameraCtrl) == 0xC8);
+
+}  // namespace al
+

--- a/lib/al/Library/Camera/CameraViewCtrlPause.cpp
+++ b/lib/al/Library/Camera/CameraViewCtrlPause.cpp
@@ -1,0 +1,7 @@
+#include "Library/Camera/CameraViewCtrlPause.h"
+
+namespace al {
+
+PauseCameraCtrl::PauseCameraCtrl(f32 v) : _4(v) {}
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraViewCtrlPause.h
+++ b/lib/al/Library/Camera/CameraViewCtrlPause.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class PauseCameraCtrl {
+public:
+    PauseCameraCtrl(f32 v);
+
+private:
+    bool mIsCameraPause = false;
+    f32 _4;
+};
+
+static_assert(sizeof(PauseCameraCtrl) == 0x8);
+
+}  // namespace al

--- a/lib/al/Library/Camera/CameraViewCtrlScene.cpp
+++ b/lib/al/Library/Camera/CameraViewCtrlScene.cpp
@@ -1,8 +1,6 @@
-#include "Library/Camera/CameraViewCtrl.h"
+#include "Library/Camera/CameraViewCtrlScene.h"
 
 namespace al {
-
-PauseCameraCtrl::PauseCameraCtrl(f32 v) : _4(v) {}
 
 SceneCameraViewCtrl::SceneCameraViewCtrl() = default;
 

--- a/lib/al/Library/Camera/CameraViewCtrlScene.h
+++ b/lib/al/Library/Camera/CameraViewCtrlScene.h
@@ -39,4 +39,3 @@ private:
 static_assert(sizeof(SceneCameraCtrl) == 0x20);
 
 }  // namespace al
-

--- a/lib/al/Library/Camera/CameraViewCtrlScene.h
+++ b/lib/al/Library/Camera/CameraViewCtrlScene.h
@@ -8,17 +8,6 @@ class CameraRequestParamHolder;
 class CameraSwitchRequester;
 class SpecialCameraHolder;
 
-class PauseCameraCtrl {
-public:
-    PauseCameraCtrl(f32 v);
-
-private:
-    bool mIsCameraPause = false;
-    f32 _4;
-};
-
-static_assert(sizeof(PauseCameraCtrl) == 0x8);
-
 class SceneCameraViewCtrl {
 public:
     SceneCameraViewCtrl();
@@ -50,3 +39,4 @@ private:
 static_assert(sizeof(SceneCameraCtrl) == 0x20);
 
 }  // namespace al
+


### PR DESCRIPTION
Add GyroCameraCtrl header, and just as the title says, the doc also has this change now. GyroCameraCtrl outweights the other 3 in terms of code size, and the three are most likely not used together, + the names add up. so i wanted to split this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/427)
<!-- Reviewable:end -->
