### PR TITLE
src: Fix param name mismatches between declarations and definitions

### DIFF
--- a/src/Amiibo/HelpAmiiboExecutor.cpp
+++ b/src/Amiibo/HelpAmiiboExecutor.cpp
@@ -1,7 +1,7 @@
 #include "Amiibo/HelpAmiiboExecutor.h"
 
 HelpAmiiboExecutor::HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor,
-                                       const char*)
+                                       const char* amiiboName)
     : mHelpAmiiboDirector(director), mHelpAmiiboActor(amiiboActor) {}
 
 void HelpAmiiboExecutor::initAfterPlacement(const al::ActorInitInfo&) {}

--- a/src/Amiibo/HelpAmiiboExecutor.cpp
+++ b/src/Amiibo/HelpAmiiboExecutor.cpp
@@ -1,7 +1,7 @@
 #include "Amiibo/HelpAmiiboExecutor.h"
 
 HelpAmiiboExecutor::HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor,
-                                       const char* amiiboName)
+                                       const char*)
     : mHelpAmiiboDirector(director), mHelpAmiiboActor(amiiboActor) {}
 
 void HelpAmiiboExecutor::initAfterPlacement(const al::ActorInitInfo&) {}

--- a/src/Amiibo/HelpAmiiboExecutor.h
+++ b/src/Amiibo/HelpAmiiboExecutor.h
@@ -22,7 +22,7 @@ enum class HelpAmiiboType : s64 {
 
 class HelpAmiiboExecutor : public al::IUseHioNode {
 public:
-    HelpAmiiboExecutor(HelpAmiiboDirector*, al::LiveActor*, const char*);
+    HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor, const char*);
 
     virtual void initAfterPlacement(const al::ActorInitInfo&);
     virtual bool isTriggerTouch(const al::NfpInfo&) const = 0;
@@ -32,7 +32,7 @@ public:
     virtual void deactivate();
     virtual HelpAmiiboType getType() const = 0;
 
-    bool tryTouch(const al::NfpInfo&);
+    bool tryTouch(const al::NfpInfo& nfpInfo);
     void tryExecute();
 
     bool isTouched() const { return mIsTouched; }

--- a/src/Amiibo/HelpAmiiboExecutor.h
+++ b/src/Amiibo/HelpAmiiboExecutor.h
@@ -22,10 +22,11 @@ enum class HelpAmiiboType : s64 {
 
 class HelpAmiiboExecutor : public al::IUseHioNode {
 public:
-    HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor, const char*);
+    HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor,
+                       const char* amiiboName);
 
     virtual void initAfterPlacement(const al::ActorInitInfo&);
-    virtual bool isTriggerTouch(const al::NfpInfo&) const = 0;
+    virtual bool isTriggerTouch(const al::NfpInfo& nfpInfo) const = 0;
     virtual bool isEnableUse() = 0;
     virtual bool execute() = 0;
     virtual void activate();

--- a/src/Amiibo/HelpAmiiboLifeMaxUpItem.h
+++ b/src/Amiibo/HelpAmiiboLifeMaxUpItem.h
@@ -14,7 +14,7 @@ class LifeMaxUpItem2D;
 
 class HelpAmiiboLifeMaxUpItem : public HelpAmiiboExecutor {
 public:
-    HelpAmiiboLifeMaxUpItem(HelpAmiiboDirector* director, al::LiveActor* amiiboActor);
+    HelpAmiiboLifeMaxUpItem(HelpAmiiboDirector* director, al::LiveActor* actor);
 
     void initAfterPlacement(const al::ActorInitInfo& initInfo) override;
     bool isTriggerTouch(const al::NfpInfo& nfpInfo) const override;

--- a/src/Boss/BarrierField.cpp
+++ b/src/Boss/BarrierField.cpp
@@ -23,12 +23,11 @@ NERVE_ACTIONS_MAKE_STRUCT(BarrierField, Appear, AppearBreedaMoonWorld, Hide, Dis
 
 BarrierField::BarrierField(const char* name) : al::LiveActor(name) {}
 
-void BarrierField::init(const al::ActorInitInfo& initInfo) {
+void BarrierField::init(const al::ActorInitInfo& info) {
     al::initNerveAction(this, "Hide", &NrvBarrierField.collector, 0);
-    al::initMapPartsActor(this, initInfo, nullptr);
-    al::tryGetArg(&mIsDisappearByShineGet, initInfo, "IsDisappearByShineGet");
-    if (al::isObjectName(initInfo, "WaterfallWorldHomeBarrier") &&
-        GameDataFunction::isWorldMoon(this))
+    al::initMapPartsActor(this, info, nullptr);
+    al::tryGetArg(&mIsDisappearByShineGet, info, "IsDisappearByShineGet");
+    if (al::isObjectName(info, "WaterfallWorldHomeBarrier") && GameDataFunction::isWorldMoon(this))
         mIsMoon = true;
     al::trySyncStageSwitchAppearAndKill(this);
 }

--- a/src/Boss/BarrierField.h
+++ b/src/Boss/BarrierField.h
@@ -8,8 +8,8 @@ struct ActorInitInfo;
 
 class BarrierField : public al::LiveActor {
 public:
-    BarrierField(const char*);
-    void init(const al::ActorInitInfo&) override;
+    BarrierField(const char* name);
+    void init(const al::ActorInitInfo& info) override;
     void appear() override;
     void kill() override;
     void disappearByShineGet();

--- a/src/Boss/Mofumofu/MofumofuWarpHole.cpp
+++ b/src/Boss/Mofumofu/MofumofuWarpHole.cpp
@@ -31,11 +31,10 @@ NERVES_MAKE_NOSTRUCT(MofumofuWarpHole, Close, Disappear, Appear, HideMove, HideW
 
 }  // namespace
 
-MofumofuWarpHole::MofumofuWarpHole(const char* name)
-    : al::LiveActor(name) {}  // TODO minor mismatch about storing `gap`
+MofumofuWarpHole::MofumofuWarpHole(const char* name) : al::LiveActor(name) {}
 
-void MofumofuWarpHole::init(const al::ActorInitInfo& actorInitInfo) {
-    al::initActorWithArchiveName(this, actorInitInfo, "MofumofuWarpHole", nullptr);
+void MofumofuWarpHole::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "MofumofuWarpHole", nullptr);
     al::initNerve(this, &Appear, 0);
     al::initJointControllerKeeper(this, 1);
     al::initJointGlobalQuatController(this, &gap, "DashSign");

--- a/src/Boss/Mofumofu/MofumofuWarpHole.h
+++ b/src/Boss/Mofumofu/MofumofuWarpHole.h
@@ -19,7 +19,7 @@ public:
     void startDashSign();
     bool isWait() const;
     bool isHideWait() const;
-    void calcDashSignFront(sead::Vector3f*) const;
+    void calcDashSignFront(sead::Vector3f* front) const;
     void exeAppear();
     void exeWait();
     void exeDisappear();

--- a/src/Enemy/EnemyCap.h
+++ b/src/Enemy/EnemyCap.h
@@ -9,11 +9,12 @@ struct EnemyStateBlowDownParam;
 
 class EnemyCap : public al::LiveActor {
 public:
-    static EnemyCap* createEnemyCap(const char*);
+    static EnemyCap* createEnemyCap(const char* name);
 
-    EnemyCap(const char*);
+    EnemyCap(const char* name);
 
-    void initPartsFixFile(al::LiveActor*, const al::ActorInitInfo&, const char*, const char*);
+    void initPartsFixFile(al::LiveActor* cap, const al::ActorInitInfo& info,
+                          const char* archiveName, const char* suffix);
 
     void makeActorAlive() override;
     void updatePose();
@@ -25,7 +26,7 @@ public:
     void startBlowDown(const al::HitSensor* source);
     void startBlowDown();
     bool isBlowDown() const;
-    void setBlowDownParam(const al::EnemyStateBlowDownParam*);
+    void setBlowDownParam(const al::EnemyStateBlowDownParam* param);
 
     al::LiveActor* getCap() { return mCap; };
 
@@ -46,12 +47,13 @@ private:
 };
 
 namespace rs {
-EnemyCap* tryCreateEnemyCap(al::LiveActor*, const al::ActorInitInfo&);
-EnemyCap* tryCreateEnemyCap(al::LiveActor*, const al::ActorInitInfo&, const char*);
-EnemyCap* tryCreateEnemyCapSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
-                                  const char*);
-bool tryStartEnemyCapBlowDown(EnemyCap*, const al::HitSensor*);
-bool tryStartEnemyCapBlowDown(EnemyCap*);
-bool tryAppearEnemyCap(EnemyCap*);
-bool isOnEnemyCap(EnemyCap*);
+EnemyCap* tryCreateEnemyCap(al::LiveActor* actor, const al::ActorInitInfo& info);
+EnemyCap* tryCreateEnemyCap(al::LiveActor* actor, const al::ActorInitInfo& info,
+                            const char* archiveName);
+EnemyCap* tryCreateEnemyCapSuffix(al::LiveActor* actor, const al::ActorInitInfo& info,
+                                  const char* archiveName, const char* suffix);
+bool tryStartEnemyCapBlowDown(EnemyCap* cap, const al::HitSensor* sensor);
+bool tryStartEnemyCapBlowDown(EnemyCap* cap);
+bool tryAppearEnemyCap(EnemyCap* cap);
+bool isOnEnemyCap(EnemyCap* cap);
 }  // namespace rs

--- a/src/Enemy/EnemyStateDamageCap.h
+++ b/src/Enemy/EnemyStateDamageCap.h
@@ -16,10 +16,10 @@ public:
     EnemyStateDamageCap(al::LiveActor* actor);
     void kill() override;
 
-    void createEnemyCap(const al::ActorInitInfo&, const char*);
-    bool tryReceiveMsgCapBlow(const al::SensorMsg*, al::HitSensor*, al::HitSensor*);
+    void createEnemyCap(const al::ActorInitInfo& info, const char* name);
+    bool tryReceiveMsgCapBlow(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self);
     bool isCapOn() const;
-    void blowCap(al::HitSensor*);
+    void blowCap(al::HitSensor* source);
     void resetCap();
     void makeActorDeadCap();
 

--- a/src/Enemy/EnemyStateHackStart.cpp
+++ b/src/Enemy/EnemyStateHackStart.cpp
@@ -28,14 +28,14 @@ EnemyStateHackStartParam::EnemyStateHackStartParam(const char* actionName, const
 
 static EnemyStateHackStartParam sEnemyStateHackStartParam("HackStart", 0, 0, 0, 0);
 
-EnemyStateHackStart::EnemyStateHackStart(al::LiveActor* rootActor,
+EnemyStateHackStart::EnemyStateHackStart(al::LiveActor* actor,
                                          const EnemyStateHackStartParam* param,
                                          PlayerHackStartShaderParam* shaderParam)
-    : al::ActorStateBase("憑依開始", rootActor), mParam(param) {
+    : al::ActorStateBase("憑依開始", actor), mParam(param) {
     if (!param)
         mParam = &sEnemyStateHackStartParam;
     initNerve(&DiveIn, 0);
-    mPlayerHackStartShaderCtrl = new PlayerHackStartShaderCtrl(rootActor, shaderParam);
+    mPlayerHackStartShaderCtrl = new PlayerHackStartShaderCtrl(actor, shaderParam);
 }
 
 IUsePlayerHack* EnemyStateHackStart::tryStart(const al::SensorMsg* msg, al::HitSensor* other,

--- a/src/Enemy/EnemyStateHackStart.h
+++ b/src/Enemy/EnemyStateHackStart.h
@@ -12,7 +12,9 @@ class PlayerHackStartShaderCtrl;
 struct PlayerHackStartShaderParam;
 
 struct EnemyStateHackStartParam {
-    EnemyStateHackStartParam(const char*, const char*, const char*, bool, bool);
+    EnemyStateHackStartParam(const char* actionName, const char* visAnimName,
+                             const char* mtpAnimName, bool hasSubActors,
+                             bool updateSubActorShadowMap);
 
     const char* actionName;
     const char* visAnimName;
@@ -23,10 +25,10 @@ struct EnemyStateHackStartParam {
 
 class EnemyStateHackStart : public al::ActorStateBase {
 public:
-    EnemyStateHackStart(al::LiveActor*, const EnemyStateHackStartParam*,
-                        PlayerHackStartShaderParam*);
+    EnemyStateHackStart(al::LiveActor* actor, const EnemyStateHackStartParam* param,
+                        PlayerHackStartShaderParam* shaderParam);
 
-    IUsePlayerHack* tryStart(const al::SensorMsg*, al::HitSensor*, al::HitSensor*);
+    IUsePlayerHack* tryStart(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self);
     void kill() override;
     bool isHackStart() const;
     f32 calcHackStartNerveRate() const;
@@ -41,6 +43,6 @@ private:
 };
 
 namespace EnemyStateHackFunction {
-void startHackSwitchShadow(al::LiveActor*, const EnemyStateHackStartParam*);
-void endHackSwitchShadow(al::LiveActor*, const EnemyStateHackStartParam*);
+void startHackSwitchShadow(al::LiveActor* actor, const EnemyStateHackStartParam* param);
+void endHackSwitchShadow(al::LiveActor* actor, const EnemyStateHackStartParam* param);
 }  // namespace EnemyStateHackFunction

--- a/src/Enemy/EnemyStateReset.cpp
+++ b/src/Enemy/EnemyStateReset.cpp
@@ -30,8 +30,7 @@ EnemyStateReset::EnemyStateReset(al::LiveActor* actor, const al::ActorInitInfo& 
 }
 
 void EnemyStateReset::appear() {
-    al::LiveActor* actor = mActor;  // getting the actor in each function call below causes
-                                    // mismatch, have to declare a variable up here for it
+    al::LiveActor* actor = mActor;
 
     al::NerveStateBase::appear();
     if (!mIsRevive) {

--- a/src/Enemy/EnemyStateReset.h
+++ b/src/Enemy/EnemyStateReset.h
@@ -12,7 +12,7 @@ class EnemyCap;
 
 class EnemyStateReset : public al::ActorStateBase {
 public:
-    EnemyStateReset(al::LiveActor*, const al::ActorInitInfo&, EnemyCap*);
+    EnemyStateReset(al::LiveActor* actor, const al::ActorInitInfo& info, EnemyCap* cap);
 
     void appear() override;
     void kill() override;

--- a/src/Enemy/EnemyStateReviveInsideScreen.h
+++ b/src/Enemy/EnemyStateReviveInsideScreen.h
@@ -7,7 +7,7 @@
 
 class EnemyStateReviveInsideScreen : public al::ActorStateBase {
 public:
-    EnemyStateReviveInsideScreen(al::LiveActor*);
+    EnemyStateReviveInsideScreen(al::LiveActor* actor);
 
     void appear() override;
     void kill() override;

--- a/src/Enemy/EnemyStateRunAway.h
+++ b/src/Enemy/EnemyStateRunAway.h
@@ -15,11 +15,12 @@ struct ParamEnemyStateRunAway {
 
 class EnemyStateRunAway : public al::ActorStateBase {
 public:
-    EnemyStateRunAway(al::LiveActor*, const ParamEnemyStateRunAway*, const char*);
+    EnemyStateRunAway(al::LiveActor* actor, const ParamEnemyStateRunAway* param,
+                      const char* animName);
 
     void appear() override;
 
-    void calcRunDirBase(sead::Vector3f*);
+    void calcRunDirBase(sead::Vector3f* direction);
 
     void exeRun();
     void exePanicRun();

--- a/src/Enemy/EnemyStateSwoon.h
+++ b/src/Enemy/EnemyStateSwoon.h
@@ -55,13 +55,13 @@ public:
     bool tryReceiveMsgPressDown(const al::SensorMsg* message);
     bool tryReceiveMsgObjHipDropAll(const al::SensorMsg* message);
     bool tryReceiveMsgTrample(const al::SensorMsg* message);
-    bool tryReceiveMsgTrample(const al::SensorMsg*, const al::HitSensor* other,
+    bool tryReceiveMsgTrample(const al::SensorMsg* message, const al::HitSensor* other,
                               const al::HitSensor* self);
     bool tryReceiveMsgTrampleReflect(const al::SensorMsg* message);
-    bool tryReceiveMsgTrampleReflect(const al::SensorMsg*, const al::HitSensor* other,
+    bool tryReceiveMsgTrampleReflect(const al::SensorMsg* message, const al::HitSensor* other,
                                      const al::HitSensor* self);
     bool tryReceiveMsgObjHipDropReflect(const al::SensorMsg* message);
-    bool tryReceiveMsgObjLeapFrog(const al::SensorMsg*, const al::HitSensor* other,
+    bool tryReceiveMsgObjLeapFrog(const al::SensorMsg* message, const al::HitSensor* other,
                                   const al::HitSensor* self);
     bool tryReceiveMsgEnableLockOn(const al::SensorMsg* message);
     bool tryReceiveMsgStartLockOn(const al::SensorMsg* message);

--- a/src/Enemy/EnemyStateWander.h
+++ b/src/Enemy/EnemyStateWander.h
@@ -15,7 +15,7 @@ public:
     bool isWait() const;
     bool isWalk() const;
     bool isFall() const;
-    void changeWalkAnim(const char*);
+    void changeWalkAnim(const char* animName);
 
 private:
     const char* mStateName;

--- a/src/Enemy/FlyerStateWander.cpp
+++ b/src/Enemy/FlyerStateWander.cpp
@@ -15,10 +15,10 @@ NERVE_IMPL(FlyerStateWander, Wait)
 NERVES_MAKE_NOSTRUCT(FlyerStateWander, Wander, Wait)
 }  // namespace
 
-FlyerStateWanderParam::FlyerStateWanderParam(s32 ukn, s32 wanderTime, s32 waitTime,
+FlyerStateWanderParam::FlyerStateWanderParam(s32 unk, s32 wanderTime, s32 waitTime,
                                              const char* actionName,
                                              const al::ActorParamMove* actorParamMove)
-    : _0(ukn), mWanderTime(wanderTime), mWaitTime(waitTime), mActionName(actionName),
+    : _0(unk), mWanderTime(wanderTime), mWaitTime(waitTime), mActionName(actionName),
       mActorParamMove(actorParamMove) {}
 
 FlyerStateWander::FlyerStateWander(al::LiveActor* actor, const FlyerStateWanderParam* param)

--- a/src/Enemy/FlyerStateWander.h
+++ b/src/Enemy/FlyerStateWander.h
@@ -11,6 +11,7 @@ struct ActorParamMove;
 
 class FlyerStateWanderParam {
 public:
+    // TODO: figure out purpose/name for this parameter/member variable
     FlyerStateWanderParam(s32 unk, s32 wanderTime, s32 waitTime, const char* actionName,
                           const al::ActorParamMove* actorParamMove);
 

--- a/src/Enemy/FlyerStateWander.h
+++ b/src/Enemy/FlyerStateWander.h
@@ -11,7 +11,7 @@ struct ActorParamMove;
 
 class FlyerStateWanderParam {
 public:
-    FlyerStateWanderParam(s32, s32 wanderTime, s32 waitTime, const char* actionName,
+    FlyerStateWanderParam(s32 unk, s32 wanderTime, s32 waitTime, const char* actionName,
                           const al::ActorParamMove* actorParamMove);
 
     s32 get_0() const { return _0; }

--- a/src/Enemy/Gamane.cpp
+++ b/src/Enemy/Gamane.cpp
@@ -64,8 +64,8 @@ static EnemyStateSwoonInitParam gEnemyStateSwoonInitParam = EnemyStateSwoonInitP
 
 Gamane::Gamane(const char* name) : al::LiveActor(name) {}
 
-void Gamane::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "Gamane", nullptr);
+void Gamane::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "Gamane", nullptr);
     al::initNerve(this, &NrvGamane.Wait, 5);
     mCapTargetInfo = rs::createCapTargetInfo(this, nullptr);
 
@@ -80,7 +80,7 @@ void Gamane::init(const al::ActorInitInfo& initInfo) {
 
     mHackState = new GamaneHackState(this);
     al::initNerveState(this, mHackState, &NrvGamane.Hack, "憑依");
-    mHackState->initialize(initInfo);
+    mHackState->initialize(info);
 
     mStateBlowDown = new al::EnemyStateBlowDown(this, &gEnemyStateBlowDownParam, "吹き飛び状態");
     al::initNerveState(this, mStateBlowDown, &NrvGamane.BlowDown, "吹き飛び");

--- a/src/Enemy/Mummy.h
+++ b/src/Enemy/Mummy.h
@@ -19,7 +19,7 @@ public:
     inline bool isAsleep() const;
 
     void startSleep();
-    void attackSensor(al::HitSensor* other, al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool isHide();
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Enemy/SenobiLeaf.h
+++ b/src/Enemy/SenobiLeaf.h
@@ -10,7 +10,7 @@ public:
     void calcAnim() override;
 
     void updatePose();
-    void registerToHost(al::LiveActor*, bool);
+    void registerToHost(al::LiveActor* host, bool flip);
 
 private:
     al::LiveActor* mHostActor = nullptr;

--- a/src/Item/Coin.h
+++ b/src/Item/Coin.h
@@ -48,9 +48,9 @@ public:
     void appearCountUpFixPos10(s32 coinIndex);
     void appearCoinRail();
     void appearCoinChameleon(const sead::Vector3f& trans, const sead::Quatf& quat,
-                             const sead::Vector3f& position);
+                             const sead::Vector3f& offset);
     void appearLimitTime(s32 timeLimit);
-    void appearBlow(const sead::Vector3f& velocity, s32 delayTime);
+    void appearBlow(const sead::Vector3f& velocity, s32 timeLimit);
     void rotate();
     void appearBlowUpCommon(s32 delayTime, f32 horizontalForce, f32 verticalForce, s32 coinCount,
                             s32 coinIndex);

--- a/src/Item/CoinStack.h
+++ b/src/Item/CoinStack.h
@@ -30,7 +30,7 @@ public:
     f32 getFallSpeed();
     void setAbove(CoinStack* stack);
     void setBelow(CoinStack* stack);
-    void signalFall(u32 delay, f32 speed);
+    void signalFall(u32 delay, f32 radius);
     void postInit(CoinStackGroup* coinStackGroup, const sead::Vector3f& transY, CoinStack* below,
                   const sead::Vector3f& clippingPos, f32 clippingRadius, const f32* fallDistance);
 

--- a/src/Layout/WindowConfirmData.h
+++ b/src/Layout/WindowConfirmData.h
@@ -21,7 +21,7 @@ public:
 
     void setConfirmMessage(const char16* message, const char16* confirmMessage,
                            const char16* cancelMessage);
-    void setConfirmData(al::LayoutActor* actor, nn::ui2d::TextureInfo* textureInfo);
+    void setConfirmData(al::LayoutActor* actor, nn::ui2d::TextureInfo* texture);
     void updateConfirmDataDate();
     void appear();
     void appearWithChoicingCancel();

--- a/src/MapObj/CoinCollectHintObj.cpp
+++ b/src/MapObj/CoinCollectHintObj.cpp
@@ -8,10 +8,10 @@
 
 CoinCollectHintObj::CoinCollectHintObj(const char* name) : al::LiveActor(name) {}
 
-void CoinCollectHintObj::init(const al::ActorInitInfo& initInfo) {
-    al::initActorSceneInfo(this, initInfo);
-    al::getStringArg(&mStageName, initInfo, "CoinCollectStageName");
-    al::getTrans(&mTrans, initInfo);
+void CoinCollectHintObj::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::getStringArg(&mStageName, info, "CoinCollectStageName");
+    al::getTrans(&mTrans, info);
 
     rs::createCoinCollectHolder(this);
     CoinCollectHolder* holder = al::getSceneObj<CoinCollectHolder>(this);

--- a/src/MapObj/PictureNoStageChange.h
+++ b/src/MapObj/PictureNoStageChange.h
@@ -4,7 +4,7 @@
 
 class PictureNoStageChange : public al::LiveActor {
 public:
-    PictureNoStageChange(const char* name, const char* archiveName);
+    PictureNoStageChange(const char* actorName, const char* archiveName);
 
     virtual void init(const al::ActorInitInfo& info) override;
     virtual bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,

--- a/src/MapObj/WorldMapParts.h
+++ b/src/MapObj/WorldMapParts.h
@@ -6,18 +6,20 @@
 
 class WorldMapParts : public al::LiveActor {
 public:
-    WorldMapParts(const char*);
+    WorldMapParts(const char* name);
 
-    void setWorldMtx(const sead::Matrix34f&);
+    void setWorldMtx(const sead::Matrix34f& srcMtx);
     void updatePose();
     void control() override;
 
-    virtual void setLocalMtx(const sead::Matrix34f&);
+    virtual void setLocalMtx(const sead::Matrix34f& srcMtx);
 
-    static void initParts(WorldMapParts*, const char*, const al::ActorInitInfo&,
-                          const sead::Matrix34f*, const sead::Matrix34f&, const char*);
-    static WorldMapParts* create(const char*, const char*, const al::ActorInitInfo&,
-                                 const sead::Matrix34f*, const sead::Matrix34f&, const char*);
+    static void initParts(WorldMapParts* mapParts, const char* arcName,
+                          const al::ActorInitInfo& initInfo, const sead::Matrix34f* worldMtx,
+                          const sead::Matrix34f& localMtx, const char* suffix);
+    static WorldMapParts* create(const char* name, const char* arcName,
+                                 const al::ActorInitInfo& initInfo, const sead::Matrix34f* worldMtx,
+                                 const sead::Matrix34f& localMtx, const char* suffix);
 
 private:
     const sead::Matrix34f* mWorldMtx = nullptr;

--- a/src/Npc/Achievement.h
+++ b/src/Npc/Achievement.h
@@ -6,8 +6,8 @@ struct AchievementInfo;
 
 class Achievement {
 public:
-    Achievement(const AchievementInfo*);
-    bool isGet(GameDataHolderAccessor) const;
+    Achievement(const AchievementInfo* info);
+    bool isGet(GameDataHolderAccessor accessor) const;
 
 private:
     bool mIsGet = false;

--- a/src/Npc/AchievementHolder.h
+++ b/src/Npc/AchievementHolder.h
@@ -16,14 +16,14 @@ public:
     AchievementHolder();
     void init(const al::ActorInitInfo&);
     void init();
-    bool isGetMoon(s32, GameDataHolderAccessor) const;
-    bool isAchieve(s32, GameDataHolderAccessor) const;
-    s32 getAchievementProgressCurrent(s32, GameDataHolderAccessor) const;
-    s32 getAchievementProgressMax(s32, GameDataHolderAccessor) const;
-    s32 getAchievementProgressCurrentRow(s32, GameDataHolderAccessor) const;
-    s32 calcAchieveTotalNum(GameDataHolderAccessor) const;
-    s32 calcMoonGetTotalNum(GameDataHolderAccessor) const;
-    Achievement* tryGetNewAchievement(GameDataHolderAccessor) const;
+    bool isGetMoon(s32 index, GameDataHolderAccessor accessor) const;
+    bool isAchieve(s32 index, GameDataHolderAccessor accessor) const;
+    s32 getAchievementProgressCurrent(s32 index, GameDataHolderAccessor accessor) const;
+    s32 getAchievementProgressMax(s32 index, GameDataHolderAccessor) const;
+    s32 getAchievementProgressCurrentRow(s32 index, GameDataHolderAccessor accessor) const;
+    s32 calcAchieveTotalNum(GameDataHolderAccessor accessor) const;
+    s32 calcMoonGetTotalNum(GameDataHolderAccessor accessor) const;
+    Achievement* tryGetNewAchievement(GameDataHolderAccessor accessor) const;
 
 private:
     sead::PtrArray<Achievement> mArray;

--- a/src/Npc/AchievementInfoReader.h
+++ b/src/Npc/AchievementInfoReader.h
@@ -17,7 +17,7 @@ class AchievementInfoReader {
 public:
     AchievementInfoReader();
     void init();
-    s32 tryFindIndexByName(const char*) const;
+    s32 tryFindIndexByName(const char* name) const;
 
     AchievementInfo* get(s32 index) { return mAchievements[index]; }
 

--- a/src/Player/CollisionShapeInfo.h
+++ b/src/Player/CollisionShapeInfo.h
@@ -13,7 +13,7 @@ enum class CollisionShapeId : u32 {
 
 class CollisionShapeInfoBase : public al::HioNode {
 public:
-    CollisionShapeInfoBase(CollisionShapeId, const char*);
+    CollisionShapeInfoBase(CollisionShapeId id, const char* name);
 
     virtual const sead::Vector3f& getBoundingCenter() const { return sead::Vector3f::zero; }
 

--- a/src/Player/CollisionShapeKeeper.h
+++ b/src/Player/CollisionShapeKeeper.h
@@ -34,9 +34,9 @@ public:
     void updateShape();
     void clearResult();
     // TODO: rename parameters
-    void calcWorldShapeInfo(const sead::Matrix34f& a1, f32 a2);
+    void calcWorldShapeInfo(const sead::Matrix34f& a2, f32 a3);
     // TODO: rename parameter
-    void calcRelativeShapeInfo(const sead::Matrix34f& a1);
+    void calcRelativeShapeInfo(const sead::Matrix34f& a2);
     void registerCollideResult(const CollidedShapeResult& result);
     void registerCollideSupportResult(const CollidedShapeResult& result);
     bool isCollidedResultFull() const;

--- a/src/Player/HackerStateWingFly.h
+++ b/src/Player/HackerStateWingFly.h
@@ -15,7 +15,8 @@ class IUsePlayerCollision;
 
 class HackerStateWingFly : public al::ActorStateBase {
 public:
-    HackerStateWingFly(al::LiveActor* actor, IUsePlayerHack** hack, IUsePlayerCollision* collision);
+    HackerStateWingFly(al::LiveActor* actor, IUsePlayerHack** hacker,
+                       IUsePlayerCollision* collision);
 
     void appear() override;
     void goFlyRise();

--- a/src/Player/PlayerActionFunction.h
+++ b/src/Player/PlayerActionFunction.h
@@ -10,6 +10,6 @@ f32 brakeLimit(f32 speed, u32 frames, f32 speedMax, f32 speedMin);
 f32 calcJumpSpeed(f32 speedFront, f32 speedMin, f32 speedMax, f32 jumpPowerMin, f32 jumpPowerMax);
 bool isOppositeDir(const sead::Vector3f& a, const sead::Vector3f& b);
 bool isOppositeVec(const sead::Vector3f& a, const sead::Vector3f& b);
-f32 calcStickPow(f32);
+f32 calcStickPow(f32 pow);
 
 }  // namespace PlayerActionFunction

--- a/src/Player/PlayerActionVelocityControl.h
+++ b/src/Player/PlayerActionVelocityControl.h
@@ -9,7 +9,7 @@ class IUsePlayerCollision;
 
 class PlayerActionVelocityControl {
 public:
-    PlayerActionVelocityControl(al::LiveActor* actor, const IUsePlayerCollision* collider);
+    PlayerActionVelocityControl(al::LiveActor* actor, const IUsePlayerCollision* collision);
 
     void calcFrontBrake(f32 decel);
     void calcSideVelocityLimit(const sead::Vector3f& moveInput, f32 brakeSideAccel,

--- a/src/Player/PlayerConst.h
+++ b/src/Player/PlayerConst.h
@@ -11,7 +11,7 @@ class ByamlIter;
 class PlayerConst : public al::HioNode {
 public:
     PlayerConst();
-    PlayerConst(const al::ByamlIter&);
+    PlayerConst(const al::ByamlIter& byaml);
 
     virtual f32 getGravity() const { return mGravity; }
 

--- a/src/Player/PlayerCostumeInfo.cpp
+++ b/src/Player/PlayerCostumeInfo.cpp
@@ -3,13 +3,9 @@
 #include "Library/Base/StringUtil.h"
 #include "Library/Math/MathUtil.h"
 
-PlayerHeadCostumeInfo::PlayerHeadCostumeInfo(const char* a1) {
-    costumeName = a1;
-}
+PlayerHeadCostumeInfo::PlayerHeadCostumeInfo(const char* costumeName) : costumeName(costumeName) {}
 
-PlayerBodyCostumeInfo::PlayerBodyCostumeInfo(const char* a1) {
-    costumeName = a1;
-}
+PlayerBodyCostumeInfo::PlayerBodyCostumeInfo(const char* costumeName) : costumeName(costumeName) {}
 
 PlayerCostumeInfo::PlayerCostumeInfo() = default;
 

--- a/src/Player/PlayerCostumeInfo.h
+++ b/src/Player/PlayerCostumeInfo.h
@@ -4,7 +4,7 @@
 
 struct PlayerHeadCostumeInfo {
 public:
-    PlayerHeadCostumeInfo(const char*);
+    PlayerHeadCostumeInfo(const char* costumeName);
 
     const char* costumeName;
     bool isFullFace = false;
@@ -23,7 +23,7 @@ public:
 
 struct PlayerBodyCostumeInfo {
 public:
-    PlayerBodyCostumeInfo(const char*);
+    PlayerBodyCostumeInfo(const char* costumeName);
 
     const char* costumeName;
     s32 warmLevel = 0;
@@ -45,7 +45,7 @@ public:
 class PlayerCostumeInfo {
 public:
     PlayerCostumeInfo();
-    void init(const PlayerBodyCostumeInfo*, const PlayerHeadCostumeInfo*);
+    void init(const PlayerBodyCostumeInfo* body, const PlayerHeadCostumeInfo* head);
     bool isEnableBigEar() const;
     bool isEnableHairNoCap() const;
     bool isEnableCostume2D() const;
@@ -60,7 +60,7 @@ public:
     bool isFollowJoeStrap() const;
     bool isPreventHeadPain() const;
     bool isInvisibleHead() const;
-    s32 calcWarmLevel(s32) const;
+    s32 calcWarmLevel(s32 baseLevel) const;
 
 private:
     const PlayerBodyCostumeInfo* mBodyInfo = nullptr;

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -30,9 +30,9 @@ public:
     bool isTriggerHipDrop() const;
     bool isTriggerHeadSliding() const;
     bool isTriggerPaddle() const;
-    bool isTriggerRolling(bool) const;
+    bool isTriggerRolling(bool a1) const;
     bool isTriggerRollingRestartSwing() const;
-    bool isTriggerRollingCancelHipDrop(bool) const;
+    bool isTriggerRollingCancelHipDrop(bool a1) const;
     bool isTriggerHackAction() const;
     bool isTriggerHackJump() const;
     bool isTriggerHackSwing() const;
@@ -61,7 +61,7 @@ public:
     bool isTriggerCapSeparateHipDrop() const;
     bool isTriggerSwingPoleClimbFast() const;
     bool isHoldPoleClimbDown() const;
-    bool isTriggerAppendCapAttack(bool) const;
+    bool isTriggerAppendCapAttack(bool a1) const;
 
     bool isHoldSpinCap() const;
     bool isHoldCapAction() const;
@@ -78,8 +78,8 @@ public:
     bool isReleaseHackJump() const;
     bool isEnableDashInput() const;
 
-    bool isThrowTypeSpiral(const sead::Vector2f&) const;
-    bool isThrowTypeRolling(const sead::Vector2f&) const;
+    bool isThrowTypeSpiral(const sead::Vector2f& a1) const;
+    bool isThrowTypeRolling(const sead::Vector2f& a1) const;
 
     void calcMoveInput(sead::Vector3f*, const sead::Vector3f&) const;
     void calcMoveDirection(sead::Vector3f*, const sead::Vector3f&) const;

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -30,8 +30,10 @@ public:
     bool isTriggerHipDrop() const;
     bool isTriggerHeadSliding() const;
     bool isTriggerPaddle() const;
+    // TODO: Add proper parameter name
     bool isTriggerRolling(bool a1) const;
     bool isTriggerRollingRestartSwing() const;
+    // TODO: Add proper parameter name
     bool isTriggerRollingCancelHipDrop(bool a1) const;
     bool isTriggerHackAction() const;
     bool isTriggerHackJump() const;
@@ -61,6 +63,7 @@ public:
     bool isTriggerCapSeparateHipDrop() const;
     bool isTriggerSwingPoleClimbFast() const;
     bool isHoldPoleClimbDown() const;
+    // TODO: Add proper parameter name
     bool isTriggerAppendCapAttack(bool a1) const;
 
     bool isHoldSpinCap() const;
@@ -78,7 +81,9 @@ public:
     bool isReleaseHackJump() const;
     bool isEnableDashInput() const;
 
+    // TODO: Add proper parameter name
     bool isThrowTypeSpiral(const sead::Vector2f& a1) const;
+    // TODO: Add proper parameter name
     bool isThrowTypeRolling(const sead::Vector2f& a1) const;
 
     void calcMoveInput(sead::Vector3f*, const sead::Vector3f&) const;

--- a/src/Player/PlayerInputFunction.h
+++ b/src/Player/PlayerInputFunction.h
@@ -9,20 +9,20 @@ class IUseSceneObjHolder;
 
 class PlayerInputFunction {
 public:
-    static bool isTriggerAction(const al::LiveActor*, s32);
-    static bool isHoldAction(const al::LiveActor*, s32);
-    static bool isReleaseAction(const al::LiveActor*, s32);
+    static bool isTriggerAction(const al::LiveActor* actor, s32 port);
+    static bool isHoldAction(const al::LiveActor* actor, s32 port);
+    static bool isReleaseAction(const al::LiveActor* actor, s32 port);
 
-    static bool isTriggerJump(const al::LiveActor*, s32);
-    static bool isHoldJump(const al::LiveActor*, s32);
-    static bool isReleaseJump(const al::LiveActor*, s32);
+    static bool isTriggerJump(const al::LiveActor* actor, s32 port);
+    static bool isHoldJump(const al::LiveActor* actor, s32 port);
+    static bool isReleaseJump(const al::LiveActor* actor, s32 port);
 
-    static bool isTriggerSubAction(const al::LiveActor*, s32);
-    static bool isHoldSubAction(const al::LiveActor*, s32);
+    static bool isTriggerSubAction(const al::LiveActor* actor, s32 port);
+    static bool isHoldSubAction(const al::LiveActor* actor, s32 port);
 
-    static bool isTriggerTalk(const al::LiveActor*, s32);
-    static bool isTriggerStartWorldWarp(const al::LiveActor*, s32);
-    static bool isTriggerCancelWorldWarp(const al::LiveActor*, s32);
+    static bool isTriggerTalk(const al::LiveActor* actor, s32 port);
+    static bool isTriggerStartWorldWarp(const al::LiveActor* actor, s32 port);
+    static bool isTriggerCancelWorldWarp(const al::LiveActor* actor, s32 port);
 };
 
 namespace rs {

--- a/src/Player/PlayerJudgeStartHipDrop.cpp
+++ b/src/Player/PlayerJudgeStartHipDrop.cpp
@@ -5,12 +5,11 @@
 #include "Player/PlayerInput.h"
 #include "Util/PlayerCollisionUtil.h"
 
-PlayerJudgeStartHipDrop::PlayerJudgeStartHipDrop(const PlayerConst* playerConst,
-                                                 const PlayerInput* playerInput,
-                                                 const IUsePlayerHeightCheck* playerHeightCheck,
-                                                 const IPlayerModelChanger* playerModelChanger)
-    : mConst(playerConst), mInput(playerInput), mHeightCheck(playerHeightCheck),
-      mModelChanger(playerModelChanger) {}
+PlayerJudgeStartHipDrop::PlayerJudgeStartHipDrop(const PlayerConst* pConst,
+                                                 const PlayerInput* input,
+                                                 const IUsePlayerHeightCheck* heightCheck,
+                                                 const IPlayerModelChanger* modelChanger)
+    : mConst(pConst), mInput(input), mHeightCheck(heightCheck), mModelChanger(modelChanger) {}
 
 bool PlayerJudgeStartHipDrop::judge() const {
     if (mModelChanger->is2DModel() || !mInput->isTriggerHipDrop())

--- a/src/Player/PlayerJudgeStartHipDrop.h
+++ b/src/Player/PlayerJudgeStartHipDrop.h
@@ -11,8 +11,9 @@ class IPlayerModelChanger;
 
 class PlayerJudgeStartHipDrop : public al::HioNode, public IJudge {
 public:
-    PlayerJudgeStartHipDrop(const PlayerConst*, const PlayerInput*, const IUsePlayerHeightCheck*,
-                            const IPlayerModelChanger*);
+    PlayerJudgeStartHipDrop(const PlayerConst* pConst, const PlayerInput* input,
+                            const IUsePlayerHeightCheck* heightCheck,
+                            const IPlayerModelChanger* modelChanger);
 
     void reset() override {}
 

--- a/src/Player/PlayerJudgeStartSquat.h
+++ b/src/Player/PlayerJudgeStartSquat.h
@@ -8,8 +8,8 @@ class PlayerCarryKeeper;
 
 class PlayerJudgeStartSquat : public IJudge {
 public:
-    PlayerJudgeStartSquat(const PlayerInput*, const PlayerCounterForceRun*,
-                          const PlayerCarryKeeper*);
+    PlayerJudgeStartSquat(const PlayerInput* input, const PlayerCounterForceRun* counterForceRun,
+                          const PlayerCarryKeeper* carryKeeper);
 
     void reset() override {}
 

--- a/src/Player/PlayerModelHolder.cpp
+++ b/src/Player/PlayerModelHolder.cpp
@@ -6,8 +6,8 @@ PlayerModelHolder::PlayerModelHolder(u32 bufferSize) {
     mBuffer.allocBuffer(bufferSize, nullptr);
 }
 
-void PlayerModelHolder::registerModel(al::LiveActor* liveActor, const char* name) {
-    Entry* entry = new Entry{liveActor};
+void PlayerModelHolder::registerModel(al::LiveActor* actor, const char* name) {
+    Entry* entry = new Entry{actor};
     entry->name = name;
     mBuffer.pushBack(entry);
 }

--- a/src/Player/PlayerModelHolder.h
+++ b/src/Player/PlayerModelHolder.h
@@ -16,13 +16,13 @@ public:
         al::LiveActor* actor;
     };
 
-    PlayerModelHolder(u32);
-    void registerModel(al::LiveActor*, const char*);
-    void changeModel(const char*);
-    al::LiveActor* findModelActor(const char*) const;
-    al::LiveActor* tryFindModelActor(const char*) const;
-    bool isCurrentModelLabel(const char*) const;
-    bool isCurrentModelLabelSubString(const char*) const;
+    PlayerModelHolder(u32 bufferSize);
+    void registerModel(al::LiveActor* actor, const char* name);
+    void changeModel(const char* name);
+    al::LiveActor* findModelActor(const char* name) const;
+    al::LiveActor* tryFindModelActor(const char* name) const;
+    bool isCurrentModelLabel(const char* name) const;
+    bool isCurrentModelLabelSubString(const char* name) const;
 
 private:
     sead::PtrArray<Entry> mBuffer;

--- a/src/Player/PlayerPainPartsKeeper.cpp
+++ b/src/Player/PlayerPainPartsKeeper.cpp
@@ -11,9 +11,9 @@
 #include "Player/PlayerCostumeInfo.h"
 #include "Player/PlayerModelHolder.h"
 
-PlayerPainPartsKeeper::PlayerPainPartsKeeper(const al::LiveActor* liveActor,
+PlayerPainPartsKeeper::PlayerPainPartsKeeper(const al::LiveActor* actor,
                                              const PlayerCostumeInfo* costumeInfo)
-    : mLiveActor(liveActor), mPlayerCostumeInfo(costumeInfo) {}
+    : mLiveActor(actor), mPlayerCostumeInfo(costumeInfo) {}
 
 void PlayerPainPartsKeeper::update() {
     updateNeedle();
@@ -57,9 +57,9 @@ bool PlayerPainPartsKeeper::isInvalidNoseDynamics() const {
 static sead::Vector3f initialPosition = {0, 0, 0};
 static sead::Vector3f initialRotation = {0, 270, 180};
 
-void PlayerPainPartsKeeper::createNoseNeedle(const PlayerModelHolder* playerModelHolder,
+void PlayerPainPartsKeeper::createNoseNeedle(const PlayerModelHolder* modelHolder,
                                              const al::ActorInitInfo& actorInitInfo) {
-    auto* playerFaceActor = playerModelHolder->findModelActor("Normal");
+    auto* playerFaceActor = modelHolder->findModelActor("Normal");
     auto* faceSubActor = al::getSubActor(playerFaceActor, "顔");
     mPlayerFaceActor = playerFaceActor;
     mNeedlesActor = new al::PartsModel("鼻のトゲ");

--- a/src/Player/PlayerPainPartsKeeper.h
+++ b/src/Player/PlayerPainPartsKeeper.h
@@ -12,13 +12,14 @@ class PlayerModelHolder;
 
 class PlayerPainPartsKeeper {
 public:
-    PlayerPainPartsKeeper(const al::LiveActor*, const PlayerCostumeInfo*);
+    PlayerPainPartsKeeper(const al::LiveActor* actor, const PlayerCostumeInfo* costumeInfo);
     void update();
     void updateNeedle();
     void resetPosition();
     bool isEnableNosePain() const;
     bool isInvalidNoseDynamics() const;
-    void createNoseNeedle(const PlayerModelHolder*, const al::ActorInitInfo&);
+    void createNoseNeedle(const PlayerModelHolder* modelHolder,
+                          const al::ActorInitInfo& actorInitInfo);
     void appearNeedle();
 
 private:

--- a/src/Player/PlayerStateHeadSliding.h
+++ b/src/Player/PlayerStateHeadSliding.h
@@ -14,7 +14,7 @@ class PlayerAnimator;
 class PlayerStateHeadSliding : public al::ActorStateBase {
 public:
     PlayerStateHeadSliding(al::LiveActor* player, const PlayerConst* pConst,
-                           const IUsePlayerCollision* collision, const PlayerInput* input,
+                           const IUsePlayerCollision* collider, const PlayerInput* input,
                            const PlayerActionDiveInWater* actionDiveInWater,
                            PlayerAnimator* animator);
 

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -43,14 +43,14 @@ public:
     enum EMaterialChangeTrigger : u32 {};
 
     PlayerTrigger();
-    void set(ECollisionTrigger);
-    void set(EAttackSensorTrigger);
-    void set(EActionTrigger);
-    void set(EReceiveSensorTrigger);
-    void set(EPreMovementTrigger);
-    void set(EDemoEndTrigger);
-    void set(EMaterialChangeTrigger);
-    void setRecMaterialTrigger(const char*);
+    void set(ECollisionTrigger flag);
+    void set(EAttackSensorTrigger flag);
+    void set(EActionTrigger flag);
+    void set(EReceiveSensorTrigger flag);
+    void set(EPreMovementTrigger flag);
+    void set(EDemoEndTrigger flag);
+    void set(EMaterialChangeTrigger flag);
+    void setRecMaterialTrigger(const char* materialTrigger);
     void clearCollisionTrigger();
     void clearAttackSensorTrigger();
     void clearActionTrigger();
@@ -58,13 +58,13 @@ public:
     void clearPreMovementTrigger();
     void clearDemoEndTrigger();
     void clearMaterialChangeTrigger();
-    bool isOn(ECollisionTrigger) const;
-    bool isOn(EAttackSensorTrigger) const;
-    bool isOn(EActionTrigger) const;
-    bool isOn(EReceiveSensorTrigger) const;
-    bool isOn(EPreMovementTrigger) const;
-    bool isOn(EDemoEndTrigger) const;
-    bool isOn(EMaterialChangeTrigger) const;
+    bool isOn(ECollisionTrigger flag) const;
+    bool isOn(EAttackSensorTrigger flag) const;
+    bool isOn(EActionTrigger flag) const;
+    bool isOn(EReceiveSensorTrigger flag) const;
+    bool isOn(EPreMovementTrigger flag) const;
+    bool isOn(EDemoEndTrigger flag) const;
+    bool isOn(EMaterialChangeTrigger flag) const;
     bool isOnUpperPunchHit() const;
     bool isOnUpperPunchHitToss() const;
     bool isOnAnyDamage() const;
@@ -75,7 +75,7 @@ public:
     bool isOnHipDropCancelThrow() const;
     bool isOnYoshiHackEnd() const;
     bool isOnCollisionExpandCheck() const;
-    bool tryGetRecMaterialCode(const char**) const;
+    bool tryGetRecMaterialCode(const char** dest) const;
 
 private:
     sead::BitFlag32 mCollisionTrigger = 0;

--- a/src/Scene/StageSceneStatePauseMenu.h
+++ b/src/Scene/StageSceneStatePauseMenu.h
@@ -58,7 +58,7 @@ public:
     bool isModeSelectEnd() const;
     bool checkNeedKillByHostAndEnd();
 
-    void startActionMario(const char*);
+    void startActionMario(const char* actionName);
     al::LiveActor* getMarioActor() const;
 
     bool isDrawLayout() const;

--- a/src/Scene/TitleMenuScene.h
+++ b/src/Scene/TitleMenuScene.h
@@ -24,7 +24,7 @@ public:
     bool isChangeLanguage() const;
     const char* getLanguage() const;
     bool isNewGame() const;
-    void startLoadDirect(bool);
+    void startLoadDirect(bool isGameLoad);
     void setScenario();
     void setLoadPercent(f32 percent);
     bool isCancelLoadWorldResource() const;

--- a/src/Sequence/WorldResourceLoader.cpp
+++ b/src/Sequence/WorldResourceLoader.cpp
@@ -11,7 +11,6 @@
 
 const s32 priority = sead::Thread::cDefaultPriority;
 
-// for some reason tools/check doesn't show this?
 WorldResourceLoader::WorldResourceLoader(GameDataHolder* dataHolder) : mDataHolder(dataHolder) {
     using WorldResourceLoaderFunctor =
         al::FunctorV0M<WorldResourceLoader*, void (WorldResourceLoader::*)()>;

--- a/src/Sequence/WorldResourceLoader.h
+++ b/src/Sequence/WorldResourceLoader.h
@@ -9,21 +9,22 @@
 
 class WorldResourceLoader : public al::HioNode {
 public:
-    WorldResourceLoader(GameDataHolder*);
+    WorldResourceLoader(GameDataHolder* dataHolder);
     virtual ~WorldResourceLoader();
     void loadResource();
     void cancelLoadWorldResource();
     void tryDestroyWorldResource();
-    bool requestLoadWorldHomeStageResource(s32 worldIndex, s32 scenario);
+    bool requestLoadWorldHomeStageResource(s32 loadWorldId, s32 scenario);
     bool isEndLoadWorldResource() const;
-    void requestLoadWorldResourceCommon(s32);
-    bool requestLoadWorldResource(s32);
+    void requestLoadWorldResourceCommon(s32 loadWorldId);
+    bool requestLoadWorldResource(s32 loadWorldId);
     void createResourcePlayer();
     void tryDestroyWorldResourceOnlyCap();
     f32 calcLoadPercent() const;
     s32 getLoadWorldId() const;
-    al::Resource* tryLoadResource(const char*, const char*, const char*);
-    void loadWorldResource(s32, s32, bool, const char*);
+    al::Resource* tryLoadResource(const char* resPath, const char* ext, const char* category);
+    void loadWorldResource(s32 loadWorldId, s32 scenario, bool isScenarioResources,
+                           const char* resourceCategory);
     f32 calcWorldResourceHeapSize() const;
 
 private:

--- a/src/System/GameConfigData.h
+++ b/src/System/GameConfigData.h
@@ -22,12 +22,12 @@ public:
     void onCameraReverseInputV();
     void offCameraReverseInputV();
     s32 getCameraStickSensitivityLevel() const;
-    void setCameraStickSensitivityLevel(s32);
+    void setCameraStickSensitivityLevel(s32 value);
     bool isValidCameraGyro() const;
     void validateCameraGyro();
     void invalidateCameraGyro();
     s32 getCameraGyroSensitivityLevel() const;
-    void setCameraGyroSensitivityLevel(s32);
+    void setCameraGyroSensitivityLevel(s32 value);
     bool isUseOpenListAdditionalButton() const;
     void onUseOpenListAdditionalButton();
     void offUseOpenListAdditionalButton();
@@ -35,9 +35,9 @@ public:
     void validatePadRumble();
     void invalidatePadRumble();
     s32 getPadRumbleLevel() const;
-    void setPadRumbleLevel(s32);
-    void write(al::ByamlWriter*) override;
-    void read(const al::ByamlIter&) override;
+    void setPadRumbleLevel(s32 value);
+    void write(al::ByamlWriter* writer) override;
+    void read(const al::ByamlIter& conf) override;
 
 private:
     s32 mCameraStickSensitivityLevel = -1;

--- a/src/System/GameDataFile.h
+++ b/src/System/GameDataFile.h
@@ -15,14 +15,14 @@ public:
 
         void clear();
 
-        bool isDisableByWorldWarpHole(bool) const;
-        bool isEnableUnlock(s32, bool, s32, bool) const;
-        bool isHintStatusUnlock(s32, s32, bool) const;
+        bool isDisableByWorldWarpHole(bool condition) const;
+        bool isEnableUnlock(s32 curWorldId, bool isGameClear, s32 scenarioNo, bool isInWorld) const;
+        bool isHintStatusUnlock(s32 curWorldId, s32 scenarioNo, bool isInWorld) const;
         bool isHintStatusUnlockByNpc() const;
         bool isHintStatusUnlockByAmiibo() const;
-        bool isEnableNameUnlockByScenario(s32, s32, bool) const;
+        bool isEnableNameUnlockByScenario(s32 curWorldId, s32 scenarioNo, bool isInWorld) const;
 
-        bool testFunc(s32, bool, s32, bool) const;
+        bool testFunc(s32 curWorldId, bool isGameClear, s32 scenarioNo, bool isInWorld) const;
 
     private:
         sead::FixedSafeString<0x80> mStageName;

--- a/src/System/GameDataHolderAccessor.h
+++ b/src/System/GameDataHolderAccessor.h
@@ -9,8 +9,8 @@ class GameDataHolder;
 
 class GameDataHolderAccessor {
 public:
-    GameDataHolderAccessor(const al::IUseSceneObjHolder*);
-    GameDataHolderAccessor(const al::SceneObjHolder*);
+    GameDataHolderAccessor(const al::IUseSceneObjHolder* holder);
+    GameDataHolderAccessor(const al::SceneObjHolder* holder);
 
     GameDataHolderAccessor(GameDataHolder* holder) { mData = holder; }
 

--- a/src/System/SaveObjInfo.h
+++ b/src/System/SaveObjInfo.h
@@ -11,16 +11,16 @@ public:
     enum class SaveType { Write, NoWriteInSameWorld, NoWriteResetMinigame, NoWriteInSameScenario };
 
     static SaveObjInfo* createSaveObjInfoWriteSaveData(const al::ActorInitInfo& initInfo,
-                                                       const al::PlacementId* placementId);
+                                                       const al::PlacementId* id);
     static SaveObjInfo*
     createSaveObjInfoNoWriteSaveDataInSameWorld(const al::ActorInitInfo& initInfo,
-                                                const al::PlacementId* placementId);
+                                                const al::PlacementId* id);
     static SaveObjInfo*
     createSaveObjInfoNoWriteSaveDataInSameWorldResetMiniGame(const al::ActorInitInfo& initInfo,
-                                                             const al::PlacementId* placementId);
+                                                             const al::PlacementId* id);
     static SaveObjInfo*
     createSaveObjInfoNoWriteSaveDataInSameScenario(const al::ActorInitInfo& initInfo,
-                                                   const al::PlacementId* placementId);
+                                                   const al::PlacementId* id);
 
     SaveObjInfo(const al::ActorInitInfo& initInfo, const al::PlacementId* placementId,
                 SaveType saveType);

--- a/src/Util/ActorDimensionUtil.h
+++ b/src/Util/ActorDimensionUtil.h
@@ -15,30 +15,32 @@ class IUsePlayerCollision;
 
 namespace rs {
 
-ActorDimensionKeeper* createDimensionKeeper(const al::LiveActor*);
+ActorDimensionKeeper* createDimensionKeeper(const al::LiveActor* actor);
 void updateDimensionKeeper(ActorDimensionKeeper*);
 const char* getSpecialPurposeName2DOnly();
 void createAndSetFilter2DOnly(al::LiveActor*);
 al::CollisionPartsFilterBase* createCollisionPartsFilter2DOnly();
-bool is2D(const IUseDimension*);
-bool isIn2DArea(const IUseDimension*);
-bool is3D(const IUseDimension*);
-bool isChange2D(const IUseDimension*);
-bool isChange3D(const IUseDimension*);
-bool isNearSnapSurface(const IUseDimension*, f32);
-void calcLockDirection(sead::Vector3f*, const IUseDimension*);
-void calcDimensionGravity(sead::Vector3f*, const IUseDimension*, const sead::Vector3f&);
-void setDimensionGravity(al::LiveActor*, const IUseDimension*);
-void syncDimensionPoseGravity(al::LiveActor*, const IUseDimension*);
-void calcLockedMoveVec(sead::Vector3f*, const IUseDimension*, f32);
-void pushOutFrom2DArea(al::LiveActor*, const IUseDimension*, f32, f32);
-void snap2D(al::LiveActor*, const IUseDimension*, f32);
-void snap2DGravity(al::LiveActor*, const IUseDimension*, f32);
-void snap2DUp(al::LiveActor*, const IUseDimension*, f32);
-void snap2DParallelizeFront(al::LiveActor*, const IUseDimension*, f32);
-bool snap2DGravityPoseWithRotateCenter(al::LiveActor*, IUsePlayerCollision*, const IUseDimension*,
-                                       f32, f32, const sead::Vector3f&);
-bool calcSnap2DPosition(sead::Vector3f*, const IUseDimension*, const sead::Vector3f&, f32);
+bool is2D(const IUseDimension* dimension);
+bool isIn2DArea(const IUseDimension* dimension);
+bool is3D(const IUseDimension* dimension);
+bool isChange2D(const IUseDimension* dimension);
+bool isChange3D(const IUseDimension* dimension);
+bool isNearSnapSurface(const IUseDimension* dimension, f32);
+void calcLockDirection(sead::Vector3f*, const IUseDimension* dimension);
+void calcDimensionGravity(sead::Vector3f*, const IUseDimension* dimension, const sead::Vector3f&);
+void setDimensionGravity(al::LiveActor*, const IUseDimension* dimension);
+void syncDimensionPoseGravity(al::LiveActor*, const IUseDimension* dimension);
+void calcLockedMoveVec(sead::Vector3f*, const IUseDimension* dimension, f32);
+void pushOutFrom2DArea(al::LiveActor*, const IUseDimension* dimension, f32, f32);
+void snap2D(al::LiveActor*, const IUseDimension* dimension, f32);
+void snap2DGravity(al::LiveActor*, const IUseDimension* dimension, f32);
+void snap2DUp(al::LiveActor*, const IUseDimension* dimension, f32);
+void snap2DParallelizeFront(al::LiveActor*, const IUseDimension* dimension, f32);
+bool snap2DGravityPoseWithRotateCenter(al::LiveActor*, IUsePlayerCollision*,
+                                       const IUseDimension* dimension, f32, f32,
+                                       const sead::Vector3f&);
+bool calcSnap2DPosition(sead::Vector3f*, const IUseDimension* dimension, const sead::Vector3f&,
+                        f32);
 void attachMtxConnectorTo2DCollision(al::MtxConnector*, const al::LiveActor*, const sead::Vector3f&,
                                      const sead::Vector3f&);
 void attachMtxConnectorTo2DCollision(al::MtxConnector*, const al::LiveActor*, bool);


### PR DESCRIPTION
Yesterday I started working on a tool in rust that uses `libclang` to do more "complex" linter checks. When thinking what linter check to implement first, I remembered #497, so I decided to implement the check mentioned there. The tool still requires discussion and refactoring before it can be upstreamed to either this repo, a new repo or viking in `nx-decomp-tools`, however the functions reported by that linter check can already be fixed, so this PR does that for everything in `src/`. Some of these functions didn't have any param names in the declarations of the functions, but others had params that were named differently between the declaration and definition. Since I fixed all these manually, I've also completely renamed some existing params and done stuff like removing some unnecessary mismatch comments

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/643)
<!-- Reviewable:end -->
