### PR TITLE
Player: Implement `PlayerJudgeWaterSurfaceRun`

### DIFF
--- a/src/Player/PlayerJudgeWaterSurfaceRun.cpp
+++ b/src/Player/PlayerJudgeWaterSurfaceRun.cpp
@@ -25,9 +25,10 @@ void PlayerJudgeWaterSurfaceRun::update() {
     const al::LiveActor* player = mPlayer;
     f32 borderSpeedH = getBorderSpeedH();
     const PlayerCounterForceRun* counterForceRun = mCounterForceRun;
-    mIsWaterSurfaceRun = mWaterSurfaceFinder->isFoundSurface() &&
-               al::isNearZeroOrGreater(mWaterSurfaceFinder->getDistance(), 0.001f) &&
-               (counterForceRun->getCounter() > 0 || al::calcSpeedH(player) > borderSpeedH);
+    mIsWaterSurfaceRun =
+        mWaterSurfaceFinder->isFoundSurface() &&
+        al::isNearZeroOrGreater(mWaterSurfaceFinder->getDistance(), 0.001f) &&
+        (counterForceRun->getCounter() > 0 || al::calcSpeedH(player) > borderSpeedH);
 }
 
 void PlayerJudgeWaterSurfaceRun::reset() {

--- a/src/Player/PlayerJudgeWaterSurfaceRun.cpp
+++ b/src/Player/PlayerJudgeWaterSurfaceRun.cpp
@@ -1,0 +1,39 @@
+#include "Player/PlayerJudgeWaterSurfaceRun.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nature/WaterSurfaceFinder.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerCounterForceRun.h"
+
+PlayerJudgeWaterSurfaceRun::PlayerJudgeWaterSurfaceRun(
+    const al::LiveActor* player, const PlayerConst* pConst,
+    const al::WaterSurfaceFinder* waterSurfaceFinder, const PlayerCounterForceRun* counterForceRun)
+    : mPlayer(player), mConst(pConst), mWaterSurfaceFinder(waterSurfaceFinder),
+      mCounterForceRun(counterForceRun) {}
+
+f32 PlayerJudgeWaterSurfaceRun::getBorderSpeedH() const {
+    return mConst->getDashFastBorderSpeed();
+}
+
+void PlayerJudgeWaterSurfaceRun::update() {
+    mIsJudge = false;
+    if (!mIsEnable)
+        return;
+
+    const al::LiveActor* player = mPlayer;
+    f32 borderSpeedH = getBorderSpeedH();
+    const PlayerCounterForceRun* counterForceRun = mCounterForceRun;
+    mIsJudge = mWaterSurfaceFinder->isFoundSurface() &&
+               al::isNearZeroOrGreater(mWaterSurfaceFinder->getDistance(), 0.001f) &&
+               (counterForceRun->getCounter() > 0 || al::calcSpeedH(player) > borderSpeedH);
+}
+
+void PlayerJudgeWaterSurfaceRun::reset() {
+    mIsJudge = false;
+}
+
+bool PlayerJudgeWaterSurfaceRun::judge() const {
+    return mIsJudge;
+}

--- a/src/Player/PlayerJudgeWaterSurfaceRun.cpp
+++ b/src/Player/PlayerJudgeWaterSurfaceRun.cpp
@@ -18,22 +18,22 @@ f32 PlayerJudgeWaterSurfaceRun::getBorderSpeedH() const {
 }
 
 void PlayerJudgeWaterSurfaceRun::update() {
-    mIsJudge = false;
+    mIsWaterSurfaceRun = false;
     if (!mIsEnable)
         return;
 
     const al::LiveActor* player = mPlayer;
     f32 borderSpeedH = getBorderSpeedH();
     const PlayerCounterForceRun* counterForceRun = mCounterForceRun;
-    mIsJudge = mWaterSurfaceFinder->isFoundSurface() &&
+    mIsWaterSurfaceRun = mWaterSurfaceFinder->isFoundSurface() &&
                al::isNearZeroOrGreater(mWaterSurfaceFinder->getDistance(), 0.001f) &&
                (counterForceRun->getCounter() > 0 || al::calcSpeedH(player) > borderSpeedH);
 }
 
 void PlayerJudgeWaterSurfaceRun::reset() {
-    mIsJudge = false;
+    mIsWaterSurfaceRun = false;
 }
 
 bool PlayerJudgeWaterSurfaceRun::judge() const {
-    return mIsJudge;
+    return mIsWaterSurfaceRun;
 }

--- a/src/Player/PlayerJudgeWaterSurfaceRun.h
+++ b/src/Player/PlayerJudgeWaterSurfaceRun.h
@@ -24,7 +24,7 @@ public:
     bool judge() const override;
 
 private:
-    bool mIsJudge = false;
+    bool mIsWaterSurfaceRun = false;
     bool mIsEnable = false;
     const al::LiveActor* mPlayer;
     const PlayerConst* mConst;

--- a/src/Player/PlayerJudgeWaterSurfaceRun.h
+++ b/src/Player/PlayerJudgeWaterSurfaceRun.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+class WaterSurfaceFinder;
+}  // namespace al
+class PlayerConst;
+class PlayerCounterForceRun;
+
+class PlayerJudgeWaterSurfaceRun : public IJudge {
+public:
+    PlayerJudgeWaterSurfaceRun(const al::LiveActor* player, const PlayerConst* pConst,
+                               const al::WaterSurfaceFinder* waterSurfaceFinder,
+                               const PlayerCounterForceRun* counterForceRun);
+
+    f32 getBorderSpeedH() const;
+
+    void update() override;
+    void reset() override;
+    bool judge() const override;
+
+private:
+    bool mIsJudge = false;
+    bool mIsEnable = false;
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const al::WaterSurfaceFinder* mWaterSurfaceFinder;
+    const PlayerCounterForceRun* mCounterForceRun;
+};


### PR DESCRIPTION
Another simple `Judge` that determines whether you can run on water:
- Water surface must be found below the player
- either be forced to run (=> rocket flower), or have a speed of more than `DashFastBorderSpeed`, which is `20` by default

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/473)
<!-- Reviewable:end -->
