### PR TITLE
Player: Implement `PlayerJudgeStartRise`

### DIFF
--- a/src/Player/PlayerJudgeStartRise.cpp
+++ b/src/Player/PlayerJudgeStartRise.cpp
@@ -1,0 +1,21 @@
+#include "Player/PlayerJudgeStartRise.h"
+
+#include "Library/LiveActor/ActorPoseUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerAreaChecker.h"
+
+PlayerJudgeStartRise::PlayerJudgeStartRise(const al::LiveActor* player,
+                                           const PlayerAreaChecker* areaChecker,
+                                           const IPlayerModelChanger* modelChanger)
+    : mPlayer(player), mAreaChecker(areaChecker), mModelChanger(modelChanger) {}
+
+void PlayerJudgeStartRise::reset() {}
+
+void PlayerJudgeStartRise::update() {}
+
+bool PlayerJudgeStartRise::judge() const {
+    if (mModelChanger->is2DModel())
+        return false;
+    return mAreaChecker->isInRise(al::getTrans(mPlayer));
+}

--- a/src/Player/PlayerJudgeStartRise.h
+++ b/src/Player/PlayerJudgeStartRise.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerAreaChecker;
+class IPlayerModelChanger;
+
+class PlayerJudgeStartRise : public IJudge {
+public:
+    PlayerJudgeStartRise(const al::LiveActor* player, const PlayerAreaChecker* areaChecker,
+                         const IPlayerModelChanger* modelChanger);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerAreaChecker* mAreaChecker;
+    const IPlayerModelChanger* mModelChanger;
+};
+
+static_assert(sizeof(PlayerJudgeStartRise) == 0x20);


### PR DESCRIPTION
Another player nerve. Although its functionality is not used in game, this is fully functional and checks whether the player is currently in a `RiseArea`, and changes into the `Rise` nerve then. This nerve just moves the player up... pretty simple. Note that this is not the same as being in a `SandGeyser` - that one works through sensor messages, not areas.