### PR TITLE
MapObj: Implement `SignBoardDanger`

### DIFF
--- a/src/MapObj/CapHanger.h
+++ b/src/MapObj/CapHanger.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class CapHanger : public al::LiveActor {
+public:
+    CapHanger(const char*, bool);
+    void init(const al::ActorInitInfo& info) override;
+    void initItem(s32, s32, const al::ActorInitInfo&);
+    void switchOn();
+    void switchOff();
+    void switchKill();
+    void initAfterPlacement() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void exeWait();
+    void exeKeep();
+    void exeRelease();
+    bool isKeep(s32) const;
+    void setPeachCastleCap(const sead::Vector3f&);
+
+private:
+    void* _108;
+    void* _110;
+    s32 _118;
+    s32 _11c;
+    s32 _120;
+    void* _128;
+    bool _130;
+    void* _138;
+    void* _140;
+    sead::Matrix34f _148;
+    sead::Matrix34f _178;
+    bool _1a8;
+};
+
+static_assert(sizeof(CapHanger) == 0x1b0);

--- a/src/MapObj/SignBoardBlow.h
+++ b/src/MapObj/SignBoardBlow.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SignBoardBlow : public al::LiveActor {
+public:
+    SignBoardBlow(const char* actorName, const char* signBoardBlowName);
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void startBlow(const sead::Vector3f&);
+    void exeWait();
+    void exeBlow();
+
+private:
+    const char* mName = nullptr;
+    sead::Vector3f _110;
+};
+
+static_assert(sizeof(SignBoardBlow) == 0x120);

--- a/src/MapObj/SignBoardDanger.cpp
+++ b/src/MapObj/SignBoardDanger.cpp
@@ -1,0 +1,201 @@
+#include "MapObj/SignBoardDanger.h"
+
+#include "Library/Controller/PadRumbleFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "MapObj/CapHanger.h"
+#include "MapObj/SignBoardBlow.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(SignBoardDanger, Wait);
+NERVE_IMPL(SignBoardDanger, Reaction);
+NERVE_IMPL(SignBoardDanger, Dead);
+
+NERVES_MAKE_STRUCT(SignBoardDanger, Wait, Dead, Reaction);
+}  // namespace
+
+SignBoardDanger::SignBoardDanger(const char* name) : al::LiveActor(name) {}
+
+// Mismatch: https://decomp.me/scratch/mqOky
+void SignBoardDanger::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+
+    sead::Vector3f upDir;
+    al::calcUpDir(&upDir, this);
+
+    sead::Vector3f trans;
+    al::getTrans(&trans, info);
+
+    mSignBoardBlow = new SignBoardBlow("壊れモデル", "SignBoardDangerBreak");
+
+    al::initCreateActorNoPlacementInfo(mSignBoardBlow, info);
+
+    mYRotation = al::getRotate(this).y;
+
+    al::initNerve(this, &NrvSignBoardDanger.Wait, 0);
+
+    makeActorAlive();
+
+    // Mismatch starts here
+    sead::Vector3f upDir2;
+    sead::Vector3f rightDir;
+    sead::Vector3f frontDir;
+    al::calcUpDir(&upDir2, this);
+    al::calcRightDir(&rightDir, this);
+    al::calcFrontDir(&frontDir, this);
+    al::getTrans(this);
+
+    f32 rotation = mYRotation;
+    al::calcUpDir(&upDir2, this);
+    al::calcRightDir(&rightDir, this);
+    al::calcFrontDir(&frontDir, this);
+    sead::Vector3f trans2 = al::getTrans(this);
+
+    sead::Quatf yDegree;
+    sead::Quatf zDegree;
+    al::makeQuatYDegree(&yDegree, rotation);
+    al::makeQuatZDegree(&zDegree, -18.0f);
+
+    sead::Vector3f baap = trans2 + 315.0f * upDir2 + -69.0f * rightDir + 0.0f * frontDir;
+
+    sead::Quatf quat = zDegree * yDegree;
+    // Mismatch ends here
+
+    mCapHanger = new CapHanger("CapHanger", false);
+    al::initCreateActorNoPlacementInfo(mCapHanger, info);
+    al::setTrans(mCapHanger, baap);
+    al::setQuat(mCapHanger, quat);
+    s32 itemType = rs::getItemType(info);
+    if (itemType != -1)
+        mCapHanger->initItem(itemType, 1, info);
+    mCapHanger->makeActorAlive();
+}
+
+bool SignBoardDanger::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    if (al::isNerve(this, &NrvSignBoardDanger.Dead)) {
+        if (rs::isMsgPlayerDisregardHomingAttack(msg) ||
+            rs::isMsgPlayerDisregardTargetMarker(msg) || al::isMsgPlayerDisregard(msg)) {
+            return true;
+        }
+
+        if (al::isSensorName(self, "Cap") && !al::isSensorCollision(other))
+            _114 = _114 < 7 ? 6 : _114;
+
+        return false;
+    }
+
+    if (rs::isMsgPlayerDisregardHomingAttack(msg) || rs::isMsgPlayerDisregardTargetMarker(msg))
+        return true;
+
+    if (rs::isMsgBreakSignBoard(msg)) {
+        SignBoardBlow* signBlow = mSignBoardBlow;
+        sead::Vector3f upDir = sead::Vector3f::ey;
+        sead::Vector3f rightDir;
+        sead::Vector3f frontDir;
+        al::calcRightDir(&rightDir, this);
+        al::calcFrontDir(&frontDir, this);
+
+        sead::Vector3f resetPos =
+            al::getTrans(this) + 30.0f * rightDir + 200.0f * upDir + 0.0f * frontDir;
+        al::resetPosition(signBlow, resetPos);
+
+        al::setRotateY(signBlow, al::getRotate(this).y);
+        alPadRumbleFunction::startPadRumble(this, "破壊汎用（小）", 1000.0f, 3000.0f, -1);
+        signBlow->startBlow(al::getActorTrans(other));
+
+        al::LiveActor* subactor = al::getSubActor(this, "残骸モデル");
+        subactor->appear();
+        al::resetPosition(subactor, al::getTrans(this));
+
+        mCapHanger->kill();
+        al::setNerve(this, &NrvSignBoardDanger.Dead);
+        return true;
+    }
+
+    if (!al::isSensorCollision(self))
+        return false;
+
+    if (!rs::isMsgCapReflectCollide(msg) ||
+        (!al::isNerve(this, &NrvSignBoardDanger.Wait) &&
+         (!al::isNerve(this, &NrvSignBoardDanger.Reaction) || !al::isGreaterEqualStep(this, 30)))) {
+        return false;
+    }
+
+    rs::requestHitReactionToAttacker(msg, self, other);
+    al::setNerve(this, &NrvSignBoardDanger.Reaction);
+    return true;
+}
+
+bool SignBoardDanger::isCanStartReaction() {
+    if (!al::isNerve(this, &NrvSignBoardDanger.Wait)) {
+        if (al::isNerve(this, &NrvSignBoardDanger.Reaction))
+            return al::isGreaterEqualStep(this, 30);
+        return false;
+    }
+    return true;
+}
+
+void SignBoardDanger::attackSensor(al::HitSensor* other, al::HitSensor* self) {
+    if (al::isNerve(this, &NrvSignBoardDanger.Dead) && (u32)_114 < 5 &&
+        al::isSensorName(other, "Cap")) {
+        al::sendMsgPush(self, other);
+    }
+}
+
+void SignBoardDanger::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Wait");
+        al::setRotateY(this, mYRotation);
+    }
+}
+
+void SignBoardDanger::exeReaction() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Reaction");
+        return;
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvSignBoardDanger.Wait);
+}
+
+void SignBoardDanger::exeDead() {
+    if (!al::isFirstStep(this)) {
+        _114--;
+        if (_114 < 1) {
+            al::setRotateY(this, mYRotation);
+            al::showModel(this);
+            al::validateClipping(this);
+            al::validateHitSensors(this);
+            al::validateCollisionParts(this);
+            al::setNerve(this, &NrvSignBoardDanger.Wait);
+            al::startHitReaction(this, "出現");
+            al::getSubActor(this, "残骸モデル")->kill();
+            mCapHanger->appear();
+            _114 = 0;
+        }
+        return;
+    }
+
+    al::hideModel(this);
+    al::invalidateClipping(this);
+    al::invalidateHitSensors(this);
+    al::validateHitSensor(this, "Cap");
+    al::invalidateCollisionParts(this);
+    _114 = 179;
+}

--- a/src/MapObj/SignBoardDanger.h
+++ b/src/MapObj/SignBoardDanger.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+class CapHanger;
+class SignBoardBlow;
+
+class SignBoardDanger : public al::LiveActor {
+public:
+    SignBoardDanger(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool isCanStartReaction();
+    void attackSensor(al::HitSensor* other, al::HitSensor* self) override;
+    void exeWait();
+    void exeReaction();
+    void exeDead();
+
+private:
+    SignBoardBlow* mSignBoardBlow = nullptr;
+    f32 mYRotation = 0.0f;
+    s32 _114 = 0;
+    CapHanger* mCapHanger = nullptr;
+};
+
+static_assert(sizeof(SignBoardDanger) == 0x120);


### PR DESCRIPTION
Likely the skull signs strewn about some areas with hazards. The one in particular I can remember is the one in the Moe-Eye subarea in Sand.

`SignBoardDanger` has a mismatch: https://decomp.me/scratch/mqOky
It's a bit weird it has a bunch of useless calls, so there's possibly some inlining going on.