### PR TITLE
Library/Obj: Fix PartsModel::updatePose

### DIFF
--- a/lib/al/Library/Obj/PartsModel.cpp
+++ b/lib/al/Library/Obj/PartsModel.cpp
@@ -118,32 +118,63 @@ void PartsModel::initPartsFixFileNoRegister(LiveActor* parent, const ActorInitIn
     makeActorAlive();
 }
 
-// NON_MATCHING: needs to have proper matrix math implemented still
 void PartsModel::updatePose() {
-    sead::Matrix34f poseMtx;
-    sead::Matrix34f jointMtx;
-
     if (!mIsUpdate)
         return;
-    if (mIsUseLocalPos) {
-        jointMtx = *mJointMtx;
+
+    if (!mIsUseLocalPos) {
+        sead::Matrix34f baseMtx = *mJointMtx;
         if (mIsUseFollowMtxScale) {
             sead::Vector3f mtxScale;
-            calcMtxScale(&mtxScale, jointMtx);
-            mtxScale *= 1.0f;
+            calcMtxScale(&mtxScale, baseMtx);
+            const sead::Vector3f& scale = sead::Vector3f::ones;
+            mtxScale.x *= scale.x;
+            mtxScale.y *= scale.y;
+            mtxScale.z *= scale.z;
             setScale(this, mtxScale);
         }
-        normalize(&jointMtx);
-        updatePoseMtx(this, &jointMtx);
+        normalize(&baseMtx);
+        updatePoseMtx(this, &baseMtx);
         return;
     }
 
-    mLocalRotate *= 0.017453f;
+    sead::Matrix34f rotationMatrix;
+    sead::Vector3f rotate(sead::Mathf::deg2rad(mLocalRotate.x),
+                          sead::Mathf::deg2rad(mLocalRotate.y),
+                          sead::Mathf::deg2rad(mLocalRotate.z));
+    rotationMatrix.makeR(rotate);
 
-    poseMtx.makeRT(mLocalRotate, mLocalTrans);
+    sead::Matrix34f translationMatrix;
+    translationMatrix.makeRT({0.0f, 0.0f, 0.0f}, mLocalTrans);
 
-    if (mIsUseFollowMtxScale || mIsUseLocalScale) {
+    sead::Matrix34f poseMatrix = rotationMatrix * translationMatrix;
+
+    sead::Matrix34f baseMtx = *mJointMtx;
+
+    if (mIsUseFollowMtxScale) {
+        sead::Matrix34f rotBaseMtx = baseMtx * rotationMatrix;
+
+        sead::Vector3f mtxScale = {0.0f, 0.0f, 0.0f};
+        calcMtxScale(&mtxScale, rotBaseMtx);
+
+        poseMatrix.m[0][3] *= mtxScale.x;
+        poseMatrix.m[1][3] *= mtxScale.y;
+        poseMatrix.m[2][3] *= mtxScale.z;
+
+        if (mIsUseLocalScale) {
+            mtxScale.x *= mLocalScale.x;
+            mtxScale.y *= mLocalScale.y;
+            mtxScale.z *= mLocalScale.z;
+        }
+
+        setScale(this, mtxScale);
+    } else if (mIsUseLocalScale) {
+        setScale(this, mLocalScale);
     }
+
+    normalize(&baseMtx);
+    baseMtx = baseMtx * poseMatrix;
+    updatePoseMtx(this, &baseMtx);
 }
 
 void PartsModel::offSyncAppearAndHide() {


### PR DESCRIPTION
I think I'm having a déjà vu. Fixes updatePose thanks to new sead changes https://github.com/open-ead/sead/pull/178

Special note on this one.  Pose matrix multiplication is inverted compared to #469 .  One of these must be wrong as` a*b` is not the same as` b*a`. I'm not well versed enough but I think EnemyCap is the wrong one.

`poseMatrix = rotationMatrix * translationMatrix` vs `poseMatrix = translationMatrix* rotationMatrix `

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/471)
<!-- Reviewable:end -->
