### PR TITLE
Player: Implement `PlayerJudgeStartRun`

### DIFF
--- a/src/Player/PlayerJudgeStartRun.cpp
+++ b/src/Player/PlayerJudgeStartRun.cpp
@@ -1,0 +1,29 @@
+#include "Player/PlayerJudgeStartRun.h"
+
+#include "Player/PlayerCounterForceRun.h"
+#include "Player/PlayerInput.h"
+#include "Util/JudgeUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeStartRun::PlayerJudgeStartRun(const al::LiveActor* player, const PlayerConst* pConst,
+                                         const IUsePlayerCollision* collision,
+                                         const PlayerInput* input,
+                                         const PlayerCounterForceRun* counterForceRun,
+                                         const IJudge* judgeWaterSurfaceRun)
+    : mPlayer(player), mCollision(collision), mInput(input), mCounterForceRun(counterForceRun),
+      mJudgeForceLand(judgeWaterSurfaceRun) {}
+
+bool PlayerJudgeStartRun::judge() const {
+    if (!rs::isCollidedGround(mCollision))
+        return false;
+    if (mCounterForceRun->isForceRun())
+        return true;
+    if (!rs::isJudge(mJudgeForceLand) &&
+        (mInput->isMove() || rs::isAutoRunOnGroundSkateCode(mPlayer, mCollision, 0.5f)))
+        return true;
+    return false;
+}
+
+void PlayerJudgeStartRun::reset() {}
+
+void PlayerJudgeStartRun::update() {}

--- a/src/Player/PlayerJudgeStartRun.h
+++ b/src/Player/PlayerJudgeStartRun.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
+class PlayerConst;
+class PlayerInput;
+class PlayerCounterForceRun;
+
+class PlayerJudgeStartRun : public IJudge {
+public:
+    PlayerJudgeStartRun(const al::LiveActor* player, const PlayerConst* pConst,
+                        const IUsePlayerCollision* collision, const PlayerInput* input,
+                        const PlayerCounterForceRun* counterForceRun,
+                        const IJudge* judgeWaterSurfaceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const IUsePlayerCollision* mCollision;
+    const PlayerInput* mInput;
+    const PlayerCounterForceRun* mCounterForceRun;
+    const IJudge* mJudgeForceLand;
+};

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -57,5 +57,6 @@ bool reboundVelocityFromCollision(al::LiveActor*, const IUsePlayerCollision*, f3
 al::HitSensor* tryGetCollidedCeilingSensor(const IUsePlayerCollision*);
 
 bool isOnGroundSlopeSlideEnd(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
+bool isAutoRunOnGroundSkateCode(const al::LiveActor*, const IUsePlayerCollision*, f32);
 
 }  // namespace rs


### PR DESCRIPTION
Simple judge that checks whether a `Run` can/should be started. It checks the following conditions in given order:

1. If the player is in-air (not touching ground), no run can be started.
2. If the player is forced to run (=> rocket flower), a run is started.
3. If the player is stunned ("force land"), no run can be started.
4. If the player holds a directional input or is on a `Skate` ground with sufficient velocity (`0.5`), a run is started.

The `judge` function is implemented a bit weirdly towards the end. I was not able to find a better match.
`decomp.me` of the situation: https://decomp.me/scratch/qeI1M

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/480)
<!-- Reviewable:end -->
