### PR TITLE
Library/Audio: Fix `AudioDirector` members

### DIFF
--- a/lib/al/Library/Audio/AudioDirector.h
+++ b/lib/al/Library/Audio/AudioDirector.h
@@ -55,6 +55,10 @@ public:
     void pauseSystem(bool, const char*, bool, f32, bool, bool, bool) override;
     AreaObjDirector* getAreaObjDirector() const override;
 
+    void setIsSafeFinalizingInParallelThread(bool isSafe) {
+        mIsSafeFinalizingInParallelThread = isSafe;
+    }
+
 private:
     SeDirector* mSeDirector;
     BgmDirector* mBgmDirector;
@@ -64,7 +68,8 @@ private:
     const AudioSystemInfo* mAudioSystemInfo;
     AreaObjDirector* mAreaObjDirector;
     AudioDuckingDirector* mAudioDuckingDirector;
-    sead::PtrArray<PauseSystemEntry> mPauseSystemEntries;
+    sead::PtrArray<PauseSystemEntry>* mPauseSystemEntries;
+    bool mIsSafeFinalizingInParallelThread;
     aal::AudioFrameProcessMgr* mAudioFrameProcessMgr;
     AudioEffectController* mAudioEffectController;
 };


### PR DESCRIPTION
Simple fix but important one. Required by `SceneUtil`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/597)
<!-- Reviewable:end -->
