### PR TITLE
All: Remove some compiler warnings

### DIFF
--- a/lib/al/Library/Audio/AudioDirector.h
+++ b/lib/al/Library/Audio/AudioDirector.h
@@ -18,11 +18,11 @@ class AudioMic;
 class AudioEventController;
 class AudioRequest;
 class AudioRequestKeeperSyncedBgm;
-class AudioSystemInfo;
+struct AudioSystemInfo;
 class AreaObjDirector;
 class AudioDuckingDirector;
 class AudioEffectController;
-class AudioDirectorInitInfo;
+struct AudioDirectorInitInfo;
 class PlayerHolder;
 
 class AudioDirector : public IUseAreaObj, public HioNode, public IAudioSystemPause {

--- a/lib/al/Library/Audio/AudioDirectorInitInfo.h
+++ b/lib/al/Library/Audio/AudioDirectorInitInfo.h
@@ -4,7 +4,7 @@
 #include "Library/Se/SeDirectorInitInfo.h"
 
 namespace al {
-class AudioSystemInfo;
+struct AudioSystemInfo;
 class AreaObjDirector;
 class DemoDirector;
 class Sequence;

--- a/lib/al/Library/Audio/System/AudioSystemInfo.h
+++ b/lib/al/Library/Audio/System/AudioSystemInfo.h
@@ -6,19 +6,13 @@ class AudioSoundArchiveInfo;
 class BgmDataBase;
 class SeDataBase;
 
-class AudioSystemInfo {
-public:
+struct AudioSystemInfo {
     AudioSystemInfo();
 
-    SeDataBase* getSeDataBase() const { return mSeDataBase; }
-
-    BgmDataBase* getBgmDataBase() const { return mBgmDataBase; }
-
-private:
     void* _0;
-    AudioEffectDataBase* mAudioEffectDataBase;
-    AudioSoundArchiveInfo* mAudioSoundArchiveInfo;
-    SeDataBase* mSeDataBase;
-    BgmDataBase* mBgmDataBase;
+    AudioEffectDataBase* audioEffectDataBase;
+    AudioSoundArchiveInfo* audioSoundArchiveInfo;
+    SeDataBase* seDataBase;
+    BgmDataBase* bgmDataBase;
 };
 }  // namespace al

--- a/lib/al/Library/Bgm/BgmKeeper.cpp
+++ b/lib/al/Library/Bgm/BgmKeeper.cpp
@@ -12,12 +12,12 @@ namespace al {
 BgmKeeper::BgmKeeper(const AudioSystemInfo* audioInfo, BgmDirector* director, const char* string)
     : mBgmDirector(director) {
     if (string != nullptr)
-        mBgmUserInfo = alBgmFunction::tryFindBgmUserInfo(audioInfo->getBgmDataBase(), string);
+        mBgmUserInfo = alBgmFunction::tryFindBgmUserInfo(audioInfo->bgmDataBase, string);
 }
 
 BgmKeeper* BgmKeeper::create(const AudioSystemInfo* audioInfo, BgmDirector* director,
                              const char* string) {
-    if (!audioInfo->getSeDataBase())
+    if (!audioInfo->seDataBase)
         return nullptr;
     return new BgmKeeper(audioInfo, director, string);
 }

--- a/lib/al/Library/Bgm/BgmKeeper.h
+++ b/lib/al/Library/Bgm/BgmKeeper.h
@@ -3,7 +3,7 @@
 #include <prim/seadSafeString.h>
 
 namespace al {
-class AudioSystemInfo;
+struct AudioSystemInfo;
 class BgmDirector;
 struct BgmUserInfo;
 

--- a/lib/al/Library/Clipping/ClippingActorInfo.h
+++ b/lib/al/Library/Clipping/ClippingActorInfo.h
@@ -7,7 +7,7 @@ enum ClippingRequestKeeper {};
 
 namespace al {
 class LiveActor;
-class ActorInitInfo;
+struct ActorInitInfo;
 class ClippingJudge;
 class ViewIdHolder;
 

--- a/lib/al/Library/Collision/CollisionPartsTriangle.cpp
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.cpp
@@ -211,49 +211,49 @@ const sead::Matrix34f& Triangle::getPrevBaseMtx() const {
 HitInfo::HitInfo() {}
 
 bool HitInfo::isCollisionAtFace() const {
-    return mCollisionLocation == CollisionLocation::Face;
+    return collisionLocation == CollisionLocation::Face;
 }
 
 bool HitInfo::isCollisionAtEdge() const {
-    return mCollisionLocation == CollisionLocation::Edge1 ||
-           mCollisionLocation == CollisionLocation::Edge2 ||
-           mCollisionLocation == CollisionLocation::Edge3;
+    return collisionLocation == CollisionLocation::Edge1 ||
+           collisionLocation == CollisionLocation::Edge2 ||
+           collisionLocation == CollisionLocation::Edge3;
 }
 
 bool HitInfo::isCollisionAtCorner() const {
-    return mCollisionLocation == CollisionLocation::Corner1 ||
-           mCollisionLocation == CollisionLocation::Corner2 ||
-           mCollisionLocation == CollisionLocation::Corner3;
+    return collisionLocation == CollisionLocation::Corner1 ||
+           collisionLocation == CollisionLocation::Corner2 ||
+           collisionLocation == CollisionLocation::Corner3;
 }
 
 const sead::Vector3f& HitInfo::tryGetHitEdgeNormal() const {
-    if (mCollisionLocation == CollisionLocation::Edge1)
-        return mTriangle.getEdgeNormal(0);
-    if (mCollisionLocation == CollisionLocation::Edge2)
-        return mTriangle.getEdgeNormal(1);
-    if (mCollisionLocation == CollisionLocation::Edge3)
-        return mTriangle.getEdgeNormal(2);
+    if (collisionLocation == CollisionLocation::Edge1)
+        return triangle.getEdgeNormal(0);
+    if (collisionLocation == CollisionLocation::Edge2)
+        return triangle.getEdgeNormal(1);
+    if (collisionLocation == CollisionLocation::Edge3)
+        return triangle.getEdgeNormal(2);
 
     return sead::Vector3f::zero;
 }
 
 void SphereHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
     // TODO add proper names here, once the missing names for _70 and _80 in HitInfo are found
-    if (mHitInfo->isCollisionAtFace()) {
+    if (hitInfo->isCollisionAtFace()) {
         calcFixVectorNormal(a1, a2);
         return;
     }
 
     sead::Vector3f v20;
-    v20.x = mHitInfo->_80.x - mHitInfo->mCollisionHitPos.x;
-    v20.y = mHitInfo->_80.y - mHitInfo->mCollisionHitPos.y;
-    v20.z = mHitInfo->_80.z - mHitInfo->mCollisionHitPos.z;
+    v20.x = hitInfo->_80.x - hitInfo->collisionHitPos.x;
+    v20.y = hitInfo->_80.y - hitInfo->collisionHitPos.y;
+    v20.z = hitInfo->_80.z - hitInfo->collisionHitPos.z;
     tryNormalizeOrZero(&v20);
 
     sead::Vector3f scaled_a1;
     sead::Vector3f scaled_a2;
-    f32 v13 = v20.dot(mHitInfo->mTriangle.getFaceNormal() * mHitInfo->_70);
-    f32 v12 = v20.dot(mHitInfo->mTriangle.getFaceNormal());
+    f32 v13 = v20.dot(hitInfo->triangle.getFaceNormal() * hitInfo->_70);
+    f32 v12 = v20.dot(hitInfo->triangle.getFaceNormal());
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a1, v20, v13);
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a2, v20, v12);
     *a1 = scaled_a1;
@@ -261,31 +261,31 @@ void SphereHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const 
 }
 
 void SphereHitInfo::calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const {
-    f32 unk = mHitInfo->_70;
-    a1->x = mHitInfo->mTriangle.getFaceNormal().x * unk;
-    a1->y = mHitInfo->mTriangle.getFaceNormal().y * unk;
-    a1->z = mHitInfo->mTriangle.getFaceNormal().z * unk;
+    f32 unk = hitInfo->_70;
+    a1->x = hitInfo->triangle.getFaceNormal().x * unk;
+    a1->y = hitInfo->triangle.getFaceNormal().y * unk;
+    a1->z = hitInfo->triangle.getFaceNormal().z * unk;
     if (a2)
-        a2->set(mHitInfo->mTriangle.getFaceNormal());
+        a2->set(hitInfo->triangle.getFaceNormal());
 }
 
 void DiskHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
     // TODO add proper names here, once the missing names for _70 and _80 in HitInfo are found
-    if (mHitInfo->isCollisionAtFace()) {
+    if (hitInfo->isCollisionAtFace()) {
         calcFixVectorNormal(a1, a2);
         return;
     }
 
     sead::Vector3f v20;
-    v20.x = mHitInfo->_80.x - mHitInfo->mCollisionHitPos.x;
-    v20.y = mHitInfo->_80.y - mHitInfo->mCollisionHitPos.y;
-    v20.z = mHitInfo->_80.z - mHitInfo->mCollisionHitPos.z;
+    v20.x = hitInfo->_80.x - hitInfo->collisionHitPos.x;
+    v20.y = hitInfo->_80.y - hitInfo->collisionHitPos.y;
+    v20.z = hitInfo->_80.z - hitInfo->collisionHitPos.z;
     tryNormalizeOrZero(&v20);
 
     sead::Vector3f scaled_a1;
     sead::Vector3f scaled_a2;
-    f32 v13 = v20.dot(mHitInfo->mTriangle.getFaceNormal() * mHitInfo->_70);
-    f32 v12 = v20.dot(mHitInfo->mTriangle.getFaceNormal());
+    f32 v13 = v20.dot(hitInfo->triangle.getFaceNormal() * hitInfo->_70);
+    f32 v12 = v20.dot(hitInfo->triangle.getFaceNormal());
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a1, v20, v13);
     sead::Vector3CalcCommon<f32>::multScalar(scaled_a2, v20, v12);
     *a1 = scaled_a1;
@@ -293,12 +293,12 @@ void DiskHitInfo::calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const {
 }
 
 void DiskHitInfo::calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const {
-    f32 unk = mHitInfo->_70;
-    a1->x = mHitInfo->mTriangle.getFaceNormal().x * unk;
-    a1->y = mHitInfo->mTriangle.getFaceNormal().y * unk;
-    a1->z = mHitInfo->mTriangle.getFaceNormal().z * unk;
+    f32 unk = hitInfo->_70;
+    a1->x = hitInfo->triangle.getFaceNormal().x * unk;
+    a1->y = hitInfo->triangle.getFaceNormal().y * unk;
+    a1->z = hitInfo->triangle.getFaceNormal().z * unk;
     if (a2)
-        a2->set(mHitInfo->mTriangle.getFaceNormal());
+        a2->set(hitInfo->triangle.getFaceNormal());
 }
 
 }  // namespace al

--- a/lib/al/Library/Collision/CollisionPartsTriangle.h
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.h
@@ -73,8 +73,7 @@ enum class CollisionLocation : u8 {
     Corner3 = 7,
 };
 
-class HitInfo {
-public:
+struct HitInfo {
     HitInfo();
 
     bool isCollisionAtFace() const;
@@ -82,62 +81,54 @@ public:
     bool isCollisionAtCorner() const;
     const sead::Vector3f& tryGetHitEdgeNormal() const;
 
-    friend class ArrowHitInfo;
-    friend class SphereHitInfo;
-    friend class DiskHitInfo;
-
-protected:
-    Triangle mTriangle;
+    Triangle triangle;
     f32 _70 = 0.0f;
-    sead::Vector3f mCollisionHitPos = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f collisionHitPos = {0.0f, 0.0f, 0.0f};
     sead::Vector3f _80 = {0.0f, 0.0f, 0.0f};
-    sead::Vector3f mCollisionMovingReaction = {0.0f, 0.0f, 0.0f};
-    CollisionLocation mCollisionLocation = CollisionLocation::None;
+    sead::Vector3f collisionMovingReaction = {0.0f, 0.0f, 0.0f};
+    CollisionLocation collisionLocation = CollisionLocation::None;
 };
 
-class ArrowHitInfo {
-public:
-    HitInfo* operator*() { return mHitInfo.data(); }
+struct ArrowHitInfo {
+    HitInfo* operator*() { return hitInfo.data(); }
 
-    const HitInfo* operator*() const { return mHitInfo.data(); }
+    const HitInfo* operator*() const { return hitInfo.data(); }
 
-    HitInfo& operator->() { return *mHitInfo; }
+    HitInfo& operator->() { return *hitInfo; }
 
-    const HitInfo& operator->() const { return *mHitInfo; }
+    const HitInfo& operator->() const { return *hitInfo; }
 
-    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
+    sead::StorageFor<HitInfo> hitInfo{sead::ZeroInitializeTag{}};
 };
 
-class SphereHitInfo {
-public:
+struct SphereHitInfo {
     void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
     void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
 
-    HitInfo* operator*() { return mHitInfo.data(); }
+    HitInfo* operator*() { return hitInfo.data(); }
 
-    const HitInfo* operator*() const { return mHitInfo.data(); }
+    const HitInfo* operator*() const { return hitInfo.data(); }
 
-    HitInfo& operator->() { return *mHitInfo; }
+    HitInfo& operator->() { return *hitInfo; }
 
-    const HitInfo& operator->() const { return *mHitInfo; }
+    const HitInfo& operator->() const { return *hitInfo; }
 
-    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
+    sead::StorageFor<HitInfo> hitInfo{sead::ZeroInitializeTag{}};
 };
 
-class DiskHitInfo {
-public:
+struct DiskHitInfo {
     void calcFixVector(sead::Vector3f* a1, sead::Vector3f* a2) const;
     void calcFixVectorNormal(sead::Vector3f* a1, sead::Vector3f* a2) const;
 
-    HitInfo* operator*() { return mHitInfo.data(); }
+    HitInfo* operator*() { return hitInfo.data(); }
 
-    const HitInfo* operator*() const { return mHitInfo.data(); }
+    const HitInfo* operator*() const { return hitInfo.data(); }
 
-    HitInfo& operator->() { return *mHitInfo; }
+    HitInfo& operator->() { return *hitInfo; }
 
-    const HitInfo& operator->() const { return *mHitInfo; }
+    const HitInfo& operator->() const { return *hitInfo; }
 
-    sead::StorageFor<HitInfo> mHitInfo{sead::ZeroInitializeTag{}};
+    sead::StorageFor<HitInfo> hitInfo{sead::ZeroInitializeTag{}};
 };
 
 }  // namespace al

--- a/lib/al/Library/LiveActor/SubActorKeeper.h
+++ b/lib/al/Library/LiveActor/SubActorKeeper.h
@@ -67,6 +67,10 @@ public:                                                                         
         m_value ^= e;                                                                              \
         return *this;                                                                              \
     }                                                                                              \
+    CLASS& operator=(const CLASS& c) {                                                             \
+        m_value = c.m_value;                                                                       \
+        return *this;                                                                              \
+    }                                                                                              \
                                                                                                    \
 private:                                                                                           \
     s32 m_value;

--- a/lib/al/Library/Scene/DemoDirector.h
+++ b/lib/al/Library/Scene/DemoDirector.h
@@ -5,8 +5,8 @@
 #include "Library/HostIO/HioNode.h"
 
 namespace al {
+struct ActorInitInfo;
 class AddDemoInfo;
-class ActorInitInfo;
 class EffectSystem;
 class LiveActor;
 class PlacementId;

--- a/lib/al/Library/Scene/SceneUtil.h
+++ b/lib/al/Library/Scene/SceneUtil.h
@@ -16,7 +16,7 @@ class Scene;
 struct SceneInitInfo;
 class StageInfo;
 class PauseCameraCtrl;
-class AudioDirectorInitInfo;
+struct AudioDirectorInitInfo;
 class Projection;
 class LiveActor;
 class LiveActorGroup;

--- a/src/Player/CollidedShapeResult.cpp
+++ b/src/Player/CollidedShapeResult.cpp
@@ -6,15 +6,15 @@ CollidedShapeResult::CollidedShapeResult(const CollisionShapeInfoBase* shapeInfo
     : mShapeInfo(shapeInfo) {}
 
 void CollidedShapeResult::setArrowHitInfo(const al::ArrowHitInfo& arrowHitInfo) {
-    *mArrowHitInfo.mHitInfo = *arrowHitInfo.mHitInfo;
+    *mArrowHitInfo.hitInfo = *arrowHitInfo.hitInfo;
 }
 
 void CollidedShapeResult::setSphereHitInfo(const al::SphereHitInfo& sphereHitInfo) {
-    *mSphereHitInfo.mHitInfo = *sphereHitInfo.mHitInfo;
+    *mSphereHitInfo.hitInfo = *sphereHitInfo.hitInfo;
 }
 
 void CollidedShapeResult::setDiskHitInfo(const al::DiskHitInfo& diskHitInfo) {
-    *mDiskHitInfo.mHitInfo = *diskHitInfo.mHitInfo;
+    *mDiskHitInfo.hitInfo = *diskHitInfo.hitInfo;
 }
 
 bool CollidedShapeResult::isArrow() const {

--- a/src/Util/StageLayoutFunction.h
+++ b/src/Util/StageLayoutFunction.h
@@ -3,7 +3,7 @@
 #include <prim/seadSafeString.h>
 
 namespace al {
-class ActorInitInfo;
+struct ActorInitInfo;
 class IUseMessageSystem;
 class IUseSceneObjHolder;
 class LayoutActor;


### PR DESCRIPTION
In my quest to remove as much warnings as possible. This fixes a few mismatched tags that where introduced recently and a single undefined copy operator.