### PR TITLE
Library/System: Implement `SystemKit`

### DIFF
--- a/lib/al/Library/System/SystemKit.cpp
+++ b/lib/al/Library/System/SystemKit.cpp
@@ -1,0 +1,57 @@
+#include "Library/System/SystemKit.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Project/File/FileLoader.h"
+#include "Project/Memory/MemorySystem.h"
+#include "Project/Resource/ResourceSystem.h"
+#include "Project/SaveData/SaveDataDirector.h"
+#include "resource/seadParallelSZSDecompressor.h"
+#include "resource/seadResourceMgr.h"
+#include "resource/seadSZSDecompressor.h"
+#include "resource/seadSharcArchiveRes.h"
+
+namespace al {
+
+SystemKit::SystemKit() = default;
+
+void SystemKit::createFileLoader(s32 threadPriority) {
+    mFileLoader = new FileLoader(threadPriority);
+}
+
+void SystemKit::createMemorySystem(sead::Heap* heap) {
+    sead::ScopedCurrentHeapSetter setter(heap);
+    mMemorySystem = new MemorySystem(heap);
+}
+
+void SystemKit::createResourceSystem(const char* archivePath, s32 threadPriority,
+                                     s32 decompressDestinationSize, bool useSubCore) {
+    sead::ResourceMgr::instance()->registerFactory(
+        new sead::DirectResourceFactory<sead::SharcArchiveRes>(), "sarc");
+    sead::ResourceMgr::instance()->registerFactory(
+        new sead::DirectResourceFactory<sead::SharcArchiveRes>(), "aras");
+
+    decompressDestinationSize =
+        decompressDestinationSize >= 0 ? decompressDestinationSize : 0x400000;
+    u8* decompressDestination = new (0x20) u8[decompressDestinationSize];
+
+    sead::ResourceMgr* instance = sead::ResourceMgr::instance();
+    if (threadPriority == -1) {
+        instance->registerDecompressor(
+            new sead::SZSDecompressor(decompressDestinationSize / 2, decompressDestination), "szs");
+    } else {
+        sead::CoreId mask = useSubCore ? sead::CoreId::cSub2 : sead::CoreId::cMain;
+        instance->registerDecompressor(new sead::ParallelSZSDecompressor(
+                                           decompressDestinationSize / 2, threadPriority, nullptr,
+                                           decompressDestination, sead::CoreIdMask(mask)),
+                                       "szs");
+    }
+
+    mResourceSystem = new ResourceSystem(archivePath);
+}
+
+void SystemKit::createSaveDataSystem(u32 workBufferSize, s32 threadPriority) {
+    mSaveDataDirector = new SaveDataDirector(workBufferSize, threadPriority);
+}
+
+}  // namespace al

--- a/lib/al/Library/System/SystemKit.cpp
+++ b/lib/al/Library/System/SystemKit.cpp
@@ -1,15 +1,15 @@
 #include "Library/System/SystemKit.h"
 
 #include <heap/seadHeapMgr.h>
+#include <resource/seadParallelSZSDecompressor.h>
+#include <resource/seadResourceMgr.h>
+#include <resource/seadSZSDecompressor.h>
+#include <resource/seadSharcArchiveRes.h>
 
 #include "Project/File/FileLoader.h"
 #include "Project/Memory/MemorySystem.h"
 #include "Project/Resource/ResourceSystem.h"
 #include "Project/SaveData/SaveDataDirector.h"
-#include "resource/seadParallelSZSDecompressor.h"
-#include "resource/seadResourceMgr.h"
-#include "resource/seadSZSDecompressor.h"
-#include "resource/seadSharcArchiveRes.h"
 
 namespace al {
 

--- a/lib/al/Library/System/SystemKit.h
+++ b/lib/al/Library/System/SystemKit.h
@@ -14,8 +14,9 @@ public:
 
     void createFileLoader(s32 threadPriority);
     void createMemorySystem(sead::Heap* heap);
-    void createResourceSystem(const char* archivePath, s32, s32, bool);
-    void createSaveDataSystem();
+    void createResourceSystem(const char* archivePath, s32 threadPriority,
+                              s32 decompressDestinationSize, bool useSubCore);
+    void createSaveDataSystem(u32 workBufferSize, s32 threadPriority);
 
     MemorySystem* getMemorySystem() { return mMemorySystem; }
 
@@ -29,10 +30,10 @@ protected:
     friend class alProjectInterface;
 
 private:
-    MemorySystem* mMemorySystem;
-    FileLoader* mFileLoader;
-    ResourceSystem* mResourceSystem;
-    SaveDataDirector* mSaveDataDirector;
+    MemorySystem* mMemorySystem = nullptr;
+    FileLoader* mFileLoader = nullptr;
+    ResourceSystem* mResourceSystem = nullptr;
+    SaveDataDirector* mSaveDataDirector = nullptr;
 };
 
 static_assert(sizeof(SystemKit) == 0x20);

--- a/lib/al/Project/Resource/ResourceSystem.h
+++ b/lib/al/Project/Resource/ResourceSystem.h
@@ -15,14 +15,16 @@ public:
     ResourceSystem(const char*);
 
     const sead::SafeString& addCategory(const sead::SafeString&, s32, sead::Heap*);
-    Resource* findOrCreateResourceCategory(const sead::SafeString&, const sead::SafeString&, const char*);
+    Resource* findOrCreateResourceCategory(const sead::SafeString&, const sead::SafeString&,
+                                           const char*);
     s64 findResourceCategoryIter(const sead::SafeString&);
     bool isEmptyCategoryResource(const sead::SafeString&);
     void createCategoryResourceAll(const sead::SafeString&);
     Resource* createResource(const sead::SafeString&, ResourceCategory*, const char*);
     void removeCategory(const sead::SafeString&);
     Resource* findResource(const sead::SafeString&);
-    Resource* findResourceCore(const sead::SafeString&, sead::RingBuffer<ResourceCategory *>::iterator *);
+    Resource* findResourceCore(const sead::SafeString&,
+                               sead::RingBuffer<ResourceCategory*>::iterator*);
     Resource* findOrCreateResource(const sead::SafeString&, const char*);
     ResourceCategory* findResourceCategory(const sead::SafeString&);
     void loadCategoryArchiveAll(const sead::SafeString&);
@@ -32,9 +34,9 @@ public:
     bool tryGetGraphicsInfoIter(ByamlIter*, const sead::SafeString&) const;
 
 private:
-    void* _0[0xc8/8];
+    void* _0[0xc8 / 8];
 };
 
 static_assert(sizeof(ResourceSystem) == 0xc8);
 
-}
+}  // namespace al

--- a/lib/al/Project/Resource/ResourceSystem.h
+++ b/lib/al/Project/Resource/ResourceSystem.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <container/seadRingBuffer.h>
+#include <heap/seadHeap.h>
+#include <prim/seadSafeString.h>
+
+namespace al {
+class Resource;
+class ByamlIter;
+
+class ResourceSystem {
+public:
+    struct ResourceCategory;
+
+    ResourceSystem(const char*);
+
+    const sead::SafeString& addCategory(const sead::SafeString&, s32, sead::Heap*);
+    Resource* findOrCreateResourceCategory(const sead::SafeString&, const sead::SafeString&, const char*);
+    s64 findResourceCategoryIter(const sead::SafeString&);
+    bool isEmptyCategoryResource(const sead::SafeString&);
+    void createCategoryResourceAll(const sead::SafeString&);
+    Resource* createResource(const sead::SafeString&, ResourceCategory*, const char*);
+    void removeCategory(const sead::SafeString&);
+    Resource* findResource(const sead::SafeString&);
+    Resource* findResourceCore(const sead::SafeString&, sead::RingBuffer<ResourceCategory *>::iterator *);
+    Resource* findOrCreateResource(const sead::SafeString&, const char*);
+    ResourceCategory* findResourceCategory(const sead::SafeString&);
+    void loadCategoryArchiveAll(const sead::SafeString&);
+    void setCurrentCategory(const char*);
+    const char* findCategoryNameFromTable(const sead::SafeString&) const;
+    bool tryGetTableCategoryIter(ByamlIter*, const sead::SafeString&) const;
+    bool tryGetGraphicsInfoIter(ByamlIter*, const sead::SafeString&) const;
+
+private:
+    void* _0[0xc8/8];
+};
+
+static_assert(sizeof(ResourceSystem) == 0xc8);
+
+}

--- a/lib/al/Project/SaveData/SaveDataDirector.h
+++ b/lib/al/Project/SaveData/SaveDataDirector.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class SaveDataDirector {
+public:
+    SaveDataDirector(u32 workBufferSize, s32 threadPriority);
+
+    void threadFunc();
+    void initCheckSaveData();
+    bool requestInitSaveDir(const char*, u32, u32);
+    bool initSaveDirSync(const char*, u32, u32);
+    bool requestFormat(s32, s32);
+    bool formatSync(s32, s32);
+    bool requestRead(const char*, u32, u32);
+    bool readSync(const char*, u32, u32);
+    bool requestWrite(const char*, u32, u32, bool);
+    bool requestFlush();
+    bool writeSync(const char*, u32, u32);
+    bool updateSequence();
+    bool isDoneSequence() const;
+    u8* getWorkBuffer();
+    s32 getResult();
+
+private:
+    void* _0[0xa8/8];
+};
+
+static_assert(sizeof(SaveDataDirector) == 0xa8);
+
+}

--- a/lib/al/Project/SaveData/SaveDataDirector.h
+++ b/lib/al/Project/SaveData/SaveDataDirector.h
@@ -25,9 +25,9 @@ public:
     s32 getResult();
 
 private:
-    void* _0[0xa8/8];
+    void* _0[0xa8 / 8];
 };
 
 static_assert(sizeof(SaveDataDirector) == 0xa8);
 
-}
+}  // namespace al


### PR DESCRIPTION
Mostly straight-forward to implement - `createResourceSystem` took a few tries, especially that block about either instantiating a `SZSDecompressor` or its parallel variant - but everything is matched now.

Requires https://github.com/open-ead/sead/pull/195

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/610)
<!-- Reviewable:end -->
