### PR TITLE
ModeBalloon: Implement `TimeBalloonStateShowAchievement`

### DIFF
--- a/src/ModeBalloon/TimeBalloonStateShowAchievement.cpp
+++ b/src/ModeBalloon/TimeBalloonStateShowAchievement.cpp
@@ -1,0 +1,26 @@
+#include "ModeBalloon/TimeBalloonStateShowAchievement.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(TimeBalloonStateShowAchievement, Show)
+
+NERVES_MAKE_NOSTRUCT(TimeBalloonStateShowAchievement, Show)
+}  // namespace
+
+TimeBalloonStateShowAchievement::TimeBalloonStateShowAchievement(const al::ActorInitInfo& info)
+    : al::NerveStateBase("実績を見るステート") {
+    initNerve(&Show, 0);
+}
+
+void TimeBalloonStateShowAchievement::appear() {
+    setDead(false);
+    al::setNerve(this, &Show);
+}
+
+void TimeBalloonStateShowAchievement::exeShow() {}
+
+void TimeBalloonStateShowAchievement::exeClose() {
+    kill();
+}

--- a/src/ModeBalloon/TimeBalloonStateShowAchievement.h
+++ b/src/ModeBalloon/TimeBalloonStateShowAchievement.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class ActorInitInfo;
+}
+
+class TimeBalloonStateShowAchievement : public al::NerveStateBase {
+public:
+    TimeBalloonStateShowAchievement(const al::ActorInitInfo& info);
+
+    void appear() override;
+
+    void exeShow();
+    void exeClose();
+
+private:
+    void* field_18 = nullptr;
+    void* field_20 = nullptr;
+    void* field_28 = nullptr;
+    al::WStringTmp<64> field_30;
+    al::WStringTmp<64> field_c8;
+};


### PR DESCRIPTION
A random number generator picked this one- and there's a lot of weird stuff going on. A bunch of unused member variables are created (including two `WStringTmp`s, which don't even make sense as member variables), and the `Close` nerve doesn't have a `NERVE_IMPL` macro. They must have commented a bunch of the code out and left it like that for release (since balloon world released as an update). I wonder what it looks like in 1.2.0.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/431)
<!-- Reviewable:end -->
