### PR TITLE
`Library/Framework`: add `al::GameFrameworkNx` header

### DIFF
--- a/lib/al/Library/Framework/GameFrameworkNx.h
+++ b/lib/al/Library/Framework/GameFrameworkNx.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <framework/nx/seadGameFrameworkNx.h>
+
+#include "Library/HostIO/HioNode.h"
+
+namespace agl {
+class DisplayList;
+class DrawContext;
+class RenderBuffer;
+class RenderTargetColor;
+}  // namespace agl
+
+namespace sead {
+class Event;
+}
+
+namespace al {
+
+class GpuPerf;
+
+class GameFrameworkNx : public sead::GameFrameworkNx, public al::HioNode {
+    SEAD_RTTI_OVERRIDE(GameFrameworkNx, sead::GameFrameworkNx);
+
+public:
+    GameFrameworkNx();
+    ~GameFrameworkNx() override;
+    void createControllerMgr(sead::TaskBase* base) override;
+    void createHostIOMgr(sead::TaskBase* base, sead::HostIOMgr::Parameter* hostioParam,
+                         sead::Heap* heap) override;
+    void createInfLoopChecker(sead::TaskBase* base, const sead::TickSpan&, s32) override;
+    void procFrame_() override;
+    void procDraw_() override;
+    void present_() override;
+
+    void clearFrameBuffer();
+    void initAgl(sead::Heap* heap, s32 virtWidth, s32 virtHeight, s32 dockedWidth, s32 dockedHeight,
+                 s32 handheldWidth, s32 handheldHeight);
+
+private:
+    agl::DrawContext* mDrawContext;
+    agl::RenderBuffer* mDockedRenderBuffer;
+    agl::RenderTargetColor* mDockedClearColor;
+    agl::RenderBuffer* mHandheldRenderBuffer;
+    agl::RenderTargetColor* mHandheldClearColor;
+    agl::DisplayList* mDisplayList[2];
+    GpuPerf* mGpuPerf;
+    s32 mCurDisplayListIdx;
+    void* mDisplayControlMemory[2];
+    bool mIsClearRenderBuffer;
+    bool mIsDocked;
+    sead::Event* mDrawReadyEvent;
+};
+
+static_assert(sizeof(GameFrameworkNx) == 0x278);
+
+}  // namespace al

--- a/lib/al/Library/Framework/GameFrameworkNx.h
+++ b/lib/al/Library/Framework/GameFrameworkNx.h
@@ -20,7 +20,7 @@ namespace al {
 
 class GpuPerf;
 
-class GameFrameworkNx : public sead::GameFrameworkNx, public al::HioNode {
+class GameFrameworkNx : public sead::GameFrameworkNx, public HioNode {
     SEAD_RTTI_OVERRIDE(GameFrameworkNx, sead::GameFrameworkNx);
 
 public:
@@ -30,15 +30,16 @@ public:
     void createHostIOMgr(sead::TaskBase* base, sead::HostIOMgr::Parameter* hostioParam,
                          sead::Heap* heap) override;
     void createInfLoopChecker(sead::TaskBase* base, const sead::TickSpan&, s32) override;
-    void procFrame_() override;
-    void procDraw_() override;
-    void present_() override;
 
     void clearFrameBuffer();
     void initAgl(sead::Heap* heap, s32 virtWidth, s32 virtHeight, s32 dockedWidth, s32 dockedHeight,
                  s32 handheldWidth, s32 handheldHeight);
 
 private:
+    void procFrame_() override;
+    void procDraw_() override;
+    void present_() override;
+
     agl::DrawContext* mDrawContext;
     agl::RenderBuffer* mDockedRenderBuffer;
     agl::RenderTargetColor* mDockedClearColor;


### PR DESCRIPTION
the params of `createInfLoopChecker` are unclear as they aren't used in the game (presumably `#ifdef`ed out).

the name `mDrawReadyEvent` comes from the fact that `present_` (which i believe does something on another thread, `Presentation Thread`, based on `presentAsync_`) sets this signal, and after `procCalc_` is run, this signal is waited for before calling `procDraw_`. would make sense if it's to do with like, making sure the frame is drawn to the screen before messing with the frame buffer again.

i originally had named `mDisplayList` like `mCommandDisplayList`, and its associated `ControlMemory` as `mCommandControlMemory`, based on the fact that they're initialised with names of `コマンド０` and `コマンド１` ("command 0" and "command 1"). i'm not totally sure on those names, and GRA told me that he had done some work on this header and given them these new names, so i decided to go with them.

`mIsClearRenderBuffer` is seemingly used for clearing the screen between frames, before drawing to it; if it is set to `false` i think that it may cause moving objects' paths to be "painted" as they move, assuming nothing else is drawn behind them. i will note though that i'm not 100% sure on that, as i see it being set to `true` in this class' ctor, and i do remember seeing that "painting" effect when i disabled some `ExecutorList`s a while ago. another point of reference for this variable is in `TitleMenuScene::appear` and that same class' dtor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/457)
<!-- Reviewable:end -->
