### PR TITLE
Player: Implement `PlayerJudgeWallHitDown`

### DIFF
--- a/src/Player/PlayerJudgeWallHitDown.cpp
+++ b/src/Player/PlayerJudgeWallHitDown.cpp
@@ -1,7 +1,9 @@
 #include "Player/PlayerJudgeWallHitDown.h"
+
 #include "Library/LiveActor/ActorPoseKeeper.h"
 #include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/Math/MathUtil.h"
+
 #include "Player/PlayerConst.h"
 #include "Player/PlayerTrigger.h"
 #include "Util/ObjUtil.h"

--- a/src/Player/PlayerJudgeWallHitDown.cpp
+++ b/src/Player/PlayerJudgeWallHitDown.cpp
@@ -1,0 +1,39 @@
+#include "Player/PlayerJudgeWallHitDown.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeWallHitDown::PlayerJudgeWallHitDown(const al::LiveActor* player,
+                                               const IUsePlayerCollision* collider,
+                                               const PlayerConst* pConst,
+                                               const PlayerTrigger* trigger)
+    : mPlayer(player), mCollider(collider), mConst(pConst), mTrigger(trigger) {}
+
+void PlayerJudgeWallHitDown::reset() {}
+
+void PlayerJudgeWallHitDown::update() {}
+
+bool PlayerJudgeWallHitDown::judge() const {
+    if (!rs::isCollidedWall(mCollider))
+        return false;
+    if (rs::isActionCodeNoActionWall(mCollider))
+        return false;
+    if (mTrigger->isOn(PlayerTrigger::ECollisionTrigger_val9))
+        return false;
+
+    const sead::Vector3f& gravity = al::getGravity(mPlayer);
+    sead::Vector3f wallNormalH = rs::getCollidedWallNormal(mCollider);
+    al::verticalizeVec(&wallNormalH, gravity, wallNormalH);
+    if (!al::tryNormalizeOrZero(&wallNormalH))
+        return false;
+
+    sead::Vector3f alongSkyFront = {0.0f, 0.0f, 0.0f};
+    if (!rs::calcAlongSkyFront(&alongSkyFront, mPlayer))
+        return false;
+
+    return al::calcAngleDegree(wallNormalH, -alongSkyFront) <= mConst->getCollisionHitDownAngleH();
+}

--- a/src/Player/PlayerJudgeWallHitDown.h
+++ b/src/Player/PlayerJudgeWallHitDown.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class IUsePlayerCollision;
+class PlayerConst;
+class PlayerTrigger;
+
+class PlayerJudgeWallHitDown : public IJudge {
+public:
+    PlayerJudgeWallHitDown(const al::LiveActor* player, const IUsePlayerCollision* collider,
+                           const PlayerConst* pConst, const PlayerTrigger* trigger);
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const IUsePlayerCollision* mCollider;
+    const PlayerConst* mConst;
+    const PlayerTrigger* mTrigger;
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -8,6 +8,8 @@ public:
     enum ECollisionTrigger : u32 {
         // used in PlayerStateHipDrop
         ECollisionTrigger_val1 = 1,
+        // used in PlayerJudgeWallHitDown
+        ECollisionTrigger_val9 = 9,
     };
 
     enum EAttackSensorTrigger : u32 {

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -45,4 +45,6 @@ bool calcSlideDir(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&)
 void moveDivingJump(al::LiveActor*, const sead::Vector3f&, f32, f32, f32, f32, f32, f32, f32, f32);
 
 void sendPlayerCollisionTouchMsg(const al::LiveActor*, al::HitSensor*, const IUsePlayerCollision*);
+
+bool calcAlongSkyFront(sead::Vector3f*, const al::LiveActor*);
 }  // namespace rs


### PR DESCRIPTION
Another relatively small player judge. This one is responsible for determining whether a specific player action leads to bumping into a wall (damage animation). All of the following checks have to succeed:
- Player must collide with a wall
- The wall must not have `NoAction` type
- PlayerCollisionTrigger value 9 must not be set (?)
- The angle between wall and opposite direction of player (away from wall) must be less than `CollisionHitDownAngleH`, which is 55° by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/616)
<!-- Reviewable:end -->
