### PR TITLE
renovate: Add trailing `/` to regex file pattern

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,7 +10,7 @@
   "customManagers": [
     {
       "customType": "regex",
-      "managerFilePatterns": ["/tools/setup.py$"],
+      "managerFilePatterns": ["/tools/setup.py$/"],
       "matchStrings": [
         "CACHE_REPO_RELEASE_URL = \"https:\\/\\/github\\.com\\/MonsterDruide1\\/OdysseyDecompToolsCache\\/releases\\/download\\/(?<currentValue>.+?)\""
       ],


### PR DESCRIPTION
Re-reading the documentation, it shows that a regex in a non-regex type needs to be marked with leading `/` and trailing `/` or `/i`:
https://docs.renovatebot.com/string-pattern-matching/

Local tests show that the file is correctly discovered now, but I cannot check whether the update is detected correctly.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/636)
<!-- Reviewable:end -->
