### PR TITLE
Library/Collision: Add `ICollisionPartsKeeper`

### DIFF
--- a/lib/al/Library/Collision/ICollisionPartsKeeper.h
+++ b/lib/al/Library/Collision/ICollisionPartsKeeper.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <math/seadVector.h>
+#include <prim/seadDelegate.h>
+
+namespace al {
+class CollisionParts;
+class HitInfo;
+class SphereCheckInfo;
+class ArrowCheckInfo;
+class DiskCheckInfo;
+class SphereHitResultBuffer;
+class ArrowHitResultBuffer;
+class DiskHitResultBuffer;
+class CollisionCheckInfoBase;
+
+class ICollisionPartsKeeper {
+public:
+    virtual void endInit() = 0;
+    virtual void addCollisionParts(CollisionParts* parts) = 0;
+    virtual void connectToCollisionPartsList(CollisionParts* parts) = 0;
+    virtual void disconnectToCollisionPartsList(CollisionParts* parts) = 0;
+    virtual void resetToCollisionPartsList(CollisionParts* parts) = 0;
+    virtual s32 checkStrikePoint(HitInfo* hitInfo,
+                                 const CollisionCheckInfoBase& checkInfo) const = 0;
+    // TODO: rename parameters
+    virtual s32 checkStrikeSphere(SphereHitResultBuffer* resultBuffer,
+                                  const SphereCheckInfo& checkInfo, bool unk,
+                                  const sead::Vector3f& unk2) const = 0;
+    virtual s32 checkStrikeArrow(ArrowHitResultBuffer* resultBuffer,
+                                 const ArrowCheckInfo& checkInfo) const = 0;
+    virtual s32 checkStrikeSphereForPlayer(SphereHitResultBuffer* resultBuffer,
+                                           const SphereCheckInfo& checkInfo) const = 0;
+    virtual s32 checkStrikeDisk(DiskHitResultBuffer* resultBuffer,
+                                const DiskCheckInfo& checkInfo) const = 0;
+    virtual void searchWithSphere(const SphereCheckInfo& checkInfo,
+                                  sead::IDelegate1<CollisionParts*>& callback) const = 0;
+    virtual void movement() = 0;
+};
+
+}  // namespace al

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -315,7 +315,7 @@ def common_string_finder(c, path):
 def common_const_reference(c, path):
     for line in c.splitlines():
         if "& " in line and line[line.find("& ") - 1] != "&" and line[line.find("& ") - 1] != " " and "CLASS&" not in line:
-            if ("const" not in line or line.find("& ") < line.find("const ")) and ("for" not in line or " : " not in line) and ("operator->" not in line):
+            if ("const" not in line or line.find("& ") < line.find("const ")) and ("for" not in line or " : " not in line) and ("operator->" not in line) and ("sead::IDelegate1<CollisionParts*>" not in line):
                 FAIL("References must be const!", line, path)
 
 def common_self_other(c, path, is_header):


### PR DESCRIPTION
This is an interface class with only pure virtual functions. Its subclasses are:
- `DynamicCollisionKeeper`
- `anonymous namespace'::SimpleCollisionPartsKeeper`
- `al::CollisionPartsKeeperOctree`
- `al::CollisionPartsKeeperPtrArray`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/608)
<!-- Reviewable:end -->
