### PR TITLE
Player: Implement `PlayerStateHeadSliding`

### DIFF
--- a/src/Player/PlayerStateHeadSliding.cpp
+++ b/src/Player/PlayerStateHeadSliding.cpp
@@ -1,0 +1,76 @@
+#include "Player/PlayerStateHeadSliding.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionDiveInWater.h"
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerInput.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateHeadSliding, Dive);
+NERVES_MAKE_NOSTRUCT(PlayerStateHeadSliding, Dive);
+}  // namespace
+
+PlayerStateHeadSliding::PlayerStateHeadSliding(al::LiveActor* player, const PlayerConst* pConst,
+                                               const IUsePlayerCollision* collider,
+                                               const PlayerInput* input,
+                                               const PlayerActionDiveInWater* actionDiveInWater,
+                                               PlayerAnimator* animator)
+    : al::ActorStateBase("ヘッドスライディング", player), mConst(pConst), mCollider(collider),
+      mInput(input), mActionDiveInWater(actionDiveInWater), mAnimator(animator) {
+    initNerve(&Dive, 0);
+}
+
+void PlayerStateHeadSliding::appear() {
+    mIsEnableDiveInWater = false;
+    setDead(false);
+    al::setNerve(this, &Dive);
+}
+
+void PlayerStateHeadSliding::kill() {
+    setDead(true);
+}
+
+bool PlayerStateHeadSliding::isEnableDiveInWater() const {
+    return mIsEnableDiveInWater;
+}
+
+void PlayerStateHeadSliding::exeDive() {
+    al::LiveActor* actor = mActor;
+    const sead::Vector3f& gravity = al::getGravity(actor);
+    if (al::isFirstStep(this)) {
+        mAnimator->startAnim("HeadSlidingStart");
+        sead::Vector3f velH = {0.0f, 0.0f, 0.0f};
+        sead::Vector3f velV = {0.0f, 0.0f, 0.0f};
+        al::separateVectorParallelVertical(&velV, &velH, gravity, al::getVelocity(actor));
+        if (!al::tryNormalizeOrZero(&velH))
+            al::calcFrontDir(&velH, actor);
+
+        if (velV.dot(gravity) > 0.0f)
+            velV = {0.0f, 0.0f, 0.0f};
+
+        velV.setScaleAdd(-mConst->getHeadSlidingJump(), gravity, velV);
+        al::setVelocity(actor, (mConst->getHeadSlidingSpeed() * velH) + velV);
+    }
+
+    sead::Vector3f moveInput = {0.0f, 0.0f, 0.0f};
+    mInput->calcMoveInput(&moveInput, -gravity);
+    rs::moveDivingJump(actor, moveInput, 0.0f, mConst->getHeadSlidingBrake(),
+                       mConst->getHeadSlidingSpeed(), mConst->getHeadSlidingSpeedMin(),
+                       mConst->getHeadSlidingSideAccel(), mConst->getHeadSlidingGravityAir(),
+                       mConst->getFallSpeedMax(), mConst->getSlerpQuatGrav());
+
+    if (mAnimator->isAnim("HeadSlidingStart") && mAnimator->isAnimEnd())
+        mAnimator->startAnim("HeadSliding");
+
+    mIsEnableDiveInWater |= mActionDiveInWater->judgeEnableDiveInWater();
+    if (rs::isOnGround(actor, mCollider))
+        kill();
+}

--- a/src/Player/PlayerStateHeadSliding.h
+++ b/src/Player/PlayerStateHeadSliding.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class IUsePlayerCollision;
+class PlayerInput;
+class PlayerActionDiveInWater;
+class PlayerAnimator;
+
+class PlayerStateHeadSliding : public al::ActorStateBase {
+public:
+    PlayerStateHeadSliding(al::LiveActor* player, const PlayerConst* pConst,
+                           const IUsePlayerCollision* collision, const PlayerInput* input,
+                           const PlayerActionDiveInWater* actionDiveInWater,
+                           PlayerAnimator* animator);
+
+    void appear() override;
+    void kill() override;
+
+    bool isEnableDiveInWater() const;
+
+    void exeDive();
+
+private:
+    const PlayerConst* mConst;
+    const IUsePlayerCollision* mCollider;
+    const PlayerInput* mInput;
+    const PlayerActionDiveInWater* mActionDiveInWater;
+    PlayerAnimator* mAnimator;
+    bool mIsEnableDiveInWater = false;
+};

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -41,4 +41,6 @@ void waitGround(al::LiveActor*, const IUsePlayerCollision*, f32, f32, f32, f32);
 void slerpUpFront(al::LiveActor*, const sead::Vector3f&, const sead::Vector3f&, f32, f32);
 
 bool calcSlideDir(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&);
+
+void moveDivingJump(al::LiveActor*, const sead::Vector3f&, f32, f32, f32, f32, f32, f32, f32, f32);
 }  // namespace rs


### PR DESCRIPTION
`HeadSliding` is codename for `Dive`: This `PlayerState` handles diving.

On the first frame of a dive, the following actions happen:
- any downward momentum is canceled (only if moving downwards ; if moving upwards, vertical speed remains unchanged. "vertical" hereby refers to "relative to gravity")
- `HeadSlidingJump` is added to the upwards velocity (opposite to gravity). This has the value `28` by default. If the player is already moving with upwards momentum, this speed is just added on-top.
- The horizontal velocity is set to `HeadSlidingSpeed`, which is 20 by default. If the player is not moving in any direction so far (horizontal speed is exactly zero), the front direction is used instead. Again, horizontal is relative to gravity.

As soon as the player touches the ground, this state is immediately killed, and grounded movement takes over instead.