### PR TITLE
all: Replace intances of mtx.getBase(vec, n) with mtx.getBase(n)

### DIFF
--- a/lib/al/Library/LiveActor/ActorActionFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorActionFunction.cpp
@@ -251,8 +251,7 @@ void startHitReactionHitEffect(const LiveActor* actor, const char* name,
 void startHitReactionHitEffect(const LiveActor* actor, const char* name,
                                const sead::Matrix34f* mtx) {
     if (actor->getHitReactionKeeper()) {
-        sead::Vector3f pos;
-        mtx->getBase(pos, 3);
+        sead::Vector3f pos = mtx->getBase(3);
 
         // copying around again to force more compact stp codegen
         sead::Vector3f x;

--- a/lib/al/Library/LiveActor/ActorPoseUtil.cpp
+++ b/lib/al/Library/LiveActor/ActorPoseUtil.cpp
@@ -49,11 +49,8 @@ void calcAnimFrontGravityPos(LiveActor* actor, const sead::Vector3f& front) {
         const sead::Matrix34f* mtx = actor->getBaseMtx();
         sead::Vector3f side;
         side.setCross(front, up);
-        if (isNearZero(side)) {
-            sead::Vector3f side;
-            mtx->getBase(side, 0);
-            up.setCross(front, side);
-        }
+        if (isNearZero(side))
+            up.setCross(front, mtx->getBase(0));
     }
 
     sead::Matrix34f mtx;

--- a/lib/al/Library/Matrix/MatrixUtil.cpp
+++ b/lib/al/Library/Matrix/MatrixUtil.cpp
@@ -269,8 +269,7 @@ bool tryNormalizeMtxScaleOrIdentity(sead::Matrix34f* outMtx, const sead::Matrix3
         return true;
     }
 
-    sead::Vector3f base;
-    mtx.getBase(base, 3);
+    sead::Vector3f base = mtx.getBase(3);
     outMtx->makeIdentity();
     outMtx->setBase(3, base);
 

--- a/src/Npc/BirdPlayerGlideCtrl.cpp
+++ b/src/Npc/BirdPlayerGlideCtrl.cpp
@@ -186,14 +186,10 @@ static bool tryCalcGlideOnNoseMtx(sead::Matrix34f* out, const al::LiveActor* act
     sead::Matrix34f mtx = sead::Matrix34f::ident;
     if (!rs::tryCalcPlayerModelNoseJointMtx(&mtx, actor))
         return false;
-    sead::Vector3f side;
-    mtx.getBase(side, 0);
-    sead::Vector3f up;
-    mtx.getBase(up, 1);
-    sead::Vector3f front;
-    mtx.getBase(front, 2);
-    sead::Vector3f pos;
-    mtx.getBase(pos, 3);
+    sead::Vector3f side = mtx.getBase(0);
+    sead::Vector3f up = mtx.getBase(1);
+    sead::Vector3f front = mtx.getBase(2);
+    sead::Vector3f pos = mtx.getBase(3);
     sead::Vector3f offset = {13, -2.5, 0};
     al::makeMtxFrontUpPos(out, front, up, pos + offset.x * side + offset.y * up + offset.z * front);
     return true;


### PR DESCRIPTION
No new implementations. Just replacing old instances with new syntax that result in cleaner code.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/533)
<!-- Reviewable:end -->
