### PR TITLE
All: Add decomp.me links to NON_MATCHING comments

### DIFF
--- a/lib/al/Library/Execute/ExecuteDirector.cpp
+++ b/lib/al/Library/Execute/ExecuteDirector.cpp
@@ -113,7 +113,7 @@ void ExecuteDirector::createExecutorListTable() {
         mDrawTables[i]->createExecutorListTable();
 }
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/P7VLh
 void ExecuteDirector::execute(const char* tableName) const {
     if (!tableName) {
         mRequestKeeper->executeRequestActorMovementAllOn();

--- a/lib/al/Library/LiveActor/ActorInitUtil.cpp
+++ b/lib/al/Library/LiveActor/ActorInitUtil.cpp
@@ -799,7 +799,6 @@ LiveActor* tryCreateLinksActorFromFactorySingle(const ActorInitInfo& initInfo,
     return createLinksActorFromFactory(initInfo, linkName, 0);
 }
 
-// NON_MATCHING: Same as above
 void createAndRegisterLinksActorFromFactory(LiveActorGroup* group, const ActorInitInfo& initInfo,
                                             const char* linkName) {
     ActorInitInfo childInitInfo;

--- a/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
+++ b/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
@@ -255,7 +255,7 @@ void ActorPoseKeeperTRMSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     *mtx = mMtx;
 }
 
-// NON_MATCHING: mismatch about storing mGravity
+// NON_MATCHING: mismatch about storing mGravity (https://decomp.me/scratch/EThQI)
 ActorPoseKeeperTRGMSV::ActorPoseKeeperTRGMSV() {
     mMtx = sead::Matrix34f::ident;
 }

--- a/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
+++ b/lib/al/Library/LiveActor/ActorPoseKeeper.cpp
@@ -255,7 +255,6 @@ void ActorPoseKeeperTRMSV::calcBaseMtx(sead::Matrix34f* mtx) const {
     *mtx = mMtx;
 }
 
-// NON_MATCHING: mismatch about storing mGravity (https://decomp.me/scratch/EThQI)
 ActorPoseKeeperTRGMSV::ActorPoseKeeperTRGMSV() {
     mMtx = sead::Matrix34f::ident;
 }

--- a/lib/al/Library/LiveActor/LiveActorKeeper.cpp
+++ b/lib/al/Library/LiveActor/LiveActorKeeper.cpp
@@ -28,7 +28,7 @@ void SubActorKeeper::registerSubActor(LiveActor* subActor, u32 syncType) {
     mCurActorCount++;
 }
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/9V8dS
 void SubActorKeeper::init(const ActorInitInfo& initInfo, const char* suffix, s32 maxSubActors) {
     sead::FixedSafeString<0x80> actorInitFileName;
     s32 creatorCount;

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -33,7 +33,7 @@ void CameraVerticalAbsorber::invalidate() {
         setNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute);
 }
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/Zhx9Y
 void CameraVerticalAbsorber::start(const sead::Vector3f& pos, const CameraStartInfo& info) {
     alCameraPoserFunction::calcTargetFront(&mPrevTargetFront, mCameraPoser);
 
@@ -79,7 +79,7 @@ void CameraVerticalAbsorber::load(const ByamlIter& data) {
     mAdvanceAbsorbScreenPosUp = getByamlKeyFloat(it2, "AdvanceAbsorbScreenPosUp");
 }
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/JdemU
 void CameraVerticalAbsorber::update() {
     if (mIsStopUpdate)
         return;

--- a/lib/al/Library/Rail/Rail.cpp
+++ b/lib/al/Library/Rail/Rail.cpp
@@ -9,7 +9,7 @@ namespace al {
 
 Rail::Rail() = default;
 
-// NON_MATCHING: mismatch during `mRailPart`-array creation
+// NON_MATCHING: mismatch during `mRailPart`-array creation (https://decomp.me/scratch/e80kr)
 void Rail::init(const PlacementInfo& info) {
     mIsClosed = false;
     tryGetArg(&mIsClosed, info, "IsClosed");
@@ -67,7 +67,7 @@ void Rail::calcPos(sead::Vector3f* pos, f32 distance) const {
     part->calcPos(pos, part->calcCurveParam(partDistance));
 }
 
-// NON_MATCHING: minor reorderings
+// NON_MATCHING: minor reorderings (https://decomp.me/scratch/bWw2E)
 s32 Rail::getIncludedSection(const RailPart** part, f32* partDistance, f32 distance) const {
     f32 distanceOnRail = normalizeLength(distance);
     f32 startDistanceOnRail = 0.0;
@@ -169,7 +169,7 @@ void Rail::calcNearestRailPointNo(s32* index, const sead::Vector3f& pos) const {
     }
 }
 
-// NON_MATCHING: mismatch in storing *rail_pos = tmp; (stp instead of two strs)
+// NON_MATCHING: mismatch in storing *rail_pos = tmp; (https://decomp.me/scratch/gS1CT)
 void Rail::calcNearestRailPointPos(sead::Vector3f* rail_pos, const sead::Vector3f& pos) const {
     if (mRailPointsCount == 0)
         return;
@@ -200,13 +200,13 @@ f32 Rail::normalizeLength(f32 distance) const {
     return sead::Mathf::clamp(distance, 0.0, getTotalLength());
 }
 
-// NON_MATCHING: diff issue due to bug in tools/check
+// NON_MATCHING: diff issue due to bug in tools/check (https://decomp.me/scratch/UFGsO)
 f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval) const {
     f32 tmp;
     return calcNearestRailPosCoord(pos, interval, &tmp);
 }
 
-// NON_MATCHING: diff issue due to bug in tools/check
+// NON_MATCHING: diff issue due to bug in tools/check (https://decomp.me/scratch/zJvN3)
 f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval, f32* distance) const {
     *distance = sead::Mathf::maxNumber();
     f32 bestParam = sead::Mathf::maxNumber();
@@ -230,7 +230,7 @@ f32 Rail::calcNearestRailPosCoord(const sead::Vector3f& pos, f32 interval, f32* 
     return bestParam;
 }
 
-// NON_MATCHING: diff issue due to bug in tools/check
+// NON_MATCHING: diff issue due to bug in tools/check (https://decomp.me/scratch/gRZVD)
 f32 Rail::calcNearestRailPos(sead::Vector3f* rail_pos, const sead::Vector3f& pos,
                              f32 interval) const {
     f32 coord = calcNearestRailPosCoord(pos, interval);
@@ -262,7 +262,6 @@ s32 Rail::calcRailPointNum(f32 distance1, f32 distance2) const {
            ((part2->getPartLength() - partDistance2) < 0.01f);
 }
 
-// NON_MATCHING: regalloc in length calculation
 f32 Rail::getIncludedSectionLength(f32* partDistance, f32* length, f32 distance) const {
     const RailPart* part = nullptr;
     getIncludedSection(&part, partDistance, distance);

--- a/lib/al/Library/Yaml/ByamlData.cpp
+++ b/lib/al/Library/Yaml/ByamlData.cpp
@@ -73,7 +73,8 @@ bool ByamlHashIter::getDataByIndex(ByamlData* data, s32 index) const {
     return true;
 }
 
-// NON_MATCHING: minor additional instructions, probably not inlined (https://decomp.me/scratch/5VLcG)
+// NON_MATCHING: minor additional instructions, probably not inlined
+// (https://decomp.me/scratch/5VLcG)
 bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     if (!mData)
         return false;

--- a/lib/al/Library/Yaml/ByamlData.cpp
+++ b/lib/al/Library/Yaml/ByamlData.cpp
@@ -73,7 +73,7 @@ bool ByamlHashIter::getDataByIndex(ByamlData* data, s32 index) const {
     return true;
 }
 
-// NON_MATCHING: minor additional instructions, probably not inlined
+// NON_MATCHING: minor additional instructions, probably not inlined (https://decomp.me/scratch/5VLcG)
 bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
     if (!mData)
         return false;
@@ -150,7 +150,7 @@ bool ByamlArrayIter::getDataByIndex(ByamlData* data, s32 index) const {
     return true;
 }
 
-// NON_MATCHING: regalloc
+// NON_MATCHING: regalloc (https://decomp.me/scratch/dGFdU)
 const u32* ByamlArrayIter::getDataTable() const {
     return reinterpret_cast<const u32*>(getOffsetData((getSize() + 7) & 0xFFFFFFFC));
 }

--- a/lib/al/Library/Yaml/ByamlHeader.cpp
+++ b/lib/al/Library/Yaml/ByamlHeader.cpp
@@ -59,7 +59,7 @@ u32 ByamlStringTableIter::getStringAddress(s32 idx) const {
     return getAddressTable()[idx];
 }
 
-// NON_MATCHING: regalloc
+// NON_MATCHING: regalloc (https://decomp.me/scratch/AdRVH)
 u32 ByamlStringTableIter::getEndAddress() const {
     u32 val = getAddressTable()[getSize()];
     return mIsRev ? bswap_32(val) : val;
@@ -166,7 +166,7 @@ void writeU24(sead::WriteStream* stream, s32 val) {
 }
 
 // NON_MATCHING: inlined verifiHeader, splitted loads for unswappedAfterOffset and diff in final
-// logic
+// logic (https://decomp.me/scratch/5xOvy)
 bool verifiByaml(const u8* data) {
     if (!verifiByamlHeader(data))
         return false;
@@ -208,7 +208,7 @@ bool verifiByaml(const u8* data) {
            (afterStringOffset <= rootOffset || !stringOffset || !rootOffset);
 }
 
-// NON_MATCHING: missing & 0xFFFF
+// NON_MATCHING: missing & 0xFFFF (https://decomp.me/scratch/dRP3R)
 bool verifiByamlHeader(const u8* data) {
     const al::ByamlHeader* header = reinterpret_cast<const al::ByamlHeader*>(data);
     return header->getTag() == BYAML_BE_TAG && (u32)(header->getVersion() - 1) < 3;

--- a/lib/al/Library/Yaml/ByamlIter.cpp
+++ b/lib/al/Library/Yaml/ByamlIter.cpp
@@ -41,7 +41,6 @@ bool ByamlIter::isTypeContainer() const {
     return isTypeHash() || isTypeArray();
 }
 
-// NON_MATCHING: stack allocated differently
 bool ByamlIter::isExistKey(const char* key) const {
     if (!mRootNode || *mRootNode != ByamlDataType::TYPE_HASH)
         return false;
@@ -296,7 +295,7 @@ bool ByamlIter::tryConvertInt(s32* value, const ByamlData* data) const {
     return true;
 }
 
-// NON_MATCHING: mismatch in inlined convert
+// NON_MATCHING: mismatch in inlined convert (https://decomp.me/scratch/BnTuu)
 bool ByamlIter::tryGetUIntByIndex(u32* value, s32 index) const {
     ByamlData data;
     if (!getByamlDataByIndex(&data, index))
@@ -305,7 +304,7 @@ bool ByamlIter::tryGetUIntByIndex(u32* value, s32 index) const {
     return tryConvertUInt(value, &data);
 }
 
-// NON_MATCHING: mismatch in inlined convert
+// NON_MATCHING: mismatch in inlined convert (https://decomp.me/scratch/d7Ooh)
 bool ByamlIter::tryGetUIntByKey(u32* value, const char* key) const {
     ByamlData data;
     if (!getByamlDataByKey(&data, key))

--- a/lib/al/Library/Yaml/Writer/ByamlWriter.cpp
+++ b/lib/al/Library/Yaml/Writer/ByamlWriter.cpp
@@ -320,7 +320,7 @@ u32 ByamlWriter::calcPackSize() const {
     return size;
 }
 
-// NON_MATCHING: offsetBigDataList increased "too early"
+// NON_MATCHING: offsetBigDataList increased "too early" (https://decomp.me/scratch/xXvTw)
 void ByamlWriter::write(sead::WriteStream* stream) {
     stream->writeU16(0x4259);
     stream->writeU16(3);

--- a/lib/al/Project/Item/ActorScoreKeeper.cpp
+++ b/lib/al/Project/Item/ActorScoreKeeper.cpp
@@ -5,7 +5,7 @@
 namespace al {
 ActorScoreKeeper::ActorScoreKeeper() = default;
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/twz7r
 void ActorScoreKeeper::init(const ByamlIter& iter) {
     if (iter.isTypeArray()) {
         mSize = iter.getSize();

--- a/lib/al/Project/Rail/BezierCurve.cpp
+++ b/lib/al/Project/Rail/BezierCurve.cpp
@@ -79,7 +79,7 @@ f32 BezierCurve::calcDeltaLength(f32 param) const {
     return tmp.length();
 }
 
-// NON_MATCHING: flipped parts of if in last statement and unoptimized 1.0f - load
+// NON_MATCHING: flipped parts of if in last statement and unoptimized 1.0f - load (https://decomp.me/scratch/hGwGZ)
 f32 BezierCurve::calcCurveParam(f32 distance) const {
     f32 percent = distance / mDistance;
     f32 partLength = calcLength(0, percent, 10);
@@ -139,7 +139,7 @@ f32 BezierCurve::calcNearestLength(f32* param, const sead::Vector3f& pos, f32 ma
     return bestDist;
 }
 
-// NON_MATCHING: Difference in loading for calcNearestParam
+// NON_MATCHING: Difference in loading for calcNearestParam (https://decomp.me/scratch/mFZVT)
 void BezierCurve::calcNearestPos(sead::Vector3f* nearest, const sead::Vector3f& pos,
                                  f32 interval) const {
     calcPos(nearest, calcNearestParam(pos, interval));

--- a/lib/al/Project/Rail/BezierCurve.cpp
+++ b/lib/al/Project/Rail/BezierCurve.cpp
@@ -79,7 +79,8 @@ f32 BezierCurve::calcDeltaLength(f32 param) const {
     return tmp.length();
 }
 
-// NON_MATCHING: flipped parts of if in last statement and unoptimized 1.0f - load (https://decomp.me/scratch/hGwGZ)
+// NON_MATCHING: flipped parts of if in last statement and unoptimized 1.0f - load
+// (https://decomp.me/scratch/hGwGZ)
 f32 BezierCurve::calcCurveParam(f32 distance) const {
     f32 percent = distance / mDistance;
     f32 partLength = calcLength(0, percent, 10);

--- a/lib/al/Project/Rail/LinearCurve.cpp
+++ b/lib/al/Project/Rail/LinearCurve.cpp
@@ -55,7 +55,7 @@ f32 LinearCurve::calcNearestLength(f32* length, const sead::Vector3f& pos, f32 p
     return len;
 }
 
-// NON_MATCHING: Difference in loading for calcNearestParam
+// NON_MATCHING: Difference in loading for calcNearestParam (https://decomp.me/scratch/u0H2R)
 void LinearCurve::calcNearestPos(sead::Vector3f* nearest, const sead::Vector3f& pos) const {
     calcPos(nearest, calcNearestParam(pos));
 }

--- a/src/Npc/FukuwaraiFaceParts.cpp
+++ b/src/Npc/FukuwaraiFaceParts.cpp
@@ -188,7 +188,7 @@ bool FukuwaraiFaceParts::receiveMsg(const al::SensorMsg* message, al::HitSensor*
     return false;
 }
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/bIDOJ
 f32 FukuwaraiFaceParts::calcScore(bool isMario) const {
     if (!isPlaced())
         return 0.0f;

--- a/src/Player/Player.cpp
+++ b/src/Player/Player.cpp
@@ -135,7 +135,7 @@ void Player::control() {
     }
 }
 
-// NON_MATCHING: issue with getting actorTrans
+// NON_MATCHING: issue with getting actorTrans (https://decomp.me/scratch/yXJNN)
 void Player::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     const sead::Vector3f& actorTransRef = al::getActorTrans(other);
     const sead::Vector3f& transRef = al::getTrans(this);

--- a/src/System/GameDataFile.cpp
+++ b/src/System/GameDataFile.cpp
@@ -5,7 +5,7 @@
 #include "System/GameDataFunction.h"
 #include "System/GameProgressData.h"
 
-// NON_MATCHING
+// NON_MATCHING: https://decomp.me/scratch/jv20V
 void GameDataFile::HintInfo::clear() {
     mStageName.clear();
     mObjId.clear();


### PR DESCRIPTION
This PR adds `decomp.me` links to all existing `NON_MATCHING` comments as suggested in #71. I've also removed three `NON_MATCHING` comments from matching functions. All of these `decomp.me` scratches have been auto generated by the version of the `decompme` tool from open-ead/nx-decomp-tools#31 without any modifications (although I have checked that each scratch compiles fine)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/627)
<!-- Reviewable:end -->
