### PR TITLE
Player: Implement `CapTargetInfo`

### DIFF
--- a/src/Player/CapTargetInfo.cpp
+++ b/src/Player/CapTargetInfo.cpp
@@ -1,0 +1,144 @@
+#include "Player/CapTargetInfo.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Matrix/MatrixUtil.h"
+
+CapTargetInfo::CapTargetInfo() {}
+
+void CapTargetInfo::init(const al::LiveActor* actor, const char* name) {
+    mActor = actor;
+    mIsExistModel = al::isExistModel(actor);
+    mHackName = nullptr;
+    mPlayerCollision = nullptr;
+    mPoseMatrix = nullptr;
+    mJointMtx = nullptr;
+    mLocalTrans = {0.0f, 0.0f, 0.0f};
+    mLocalRotate = {0.0f, 0.0f, 0.0f};
+    mLockOnScale = 1.0f;
+    mIsUseLockOnFollowMtxScale = false;
+    mLockOnAnimName = "Capture";
+    mIsEscapeLocalOffset = false;
+    mEscapeLocalOffset = {0.0f, 0.0f, 0.0f};
+    mName = name;
+    _72 = false;
+    mIsUseDepthShadow = false;
+    _74 = false;
+    mIsLockOn = true;
+    mIsLockOnStart = false;
+    mIsSetHackNameToCamera = false;
+    _78 = false;
+    _79 = false;
+    mIsInvalidHackThrow = false;
+    mIsInvalidCapEye = false;
+    _7c = false;
+    _7d = false;
+    _7e = false;
+}
+
+void CapTargetInfo::setFollowLockOnMtx(const char* jointName, const sead::Vector3f& localTrans,
+                                       const sead::Vector3f& localRotate) {
+    if (jointName)
+        mJointMtx = al::getJointMtxPtr(mActor, jointName);
+    else
+        mJointMtx = mActor->getBaseMtx();
+
+    mLocalTrans = localTrans;
+    mLocalRotate = localRotate;
+}
+
+void CapTargetInfo::setLockOnStartAnimName(const char* animName) {
+    mLockOnStartAnimName = animName;
+    mIsLockOnStart = !al::isEqualString(animName, "Capture");
+
+    if (!al::isEqualString(animName, "Capture")) {
+        mIsLockOn = false;
+        return;
+    }
+
+    mIsLockOn = al::isEqualString(mLockOnAnimName, "Capture");
+}
+
+void CapTargetInfo::setLockOnAnimName(const char* animName) {
+    mLockOnAnimName = animName;
+
+    if (!al::isEqualString(mLockOnAnimName, "Capture")) {
+        mIsLockOn = false;
+        return;
+    }
+
+    mIsLockOn = al::isEqualString(mLockOnStartAnimName, "Capture");
+}
+
+void CapTargetInfo::setHackName(const char* hackName) {
+    mHackName = hackName;
+}
+
+void CapTargetInfo::makeLockOnMtx(sead::Matrix34f* outMtx) const {
+    if (mPoseMatrix != nullptr) {
+        *outMtx = *mPoseMatrix;
+        return;
+    }
+
+    if (mJointMtx == nullptr) {
+        al::makeMtxRT(outMtx, mActor);
+        return;
+    }
+
+    sead::Matrix34f rotationMatrix;
+    sead::Vector3f rotate(sead::Mathf::deg2rad(mLocalRotate.x),
+                          sead::Mathf::deg2rad(mLocalRotate.y),
+                          sead::Mathf::deg2rad(mLocalRotate.z));
+    rotationMatrix.makeR(rotate);
+
+    sead::Matrix34f translationMatrix;
+    translationMatrix.makeRT({0.0f, 0.0f, 0.0f}, mLocalTrans * al::getScaleY(mActor));
+
+    sead::Matrix34f poseMatrix = rotationMatrix * translationMatrix;
+
+    if (mIsUseFollowScaleLocalOffset) {
+        sead::Matrix34f baseMtx = sead::Matrix34f::ident;
+        baseMtx = *mJointMtx * rotationMatrix;
+
+        sead::Vector3f mtxScale = {0.0f, 0.0f, 0.0f};
+        al::calcMtxScale(&mtxScale, baseMtx);
+        poseMatrix.m[0][3] *= mtxScale.x;
+        poseMatrix.m[1][3] *= mtxScale.y;
+        poseMatrix.m[2][3] *= mtxScale.z;
+    }
+
+    sead::Matrix34f baseMtx = *mJointMtx;
+    al::normalize(&baseMtx);
+    *outMtx = baseMtx * poseMatrix;
+}
+
+void CapTargetInfo::calcLockOnFollowTargetScale(sead::Vector3f* targetScale) const {
+    if (!mIsUseLockOnFollowMtxScale) {
+        *targetScale = {mLockOnScale, mLockOnScale, mLockOnScale};
+        return;
+    }
+
+    if (mPoseMatrix != nullptr) {
+        al::calcMtxScale(targetScale, *mPoseMatrix);
+        *targetScale *= mLockOnScale;
+        return;
+    }
+
+    sead::Matrix34f baseMtx = sead::Matrix34f::ident;
+    if (mJointMtx != nullptr)
+        baseMtx = *mJointMtx;
+    else
+        al::makeMtxRT(&baseMtx, mActor);
+
+    sead::Matrix34f rotationMatrix;
+    sead::Vector3f rotate(sead::Mathf::deg2rad(mLocalRotate.x),
+                          sead::Mathf::deg2rad(mLocalRotate.y),
+                          sead::Mathf::deg2rad(mLocalRotate.z));
+    rotationMatrix.makeR(rotate);
+
+    al::calcMtxScale(targetScale, baseMtx * rotationMatrix);
+    *targetScale *= mLockOnScale;
+}

--- a/src/Player/CapTargetInfo.cpp
+++ b/src/Player/CapTargetInfo.cpp
@@ -53,24 +53,14 @@ void CapTargetInfo::setFollowLockOnMtx(const char* jointName, const sead::Vector
 void CapTargetInfo::setLockOnStartAnimName(const char* animName) {
     mLockOnStartAnimName = animName;
     mIsLockOnStart = !al::isEqualString(animName, "Capture");
-
-    if (!al::isEqualString(animName, "Capture")) {
-        mIsLockOn = false;
-        return;
-    }
-
-    mIsLockOn = al::isEqualString(mLockOnAnimName, "Capture");
+    mIsLockOn =
+        al::isEqualString(animName, "Capture") && al::isEqualString(mLockOnAnimName, "Capture");
 }
 
 void CapTargetInfo::setLockOnAnimName(const char* animName) {
     mLockOnAnimName = animName;
-
-    if (!al::isEqualString(mLockOnAnimName, "Capture")) {
-        mIsLockOn = false;
-        return;
-    }
-
-    mIsLockOn = al::isEqualString(mLockOnStartAnimName, "Capture");
+    mIsLockOn = al::isEqualString(mLockOnAnimName, "Capture") &&
+                al::isEqualString(mLockOnStartAnimName, "Capture");
 }
 
 void CapTargetInfo::setHackName(const char* hackName) {
@@ -121,14 +111,14 @@ void CapTargetInfo::calcLockOnFollowTargetScale(sead::Vector3f* targetScale) con
         return;
     }
 
-    if (mPoseMatrix != nullptr) {
+    if (mPoseMatrix) {
         al::calcMtxScale(targetScale, *mPoseMatrix);
         *targetScale *= mLockOnScale;
         return;
     }
 
     sead::Matrix34f baseMtx = sead::Matrix34f::ident;
-    if (mJointMtx != nullptr)
+    if (mJointMtx)
         baseMtx = *mJointMtx;
     else
         al::makeMtxRT(&baseMtx, mActor);

--- a/src/Player/CapTargetInfo.cpp
+++ b/src/Player/CapTargetInfo.cpp
@@ -68,12 +68,12 @@ void CapTargetInfo::setHackName(const char* hackName) {
 }
 
 void CapTargetInfo::makeLockOnMtx(sead::Matrix34f* outMtx) const {
-    if (mPoseMatrix != nullptr) {
+    if (mPoseMatrix) {
         *outMtx = *mPoseMatrix;
         return;
     }
 
-    if (mJointMtx == nullptr) {
+    if (!mJointMtx) {
         al::makeMtxRT(outMtx, mActor);
         return;
     }

--- a/src/Player/CapTargetInfo.h
+++ b/src/Player/CapTargetInfo.h
@@ -5,20 +5,54 @@
 
 namespace al {
 class LiveActor;
-}
+class IusePlayerCollision;
+}  // namespace al
 
 class CapTargetInfo {
 public:
     CapTargetInfo();
 
-    void init(const al::LiveActor*, const char*);
-    void setFollowLockOnMtx(const char*, const sead::Vector3f&, const sead::Vector3f&);
-    void setLockOnStartAnimName(const char*);
-    void setLockOnAnimName(const char*);
-    void setHackName(const char*);
-    void makeLockOnMtx(sead::Matrix34f*) const;
-    void calcLockOnFollowTargetScale(sead::Vector3f*) const;
+    void init(const al::LiveActor* actor, const char* name);
+    void setFollowLockOnMtx(const char* jointName, const sead::Vector3f& localTrans,
+                            const sead::Vector3f& localRotate);
+    void setLockOnStartAnimName(const char* animName);
+    void setLockOnAnimName(const char* animName);
+    void setHackName(const char* hackName);
+    void makeLockOnMtx(sead::Matrix34f* outMtx) const;
+    void calcLockOnFollowTargetScale(sead::Vector3f* targetScale) const;
+
+    void setPoseMatrix(sead::Matrix34f* mtx) { mPoseMatrix = mtx; }
 
 private:
-    void* filler[16];
+    const al::LiveActor* mActor = nullptr;
+    const char* mHackName = nullptr;
+    al::IusePlayerCollision* mPlayerCollision = nullptr;
+    sead::Matrix34f* mPoseMatrix = nullptr;
+    const sead::Matrix34f* mJointMtx = nullptr;
+    sead::Vector3f mLocalTrans = sead::Vector3f::zero;
+    sead::Vector3f mLocalRotate = sead::Vector3f::zero;
+    f32 mLockOnScale = 1.0f;
+    bool mIsUseLockOnFollowMtxScale = false;
+    bool mIsUseFollowScaleLocalOffset = false;
+    const char* mLockOnStartAnimName = "Capture";
+    const char* mLockOnAnimName = "Capture";
+    bool mIsEscapeLocalOffset = false;
+    sead::Vector3f mEscapeLocalOffset = {0.0f, 0.0f, 0.0f};
+    const char* mName = nullptr;
+    bool mIsExistModel = false;
+    bool mIsLockOnOnly = false;
+    bool _72 = false;
+    bool mIsUseDepthShadow = false;
+    bool _74 = false;
+    bool mIsLockOn = true;
+    bool mIsLockOnStart = false;
+    bool mIsSetHackNameToCamera = false;
+    bool _78 = false;
+    bool _79 = false;
+    bool mIsInvalidHackThrow = false;
+    bool mIsInvalidCapEye = false;
+    bool _7c = false;
+    bool _7d = false;
+    bool _7e = false;
+    bool _7f = false;
 };

--- a/src/Player/CapTargetInfo.h
+++ b/src/Player/CapTargetInfo.h
@@ -5,7 +5,7 @@
 
 namespace al {
 class LiveActor;
-class IusePlayerCollision;
+class IUsePlayerCollision;
 }  // namespace al
 
 class CapTargetInfo {
@@ -26,7 +26,7 @@ public:
 private:
     const al::LiveActor* mActor = nullptr;
     const char* mHackName = nullptr;
-    al::IusePlayerCollision* mPlayerCollision = nullptr;
+    al::IUsePlayerCollision* mPlayerCollision = nullptr;
     sead::Matrix34f* mPoseMatrix = nullptr;
     const sead::Matrix34f* mJointMtx = nullptr;
     sead::Vector3f mLocalTrans = sead::Vector3f::zero;


### PR DESCRIPTION
Needed by HackFork. Requires https://github.com/open-ead/sead/pull/178 for all functions to match. Most names come from `CapTargetInfoFunction::initIterCapTargetInfo` although there are quite many variables that are simply not used. It might share a common struct with another class.

This also double checks that EnemyCap has a mistake in the poseMatrix as this matches with PartsModel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/477)
<!-- Reviewable:end -->
