### PR TITLE
linter: Check for namespaces at start of the line

### DIFF
--- a/lib/al/Library/Demo/DemoFunction.h
+++ b/lib/al/Library/Demo/DemoFunction.h
@@ -9,8 +9,8 @@ class DemoActorHolder;
 class LiveActor;
 class Scene;
 
-al::AddDemoInfo* registDemoRequesterToAddDemoInfo(const LiveActor* actor,
-                                                  const ActorInitInfo& initInfo, s32 index);
+AddDemoInfo* registDemoRequesterToAddDemoInfo(const LiveActor* actor, const ActorInitInfo& initInfo,
+                                              s32 index);
 void registActorToDemoInfo(LiveActor* actor, const ActorInitInfo& initInfo);
 void addDemoActorFromAddDemoInfo(const LiveActor* actor, const AddDemoInfo* info);
 void addDemoActorFromDemoActorHolder(const LiveActor* actor, const DemoActorHolder* holder);

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -75,7 +75,7 @@ def common_no_namespace_qualifiers(c, path):
                 del nest_level[-1]
                 continue
 
-            matches = re.findall(r"[\(,\s]([^\(,\s]+::)+[^\(,\s]+", x)
+            matches = re.findall(r"([^\(,\s]+::)+[^\(,\s]+", x)
             for match in matches:
                 match = match[0:-2]
                 # examples: "sead", "al", "nn::g3d"


### PR DESCRIPTION
As noted in #561 the linter doesn't work because is searching for a namespace after a "(", coma or space. In this case is the first thing on the string which doesn't meet the requirements.

The fix is rather simple. Simply remove this limitation as I didn't see any false triggers from this change. Alternatively `[^\(,\s]` can be used instead but I prefer to keep the regex as minimum as possible.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/563)
<!-- Reviewable:end -->
