### PR TITLE
Custom linter: enforce `is`/`has` prefix for inlined boolean getters

### DIFF
--- a/src/Util/ActorDimensionKeeper.h
+++ b/src/Util/ActorDimensionKeeper.h
@@ -18,15 +18,15 @@ public:
     void forceEndChange2DKeep();
     void update();
 
-    bool getIs2D() const { return mIs2D; }
+    bool is2D() const { return mIs2D; }
 
-    bool getIsIn2DArea() const { return mIsIn2DArea; }
+    bool isIn2DArea() const { return mIsIn2DArea; }
 
-    bool getIsCurrently2D() const { return mIsCurrently2D; }
+    bool isCurrently2D() const { return mIsCurrently2D; }
 
-    bool getIsCanChange2D() const { return mIsCanChange2D; }
+    bool isCanChange2D() const { return mIsCanChange2D; }
 
-    bool getIsCanChange3D() const { return mIsCanChange3D; }
+    bool isCanChange3D() const { return mIsCanChange3D; }
 
 private:
     const al::LiveActor* mActor;

--- a/src/Util/ActorDimensionUtil.cpp
+++ b/src/Util/ActorDimensionUtil.cpp
@@ -10,24 +10,24 @@ ActorDimensionKeeper* createDimensionKeeper(const al::LiveActor* actor) {
 }
 
 bool is2D(const IUseDimension* dimension) {
-    return dimension->getActorDimensionKeeper()->getIs2D();
+    return dimension->getActorDimensionKeeper()->is2D();
 }
 
 bool is3D(const IUseDimension* dimension) {
     ActorDimensionKeeper* keeper = dimension->getActorDimensionKeeper();
-    return !keeper->getIs2D() && !keeper->getIsCurrently2D();
+    return !keeper->is2D() && !keeper->isCurrently2D();
 }
 
 bool isChange2D(const IUseDimension* dimension) {
-    return dimension->getActorDimensionKeeper()->getIsCanChange2D();
+    return dimension->getActorDimensionKeeper()->isCanChange2D();
 }
 
 bool isChange3D(const IUseDimension* dimension) {
-    return dimension->getActorDimensionKeeper()->getIsCanChange3D();
+    return dimension->getActorDimensionKeeper()->isCanChange3D();
 }
 
 bool isIn2DArea(const IUseDimension* dimension) {
-    return dimension->getActorDimensionKeeper()->getIsIn2DArea();
+    return dimension->getActorDimensionKeeper()->isIn2DArea();
 }
 
 }  // namespace rs

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -461,6 +461,10 @@ def header_lowercase_member_offset_vars(c, path):
         if re.search(r"\s(field|gap|filler|pad)?_[0-9a-z]*[A-Z]", line):
             CHECK(lambda a: "#define" in a, line, "Characters in the names of offset variables need to be lowercase!", path)
 
+def header_bool_getter_name_prefix(c, path):
+    for line in c.splitlines():
+        if re.search(r"bool\s(?!(is|has|get_))\w+\(\)\s*const\s*{", line):
+            FAIL("Boolean getter names should be prefix with `is` or `has`", line, path)
 
 # Source files
 
@@ -510,6 +514,7 @@ def check_header(c, path):
     header_lowercase_member_offset_vars(c, path)
     common_self_other(c, path, True)
     common_consistent_float_literals(c, path)
+    header_bool_getter_name_prefix(c, path)
 
 def _check_file_content(content, file_str):
     if file_str.endswith('.h'):


### PR DESCRIPTION
This PR adds a linter check that requires the names of header defined boolean getters to be prefixed with `is` or `has` (or `get_` for offset named variables). Because all of the getters that needed to be renamed where in `ActorDimensionKeeper`, this PR uses #624 as a base and should wait for that PR to be merged first (although the linter check should be ready for review)

Fixes #443

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/625)
<!-- Reviewable:end -->
