### PR TITLE
CI: Trigger full-sync on `OdysseyDecompTracker` on push to master

### DIFF
--- a/.github/workflows/tracker-trigger-full-sync.yml
+++ b/.github/workflows/tracker-trigger-full-sync.yml
@@ -1,0 +1,20 @@
+name: Trigger full-sync on the tracker repo on push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  api-trigger-workflow:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Curl the api to start workflow 
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.HEADERS_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/MonsterDruide1/OdysseyDecompTracker/actions/workflows/155550252/dispatches \
+          -d '{"ref":"master"}'


### PR DESCRIPTION
This PR adds a workflow that triggers the `full-sync` workflow on `OdysseyDecompTracker` using the github api every time something is pushed to `master`. You can create a new access token/secret, but the current `HEADERS_TOKEN` secret should be enough for this workflow.

I have tested this workflow by on my testing repo and I've also tested running the curl command locally.

(I got the action id from: https://api.github.com/repos/MonsterDruide1/OdysseyDecompTracker/actions/workflows)