### PR TITLE
Player: Implement `PlayerStateDamageLife`

### DIFF
--- a/src/Player/PlayerStateDamageLife.cpp
+++ b/src/Player/PlayerStateDamageLife.cpp
@@ -1,0 +1,174 @@
+#include "Player/PlayerStateDamageLife.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/IUsePlayerCeilingCheck.h"
+#include "Player/PlayerActionAirMoveControl.h"
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerFunction.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateDamageLife, Damage);
+NERVE_IMPL(PlayerStateDamageLife, Land);
+NERVE_IMPL(PlayerStateDamageLife, Dead);
+
+NERVES_MAKE_NOSTRUCT(PlayerStateDamageLife, Damage, Land, Dead);
+}  // namespace
+
+PlayerStateDamageLife::PlayerStateDamageLife(al::LiveActor* player, const PlayerConst* pConst,
+                                             const IUsePlayerCollision* collider,
+                                             const PlayerInput* input,
+                                             const IUsePlayerCeilingCheck* ceilingCheck,
+                                             PlayerAnimator* animator, PlayerTrigger* trigger)
+    : al::ActorStateBase("ダメージ", player), mConst(pConst), mCollider(collider),
+      mCeilingCheck(ceilingCheck), mAnimator(animator), mTrigger(trigger) {
+    mActionAirMoveControl = new PlayerActionAirMoveControl(player, pConst, input, collider, true);
+    initNerve(&Damage, 0);
+}
+
+void PlayerStateDamageLife::appear() {
+    ActorStateBase::appear();
+    mBrakeLandUpFactor = 0.0f;
+    rs::calcGroundNormalOrGravityDir(&mUp, mActor, mCollider);
+    mIsNoDamageDown = mTrigger->isOnNoDamageDown();
+
+    if (PlayerFunction::isPlayerDeadStatus(mActor)) {
+        al::setVelocityZero(mActor);
+        al::setNerve(this, &Dead);
+        return;
+    }
+
+    if (mTrigger->isOn(PlayerTrigger::EActionTrigger_val6)) {
+        al::setNerve(this, &Land);
+        return;
+    }
+
+    if (mTrigger->isOn(PlayerTrigger::EPreMovementTrigger_val2)) {
+        al::LiveActor* player = mActor;
+        const sead::Vector3f& gravity = al::getGravity(player);
+        sead::Vector3f velH = {0.0f, 0.0f, 0.0f};
+        sead::Vector3f velV = {0.0f, 0.0f, 0.0f};
+        al::separateVelocityHV(&velH, &velV, player);
+        sead::Vector3f velDirH = {0.0f, 0.0f, 0.0f};
+        if (al::tryNormalizeOrZero(&velDirH, velH))
+            velDirH.negate();
+        else
+            al::calcFrontDir(&velDirH, player);
+
+        sead::Quatf quat = sead::Quatf::unit;
+        al::makeQuatFrontUp(&quat, velDirH, -gravity);
+        al::updatePoseQuat(player, quat);
+
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+        mActionAirMoveControl->setup(1000.0f, velH.length(), 0, -velV.dot(gravity),
+                                     mConst->getGravityDamage(), 9999, 1.0f);
+        mBrakeLandUpFactor = 0.0f;
+    } else {
+        if (rs::isPlayer3D(mActor)) {
+            sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+            al::calcFrontDir(&front, mActor);
+            al::setVelocity(mActor, front * -mConst->getPushPowerDamage());
+        }
+
+        mActionAirMoveControl->setup(mConst->getJumpMoveSpeedMax(), mConst->getPushPowerDamage(), 0,
+                                     mConst->getHopPowerDamage(), mConst->getGravityDamage(), 9999,
+                                     1.0f);
+    }
+
+    al::setNerve(this, &Damage);
+}
+
+bool PlayerStateDamageLife::isLand() const {
+    return al::isNerve(this, &Land);
+}
+
+bool PlayerStateDamageLife::isEnableCancel() const {
+    return isLand() && al::isGreaterEqualStep(this, mConst->getDamageCancelFrame());
+}
+
+bool PlayerStateDamageLife::isFormSquat() const {
+    return !isDead() && !mCeilingCheck->isEnableStandUp();
+}
+
+void PlayerStateDamageLife::exeDamage() {
+    al::LiveActor* player = mActor;
+    if (al::isFirstStep(this)) {
+        if (mAnimator->isSubAnimPlaying())
+            mAnimator->endSubAnim();
+
+        if (rs::isPlayer2D(player))
+            mAnimator->startAnim("Damage");
+        else if (mIsNoDamageDown)
+            mAnimator->startAnim("NoDamageDown");
+        else
+            mAnimator->startAnim("DamageDown");
+    }
+
+    mActionAirMoveControl->update();
+    if (rs::isOnGroundLessAngle(player, mCollider, mConst->getStandAngleMin())) {
+        rs::startHitReactionLandIfLanding(player, mCollider, false);
+        rs::brakeLandVelocityGroundNormal(player, &mUp, mCollider, -al::getGravity(player),
+                                          mBrakeLandUpFactor, mConst->getGravity());
+        al::setNerve(this, &Land);
+        return;
+    }
+
+    if (rs::isPlayer2D(player) || al::isGreaterEqualStep(this, 120)) {
+        kill();
+        return;
+    }
+}
+
+void PlayerStateDamageLife::exeLand() {
+    if (al::isFirstStep(this) && rs::isPlayer3D(mActor))
+        mAnimator->startAnim("DamageLand");
+    al::LiveActor* player = mActor;
+
+    if (rs::isOnGroundLessAngle(player, mCollider, mConst->getStandAngleMin())) {
+        rs::brakeLandVelocityGroundNormal(player, &mUp, mCollider, mUp, mBrakeLandUpFactor,
+                                          mConst->getGravity());
+    } else {
+        al::tryAddVelocityLimit(player, al::getGravity(player) * mConst->getGravityAir(),
+                                mConst->getFallSpeedMax());
+    }
+
+    if (rs::isPlayer2D(player))
+        kill();
+
+    if (mAnimator->isAnimEnd())
+        kill();
+}
+
+void PlayerStateDamageLife::exeDead() {
+    if (al::isFirstStep(this)) {
+        al::LiveActor* player = mActor;
+        if (rs::isPlayer2D(player)) {
+            mAnimator->startAnim("Dead");
+        } else {
+            if (mAnimator->isSubAnimPlaying())
+                mAnimator->endSubAnim();
+
+            if (mTrigger->isOn(PlayerTrigger::ECollisionTrigger_val6))
+                mAnimator->startAnim("DeadPoison");
+            else
+                mAnimator->startAnimDead();
+
+            rs::faceToCamera(player);
+        }
+
+        rs::slerpUp(player, -al::getGravity(player), 1.0f, 0.0f);
+    }
+
+    if (mAnimator->isAnimEnd())
+        kill();
+}

--- a/src/Player/PlayerStateDamageLife.cpp
+++ b/src/Player/PlayerStateDamageLife.cpp
@@ -37,7 +37,7 @@ PlayerStateDamageLife::PlayerStateDamageLife(al::LiveActor* player, const Player
 }
 
 void PlayerStateDamageLife::appear() {
-    ActorStateBase::appear();
+    al::ActorStateBase::appear();
     mBrakeLandUpFactor = 0.0f;
     rs::calcGroundNormalOrGravityDir(&mUp, mActor, mCollider);
     mIsNoDamageDown = mTrigger->isOnNoDamageDown();

--- a/src/Player/PlayerStateDamageLife.cpp
+++ b/src/Player/PlayerStateDamageLife.cpp
@@ -123,10 +123,8 @@ void PlayerStateDamageLife::exeDamage() {
         return;
     }
 
-    if (rs::isPlayer2D(player) || al::isGreaterEqualStep(this, 120)) {
+    if (rs::isPlayer2D(player) || al::isGreaterEqualStep(this, 120))
         kill();
-        return;
-    }
 }
 
 void PlayerStateDamageLife::exeLand() {

--- a/src/Player/PlayerStateDamageLife.h
+++ b/src/Player/PlayerStateDamageLife.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class PlayerConst;
+class IUsePlayerCollision;
+class PlayerInput;
+class IUsePlayerCeilingCheck;
+class PlayerAnimator;
+class PlayerTrigger;
+class PlayerActionAirMoveControl;
+
+class PlayerStateDamageLife : public al::ActorStateBase {
+public:
+    PlayerStateDamageLife(al::LiveActor* player, const PlayerConst* pConst,
+                          const IUsePlayerCollision* collider, const PlayerInput* input,
+                          const IUsePlayerCeilingCheck* ceilingCheck, PlayerAnimator* animator,
+                          PlayerTrigger* trigger);
+    void appear() override;
+    bool isLand() const;
+    bool isEnableCancel() const;
+    bool isFormSquat() const;
+    void exeDamage();
+    void exeLand();
+    void exeDead();
+
+private:
+    const PlayerConst* mConst;
+    const IUsePlayerCollision* mCollider;
+    const IUsePlayerCeilingCheck* mCeilingCheck;
+    PlayerAnimator* mAnimator;
+    PlayerTrigger* mTrigger;
+    PlayerActionAirMoveControl* mActionAirMoveControl = nullptr;
+    sead::Vector3f mUp = sead::Vector3f::zero;
+    f32 mBrakeLandUpFactor = 0.0f;
+    bool mIsNoDamageDown = false;
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -8,6 +8,8 @@ public:
     enum ECollisionTrigger : u32 {
         // used in PlayerStateHipDrop
         ECollisionTrigger_val1 = 1,
+        // used in PlayerStateDamageLife
+        ECollisionTrigger_val6 = 6,
         // used in PlayerJudgeWallHitDown
         ECollisionTrigger_val9 = 9,
     };
@@ -20,6 +22,8 @@ public:
     enum EActionTrigger : u32 {
         // used in PlayerStateHipDrop
         EActionTrigger_val3 = 3,
+        // used in PlayerStateDamageLife
+        EActionTrigger_val6 = 6,
         // used in PlayerJudgeForceLand
         EActionTrigger_val11 = 11,
         // used in PlayerJudgeWallCatch
@@ -29,7 +33,10 @@ public:
 
     enum EReceiveSensorTrigger : u32 {};
 
-    enum EPreMovementTrigger : u32 {};
+    enum EPreMovementTrigger : u32 {
+        // used in PlayerStateDamageLife
+        EPreMovementTrigger_val2 = 2,
+    };
 
     enum EDemoEndTrigger : u32 {};
 

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -28,6 +28,13 @@ bool findGrabCeilPosWallHit(const al::CollisionParts**, sead::Vector3f*, sead::V
                             sead::Vector3f*, const al::LiveActor*, const sead::Vector3f&,
                             const sead::Vector3f&, f32, f32, f32);
 
+void brakeLandVelocityGroundNormal(al::LiveActor*, sead::Vector3f*, const IUsePlayerCollision*,
+                                   const sead::Vector3f&, f32, f32);
+
+void faceToCamera(al::LiveActor*);
+
+void slerpUp(al::LiveActor*, const sead::Vector3f&, f32, f32);
+
 void calcOffsetAllRoot(sead::Vector3f* offset, const PlayerModelHolder* model);
 
 bool convergeOnGroundCount(s32*, const al::LiveActor*, const IUsePlayerCollision*, s32, s32);

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -60,4 +60,6 @@ al::HitSensor* tryGetCollidedCeilingSensor(const IUsePlayerCollision*);
 bool isOnGroundSlopeSlideEnd(const al::LiveActor*, const IUsePlayerCollision*, const PlayerConst*);
 bool isAutoRunOnGroundSkateCode(const al::LiveActor*, const IUsePlayerCollision*, f32);
 
+void startHitReactionLandIfLanding(const al::LiveActor*, const IUsePlayerCollision*, bool);
+
 }  // namespace rs


### PR DESCRIPTION
Contrary to what the name suggests, this state does not only trigger when the player receives damage, but also when bonking into a wall - see #616 here.

Apart from that, here are some other possibly interesting facts:
- When the player is in 2D mode, this state only lasts for a single frame
- The player can be forced into a squat after damage, if the ceiling is not high enough to stand up
- The state can be canceled after landing on the ground for the first time, and waiting another `DamageCancelFrame` frames (default: 45)
- This state is usually lasts until the player falls onto the ground (=> Land) and for the duration of the `DamageLand` animation (78 frames), but as stated before, can be canceled 45 frames after landing or is automatically stopped after falling for 120 frames
- If the player leaves the ground after landing for the first time (sliding off should not be possible as horizontal momentum is immediately canceled, but the ground could retract away from under the player or similar), timers or animations are *not* reset, but the player falls with standard gravity again

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/617)
<!-- Reviewable:end -->
