### PR TITLE
Library/Execute: Implement ExecuteRequestKeeper

### DIFF
--- a/lib/al/Library/Execute/ActorExecuteInfo.h
+++ b/lib/al/Library/Execute/ActorExecuteInfo.h
@@ -15,9 +15,13 @@ public:
 
     ExecuteRequestKeeper* getRequestKeeper() const { return mRequestKeeper; }
 
-    ModelDrawerBase* getDrawer(s32 idx) const { return mDrawers[idx]; }
+    s32 getUpdaterCount() const { return mUpdaterCount; }
+
+    ExecutorActorExecuteBase* getUpdater(s32 idx) const { return mUpdaters[idx]; }
 
     s32 getDrawerCount() const { return mDrawerCount; }
+
+    ModelDrawerBase* getDrawer(s32 idx) const { return mDrawers[idx]; }
 
 private:
     ExecuteRequestKeeper* mRequestKeeper = nullptr;

--- a/lib/al/Library/Execute/ExecuteRequestKeeper.cpp
+++ b/lib/al/Library/Execute/ExecuteRequestKeeper.cpp
@@ -13,8 +13,8 @@ ExecuteRequestInfo::ExecuteRequestInfo() = default;
 ExecuteRequestTable::ExecuteRequestTable(s32 maxSize) : mMaxSize{maxSize} {
     LiveActor** actors = new LiveActor*[mMaxSize];
 
-    if (mMaxSize != 0)
-        memset(actors, 0, (s64)mMaxSize * 8);
+    for (s64 i = 0; i != mMaxSize; i++)
+        actors[i] = nullptr;
 
     mRequests = actors;
 }

--- a/lib/al/Library/Execute/ExecuteRequestKeeper.cpp
+++ b/lib/al/Library/Execute/ExecuteRequestKeeper.cpp
@@ -1,0 +1,102 @@
+#include "Library/Execute/ExecuteRequestKeeper.h"
+
+#include "Library/Execute/ActorExecuteInfo.h"
+#include "Library/Execute/ExecutorActorExecuteBase.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Model/ModelDrawerBase.h"
+#include "Library/Model/ModelKeeper.h"
+
+namespace al {
+
+ExecuteRequestInfo::ExecuteRequestInfo() = default;
+
+ExecuteRequestTable::ExecuteRequestTable(s32 maxSize) : mMaxSize{maxSize} {
+    LiveActor** actors = new LiveActor*[mMaxSize];
+
+    if (mMaxSize != 0)
+        memset(actors, 0, (s64)mMaxSize * 8);
+
+    mRequests = actors;
+}
+
+ExecuteRequestKeeper::ExecuteRequestKeeper(s32 maxSize) {
+    for (s32 i = 0; i < 4; i++)
+        mRequestTables[i] = new ExecuteRequestTable(maxSize);
+}
+
+void ExecuteRequestKeeper::executeRequestActorMovementAllOn() {
+    ExecuteRequestTable* movementOn = mRequestTables[Request_Movement];
+
+    for (s32 i = 0; i < movementOn->getSize(); i++) {
+        LiveActor* actor = movementOn->getRequest(i);
+        ActorExecuteInfo* info = actor->getExecuteInfo();
+        for (s32 j = 0; j < info->getUpdaterCount(); j++)
+            info->getUpdater(j)->addActor(actor);
+    }
+
+    movementOn->clear();
+}
+
+void ExecuteRequestKeeper::executeRequestActorMovementAllOff() {
+    ExecuteRequestTable* movementOff = mRequestTables[Request_RemoveFromMovement];
+
+    for (s32 i = 0; i < movementOff->getSize(); i++) {
+        LiveActor* actor = movementOff->getRequest(i);
+        ActorExecuteInfo* info = actor->getExecuteInfo();
+        for (s32 j = 0; j < info->getUpdaterCount(); j++)
+            info->getUpdater(j)->removeActor(actor);
+    }
+
+    movementOff->clear();
+}
+
+void ExecuteRequestKeeper::executeRequestActorDrawAllOn() {
+    ExecuteRequestTable* drawOn = mRequestTables[Request_Draw];
+
+    for (s32 i = 0; i < drawOn->getSize(); i++) {
+        LiveActor* actor = drawOn->getRequest(i);
+        ActorExecuteInfo* info = actor->getExecuteInfo();
+        for (s32 j = 0; j < info->getDrawerCount(); j++)
+            info->getDrawer(j)->addModel(actor->getModelKeeper()->getModelCtrl());
+    }
+
+    drawOn->clear();
+}
+
+void ExecuteRequestKeeper::executeRequestActorDrawAllOff() {
+    ExecuteRequestTable* drawOff = mRequestTables[Request_RemoveFromDraw];
+
+    for (s32 i = 0; i < drawOff->getSize(); i++) {
+        LiveActor* actor = drawOff->getRequest(i);
+        ActorExecuteInfo* info = actor->getExecuteInfo();
+        for (s32 j = 0; j < info->getDrawerCount(); j++)
+            info->getDrawer(j)->removeModel(actor->getModelKeeper()->getModelCtrl());
+    }
+
+    drawOff->clear();
+}
+
+void ExecuteRequestKeeper::request(LiveActor* actor, s32 requestType) {
+    ExecuteRequestTable* addRequestTable = mRequestTables[requestType];
+    ExecuteRequestTable* removeRequestTable = nullptr;
+
+    switch (requestType) {
+    case Request_Movement:
+        removeRequestTable = mRequestTables[Request_RemoveFromMovement];
+        break;
+    case Request_RemoveFromMovement:
+        removeRequestTable = mRequestTables[Request_Movement];
+        break;
+    case Request_Draw:
+        removeRequestTable = mRequestTables[Request_RemoveFromDraw];
+        break;
+    case Request_RemoveFromDraw:
+        removeRequestTable = mRequestTables[Request_Draw];
+        break;
+    }
+
+    removeRequestTable->removeRequest(actor);
+    addRequestTable->addRequest(actor);
+}
+
+}  // namespace al

--- a/lib/al/Library/Execute/ExecuteRequestKeeper.h
+++ b/lib/al/Library/Execute/ExecuteRequestKeeper.h
@@ -10,7 +10,7 @@ public:
     ExecuteRequestInfo();
 
 private:
-    u64 _0;
+    u64 _0 = 0;
 };
 
 static_assert(sizeof(ExecuteRequestInfo) == 0x8);
@@ -19,10 +19,33 @@ class ExecuteRequestTable {
 public:
     ExecuteRequestTable(s32 maxSize);
 
+    void addRequest(LiveActor* actor) {
+        for (s32 i = 0; i < mSize; i++)
+            if (mRequests[i] == actor)
+                return;
+
+        mRequests[mSize++] = actor;
+    }
+
+    void removeRequest(LiveActor* actor) {
+        for (s32 i = 0; i < mSize; i++) {
+            if (mRequests[i] == actor) {
+                mRequests[i] = mRequests[mSize - 1];
+                mSize--;
+            }
+        }
+    }
+
+    s32 getSize() const { return mSize; };
+
+    void clear() { mSize = 0; };
+
+    LiveActor* getRequest(s32 index) const { return mRequests[index]; };
+
 private:
-    s32 mCount;
-    s32 mMaxSize;
-    LiveActor** mRequests;
+    s32 mMaxSize = 0;
+    s32 mSize = 0;
+    LiveActor** mRequests = nullptr;
 };
 
 static_assert(sizeof(ExecuteRequestTable) == 0x10);
@@ -42,13 +65,10 @@ public:
     void executeRequestActorMovementAllOff();
     void executeRequestActorDrawAllOn();
     void executeRequestActorDrawAllOff();
-    void request(LiveActor* actor, Request requestType);
+    void request(LiveActor* actor, s32 requestType);
 
 private:
-    ExecuteRequestTable* mMovementOn;
-    ExecuteRequestTable* mMovementOff;
-    ExecuteRequestTable* mDrawOn;
-    ExecuteRequestTable* mDrawOff;
+    ExecuteRequestTable* mRequestTables[4];
 };
 
 static_assert(sizeof(ExecuteRequestKeeper) == 0x20);

--- a/lib/al/Library/Execute/ExecutorActorExecuteBase.h
+++ b/lib/al/Library/Execute/ExecutorActorExecuteBase.h
@@ -2,10 +2,12 @@
 
 #include <container/seadPtrArray.h>
 
+#include "Library/HostIO/HioNode.h"
+
 namespace al {
 class LiveActor;
 
-class ExecutorActorExecuteBase {
+class ExecutorActorExecuteBase : public HioNode {
 public:
     ExecutorActorExecuteBase(const char* name);
 

--- a/lib/al/Library/Execute/ExecutorActorExecuteBase.h
+++ b/lib/al/Library/Execute/ExecutorActorExecuteBase.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+namespace al {
+class LiveActor;
+
+class ExecutorActorExecuteBase {
+public:
+    ExecutorActorExecuteBase(const char* name);
+
+    void registerActor(LiveActor* actor);
+    void createExecutorTable();
+    void addActor(LiveActor* actor);
+    void removeActor(LiveActor* actor);
+
+    virtual void execute() const = 0;
+
+private:
+    const char* mName;
+    sead::PtrArray<LiveActor> mActors;
+};
+
+static_assert(sizeof(ExecutorActorExecuteBase) == 0x20);
+
+}  // namespace al


### PR DESCRIPTION
Weird way to implement this keeper. `ExecuteRequestKeeper::request` has a potential out of bounds write. `ExecuteRequestTable` can add more elements than the array size.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/630)
<!-- Reviewable:end -->
