### PR TITLE
Player: Implement `PlayerJudgeStartWaterSurfaceRun`

### DIFF
--- a/src/Player/PlayerJudgeStartWaterSurfaceRun.cpp
+++ b/src/Player/PlayerJudgeStartWaterSurfaceRun.cpp
@@ -1,0 +1,23 @@
+#include "Player/PlayerJudgeStartWaterSurfaceRun.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nature/WaterSurfaceFinder.h"
+
+#include "Player/PlayerCounterForceRun.h"
+
+PlayerJudgeStartWaterSurfaceRun::PlayerJudgeStartWaterSurfaceRun(
+    const al::LiveActor* player, const al::WaterSurfaceFinder* waterSurfaceFinder,
+    const PlayerCounterForceRun* counterForceRun)
+    : mPlayer(player), mWaterSurfaceFinder(waterSurfaceFinder), mCounterForceRun(counterForceRun) {}
+
+void PlayerJudgeStartWaterSurfaceRun::reset() {}
+
+void PlayerJudgeStartWaterSurfaceRun::update() {}
+
+bool PlayerJudgeStartWaterSurfaceRun::judge() const {
+    return mCounterForceRun->getCounter() > 0 && mWaterSurfaceFinder->isFoundSurface() &&
+           al::isNearZeroOrGreater(mWaterSurfaceFinder->getDistance(), 0.001f) &&
+           al::getGravity(mPlayer).dot(al::getVelocity(mPlayer)) > 0.0f;
+}

--- a/src/Player/PlayerJudgeStartWaterSurfaceRun.h
+++ b/src/Player/PlayerJudgeStartWaterSurfaceRun.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+class WaterSurfaceFinder;
+}  // namespace al
+class PlayerCounterForceRun;
+
+class PlayerJudgeStartWaterSurfaceRun : public IJudge {
+public:
+    PlayerJudgeStartWaterSurfaceRun(const al::LiveActor* player,
+                                    const al::WaterSurfaceFinder* waterSurfaceFinder,
+                                    const PlayerCounterForceRun* counterForceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const al::WaterSurfaceFinder* mWaterSurfaceFinder;
+    const PlayerCounterForceRun* mCounterForceRun;
+};


### PR DESCRIPTION
First starting to run on water apparently has a different judge. It requires:
- be forced to run (=> rocket flower)
- water surface found below the player
- player must be moving downwards (as determined by gravity)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/475)
<!-- Reviewable:end -->
