### PR TITLE
Player: Implement `PlayerStateWallAir`

### DIFF
--- a/src/Player/PlayerStateNormalWallJump.h
+++ b/src/Player/PlayerStateNormalWallJump.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class PlayerTrigger;
+class PlayerAnimator;
+class PlayerActionDiveInWater;
+class PlayerActionAirMoveControl;
+
+class PlayerStateNormalWallJump : public al::ActorStateBase {
+public:
+    PlayerStateNormalWallJump(al::LiveActor*, const PlayerConst*, const PlayerInput*,
+                              const IUsePlayerCollision*, const PlayerTrigger*, PlayerAnimator*,
+                              PlayerActionDiveInWater*);
+
+    void appear() override;
+    void exeJump();
+
+    const sead::Vector3f& getFront() const { return mFront; }
+
+private:
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollider;
+    const PlayerTrigger* mTrigger;
+    PlayerAnimator* mAnimator;
+    PlayerActionDiveInWater* mActionDiveInWater;
+    PlayerActionAirMoveControl* mAirMoveControl = nullptr;
+    const char* mAnimationName = "WallJump";
+    sead::Vector3f mFront;
+    bool _6c = false;
+};

--- a/src/Player/PlayerStateNormalWallSlide.h
+++ b/src/Player/PlayerStateNormalWallSlide.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class PlayerAnimator;
+
+class PlayerStateNormalWallSlide : public al::ActorStateBase {
+public:
+    PlayerStateNormalWallSlide(al::LiveActor*, const PlayerConst*, const PlayerInput*,
+                               IUsePlayerCollision*, PlayerAnimator*);
+
+    void appear() override;
+    void exeKeep();
+    bool followNormal();
+    void exeSlide();
+
+    const sead::Vector3f& getNormalStart() const { return mNormalStart; }
+
+private:
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    IUsePlayerCollision* mCollision;
+    PlayerAnimator* mAnimator;
+    sead::Vector3f mNormalStart = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mNormalEnd = {0.0f, 0.0f, 0.0f};
+    f32 _58 = 0;
+    s32 _5c = 0;
+    bool _60 = 0;
+};

--- a/src/Player/PlayerStateWallAir.cpp
+++ b/src/Player/PlayerStateWallAir.cpp
@@ -1,0 +1,99 @@
+#include "Player/PlayerStateWallAir.h"
+
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerJudgePreInputJump.h"
+#include "Player/PlayerStateNormalWallJump.h"
+#include "Player/PlayerStateNormalWallSlide.h"
+#include "Player/PlayerWallActionHistory.h"
+#include "Util/JudgeUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateWallAir, Slide)
+NERVE_IMPL(PlayerStateWallAir, Jump)
+
+NERVES_MAKE_NOSTRUCT(PlayerStateWallAir, Slide, Jump)
+}  // namespace
+
+PlayerStateWallAir::PlayerStateWallAir(al::LiveActor* player, const PlayerConst* pConst,
+                                       const PlayerInput* input, const PlayerTrigger* trigger,
+                                       IUsePlayerCollision* collision, IJudge* judgeWallKeep,
+                                       PlayerJudgePreInputJump* judgePreInputJump,
+                                       PlayerAnimator* animator,
+                                       PlayerWallActionHistory* wallActionHistory,
+                                       PlayerActionDiveInWater* actionDiveInWater)
+    : al::ActorStateBase("空中壁接触", player), mConst(pConst), mJudgeWallKeep(judgeWallKeep),
+      mJudgePreInputJump(judgePreInputJump), mCollision(collision),
+      mWallActionHistory(wallActionHistory) {
+    initNerve(&Slide, 2);
+    mStateNormalWallSlide =
+        new PlayerStateNormalWallSlide(player, mConst, input, collision, animator);
+    mStateNormalWallJump = new PlayerStateNormalWallJump(player, mConst, input, collision, trigger,
+                                                         animator, actionDiveInWater);
+    al::initNerveState(this, mStateNormalWallSlide, &Slide, "壁すべり");
+    al::initNerveState(this, mStateNormalWallJump, &Jump, "壁ジャンプ");
+}
+
+void PlayerStateWallAir::appear() {
+    setDead(false);
+    al::setNerve(this, &Slide);
+}
+
+bool PlayerStateWallAir::isAir() const {
+    return al::isNerve(this, &Jump) && al::isGreaterStep(this, 0);
+}
+
+bool PlayerStateWallAir::isJustJump() const {
+    return al::isNerve(this, &Jump) && al::isFirstStep(this);
+}
+
+bool PlayerStateWallAir::isEnableReactionCapCatch() const {
+    return !isDead() && al::isNerve(this, &Jump);
+}
+
+void PlayerStateWallAir::startSlideSpinAttack() {
+    al::LiveActor* player = mActor;
+    const sead::Vector3f& gravity = al::getGravity(player);
+    mWallActionHistory->recordWallJump(mCollision, al::getTrans(player) + gravity * 20.0f);
+
+    sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+    al::calcFrontDir(&front, player);
+
+    sead::Quatf quat = sead::Quatf::unit;
+    al::makeQuatFrontUp(&quat, -front, -gravity);
+    al::updatePoseQuat(player, quat);
+}
+
+void PlayerStateWallAir::calcSnapMoveCutDir(sead::Vector3f* snap) const {
+    if (al::isNerve(this, &Slide))
+        snap->set(mStateNormalWallSlide->getNormalStart());
+    else
+        snap->set(mStateNormalWallJump->getFront());
+}
+
+void PlayerStateWallAir::exeSlide() {
+    if (al::updateNerveState(this)) {
+        mWallActionHistory->recordWallLeave(al::getTrans(mActor),
+                                            mStateNormalWallSlide->getNormalStart());
+        kill();
+        return;
+    }
+
+    if (rs::judgeAndResetReturnTrue(mJudgePreInputJump)) {
+        mWallActionHistory->recordWallJump(mCollision, al::getTrans(mActor));
+        al::setNerve(this, &Jump);
+    }
+}
+
+void PlayerStateWallAir::exeJump() {
+    if (al::updateNerveState(this)) {
+        kill();
+        return;
+    }
+
+    if (rs::updateJudgeAndResult(mJudgeWallKeep))
+        al::setNerve(this, &Slide);
+}

--- a/src/Player/PlayerStateWallAir.cpp
+++ b/src/Player/PlayerStateWallAir.cpp
@@ -67,11 +67,11 @@ void PlayerStateWallAir::startSlideSpinAttack() {
     al::updatePoseQuat(player, quat);
 }
 
-void PlayerStateWallAir::calcSnapMoveCutDir(sead::Vector3f* snap) const {
+void PlayerStateWallAir::calcSnapMoveCutDir(sead::Vector3f* cutDir) const {
     if (al::isNerve(this, &Slide))
-        snap->set(mStateNormalWallSlide->getNormalStart());
+        cutDir->set(mStateNormalWallSlide->getNormalStart());
     else
-        snap->set(mStateNormalWallJump->getFront());
+        cutDir->set(mStateNormalWallJump->getFront());
 }
 
 void PlayerStateWallAir::exeSlide() {

--- a/src/Player/PlayerStateWallAir.h
+++ b/src/Player/PlayerStateWallAir.h
@@ -29,7 +29,7 @@ public:
     bool isJustJump() const;
     bool isEnableReactionCapCatch() const;
     void startSlideSpinAttack();
-    void calcSnapMoveCutDir(sead::Vector3f* snap) const;
+    void calcSnapMoveCutDir(sead::Vector3f* cutDir) const;
     void exeSlide();
     void exeJump();
 

--- a/src/Player/PlayerStateWallAir.h
+++ b/src/Player/PlayerStateWallAir.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class IJudge;
+class IUsePlayerCollision;
+class PlayerActionDiveInWater;
+class PlayerAnimator;
+class PlayerJudgePreInputJump;
+class PlayerWallActionHistory;
+class PlayerStateNormalWallSlide;
+class PlayerStateNormalWallJump;
+class PlayerConst;
+class PlayerInput;
+class PlayerTrigger;
+
+class PlayerStateWallAir : public al::ActorStateBase {
+public:
+    PlayerStateWallAir(al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+                       const PlayerTrigger* trigger, IUsePlayerCollision* collision,
+                       IJudge* judgeWallKeep, PlayerJudgePreInputJump* judgePreInputJump,
+                       PlayerAnimator* animator, PlayerWallActionHistory* wallActionHistory,
+                       PlayerActionDiveInWater* actionDiveInWater);
+
+    void appear() override;
+    bool isAir() const;
+    bool isJustJump() const;
+    bool isEnableReactionCapCatch() const;
+    void startSlideSpinAttack();
+    void calcSnapMoveCutDir(sead::Vector3f* snap) const;
+    void exeSlide();
+    void exeJump();
+
+private:
+    const PlayerConst* mConst;
+    PlayerStateNormalWallSlide* mStateNormalWallSlide = nullptr;
+    PlayerStateNormalWallJump* mStateNormalWallJump = nullptr;
+    IJudge* mJudgeWallKeep;
+    PlayerJudgePreInputJump* mJudgePreInputJump;
+    const IUsePlayerCollision* mCollision;
+    PlayerWallActionHistory* mWallActionHistory;
+};


### PR DESCRIPTION
A "meta-state", which either passes execution to `PlayerStateNormalWallJump` or `PlayerStateNormalWallSlide`, depending on the current action. Because of this, it contains very little code/logic itself - the actual control logic is tucked away in those two states instead.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/476)
<!-- Reviewable:end -->
