### PR TITLE
all: Fix all compiler warnings

### DIFF
--- a/lib/al/Library/LiveActor/LiveActorKit.cpp
+++ b/lib/al/Library/LiveActor/LiveActorKit.cpp
@@ -48,7 +48,8 @@ LiveActorKit::~LiveActorKit() {
     }
     if (mClippingDirector) {
 #pragma clang diagnostic push
-        // in this case, mClippingDirector has the correct type, causing the destructor to be called correctly
+        // in this case, mClippingDirector has the correct type,
+        // causing the destructor to be called correctly
 #pragma clang diagnostic ignored "-Wdelete-non-virtual-dtor"
         delete mClippingDirector;
 #pragma clang diagnostic pop

--- a/lib/al/Library/LiveActor/LiveActorKit.cpp
+++ b/lib/al/Library/LiveActor/LiveActorKit.cpp
@@ -47,7 +47,11 @@ LiveActorKit::~LiveActorKit() {
         mCameraDirector = nullptr;
     }
     if (mClippingDirector) {
+#pragma clang diagnostic push
+        // in this case, mClippingDirector has the correct type, causing the destructor to be called correctly
+#pragma clang diagnostic ignored "-Wdelete-non-virtual-dtor"
         delete mClippingDirector;
+#pragma clang diagnostic pop
         mClippingDirector = nullptr;
     }
     if (mModelGroup) {

--- a/lib/al/Library/Memory/HeapUtil.cpp
+++ b/lib/al/Library/Memory/HeapUtil.cpp
@@ -76,7 +76,7 @@ bool printAllSequenceHeap() {
 }
 
 void createSceneHeap(const char* stageName, bool backwards) {
-    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
+    sead::ScopedCurrentHeapSetter heapSetter{getSequenceHeap()};
 
     SystemKit* systemKit = alProjectInterface::getSystemKit();
     bool isSceneHeapCreated = systemKit->getMemorySystem()->createSceneHeap(stageName, backwards);
@@ -89,7 +89,7 @@ void createSceneHeap(const char* stageName, bool backwards) {
 }
 
 void createSceneResourceHeap(const char* stageName) {
-    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
+    sead::ScopedCurrentHeapSetter heapSetter{getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createSceneResourceHeap(stageName,
                                                                                    false);
@@ -118,7 +118,7 @@ void destroySceneHeap(bool removeCategory) {
 }
 
 void createCourseSelectHeap() {
-    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
+    sead::ScopedCurrentHeapSetter heapSetter{getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createCourseSelectHeap();
 
@@ -133,7 +133,7 @@ void destroyCourseSelectHeap() {
 }
 
 void createWorldResourceHeap(bool useCategory) {
-    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
+    sead::ScopedCurrentHeapSetter heapSetter{getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createWorldResourceHeap();
 

--- a/lib/al/Library/Memory/HeapUtil.cpp
+++ b/lib/al/Library/Memory/HeapUtil.cpp
@@ -76,7 +76,7 @@ bool printAllSequenceHeap() {
 }
 
 void createSceneHeap(const char* stageName, bool backwards) {
-    sead::ScopedCurrentHeapSetter heapSetter = sead::ScopedCurrentHeapSetter(getSequenceHeap());
+    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
 
     SystemKit* systemKit = alProjectInterface::getSystemKit();
     bool isSceneHeapCreated = systemKit->getMemorySystem()->createSceneHeap(stageName, backwards);
@@ -89,7 +89,7 @@ void createSceneHeap(const char* stageName, bool backwards) {
 }
 
 void createSceneResourceHeap(const char* stageName) {
-    sead::ScopedCurrentHeapSetter heapSetter = sead::ScopedCurrentHeapSetter(getSequenceHeap());
+    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createSceneResourceHeap(stageName,
                                                                                    false);
@@ -118,7 +118,7 @@ void destroySceneHeap(bool removeCategory) {
 }
 
 void createCourseSelectHeap() {
-    sead::ScopedCurrentHeapSetter heapSetter = sead::ScopedCurrentHeapSetter(getSequenceHeap());
+    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createCourseSelectHeap();
 
@@ -133,7 +133,7 @@ void destroyCourseSelectHeap() {
 }
 
 void createWorldResourceHeap(bool useCategory) {
-    sead::ScopedCurrentHeapSetter heapSetter = sead::ScopedCurrentHeapSetter(getSequenceHeap());
+    sead::ScopedCurrentHeapSetter heapSetter {getSequenceHeap()};
 
     alProjectInterface::getSystemKit()->getMemorySystem()->createWorldResourceHeap();
 

--- a/lib/al/Library/Nerve/NerveSetupUtil.h
+++ b/lib/al/Library/Nerve/NerveSetupUtil.h
@@ -75,7 +75,7 @@ al::initNerveAction(this, "Hide", &NrvExampleUseCase.collector, 0);
 
 #define NERVE_HOST_TYPE_IMPL(Class, Action) NERVE_HOST_TYPE_IMPL_(Class, Action, Action)
 
-#define NERVE_MAKE(Class, Action) Class##Nrv##Action Action;
+#define NERVE_MAKE(Class, Action) [[maybe_unused]] Class##Nrv##Action Action;
 
 #define NERVES_MAKE_STRUCT(Class, ...)                                                             \
     struct {                                                                                       \

--- a/lib/al/Library/Yaml/Writer/ByamlWriterStringTable.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterStringTable.cpp
@@ -112,7 +112,7 @@ void ByamlWriterStringTable::write(sead::WriteStream* stream) const {
 }
 
 void ByamlWriterStringTable::print() const {
-    for (auto& node : mList)
+    for ([[maybe_unused]] auto& _ : mList)
         ;
 }
 

--- a/lib/al/Project/Clipping/ClippingDirector.h
+++ b/lib/al/Project/Clipping/ClippingDirector.h
@@ -22,6 +22,9 @@ class ClippingDirector : public HioNode, public IUseExecutor {
 public:
     ClippingDirector(s32 maxActors, const AreaObjDirector* areaObjDirector,
                      const PlayerHolder* playerHolder, const SceneCameraInfo* sceneCameraInfo);
+    // BUG: this destructor should have been virtual.
+    // This means that `delete clippingDirector::IUseExecutor` (or with HioNode) will cause the
+    // destructor of ClippingDirector to not be called, causing a memory leak.
     ~ClippingDirector();
 
     void endInit(const AreaObjDirector* areaObjDirector);

--- a/src/MapObj/AnagramAlphabet.cpp
+++ b/src/MapObj/AnagramAlphabet.cpp
@@ -6,7 +6,6 @@ namespace {
 NERVE_IMPL(AnagramAlphabet, Wait);
 NERVE_IMPL(AnagramAlphabet, Complete);
 
-// TODO: Remove this once this class is implemented and the nerves are used
-[[maybe_unused]]
-NERVES_MAKE_STRUCT(AnagramAlphabet, Wait, Complete);
+// TODO: Remove maybe_unused once this class is implemented and the nerves are used
+[[maybe_unused]] NERVES_MAKE_STRUCT(AnagramAlphabet, Wait, Complete);
 }  // namespace

--- a/src/MapObj/AnagramAlphabet.cpp
+++ b/src/MapObj/AnagramAlphabet.cpp
@@ -6,10 +6,7 @@ namespace {
 NERVE_IMPL(AnagramAlphabet, Wait);
 NERVE_IMPL(AnagramAlphabet, Complete);
 
+// TODO: Remove this once this class is implemented and the nerves are used
+[[maybe_unused]]
 NERVES_MAKE_STRUCT(AnagramAlphabet, Wait, Complete);
 }  // namespace
-
-// TODO: Remove this once this class is implemented and the nerves are used
-inline void dummy() {
-    (void)NrvAnagramAlphabet;
-}

--- a/src/MapObj/AnagramAlphabet.cpp
+++ b/src/MapObj/AnagramAlphabet.cpp
@@ -8,3 +8,8 @@ NERVE_IMPL(AnagramAlphabet, Complete);
 
 NERVES_MAKE_STRUCT(AnagramAlphabet, Wait, Complete);
 }  // namespace
+
+// TODO: Remove this once this class is implemented and the nerves are used
+inline void dummy() {
+    (void)NrvAnagramAlphabet;
+}

--- a/src/Sequence/HakoniwaSequence.cpp
+++ b/src/Sequence/HakoniwaSequence.cpp
@@ -18,7 +18,7 @@ void HakoniwaSequence::drawMain() const {
         buffer = info->handheldRenderBuffer;
 
     mScreenCaptureExecutor->tryCaptureAndDraw(context, buffer, 0);
-    sead::Viewport viewport = sead::Viewport(*buffer);
+    sead::Viewport viewport {*buffer};
     viewport.apply(context, *buffer);
     buffer->bind(context);
     al::setRenderBuffer(mLayoutKit, buffer);

--- a/src/Sequence/HakoniwaSequence.cpp
+++ b/src/Sequence/HakoniwaSequence.cpp
@@ -18,7 +18,7 @@ void HakoniwaSequence::drawMain() const {
         buffer = info->handheldRenderBuffer;
 
     mScreenCaptureExecutor->tryCaptureAndDraw(context, buffer, 0);
-    sead::Viewport viewport {*buffer};
+    sead::Viewport viewport{*buffer};
     viewport.apply(context, *buffer);
     buffer->bind(context);
     al::setRenderBuffer(mLayoutKit, buffer);

--- a/src/System/GameSystem.cpp
+++ b/src/System/GameSystem.cpp
@@ -5,7 +5,6 @@
 namespace {
 NERVE_IMPL(GameSystem, Play);
 
-// TODO: Remove this once this class is implemented and the nerves are used
-[[maybe_unused]]
-NERVES_MAKE_STRUCT(GameSystem, Play);
+// TODO: Remove maybe_unused once this class is implemented and the nerves are used
+[[maybe_unused]] NERVES_MAKE_STRUCT(GameSystem, Play);
 }  // namespace

--- a/src/System/GameSystem.cpp
+++ b/src/System/GameSystem.cpp
@@ -7,3 +7,8 @@ NERVE_IMPL(GameSystem, Play);
 
 NERVES_MAKE_STRUCT(GameSystem, Play);
 }  // namespace
+
+// TODO: Remove this once this class is implemented and the nerves are used
+inline void dummy() {
+    (void)NrvGameSystem;
+}

--- a/src/System/GameSystem.cpp
+++ b/src/System/GameSystem.cpp
@@ -5,10 +5,7 @@
 namespace {
 NERVE_IMPL(GameSystem, Play);
 
+// TODO: Remove this once this class is implemented and the nerves are used
+[[maybe_unused]]
 NERVES_MAKE_STRUCT(GameSystem, Play);
 }  // namespace
-
-// TODO: Remove this once this class is implemented and the nerves are used
-inline void dummy() {
-    (void)NrvGameSystem;
-}

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -232,7 +232,7 @@ def common_sead_types(c, path):
 
 def common_void_params(c, path):
     for line in c.splitlines():
-        if "(void)" in line:
+        if "(void);" in line or "(void) {" in line or "(void) const" in line:
             FAIL("Function parameters should be empty instead of \"(void)\"!", line, path)
             return
 
@@ -285,15 +285,16 @@ def common_string_finder(c, path):
     string_table = get_string_table()
 
     for line in c.splitlines():
+        line = line.split("//")[0]
         if "#include" in line:
             continue
         if "extern \"C\"" in line:
             continue
-        if "__asm__" in line:
+        if "__asm__" in line or "asm(" in line or "asm volatile(" in line:
             continue
         if "asm volatile" in line:
             continue
-        if "//" in line:
+        if "#pragma" in line:
             continue
 
         matches = re.findall(r'(u?".*?")', line)


### PR DESCRIPTION
Does exactly what it says on the cover - all warnings are either fixed if the compiler is right to complain about them, or silenced either through workarounds (unused functions referencing "unused" variables = missing code ; `#pragma`s).

https://github.com/open-ead/sead/pull/198 is also needed to fully fix everything, but is independent from this PR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/614)
<!-- Reviewable:end -->
