### PR TITLE
Layout: Default params for layout functions

### DIFF
--- a/lib/al/Library/Layout/LayoutActionFunction.h
+++ b/lib/al/Library/Layout/LayoutActionFunction.h
@@ -11,57 +11,65 @@ class MessageTagDataHolder;
 class Nerve;
 class ReplaceTagProcessorBase;
 
-void startAction(IUseLayoutAction* layout, const char* actionName, const char* paneName);
+void startAction(IUseLayoutAction* layout, const char* actionName, const char* paneName = nullptr);
 s32 startActionAtRandomFrame(IUseLayoutAction* layout, const char* actionName,
-                             const char* paneName);
+                             const char* paneName = nullptr);
 void startFreezeAction(IUseLayoutAction* layout, const char* actionName, f32 frame,
-                       const char* paneName);
-void startFreezeActionEnd(IUseLayoutAction* layout, const char* actionName, const char* paneName);
+                       const char* paneName = nullptr);
+void startFreezeActionEnd(IUseLayoutAction* layout, const char* actionName,
+                          const char* paneName = nullptr);
 
-f32 getActionFrameMax(const IUseLayoutAction* layout, const char* actionName, const char* paneName);
+f32 getActionFrameMax(const IUseLayoutAction* layout, const char* actionName,
+                      const char* paneName = nullptr);
 
 void startFreezeGaugeAction(IUseLayoutAction* layout, f32 value, f32 minFrame, f32 maxFrame,
-                            const char* actionName, const char* paneName);
+                            const char* actionName, const char* paneName = nullptr);
 
-bool tryStartAction(IUseLayoutAction* layout, const char* actionName, const char* paneName);
+bool tryStartAction(IUseLayoutAction* layout, const char* actionName,
+                    const char* paneName = nullptr);
 
 bool isExistAction(const IUseLayoutAction* layout, const char* actionName, const char* paneName);
-bool isActionEnd(const IUseLayoutAction* layout, const char* paneName);
-bool isExistAction(const IUseLayoutAction* layout, const char* paneName);
-bool isActionOneTime(const IUseLayoutAction* layout, const char* actionName, const char* paneName);
+bool isActionEnd(const IUseLayoutAction* layout, const char* paneName = nullptr);
+bool isExistAction(const IUseLayoutAction* layout, const char* paneName = nullptr);
+bool isActionOneTime(const IUseLayoutAction* layout, const char* actionName,
+                     const char* paneName = nullptr);
 
-f32 getActionFrame(const IUseLayoutAction* layout, const char* paneName);
-void setActionFrame(IUseLayoutAction* layout, f32 frame, const char* paneName);
-f32 getActionFrameRate(const IUseLayoutAction* layout, const char* paneName);
-void setActionFrameRate(IUseLayoutAction* layout, f32 frameRate, const char* paneName);
+f32 getActionFrame(const IUseLayoutAction* layout, const char* paneName = nullptr);
+void setActionFrame(IUseLayoutAction* layout, f32 frame, const char* paneName = nullptr);
+f32 getActionFrameRate(const IUseLayoutAction* layout, const char* paneName = nullptr);
+void setActionFrameRate(IUseLayoutAction* layout, f32 frameRate, const char* paneName = nullptr);
 
-const char* getActionName(const IUseLayoutAction* layout, const char* paneName);
+const char* getActionName(const IUseLayoutAction* layout, const char* paneName = nullptr);
 
-bool isActionPlaying(const IUseLayoutAction* layout, const char* actionName, const char* paneName);
-bool isAnyActionPlaying(const IUseLayoutAction* layout, const char* paneName);
+bool isActionPlaying(const IUseLayoutAction* layout, const char* actionName,
+                     const char* paneName = nullptr);
+bool isAnyActionPlaying(const IUseLayoutAction* layout, const char* paneName = nullptr);
 
 void setNerveAtActionEnd(LayoutActor* layout, const Nerve* nerve);
 
-void startTextPaneAnim(LayoutActor*, const char16*, const MessageTagDataHolder*,
+void startTextPaneAnim(LayoutActor* layout, const char16*, const MessageTagDataHolder*,
                        const ReplaceTagProcessorBase*);
-void startTextPaneAnimWithAudioUser(LayoutActor*, const char16*, const MessageTagDataHolder*,
+void startTextPaneAnimWithAudioUser(LayoutActor* layout, const char16*, const MessageTagDataHolder*,
                                     const ReplaceTagProcessorBase*, const IUseAudioKeeper*);
-void startAndSetTextPaneAnimStage(LayoutActor*, const char*, const char*,
+void startAndSetTextPaneAnimStage(LayoutActor* layout, const char*, const char*,
                                   const MessageTagDataHolder*, const ReplaceTagProcessorBase*);
-void startAndSetTextPaneAnimSystem(LayoutActor*, const char*, const char*,
+void startAndSetTextPaneAnimSystem(LayoutActor* layout, const char*, const char*,
                                    const MessageTagDataHolder*, const ReplaceTagProcessorBase*);
-void endTextPaneAnim(LayoutActor*);
-void skipTextPaneAnim(LayoutActor*);
-void flushTextPaneAnim(LayoutActor*);
-void changeNextPage(LayoutActor*, const MessageTagDataHolder*, const ReplaceTagProcessorBase*);
-bool tryChangeNextPage(LayoutActor*, const MessageTagDataHolder*, const ReplaceTagProcessorBase*);
-bool isExistNextPage(const LayoutActor*);
-bool isEndTextPaneAnim(const LayoutActor*, bool);
-const char16* getCurrentMessagePaneAnim(const LayoutActor*);
-s32 calcCurrentMessageTextNum(const LayoutActor*);
+void endTextPaneAnim(LayoutActor* layout);
+void skipTextPaneAnim(LayoutActor* layout);
+void flushTextPaneAnim(LayoutActor* layout);
+void changeNextPage(LayoutActor* layout, const MessageTagDataHolder*,
+                    const ReplaceTagProcessorBase*);
+bool tryChangeNextPage(LayoutActor* layout, const MessageTagDataHolder*,
+                       const ReplaceTagProcessorBase*);
+bool isExistNextPage(const LayoutActor* layout);
+bool isEndTextPaneAnim(const LayoutActor* layout, bool);
+const char16* getCurrentMessagePaneAnim(const LayoutActor* layout);
+s32 calcCurrentMessageTextNum(const LayoutActor* layout);
 s32 calcShowTextTime(s32);
-bool tryStartTextAnim(LayoutActor*, const char16*);
-bool tryStartTextTagVoice(LayoutActor*, const char16*, const IUseAudioKeeper*, const char*,
+bool tryStartTextAnim(LayoutActor* layout, const char16*);
+bool tryStartTextTagVoice(LayoutActor* layout, const char16*, const IUseAudioKeeper*, const char*,
                           sead::FixedSafeString<64>*);
-void startHitReaction(const LayoutActor*, const char*, const char*);
+void startHitReaction(const LayoutActor* layout, const char* hitReactionName,
+                      const char* paneName = nullptr);
 }  // namespace al

--- a/lib/al/Library/Layout/LayoutActor.h
+++ b/lib/al/Library/Layout/LayoutActor.h
@@ -77,7 +77,7 @@ public:
     void initLayoutPartsActorKeeper(s32 capacity);
     void initEffectKeeper(EffectKeeper*);
     void initAudioKeeper(AudioKeeper*);
-    void initNerve(const Nerve*, s32);
+    void initNerve(const Nerve* nerve, s32 maxStates = 0);
     void setMainGroupName(const char*);
     void syncAction();
 

--- a/lib/al/Library/Layout/LayoutActorUtil.h
+++ b/lib/al/Library/Layout/LayoutActorUtil.h
@@ -84,7 +84,7 @@ bool isReleaseTouchPane(const IUseLayout*, const char*);
 s32 getPaneChildNum(const IUseLayout*, const char*);
 const char* getPaneChildName(const IUseLayout*, const char*, s32);
 void setPaneStringLength(IUseLayout*, const char*, const char16*, u16, u16);
-void setPaneString(IUseLayout*, const char*, const char16*, u16);
+void setPaneString(IUseLayout*, const char*, const char16*, u16 = 0);
 void setPaneCounterDigit1(IUseLayout*, const char*, s32, u16);
 void setPaneCounterDigit2(IUseLayout*, const char*, s32, u16);
 void setPaneCounterDigit3(IUseLayout*, const char*, s32, u16);

--- a/lib/al/Library/Layout/LayoutInitInfo.h
+++ b/lib/al/Library/Layout/LayoutInitInfo.h
@@ -46,9 +46,9 @@ void initLayoutActor(LayoutActor* layoutActor, const LayoutInitInfo& info, const
                      const char* suffix = nullptr);
 void initLayoutActorLocalized(LayoutActor* layoutActor, const LayoutInitInfo& info,
                               const char* archiveName, const char* suffix = nullptr);
-void initLayoutActorUseOtherMessage(LayoutActor* layoutActor, const LayoutInitInfo& info,
-                                    const char* archiveName, const char* suffix,
-                                    const char* messageArchiveName);
+void initLayoutActorUseOtherMessage(LayoutActor* _layoutActor, const LayoutInitInfo& _info,
+                                    const char* _archiveName, const char* _messageArchiveName,
+                                    const char* _suffix);
 void initLayoutTextPaneAnimator(LayoutActor* layoutActor, const char* archiveName);
 void initLayoutTextPaneAnimatorWithShadow(LayoutActor* layoutActor, const char* archiveName);
 void initLayoutPartsActor(LayoutActor* partsActor, LayoutActor* parentActor,

--- a/lib/al/Library/Layout/LayoutInitInfo.h
+++ b/lib/al/Library/Layout/LayoutInitInfo.h
@@ -42,15 +42,20 @@ private:
     LayoutSystem* mLayoutSystem;
 };
 
-void initLayoutActor(LayoutActor*, const LayoutInitInfo&, const char*, const char*);
-void initLayoutActorLocalized(LayoutActor*, const LayoutInitInfo&, const char*, const char*);
-void initLayoutActorUseOtherMessage(LayoutActor*, const LayoutInitInfo&, const char*, const char*,
-                                    const char*);
-void initLayoutTextPaneAnimator(LayoutActor*, const char*);
-void initLayoutTextPaneAnimatorWithShadow(LayoutActor*, const char*);
-void initLayoutPartsActor(LayoutActor*, LayoutActor*, const LayoutInitInfo&, const char*,
-                          const char*);
-void initLayoutPartsActorLocalized(LayoutActor*, LayoutActor*, const LayoutInitInfo&, const char*,
-                                   const char*);
+void initLayoutActor(LayoutActor* layoutActor, const LayoutInitInfo& info, const char* archiveName,
+                     const char* suffix = nullptr);
+void initLayoutActorLocalized(LayoutActor* layoutActor, const LayoutInitInfo& info,
+                              const char* archiveName, const char* suffix = nullptr);
+void initLayoutActorUseOtherMessage(LayoutActor* layoutActor, const LayoutInitInfo& info,
+                                    const char* archiveName, const char* suffix,
+                                    const char* messageArchiveName);
+void initLayoutTextPaneAnimator(LayoutActor* layoutActor, const char* archiveName);
+void initLayoutTextPaneAnimatorWithShadow(LayoutActor* layoutActor, const char* archiveName);
+void initLayoutPartsActor(LayoutActor* partsActor, LayoutActor* parentActor,
+                          const LayoutInitInfo& info, const char* archiveName,
+                          const char* suffix = nullptr);
+void initLayoutPartsActorLocalized(LayoutActor* partsActor, LayoutActor* parentActor,
+                                   const LayoutInitInfo& info, const char* archiveName,
+                                   const char* suffix = nullptr);
 
 }  // namespace al

--- a/lib/al/Library/Nerve/NerveExecutor.h
+++ b/lib/al/Library/Nerve/NerveExecutor.h
@@ -17,7 +17,7 @@ public:
 
     virtual ~NerveExecutor();
 
-    void initNerve(const Nerve* nerve, s32 stateCount);
+    void initNerve(const Nerve* nerve, s32 stateCount = 0);
     void updateNerve();
 
 private:

--- a/lib/al/Library/Play/Layout/SimpleLayoutAppear.cpp
+++ b/lib/al/Library/Play/Layout/SimpleLayoutAppear.cpp
@@ -11,7 +11,7 @@ SimpleLayoutAppear::SimpleLayoutAppear(const char* name, const char* layoutName,
 }
 
 void SimpleLayoutAppear::appear() {
-    startAction(this, "Appear", nullptr);
+    startAction(this, "Appear");
     LayoutActor::appear();
 }
 }  // namespace al

--- a/lib/al/Library/Play/Layout/SimpleLayoutAppearWait.cpp
+++ b/lib/al/Library/Play/Layout/SimpleLayoutAppearWait.cpp
@@ -19,7 +19,7 @@ SimpleLayoutAppearWait::SimpleLayoutAppearWait(const char* name, const char* lay
                                                const LayoutInitInfo& info, const char* archiveName)
     : LayoutActor(name) {
     initLayoutActor(this, info, layoutName, archiveName);
-    initNerve(&Appear, 0);
+    initNerve(&Appear);
 }
 
 SimpleLayoutAppearWait::SimpleLayoutAppearWait(LayoutActor* parentActor, const char* name,
@@ -27,11 +27,11 @@ SimpleLayoutAppearWait::SimpleLayoutAppearWait(LayoutActor* parentActor, const c
                                                const char* archiveName)
     : LayoutActor(name) {
     initLayoutPartsActor(this, parentActor, info, layoutName, archiveName);
-    initNerve(&Appear, 0);
+    initNerve(&Appear);
 }
 
 void SimpleLayoutAppearWait::appear() {
-    startAction(this, "Appear", nullptr);
+    startAction(this, "Appear");
     LayoutActor::appear();
     setNerve(this, &Appear);
 }
@@ -47,7 +47,7 @@ void SimpleLayoutAppearWait::exeAppear() {
 
 void SimpleLayoutAppearWait::exeWait() {
     if (isFirstStep(this))
-        startAction(this, "Wait", 0);
+        startAction(this, "Wait");
 }
 
 }  // namespace al

--- a/lib/al/Library/Play/Layout/SimpleLayoutAppearWaitEnd.cpp
+++ b/lib/al/Library/Play/Layout/SimpleLayoutAppearWaitEnd.cpp
@@ -26,7 +26,7 @@ SimpleLayoutAppearWaitEnd::SimpleLayoutAppearWaitEnd(const char* name, const cha
         initLayoutActorLocalized(this, info, layoutName, archiveName);
     else
         initLayoutActor(this, info, layoutName, archiveName);
-    initNerve(&NrvHostType.Appear, 0);
+    initNerve(&NrvHostType.Appear);
 }
 
 SimpleLayoutAppearWaitEnd::SimpleLayoutAppearWaitEnd(LayoutActor* parentActor, const char* name,
@@ -35,11 +35,11 @@ SimpleLayoutAppearWaitEnd::SimpleLayoutAppearWaitEnd(LayoutActor* parentActor, c
                                                      const char* archiveName)
     : LayoutActor(name) {
     initLayoutPartsActor(this, parentActor, info, layoutName, archiveName);
-    initNerve(&NrvHostType.Appear, 0);
+    initNerve(&NrvHostType.Appear);
 };
 
 void SimpleLayoutAppearWaitEnd::appear() {
-    startAction(this, "Appear", nullptr);
+    startAction(this, "Appear");
     LayoutActor::appear();
     setNerve(this, &NrvHostType.Appear);
 }
@@ -50,27 +50,27 @@ void SimpleLayoutAppearWaitEnd::end() {
 }
 
 void SimpleLayoutAppearWaitEnd::startWait() {
-    startAction(this, "Wait", nullptr);
+    startAction(this, "Wait");
     LayoutActor::appear();
     setNerve(this, &NrvHostType.Wait);
 }
 
 void SimpleLayoutAppearWaitEnd::exeAppear() {
-    if (isActionEnd(this, nullptr))
+    if (isActionEnd(this))
         setNerve(this, &NrvHostType.Wait);
 }
 
 void SimpleLayoutAppearWaitEnd::exeWait() {
     if (isFirstStep(this))
-        startAction(this, "Wait", nullptr);
+        startAction(this, "Wait");
     if (mLifetime >= 0 && isGreaterEqualStep(this, mLifetime))
         setNerve(this, &End);
 }
 
 void SimpleLayoutAppearWaitEnd::exeEnd() {
     if (isFirstStep(this))
-        startAction(this, "End", nullptr);
-    if (isActionEnd(this, nullptr))
+        startAction(this, "End");
+    if (isActionEnd(this))
         kill();
 }
 

--- a/lib/al/Library/Play/Layout/SimpleLayoutText.cpp
+++ b/lib/al/Library/Play/Layout/SimpleLayoutText.cpp
@@ -22,7 +22,7 @@ SimpleLayoutText::SimpleLayoutText(const LayoutInitInfo& info, const char* name,
                                    const char* paneName, const char* archiveName)
     : LayoutActor("テキストレイアウト"), mPaneName(paneName) {
     initLayoutActor(this, info, name, archiveName);
-    initNerve(&Wait, 0);
+    initNerve(&Wait);
     kill();
 }
 
@@ -45,7 +45,7 @@ void SimpleLayoutText::setText(const char* text) {
     sead::StringUtil::convertUtf8ToUtf16(utf16str.getBuffer(), utf16str.getBufferSize(), text, -1);
 
     // doesn't match with call to setText(const char16*)
-    setPaneString(this, mPaneName, utf16str.cstr(), 0);
+    setPaneString(this, mPaneName, utf16str.cstr());
 }
 
 void SimpleLayoutText::start(const sead::Vector2f& pos, const char16* str, s32 lifetime) {
@@ -57,7 +57,7 @@ void SimpleLayoutText::start(const sead::Vector2f& pos, const char16* str, s32 l
 }
 
 void SimpleLayoutText::setText(const char16* str) {
-    setPaneString(this, mPaneName, str, 0);
+    setPaneString(this, mPaneName, str);
 }
 
 void SimpleLayoutText::start(const sead::Vector2f& pos, const char* category, const char* key,

--- a/lib/al/Library/Play/Layout/SimplePopupMessageLayout.cpp
+++ b/lib/al/Library/Play/Layout/SimplePopupMessageLayout.cpp
@@ -28,11 +28,11 @@ SimplePopupMessageLayout::SimplePopupMessageLayout(const char* name, const char*
         initLayoutActorLocalized(this, info, layoutName, archiveName);
     else
         initLayoutActor(this, info, layoutName, archiveName);
-    initNerve(&NrvHostType.Appear, 0);
+    initNerve(&NrvHostType.Appear);
 }
 
 void SimplePopupMessageLayout::appear() {
-    startAction(this, "Appear", nullptr);
+    startAction(this, "Appear");
     LayoutActor::appear();
     setNerve(this, &NrvHostType.Appear);
 }
@@ -43,7 +43,7 @@ void SimplePopupMessageLayout::end() {
 }
 
 void SimplePopupMessageLayout::startWait() {
-    startAction(this, "Wait", nullptr);
+    startAction(this, "Wait");
     LayoutActor::appear();
     setNerve(this, &NrvHostType.Wait);
 }
@@ -51,7 +51,7 @@ void SimplePopupMessageLayout::startWait() {
 void SimplePopupMessageLayout::exeAppear() {
     refreshPos();
 
-    if (isActionEnd(this, nullptr))
+    if (isActionEnd(this))
         setNerve(this, &NrvHostType.Wait);
 }
 
@@ -65,7 +65,7 @@ void SimplePopupMessageLayout::exeWait() {
     refreshPos();
 
     if (isFirstStep(this))
-        startAction(this, "Wait", nullptr);
+        startAction(this, "Wait");
     if (mLifetime >= 0 && isGreaterEqualStep(this, mLifetime))
         setNerve(this, &End);
 }
@@ -74,8 +74,8 @@ void SimplePopupMessageLayout::exeEnd() {
     refreshPos();
 
     if (isFirstStep(this))
-        startAction(this, "End", nullptr);
-    if (isActionEnd(this, nullptr))
+        startAction(this, "End");
+    if (isActionEnd(this))
         kill();
 }
 

--- a/lib/al/Library/Play/Layout/WipeSimple.cpp
+++ b/lib/al/Library/Play/Layout/WipeSimple.cpp
@@ -22,18 +22,18 @@ WipeSimple::WipeSimple(const char* name, const char* layoutName, const LayoutIni
                        const char* actorName)
     : LayoutActor(name) {
     initLayoutActor(this, info, layoutName, actorName);
-    initNerve(&NrvWipeSimple.Close, 0);
+    initNerve(&NrvWipeSimple.Close);
 }
 
 void WipeSimple::startClose(s32 frames) {
     mFrames = frames;
-    startAction(this, "Appear", nullptr);
+    startAction(this, "Appear");
     LayoutActor::appear();
 
     if (mFrames <= 0)
-        setActionFrameRate(this, 1.0f, nullptr);
+        setActionFrameRate(this, 1.0f);
     else
-        setActionFrameRate(this, getActionFrameMax(this, "Appear", nullptr) / mFrames, nullptr);
+        setActionFrameRate(this, getActionFrameMax(this, "Appear") / mFrames);
 
     setNerve(this, &NrvWipeSimple.Close);
 }
@@ -44,14 +44,14 @@ void WipeSimple::tryStartClose(s32 frames) {
 }
 
 void WipeSimple::startCloseEnd() {
-    startAction(this, "Wait", nullptr);
+    startAction(this, "Wait");
     LayoutActor::appear();
     setNerve(this, &NrvWipeSimple.CloseEnd);
 }
 
 void WipeSimple::startOpen(s32 frames) {
     mFrames = frames;
-    startAction(this, "End", nullptr);
+    startAction(this, "End");
     setNerve(this, &Open);
 }
 
@@ -69,23 +69,23 @@ bool WipeSimple::isOpenEnd() const {
 }
 
 void WipeSimple::exeClose() {
-    if (!isFirstStep(this) && isActionEnd(this, nullptr))
+    if (!isFirstStep(this) && isActionEnd(this))
         setNerve(this, &NrvWipeSimple.CloseEnd);
 }
 
 void WipeSimple::exeCloseEnd() {
     if (isFirstStep(this))
-        startAction(this, "Wait", nullptr);
+        startAction(this, "Wait");
 }
 
 void WipeSimple::exeOpen() {
     if (isFirstStep(this)) {
         if (mFrames <= 0)
-            setActionFrameRate(this, 1.0f, nullptr);
+            setActionFrameRate(this, 1.0f);
         else
-            setActionFrameRate(this, getActionFrameMax(this, "End", nullptr) / mFrames, nullptr);
+            setActionFrameRate(this, getActionFrameMax(this, "End") / mFrames);
     }
-    if (isActionEnd(this, nullptr))
+    if (isActionEnd(this))
         kill();
 }
 

--- a/src/Layout/AimingCursor.cpp
+++ b/src/Layout/AimingCursor.cpp
@@ -16,8 +16,8 @@ NERVES_MAKE_NOSTRUCT(AimingCursor, Appear, End, Wait);
 
 AimingCursor::AimingCursor(const char* name, const al::LayoutInitInfo& info)
     : al::LayoutActor(name) {
-    al::initLayoutActor(this, info, "Aiming", nullptr);
-    initNerve(&Appear, 0);
+    al::initLayoutActor(this, info, "Aiming");
+    initNerve(&Appear);
     kill();
 }
 
@@ -57,19 +57,19 @@ bool AimingCursor::tryLookOff() {
 
 void AimingCursor::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void AimingCursor::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void AimingCursor::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/AmiiboNpcLayout.cpp
+++ b/src/Layout/AmiiboNpcLayout.cpp
@@ -20,34 +20,34 @@ NERVES_MAKE_NOSTRUCT(AmiiboNpcLayout, Appear, Decide, End, Wait);
 
 AmiiboNpcLayout::AmiiboNpcLayout(const al::LayoutInitInfo& info)
     : al::LayoutActor("AmiiboNpc用レイアウト") {
-    al::initLayoutActor(this, info, "ControllerGuideAmiibo", nullptr);
-    initNerve(&Appear, 0);
-    al::startAction(this, "Appear", nullptr);
+    al::initLayoutActor(this, info, "ControllerGuideAmiibo");
+    initNerve(&Appear);
+    al::startAction(this, "Appear");
     mFooterParts = new FooterParts(this, info, al::getSystemMessageString(this, "Footer", "Return"),
                                    "TxtGuide", "ParFooter");
     mAmiiboIcon = new al::LayoutActor("AmiiboNpc用レイアウト[アイコン]");
-    al::initLayoutPartsActor(mAmiiboIcon, this, info, "ParAmiiboIcon", nullptr);
+    al::initLayoutPartsActor(mAmiiboIcon, this, info, "ParAmiiboIcon");
     kill();
 }
 
 void AmiiboNpcLayout::startTouch() {
     mAmiiboIcon->appear();
-    al::startAction(mAmiiboIcon, "Appear", nullptr);
+    al::startAction(mAmiiboIcon, "Appear");
 }
 
 void AmiiboNpcLayout::endTouch() {
-    al::startAction(mAmiiboIcon, "End", nullptr);
+    al::startAction(mAmiiboIcon, "End");
 }
 
 void AmiiboNpcLayout::appear() {
     al::LayoutActor::appear();
     al::setNerve(this, &Appear);
-    al::startAction(mAmiiboIcon, "Hide", nullptr);
+    al::startAction(mAmiiboIcon, "Hide");
 }
 
 void AmiiboNpcLayout::control() {
     if (isIconEndActionEnd())
-        al::startAction(mAmiiboIcon, "Wait", nullptr);
+        al::startAction(mAmiiboIcon, "Wait");
 }
 
 void AmiiboNpcLayout::decide() {
@@ -55,41 +55,40 @@ void AmiiboNpcLayout::decide() {
 }
 
 void AmiiboNpcLayout::end() {
-    al::startAction(mAmiiboIcon, "Hide", nullptr);
+    al::startAction(mAmiiboIcon, "Hide");
     al::setNerve(this, &End);
 }
 
 bool AmiiboNpcLayout::isIconEndActionEnd() const {
-    return al::isActionPlaying(mAmiiboIcon, "End", nullptr) &&
-           al::isActionEnd(mAmiiboIcon, nullptr);
+    return al::isActionPlaying(mAmiiboIcon, "End") && al::isActionEnd(mAmiiboIcon);
 }
 
 void AmiiboNpcLayout::exeAppear() {
     if (al::isFirstStep(this)) {
-        al::startAction(this, "Appear", nullptr);
+        al::startAction(this, "Appear");
         al::startAction(this, "Loop", "Loop");
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void AmiiboNpcLayout::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void AmiiboNpcLayout::exeDecide() {
     if (al::isFirstStep(this)) {
-        al::startAction(this, "Decide", nullptr);
-        al::startHitReaction(this, "タッチ", nullptr);
+        al::startAction(this, "Decide");
+        al::startHitReaction(this, "タッチ");
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }
 
 void AmiiboNpcLayout::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/BootLayout.cpp
+++ b/src/Layout/BootLayout.cpp
@@ -16,15 +16,15 @@ NERVES_MAKE_NOSTRUCT(BootLayout, Appear, Wait, StartWipe, EndWipe, End);
 }  // namespace
 
 BootLayout::BootLayout(const al::LayoutInitInfo& info) : al::LayoutActor("[起動]BootLoading") {
-    al::initLayoutActor(this, info, "BootLoading", 0);
+    al::initLayoutActor(this, info, "BootLoading");
     mParBg = new al::LayoutActor("[起動]BG");
-    al::initLayoutPartsActor(mParBg, this, info, "ParBG", 0);
-    initNerve(&Appear, 0);
+    al::initLayoutPartsActor(mParBg, this, info, "ParBG");
+    initNerve(&Appear);
 }
 
 void BootLayout::appear() {
-    al::startAction(this, "Appear", 0);
-    al::startAction(mParBg, "Hide", 0);
+    al::startAction(this, "Appear");
+    al::startAction(mParBg, "Hide");
     al::LayoutActor::appear();
     al::setNerve(this, &Appear);
 }
@@ -34,8 +34,8 @@ void BootLayout::kill() {
 }
 
 void BootLayout::startWipe() {
-    al::startAction(this, "Wait", 0);
-    al::startAction(mParBg, "Hide", 0);
+    al::startAction(this, "Wait");
+    al::startAction(mParBg, "Hide");
     al::LayoutActor::appear();
     al::setNerve(this, &StartWipe);
 }
@@ -63,11 +63,11 @@ bool BootLayout::isEndWipe() const {
 }
 
 f32 BootLayout::getBgFrame() const {
-    return al::getActionFrame(mParBg, 0);
+    return al::getActionFrame(mParBg);
 }
 
 void BootLayout::exeAppear() {
-    if (al::isActionEnd(this, 0))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
@@ -79,7 +79,7 @@ void BootLayout::exeWait() {
 void BootLayout::exeStartWipe() {
     if (al::isFirstStep(this))
         al::startAction(mParBg, "Appear", "Main");
-    if (!al::isActionEnd(mParBg, 0))
+    if (!al::isActionEnd(mParBg))
         return;
     al::startAction(mParBg, "Wait", "Main");
     al::setNerve(this, &EndWipe);

--- a/src/Layout/ButtonMiiverse.cpp
+++ b/src/Layout/ButtonMiiverse.cpp
@@ -21,8 +21,8 @@ NERVES_MAKE_STRUCT(ButtonMiiverse, Wait, Decide, OnWait, Disable, HoldOn, HoldOf
 ButtonMiiverse::ButtonMiiverse() : al::LayoutActor("Miiverseボタン") {}
 
 void ButtonMiiverse::init(const al::LayoutInitInfo& info) {
-    al::initLayoutActor(this, info, "ButtonMiiverse", 0);
-    initNerve(&NrvButtonMiiverse.Wait, 0);
+    al::initLayoutActor(this, info, "ButtonMiiverse");
+    initNerve(&NrvButtonMiiverse.Wait);
     appear();
 }
 
@@ -51,14 +51,14 @@ void ButtonMiiverse::invalidate() {
 
 void ButtonMiiverse::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", 0);
+        al::startAction(this, "Wait");
     if (al::isHoldTouchPane(this, "Hit"))
         al::setNerve(this, &NrvButtonMiiverse.HoldOn);
 }
 
 void ButtonMiiverse::exeHoldOn() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Touch", 0);
+        al::startAction(this, "Touch");
     if (al::isReleaseTouchPane(this, "Hit"))
         al::setNerve(this, &NrvButtonMiiverse.Decide);
     else if (!al::isTouchPosInPane(this, "Hit"))
@@ -67,7 +67,7 @@ void ButtonMiiverse::exeHoldOn() {
 
 void ButtonMiiverse::exeHoldOff() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Touch", 0);
+        al::startAction(this, "Touch");
     if (al::isTouchPosInPane(this, "Hit"))
         al::setNerve(this, &NrvButtonMiiverse.HoldOn);
     else if (al::isPadReleaseTouch())
@@ -76,16 +76,16 @@ void ButtonMiiverse::exeHoldOff() {
 
 void ButtonMiiverse::exeDecide() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Decide", 0);
+        al::startAction(this, "Decide");
     al::setNerveAtActionEnd(this, &NrvButtonMiiverse.OnWait);
 }
 
 void ButtonMiiverse::exeOnWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", 0);
+        al::startAction(this, "Wait");
 }
 
 void ButtonMiiverse::exeDisable() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Disable", 0);
+        al::startAction(this, "Disable");
 }

--- a/src/Layout/CoinCollectLayout.cpp
+++ b/src/Layout/CoinCollectLayout.cpp
@@ -19,8 +19,8 @@ NERVES_MAKE_NOSTRUCT(CoinCollectLayout, Start, Wait, End);
 
 CoinCollectLayout::CoinCollectLayout(const al::LayoutInitInfo& info)
     : al::LayoutActor("コレクトコインレイアウト") {
-    al::initLayoutActor(this, info, "PopUpCollectCoin", nullptr);
-    initNerve(&Start, 0);
+    al::initLayoutActor(this, info, "PopUpCollectCoin");
+    initNerve(&Start);
 }
 
 void CoinCollectLayout::appearCounter(s32 maxCoins, s32 currentCoins,
@@ -40,8 +40,8 @@ void CoinCollectLayout::appearCounter(s32 maxCoins, s32 currentCoins,
 
 void CoinCollectLayout::exeStart() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
     updatePos();
 }
@@ -55,7 +55,7 @@ void CoinCollectLayout::updatePos() {
 
 void CoinCollectLayout::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
     if (al::isGreaterEqualStep(this, 120)) {
         al::setNerve(this, &End);
         return;
@@ -65,8 +65,8 @@ void CoinCollectLayout::exeWait() {
 
 void CoinCollectLayout::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr)) {
+        al::startAction(this, "End");
+    if (al::isActionEnd(this)) {
         kill();
         return;
     }

--- a/src/Layout/CoinCounter.cpp
+++ b/src/Layout/CoinCounter.cpp
@@ -26,18 +26,18 @@ NERVES_MAKE_STRUCT(CoinCounter, End, Appear, CountAnimAdd, CountAnimSub, Add, Su
 CoinCounter::CoinCounter(const char* name, const al::LayoutInitInfo& initInfo, bool isCoin)
     : al::LayoutActor(name), mIsCoin(isCoin) {
     if (mIsCoin) {
-        al::initLayoutActor(this, initInfo, "CounterCoin", nullptr);
+        al::initLayoutActor(this, initInfo, "CounterCoin");
         mNumDigits = 4;
         mPanelName = "Coin";
     } else {
-        al::initLayoutActor(this, initInfo, "CounterCollectCoin", nullptr);
+        al::initLayoutActor(this, initInfo, "CounterCollectCoin");
         mNumDigits = 3;
         mPanelName = "CollectCoin";
-        al::setPaneString(this, "TxtIcon", rs::getWorldCoinCollectPictureFont(this), 0);
-        al::setPaneString(this, "TxtIconSh", rs::getWorldCoinCollectPictureFont(this), 0);
+        al::setPaneString(this, "TxtIcon", rs::getWorldCoinCollectPictureFont(this));
+        al::setPaneString(this, "TxtIconSh", rs::getWorldCoinCollectPictureFont(this));
     }
 
-    initNerve(&NrvCoinCounter.End, 0);
+    initNerve(&NrvCoinCounter.End);
     kill();
     updatePanel(mCoinNum, mNumDigits);
 }
@@ -68,7 +68,7 @@ bool CoinCounter::isWait() const {
 
 void CoinCounter::tryStart() {
     if (al::isNerve(this, &NrvCoinCounter.End)) {
-        al::startAction(this, "Appear", nullptr);
+        al::startAction(this, "Appear");
         updateCountImmidiate();
         al::LayoutActor::appear();
         al::setNerve(this, &NrvCoinCounter.Appear);
@@ -137,21 +137,21 @@ s32 CoinCounter::getCountTotalFromData() const {
 }
 
 void CoinCounter::exeAppear() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void CoinCounter::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
     if (mIsUpdateCount)
         tryUpdateCount();
 }
 
 void CoinCounter::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }
 
@@ -160,7 +160,7 @@ void CoinCounter::exeAdd() {
         al::startAction(this, "Add", mPanelName);
         updatePanel(mCoinNum, mNumDigits);
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
@@ -169,7 +169,7 @@ void CoinCounter::exeSub() {
         al::startAction(this, "Add", mPanelName);
         updatePanel(mCoinNum, mNumDigits);
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 

--- a/src/Layout/Compass.cpp
+++ b/src/Layout/Compass.cpp
@@ -33,8 +33,8 @@ bool isAreaMadness(al::AreaObj* area) {
 Compass::Compass(const char* name, const al::LayoutInitInfo& info,
                  const al::PlayerHolder* playerHolder)
     : al::LayoutActor(name), mPlayerHolder(playerHolder) {
-    al::initLayoutActor(this, info, "TestCompass", nullptr);
-    initNerve(&Appear, 0);
+    al::initLayoutActor(this, info, "TestCompass");
+    initNerve(&Appear);
 
     mSceneCamInfo = getCameraDirector()->getSceneCameraInfo();
     kill();
@@ -90,7 +90,7 @@ void Compass::end() {
 
 void Compass::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
+        al::startAction(this, "Appear");
 
     updateLayout();
     al::setNerveAtActionEnd(this, &Wait);
@@ -100,17 +100,17 @@ void Compass::exeAppear() {
 
 void Compass::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 
     updateLayout();
 }
 
 void Compass::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
 
     updateLayout();
 
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/CounterLife.cpp
+++ b/src/Layout/CounterLife.cpp
@@ -26,8 +26,8 @@ CounterLife::CounterLife(const char* name, const char* resName, const al::Layout
     if (al::isEqualString(resName, "CounterLifeUp"))
         mIsCounterUp = true;
 
-    al::initLayoutActor(this, info, resName, nullptr);
-    initNerve(&End, 0);
+    al::initLayoutActor(this, info, resName);
+    initNerve(&End);
 
     if (mIsCounterUp)
         return;
@@ -108,7 +108,7 @@ bool CounterLife::isWait() const {
 void CounterLife::exeNone() {}
 
 void CounterLife::exeAppear() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
@@ -129,7 +129,7 @@ void CounterLife::exeEnd() {
     if (al::isFirstStep(this))
         al::startAction(this, "End", "Main");
 
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }
 

--- a/src/Layout/FilterFly.cpp
+++ b/src/Layout/FilterFly.cpp
@@ -20,14 +20,14 @@ const sead::Vector2f sStartingPosition = {600.0f, -300.0f};
 FilterFly::FilterFly(const char* name, const al::LayoutInitInfo& info, const char* suffix)
     : al::LayoutActor(name) {
     al::initLayoutActor(this, info, "FilterFly", suffix);
-    initNerve(&Wait, 0);
+    initNerve(&Wait);
     al::setPaneLocalTrans(this, "RootPane", sStartingPosition);
     kill();
 }
 
 void FilterFly::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", 0);
+        al::startAction(this, "Wait");
     if (al::isGreaterStep(this, 180))
         al::setNerve(this, &WaitEnd);
 }
@@ -36,7 +36,7 @@ void FilterFly::exeWaitEnd() {}
 
 void FilterFly::exeMove() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Loop", 0);
+        al::startAction(this, "Loop");
 
     sead::Vector2f currentPos = {al::getLocalTrans(this).x, al::getLocalTrans(this).y};
     sead::Vector2f direction = mTargetPos - currentPos;

--- a/src/Layout/FilterScope.cpp
+++ b/src/Layout/FilterScope.cpp
@@ -16,7 +16,7 @@ NERVES_MAKE_NOSTRUCT(FilterScope, Appear, Wait, End);
 FilterScope::FilterScope(const char* name, const al::LayoutInitInfo& info, const char* suffix)
     : al::LayoutActor(name) {
     al::initLayoutActor(this, info, "FilterScope", suffix);
-    initNerve(&Appear, 0);
+    initNerve(&Appear);
     kill();
 }
 
@@ -31,20 +31,20 @@ void FilterScope::end() {
 
 void FilterScope::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", 0);
-    if (al::isActionEnd(this, 0))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void FilterScope::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", 0);
+        al::startAction(this, "Wait");
 }
 
 void FilterScope::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", 0);
-    if (al::isActionEnd(this, 0))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }
 

--- a/src/Layout/FooterParts.cpp
+++ b/src/Layout/FooterParts.cpp
@@ -17,15 +17,15 @@ NERVES_MAKE_NOSTRUCT(FooterParts, Wait, FadeOut, FadeIn);
 FooterParts::FooterParts(al::LayoutActor* parentLayout, const al::LayoutInitInfo& info,
                          const char16* footerText, const char* textPane, const char* partPane)
     : al::LayoutActor("フッターパーツ"), mTextPane(textPane), mText(footerText) {
-    al::initLayoutPartsActor(this, parentLayout, info, partPane, nullptr);
+    al::initLayoutPartsActor(this, parentLayout, info, partPane);
 
-    al::setPaneString(this, mTextPane, mText, 0);
-    initNerve(&Wait, 0);
+    al::setPaneString(this, mTextPane, mText);
+    initNerve(&Wait);
 }
 
 void FooterParts::changeText(const char16* text) {
     mText = text;
-    al::setPaneString(this, mTextPane, text, 0);
+    al::setPaneString(this, mTextPane, text);
 }
 
 void FooterParts::changeTextFade(const char16* text) {
@@ -42,16 +42,16 @@ bool FooterParts::tryChangeTextFade(const char16* text) {
 
 void FooterParts::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", 0);
+        al::startAction(this, "Wait");
 }
 
 void FooterParts::exeFadeOut() {}
 
 void FooterParts::exeFadeIn() {
     if (al::isFirstStep(this)) {
-        al::setPaneString(this, mTextPane, mText, 0);
-        al::startAction(this, "FadeIn", 0);
+        al::setPaneString(this, mTextPane, mText);
+        al::startAction(this, "FadeIn");
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }

--- a/src/Layout/GaugeAir.cpp
+++ b/src/Layout/GaugeAir.cpp
@@ -17,8 +17,8 @@ NERVES_MAKE_STRUCT(GaugeAir, Wait, End);
 }  // namespace
 
 GaugeAir::GaugeAir(const char* name, const al::LayoutInitInfo& info) : al::LayoutActor(name) {
-    al::initLayoutActor(this, info, "GaugeAir", nullptr);
-    initNerve(&Appear, 0);
+    al::initLayoutActor(this, info, "GaugeAir");
+    initNerve(&Appear);
     kill();
 }
 
@@ -71,8 +71,8 @@ void GaugeAir::setRate(f32 rate) {
 
 void GaugeAir::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         return al::setNerve(this, &NrvGaugeAir.Wait);
 }
 
@@ -88,16 +88,16 @@ void GaugeAir::exeEnd() {
         return;
 
     if (al::isStep(this, 30))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
 
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }
 
 void GaugeAir::exeFastEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
 
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/HardIconParts.cpp
+++ b/src/Layout/HardIconParts.cpp
@@ -17,7 +17,7 @@ NERVES_MAKE_NOSTRUCT(HardIconParts, Hide, Appear, Wait, PageNext, PageEnd, End);
 }  // namespace
 
 HardIconParts::HardIconParts(const char* name) : al::LayoutActor(name) {
-    initNerve(&Hide, 0);
+    initNerve(&Hide);
 }
 
 bool HardIconParts::isHide() const {
@@ -46,34 +46,34 @@ void HardIconParts::startEnd() {
 
 void HardIconParts::exeHide() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Hide", nullptr);
+        al::startAction(this, "Hide");
 }
 
 void HardIconParts::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
+        al::startAction(this, "Appear");
     al::setNerveAtActionEnd(this, &Wait);
 }
 
 void HardIconParts::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void HardIconParts::exePageNext() {
     if (al::isFirstStep(this))
-        al::startAction(this, "PageNext", nullptr);
+        al::startAction(this, "PageNext");
     al::setNerveAtActionEnd(this, &Hide);
 }
 
 void HardIconParts::exePageEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "PageEnd", nullptr);
+        al::startAction(this, "PageEnd");
     al::setNerveAtActionEnd(this, &Hide);
 }
 
 void HardIconParts::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
     al::setNerveAtActionEnd(this, &Hide);
 }

--- a/src/Layout/MenuSelectParts.cpp
+++ b/src/Layout/MenuSelectParts.cpp
@@ -68,15 +68,15 @@ MenuSelectParts::MenuSelectParts(const char* name, al::LayoutActor* layoutActor,
 
         al::StringTmp<32> name("%s%02d", "ParList", i);
 
-        al::initLayoutPartsActor(mLayoutArray[i], layoutActor, info, name.cstr(), nullptr);
+        al::initLayoutPartsActor(mLayoutArray[i], layoutActor, info, name.cstr());
         al::startAction(mLayoutArray[i], "Active", "State");
     }
 
     mCursorActor = new al::LayoutActor("カーソルパーツ");
-    al::initLayoutPartsActor(mCursorActor, layoutActor, info, "ParCursor", nullptr);
+    al::initLayoutPartsActor(mCursorActor, layoutActor, info, "ParCursor");
 
-    al::startAction(mCursorActor, "Hide", nullptr);
-    initNerve(&Hide, 0);
+    al::startAction(mCursorActor, "Hide");
+    initNerve(&Hide);
 }
 
 void MenuSelectParts::update() {
@@ -91,9 +91,9 @@ void MenuSelectParts::appear(s32 menuItemAmount) {
 
     for (s32 i = 0; i < mMenuItemAmount; i++) {
         if (i == mCursorItemIndex)
-            al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(i)], "Select", nullptr);
+            al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(i)], "Select");
         else
-            al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(i)], "Wait", nullptr);
+            al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(i)], "Wait");
         al::startAction(mLayoutArray[calcPartsIndex(i)], "Active", "State");
     }
 
@@ -111,12 +111,12 @@ void MenuSelectParts::appear(s32 menuItemAmount) {
 void MenuSelectParts::startActionPartsIllustSelectIndex() {}
 
 void MenuSelectParts::appearWait() {
-    al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select", nullptr);
+    al::startFreezeActionEnd(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select");
     al::setNerve(this, &NrvMenuSelectParts.Select);
 }
 
 void MenuSelectParts::setSelectMessage(s32 index, const char16* message) {
-    al::setPaneString(mLayoutArray[calcPartsIndex(index)], "TxtContent", message, 0);
+    al::setPaneString(mLayoutArray[calcPartsIndex(index)], "TxtContent", message);
 }
 
 bool MenuSelectParts::isDecideContinue() const {
@@ -193,17 +193,17 @@ void MenuSelectParts::exeHide() {}
 void MenuSelectParts::exeAppear() {
     if (al::isFirstStep(this)) {
         setCursorPaneTrans(mCursorActor, mLayoutArray[calcPartsIndex(mCursorItemIndex)]);
-        al::startAction(mCursorActor, "Appear", nullptr);
+        al::startAction(mCursorActor, "Appear");
         startActionMarioSelectIndex();
         for (s32 i = 0; i < mMenuItemAmount; i++) {
             if (i == mCursorItemIndex)
                 continue;
-            al::startAction(mLayoutArray[calcPartsIndex(i)], "Wait", nullptr);
+            al::startAction(mLayoutArray[calcPartsIndex(i)], "Wait");
         }
     }
     setCursorPaneTrans(mCursorActor, mLayoutArray[calcPartsIndex(mCursorItemIndex)]);
 
-    if (al::isActionEnd(mCursorActor, nullptr))
+    if (al::isActionEnd(mCursorActor))
         al::setNerve(this, &NrvMenuSelectParts.Select);
 }
 
@@ -233,7 +233,7 @@ void MenuSelectParts::startActionMarioSelectIndex() {
 void MenuSelectParts::exeSelect() {
     if (al::isFirstStep(this)) {
         if (al::isNerve(this, &NrvMenuSelectParts.Select))
-            al::startAction(mCursorActor, "Wait", nullptr);
+            al::startAction(mCursorActor, "Wait");
         mKeyRepeatCtrl->reset();
     }
 
@@ -242,7 +242,7 @@ void MenuSelectParts::exeSelect() {
     if (mKeyRepeatCtrl->isUp() || mKeyRepeatCtrl->isDown()) {
         s32 direction = mKeyRepeatCtrl->isUp() ? -1 : 1;
 
-        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Wait", nullptr);
+        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Wait");
         mCursorItemIndex =
             al::modi(mCursorItemIndex + direction + mMenuItemAmount, mMenuItemAmount);
 
@@ -255,25 +255,25 @@ void MenuSelectParts::exeSelect() {
         alPadRumbleFunction::startPadRumbleNo3DWithParam(
             alPadRumbleFunction::getPadRumbleDirector(mLayoutActor), "240Hz単発", param, -1);
 
-        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select", nullptr);
+        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select");
         startActionMarioSelectIndex();
     }
 
     if (rs::isTriggerUiCancel(mLayoutActor) || rs::isTriggerUiPause(mLayoutActor)) {
         if (mIsMainMenu)
             return;
-        al::startAction(mLayoutArray[sPauseMenuParts[mCursorItemIndex]], "Wait", nullptr);
+        al::startAction(mLayoutArray[sPauseMenuParts[mCursorItemIndex]], "Wait");
         startActionMario(mMarioActor, "PauseMenuContinue");
         if (mCursorItemIndex != mDefaultIndex)
             mCursorItemIndex = mDefaultIndex;
-        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select", nullptr);
+        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Select");
         setCursorPaneTrans(mCursorActor, mLayoutArray[calcPartsIndex(mCursorItemIndex)]);
-        al::startHitReaction(mLayoutActor, "キャンセル", nullptr);
+        al::startHitReaction(mLayoutActor, "キャンセル");
         al::setNerve(this, &NrvMenuSelectParts.DecideParts);
     } else {
         setCursorPaneTrans(mCursorActor, mLayoutArray[calcPartsIndex(mCursorItemIndex)]);
         if (rs::isTriggerUiDecide(mLayoutActor)) {
-            al::startHitReaction(mLayoutActor, "決定", nullptr);
+            al::startHitReaction(mLayoutActor, "決定");
             al::setNerve(this, &NrvMenuSelectParts.DecideParts);
         }
     }
@@ -291,7 +291,7 @@ void MenuSelectParts::startActionMario(al::LiveActor* marioActor, const char* ac
 
 void MenuSelectParts::exeDecideParts() {
     if (al::isFirstStep(this)) {
-        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Decide", nullptr);
+        al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Decide");
 
         if (calcPartsIndex(mCursorItemIndex) == Selection::Continue)
             startActionMario(mMarioActor, "PauseMenuContinueEnd");
@@ -299,12 +299,12 @@ void MenuSelectParts::exeDecideParts() {
             al::setNerve(this, &NrvMenuSelectParts.SelectSecond);
             return;
         }
-        al::startAction(mCursorActor, "End", nullptr);
+        al::startAction(mCursorActor, "End");
     }
 
-    if (al::isActionEnd(mLayoutArray[calcPartsIndex(mCursorItemIndex)], nullptr) &&
-        al::isActionEnd(mCursorActor, nullptr)) {
-        al::startAction(mCursorActor, "Hide", nullptr);
+    if (al::isActionEnd(mLayoutArray[calcPartsIndex(mCursorItemIndex)]) &&
+        al::isActionEnd(mCursorActor)) {
+        al::startAction(mCursorActor, "Hide");
         al::setNerve(this, &NrvMenuSelectParts.DecideInterval);
     }
 }

--- a/src/Layout/MiniGameCueLayout.cpp
+++ b/src/Layout/MiniGameCueLayout.cpp
@@ -15,39 +15,39 @@ NERVES_MAKE_NOSTRUCT(MiniGameCueLayout, Wait, Appear);
 
 MiniGameCueLayout::MiniGameCueLayout(const char* name, const al::LayoutInitInfo& info)
     : al::LayoutActor(name) {
-    al::initLayoutActor(this, info, "MiniGameCue", nullptr);
-    initNerve(&Wait, 0);
+    al::initLayoutActor(this, info, "MiniGameCue");
+    initNerve(&Wait);
     kill();
 }
 
 void MiniGameCueLayout::appearMiss() {
     al::setNerve(this, &Appear);
-    al::startAction(this, "Miss", nullptr);
+    al::startAction(this, "Miss");
     appear();
 }
 
 void MiniGameCueLayout::appearCount(s32 count) {
     al::setPaneNumberDigit1(this, "TxtCount", count, 0);
     al::setNerve(this, &Appear);
-    al::startAction(this, "Count", nullptr);
+    al::startAction(this, "Count");
     appear();
 }
 
 void MiniGameCueLayout::appearGo() {
     al::setNerve(this, &Appear);
-    al::startAction(this, "Go", nullptr);
+    al::startAction(this, "Go");
     appear();
 }
 
 void MiniGameCueLayout::appearFinish() {
     al::setNerve(this, &Appear);
-    al::startAction(this, "Finish", nullptr);
+    al::startAction(this, "Finish");
     appear();
 }
 
 void MiniGameCueLayout::exeWait() {}
 
 void MiniGameCueLayout::exeAppear() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/MiniGameLayout.cpp
+++ b/src/Layout/MiniGameLayout.cpp
@@ -19,8 +19,8 @@ NERVES_MAKE_NOSTRUCT(MiniGameLayout, Wait, End, Appear);
 
 MiniGameLayout::MiniGameLayout(const char* name, const al::LayoutInitInfo& info)
     : al::LayoutActor(name) {
-    al::initLayoutActor(this, info, "MiniGame", nullptr);
-    initNerve(&Appear, 0);
+    al::initLayoutActor(this, info, "MiniGame");
+    initNerve(&Appear);
     kill();
 }
 
@@ -36,7 +36,7 @@ void MiniGameLayout::kill() {
 
 void MiniGameLayout::startJumprope() {
     al::setPaneString(this, "TxtTitle",
-                      al::getSystemMessageString(this, "MiniGame", "TitleJumprope"), 0);
+                      al::getSystemMessageString(this, "MiniGame", "TitleJumprope"));
     al::startAction(this, "Jumprope", "State");
     startNewRecordWait();
     al::setNerve(this, &Appear);
@@ -45,7 +45,7 @@ void MiniGameLayout::startJumprope() {
 
 void MiniGameLayout::startRace() {
     al::setPaneString(this, "TxtTitle",
-                      al::getSystemMessageString(this, "MiniGame", "TitleRaceManRace"), 0);
+                      al::getSystemMessageString(this, "MiniGame", "TitleRaceManRace"));
     al::startAction(this, "Runrace", "State");
     startNewRecordWait();
     al::setNerve(this, &Appear);
@@ -54,7 +54,7 @@ void MiniGameLayout::startRace() {
 
 void MiniGameLayout::startVolleyball() {
     al::setPaneString(this, "TxtTitle",
-                      al::getSystemMessageString(this, "MiniGame", "TitleVolleyball"), 0);
+                      al::getSystemMessageString(this, "MiniGame", "TitleVolleyball"));
     al::startAction(this, "Volleyball", "State");
     startNewRecordWait();
     al::setNerve(this, &Appear);
@@ -68,19 +68,19 @@ void MiniGameLayout::end() {
 void MiniGameLayout::setBestCount(s32 count) {
     al::replaceMessageTagScore(
         &mScoreText, this, al::getSystemMessageString(this, "MiniGame", "Counter"), count, "Score");
-    al::setPaneString(this, "TxtBestRecord", mScoreText.cstr(), 0);
+    al::setPaneString(this, "TxtBestRecord", mScoreText.cstr());
 }
 
 void MiniGameLayout::setTodayCount(s32 count) {
     al::replaceMessageTagScore(
         &mScoreText, this, al::getSystemMessageString(this, "MiniGame", "Counter"), count, "Score");
-    al::setPaneString(this, "TxtBestRecordToday", mScoreText.cstr(), 0);
+    al::setPaneString(this, "TxtBestRecordToday", mScoreText.cstr());
 }
 
 void MiniGameLayout::setCount(s32 count) {
     al::replaceMessageTagScore(
         &mScoreText, this, al::getSystemMessageString(this, "MiniGame", "Counter"), count, "Score");
-    al::setPaneString(this, "TxtRecord", mScoreText.cstr(), 0);
+    al::setPaneString(this, "TxtRecord", mScoreText.cstr());
 }
 
 void MiniGameLayout::startNewRecord() {
@@ -101,19 +101,19 @@ bool MiniGameLayout::isEnd() const {
 
 void MiniGameLayout::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void MiniGameLayout::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void MiniGameLayout::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/PlayGuideBgm.cpp
+++ b/src/Layout/PlayGuideBgm.cpp
@@ -21,7 +21,7 @@ PlayGuideBgm::PlayGuideBgm(const char* name, const al::LayoutInitInfo& info)
     mLayout = new al::SimpleLayoutAppearWaitEnd("[シーン情報]BGM再生", "PlayGuideBgm", info,
                                                 nullptr, false);
     al::killLayoutIfActive(mLayout);
-    initNerve(&NrvPlayGuideBgm.Hide, 0);
+    initNerve(&NrvPlayGuideBgm.Hide);
     appear();
 }
 

--- a/src/Layout/PlayGuideCamera.cpp
+++ b/src/Layout/PlayGuideCamera.cpp
@@ -23,8 +23,8 @@ NERVES_MAKE_STRUCT(PlayGuideCamera, Hide, Appear, End);
 PlayGuideCamera::PlayGuideCamera(const char* name, const al::LayoutInitInfo& info,
                                  const al::LiveActor* player)
     : al::LayoutActor(name), mPlayer(player) {
-    al::initLayoutActor(this, info, "PlayGuideCamera", nullptr);
-    initNerve(&NrvPlayGuideCamera.Hide, 0);
+    al::initLayoutActor(this, info, "PlayGuideCamera");
+    initNerve(&NrvPlayGuideCamera.Hide);
     appear();
     hide();
 }
@@ -58,11 +58,11 @@ bool PlayGuideCamera::tryAppear() {
 
 void PlayGuideCamera::exeAppear() {
     if (al::isFirstStep(this)) {
-        al::startAction(this, "Appear", nullptr);
+        al::startAction(this, "Appear");
         al::showPaneRoot(this);
         mIsShown = true;
     }
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
     else if (!al::isExistCameraInputAtDisableTiming(this, 0))
         mIsShown = false;
@@ -70,7 +70,7 @@ void PlayGuideCamera::exeAppear() {
 
 void PlayGuideCamera::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 
     if (al::isGreaterEqualStep(this, 30)) {
         al::setNerve(this, &NrvPlayGuideCamera.End);
@@ -88,9 +88,9 @@ void PlayGuideCamera::exeWait() {
 
 void PlayGuideCamera::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
 
-    if (al::isActionEnd(this, nullptr)) {
+    if (al::isActionEnd(this)) {
         al::hidePaneRoot(this);
         al::setNerve(this, &NrvPlayGuideCamera.Hide);
     }

--- a/src/Layout/PlayGuideMap.cpp
+++ b/src/Layout/PlayGuideMap.cpp
@@ -21,7 +21,7 @@ PlayGuideMap::PlayGuideMap(const char* name, const al::LayoutInitInfo& info)
     mLayout = new al::SimpleLayoutAppearWaitEnd("[シーン情報]地図操作説明", "PlayGuideMap", info,
                                                 nullptr, false);
     al::killLayoutIfActive(mLayout);
-    initNerve(&NrvPlayGuideMap.Hide, 0);
+    initNerve(&NrvPlayGuideMap.Hide);
 }
 
 void PlayGuideMap::start() {

--- a/src/Layout/PlayGuideSkip.cpp
+++ b/src/Layout/PlayGuideSkip.cpp
@@ -17,9 +17,9 @@ NERVES_MAKE_NOSTRUCT(PlayGuideSkip, Appear, Wait, End);
 
 PlayGuideSkip::PlayGuideSkip(const char* name, const al::LayoutInitInfo& info)
     : al::LayoutActor(name) {
-    al::initLayoutActorLocalized(this, info, "PlayGuideSkip", nullptr);
+    al::initLayoutActorLocalized(this, info, "PlayGuideSkip");
     al::setPaneSystemMessage(this, "TxtGuide", "PlayGuideSkip", "PlayGuideDemoSkip");
-    initNerve(&Appear, 0);
+    initNerve(&Appear);
 }
 
 void PlayGuideSkip::kill() {
@@ -35,7 +35,7 @@ bool PlayGuideSkip::tryAppear() {
 }
 
 void PlayGuideSkip::appearCore() {
-    al::startAction(this, "Appear", nullptr);
+    al::startAction(this, "Appear");
     al::LayoutActor::appear();
     al::setNerve(this, &Appear);
 }
@@ -50,19 +50,19 @@ bool PlayGuideSkip::isEnableSkipDemo() const {
 }
 
 void PlayGuideSkip::exeAppear() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void PlayGuideSkip::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void PlayGuideSkip::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
+        al::startAction(this, "End");
 
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }

--- a/src/Layout/RaceCountDownLayout.cpp
+++ b/src/Layout/RaceCountDownLayout.cpp
@@ -20,14 +20,14 @@ NERVES_MAKE_NOSTRUCT(RaceCountDownLayout, Wait, CountDown, CountDownEnd, Finish,
 RaceCountDownLayout::RaceCountDownLayout(const al::LayoutInitInfo& info)
     : al::LayoutActor("[レース]カウントダウン") {
     mCountLayout = new al::LayoutActor("[レース]カウントダウン数字");
-    al::initLayoutActor(this, info, "MiniGameCue", nullptr);
-    al::initLayoutActor(mCountLayout, info, "MiniGameCount", nullptr);
-    initNerve(&Wait, 0);
+    al::initLayoutActor(this, info, "MiniGameCue");
+    al::initLayoutActor(mCountLayout, info, "MiniGameCount");
+    initNerve(&Wait);
 }
 
 void RaceCountDownLayout::startCountDown(s32 count) {
     mCount = count;
-    al::startAction(this, "Hide", nullptr);
+    al::startAction(this, "Hide");
     al::setNerve(this, &CountDown);
     appear();
 }
@@ -64,7 +64,7 @@ void RaceCountDownLayout::exeCountDown() {
 
         toggleNumberLayouts(mCountLayout, mCount);
 
-        al::startAction(mCountLayout, "Count", nullptr);
+        al::startAction(mCountLayout, "Count");
         mCountLayout->appear();
     }
 
@@ -73,7 +73,7 @@ void RaceCountDownLayout::exeCountDown() {
 
     mCount--;
 
-    al::startAction(mCountLayout, "Count", nullptr);
+    al::startAction(mCountLayout, "Count");
     toggleNumberLayouts(mCountLayout, mCount);
 
     if (mCount != 0) {
@@ -81,20 +81,20 @@ void RaceCountDownLayout::exeCountDown() {
     } else {
         al::startSe(this, "Count2");
         mCountLayout->kill();
-        al::startAction(this, "Go", nullptr);
+        al::startAction(this, "Go");
         al::setNerve(this, &CountDownEnd);
     }
 }
 
 void RaceCountDownLayout::exeCountDownEnd() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         kill();
 }
 
 void RaceCountDownLayout::exeFinish() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Finish", nullptr);
-    if (al::isActionEnd(this, nullptr) && al::isGreaterEqualStep(this, 120)) {
+        al::startAction(this, "Finish");
+    if (al::isActionEnd(this) && al::isGreaterEqualStep(this, 120)) {
         al::setNerve(this, &FinishEnd);
         kill();
     }

--- a/src/Layout/SimpleLayoutMenu.cpp
+++ b/src/Layout/SimpleLayoutMenu.cpp
@@ -23,7 +23,7 @@ SimpleLayoutMenu::SimpleLayoutMenu(const char* name, const char* layoutName,
     else
         al::initLayoutActor(this, info, layoutName, archiveName);
 
-    initNerve(&NrvHostType.Appear, 0);
+    initNerve(&NrvHostType.Appear);
 }
 
 SimpleLayoutMenu::SimpleLayoutMenu(al::LayoutActor* parent, const char* name,
@@ -31,11 +31,11 @@ SimpleLayoutMenu::SimpleLayoutMenu(al::LayoutActor* parent, const char* name,
                                    const char* archiveName)
     : al::LayoutActor(name) {
     al::initLayoutPartsActor(this, parent, info, layoutName, archiveName);
-    initNerve(&NrvHostType.Appear, 0);
+    initNerve(&NrvHostType.Appear);
 }
 
 void SimpleLayoutMenu::startAppear(const char* actionName) {
-    al::startAction(this, actionName, nullptr);
+    al::startAction(this, actionName);
     al::LayoutActor::appear();
     setNerve(this, &NrvHostType.Appear);
 }
@@ -43,24 +43,24 @@ void SimpleLayoutMenu::startAppear(const char* actionName) {
 void SimpleLayoutMenu::startEnd(const char* actionName) {
     if (al::isNerve(this, &NrvHostType.End) || isEndWait())
         return;
-    al::startAction(this, actionName, nullptr);
+    al::startAction(this, actionName);
     al::setNerve(this, &NrvHostType.End);
 }
 
 void SimpleLayoutMenu::exeAppear() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &NrvHostType.Wait);
 }
 
 void SimpleLayoutMenu::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
     if (mWaitDuration >= 0 && al::isGreaterEqualStep(this, mWaitDuration))
         al::setNerve(this, &NrvHostType.End);
 }
 
 void SimpleLayoutMenu::exeEnd() {
-    if (al::isActionEnd(this, nullptr))
+    if (al::isActionEnd(this))
         al::setNerve(this, &NrvHostType.EndWait);
 }
 

--- a/src/Layout/TestFilterGlasses.cpp
+++ b/src/Layout/TestFilterGlasses.cpp
@@ -17,7 +17,7 @@ TestFilterGlasses::TestFilterGlasses(const char* name, const al::LayoutInitInfo&
                                      const char* suffix)
     : al::LayoutActor(name) {
     al::initLayoutActor(this, info, "FilterGlasses", suffix);
-    initNerve(&Appear, 0);
+    initNerve(&Appear);
     kill();
 }
 
@@ -32,20 +32,20 @@ void TestFilterGlasses::end() {
 
 void TestFilterGlasses::exeAppear() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Appear", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
         al::setNerve(this, &Wait);
 }
 
 void TestFilterGlasses::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, "Wait", nullptr);
+        al::startAction(this, "Wait");
 }
 
 void TestFilterGlasses::exeEnd() {
     if (al::isFirstStep(this))
-        al::startAction(this, "End", nullptr);
-    if (al::isActionEnd(this, nullptr))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
         kill();
 }
 

--- a/src/Layout/WindowConfirmData.cpp
+++ b/src/Layout/WindowConfirmData.cpp
@@ -29,9 +29,9 @@ WindowConfirmData::WindowConfirmData(const al::LayoutInitInfo& info, const char*
                                      const char* name, bool createDataParts)
     : al::NerveExecutor(name) {
     mWindowConfirmLayout = new al::SimpleLayoutAppearWaitEnd("セーブデータ確認ウィンドウ",
-                                                             layoutName, info, nullptr, 0);
+                                                             layoutName, info, nullptr, false);
     mParCursor = new al::LayoutActor("カーソル");
-    al::initLayoutPartsActor(mParCursor, mWindowConfirmLayout, info, "ParCursor", nullptr);
+    al::initLayoutPartsActor(mParCursor, mWindowConfirmLayout, info, "ParCursor");
 
     mParOptions[PaneType_Confirm] = new al::LayoutActor("決定");
     al::initLayoutPartsActor(mParOptions[PaneType_Confirm], mWindowConfirmLayout, info, "ParList00",
@@ -43,25 +43,25 @@ WindowConfirmData::WindowConfirmData(const al::LayoutInitInfo& info, const char*
 
     if (createDataParts) {
         mParData = new al::LayoutActor("対象データ");
-        al::initLayoutPartsActor(mParData, mWindowConfirmLayout, info, "ParData", nullptr);
+        al::initLayoutPartsActor(mParData, mWindowConfirmLayout, info, "ParData");
     }
 
-    initNerve(&Disable, 0);
+    initNerve(&Disable);
 }
 
 void WindowConfirmData::setConfirmMessage(const char16* message, const char16* confirmMessage,
                                           const char16* cancelMessage) {
-    al::setPaneString(mWindowConfirmLayout, "TxtMessage", message, 0);
-    al::setPaneString(mParOptions[PaneType_Confirm], "TxtContent", confirmMessage, 0);
-    al::setPaneString(mParOptions[PaneType_Cancel], "TxtContent", cancelMessage, 0);
+    al::setPaneString(mWindowConfirmLayout, "TxtMessage", message);
+    al::setPaneString(mParOptions[PaneType_Confirm], "TxtContent", confirmMessage);
+    al::setPaneString(mParOptions[PaneType_Cancel], "TxtContent", cancelMessage);
 }
 
 void WindowConfirmData::setConfirmData(al::LayoutActor* actor, nn::ui2d::TextureInfo* texture) {
-    al::setPaneString(mParData, "TxtNumber", al::getPaneStringBuffer(actor, "TxtNumber"), 0);
-    al::setPaneString(mParData, "TxtWorld", al::getPaneStringBuffer(actor, "TxtWorld"), 0);
-    al::setPaneString(mParData, "TxtShine", al::getPaneStringBuffer(actor, "TxtShine"), 0);
-    al::setPaneString(mParData, "TxtDay", al::getPaneStringBuffer(actor, "TxtDay"), 0);
-    al::setPaneString(mParData, "TxtPlay", al::getPaneStringBuffer(actor, "TxtPlay"), 0);
+    al::setPaneString(mParData, "TxtNumber", al::getPaneStringBuffer(actor, "TxtNumber"));
+    al::setPaneString(mParData, "TxtWorld", al::getPaneStringBuffer(actor, "TxtWorld"));
+    al::setPaneString(mParData, "TxtShine", al::getPaneStringBuffer(actor, "TxtShine"));
+    al::setPaneString(mParData, "TxtDay", al::getPaneStringBuffer(actor, "TxtDay"));
+    al::setPaneString(mParData, "TxtPlay", al::getPaneStringBuffer(actor, "TxtPlay"));
     al::setPaneTexture(mParData, "PicDummy", texture);
 
     al::startAction(mParData, al::getActionName(actor, "State"), "State");
@@ -77,7 +77,7 @@ void WindowConfirmData::updateConfirmDataDate() {
 
     al::WStringTmp<128> dateStr(u"---");
     al::replaceMessageTagTimeDirectDateDetail(&dateStr, mWindowConfirmLayout, replaceTimeInfo);
-    al::setPaneString(mParData, "TxtDay", dateStr.cstr(), 0);
+    al::setPaneString(mParData, "TxtDay", dateStr.cstr());
 }
 
 void WindowConfirmData::appear() {
@@ -103,16 +103,16 @@ bool WindowConfirmData::isEndSelect() {
     if (!al::isNerve(this, &Select))
         return false;
 
-    if (!al::isActionPlaying(mParCursor, "End", nullptr))
+    if (!al::isActionPlaying(mParCursor, "End"))
         return false;
 
-    if (!al::isActionEnd(mParCursor, nullptr))
+    if (!al::isActionEnd(mParCursor))
         return false;
 
-    if (!al::isActionPlaying(mParOptions[mSelectionIndex], "Decide", nullptr))
+    if (!al::isActionPlaying(mParOptions[mSelectionIndex], "Decide"))
         return false;
 
-    if (!al::isActionEnd(mParOptions[mSelectionIndex], nullptr))
+    if (!al::isActionEnd(mParOptions[mSelectionIndex]))
         return false;
 
     return true;
@@ -133,7 +133,7 @@ bool WindowConfirmData::isDisable() {
 void WindowConfirmData::exeAppear() {
     if (al::isFirstStep(this)) {
         mWindowConfirmLayout->appear();
-        al::startAction(mParCursor, "Hide", nullptr);
+        al::startAction(mParCursor, "Hide");
         changeSelectingIdx(mSelectionIndex);
     }
     if (mWindowConfirmLayout->isWait())
@@ -151,11 +151,11 @@ void WindowConfirmData::changeSelectingIdx(s32 index) {
 void WindowConfirmData::exeWait() {
     if (al::isFirstStep(this)) {
         updateCursorPos();
-        al::startAction(mParCursor, "Appear", nullptr);
+        al::startAction(mParCursor, "Appear");
     }
 
-    if (al::isActionPlaying(mParCursor, "Appear", nullptr) && al::isActionEnd(mParCursor, nullptr))
-        al::startAction(mParCursor, "Wait", nullptr);
+    if (al::isActionPlaying(mParCursor, "Appear") && al::isActionEnd(mParCursor))
+        al::startAction(mParCursor, "Wait");
 
     updateCursorPos();
 
@@ -174,17 +174,17 @@ void WindowConfirmData::exeWait() {
     }
 
     if (rs::isTriggerUiDecide(mWindowConfirmLayout)) {
-        al::startHitReaction(mWindowConfirmLayout, "決定", nullptr);
+        al::startHitReaction(mWindowConfirmLayout, "決定");
         al::setNerve(this, &Select);
         return;
     }
 
     if (rs::isTriggerUiCancel(mWindowConfirmLayout)) {
-        al::startHitReaction(mWindowConfirmLayout, "キャンセル", nullptr);
+        al::startHitReaction(mWindowConfirmLayout, "キャンセル");
 
         if (mSelectionIndex != PaneType_Cancel) {
-            al::startAction(mParOptions[PaneType_Confirm], "Wait", nullptr);
-            al::startAction(mParOptions[PaneType_Cancel], "Select", nullptr);
+            al::startAction(mParOptions[PaneType_Confirm], "Wait");
+            al::startAction(mParOptions[PaneType_Cancel], "Select");
             mSelectionIndex = PaneType_Cancel;
             updateCursorPos();
         }
@@ -204,8 +204,8 @@ void WindowConfirmData::updateCursorPos() {
 
 void WindowConfirmData::exeSelect() {
     if (al::isFirstStep(this)) {
-        al::startAction(mParCursor, "End", nullptr);
-        al::startAction(mParOptions[mSelectionIndex], "Decide", nullptr);
+        al::startAction(mParCursor, "End");
+        al::startAction(mParOptions[mSelectionIndex], "Decide");
     }
 }
 

--- a/src/Scene/StageSceneStateStartSeparatePlay.cpp
+++ b/src/Scene/StageSceneStateStartSeparatePlay.cpp
@@ -105,7 +105,7 @@ void StageSceneStateStartSeparatePlay::exeFadeOut() {
     if (al::isFirstStep(this)) {
         mWipeSimple->startClose(60);
         al::startSe(mControllerGuideMulti, "Decide");
-        al::startAction(mControllerGuideMulti, "Decide", nullptr);
+        al::startAction(mControllerGuideMulti, "Decide");
     }
     if (mWipeSimple->isCloseEnd())
         al::setNerve(this, &Applet);


### PR DESCRIPTION
Adds a default `nullptr` argument to the paneName in all of the layout functions.
Also gives al::LayoutActor::initNerve's `maxStates` argument a default parameter of 0.
Also makes it so you don't have to supply `nullptr` for the suffix when creating layout actors.
`setPaneString`'s last argument also accepts a default param of 0 now.

These changes should be reflected for `LiveActor`s as well but not in this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/528)
<!-- Reviewable:end -->
