### PR TITLE
Player: Implement `PlayerStateGroundSpin`

### DIFF
--- a/src/Player/PlayerActionGroundMoveControl.h
+++ b/src/Player/PlayerActionGroundMoveControl.h
@@ -35,7 +35,7 @@ public:
     void updatePoseUpFront(const sead::Vector3f&, const sead::Vector3f&, f32);
 
     const sead::Vector3f& getGroundNormal() const { return mGroundNormal; }
-    
+
     void set_c4(bool c4) { _c4 = c4; }
 
 private:

--- a/src/Player/PlayerActionGroundMoveControl.h
+++ b/src/Player/PlayerActionGroundMoveControl.h
@@ -34,8 +34,18 @@ public:
     f32 calcAccelRate(f32) const;
     void updatePoseUpFront(const sead::Vector3f&, const sead::Vector3f&, f32);
 
+    const sead::Vector3f& getGroundNormal() const { return mGroundNormal; }
+    
+    void set_c4(bool c4) { _c4 = c4; }
+
 private:
-    void* filler[0xD8 / 8];
+    void* _0[5];
+    bool _28;
+    sead::Vector3f mGroundNormal;
+    void* _38[17];
+    f32 _c0;
+    bool _c4;
+    void* _c8[2];
 };
 
 static_assert(sizeof(PlayerActionGroundMoveControl) == 0xD8);

--- a/src/Player/PlayerInput.h
+++ b/src/Player/PlayerInput.h
@@ -89,6 +89,8 @@ public:
     void calcMoveInput(sead::Vector3f*, const sead::Vector3f&) const;
     void calcMoveDirection(sead::Vector3f*, const sead::Vector3f&) const;
 
+    bool isSpinClockwise() const;
+
 private:
     const al::LiveActor* mLiveActor;
     const IUsePlayerCollision* mPlayerCollision;

--- a/src/Player/PlayerStateGroundSpin.cpp
+++ b/src/Player/PlayerStateGroundSpin.cpp
@@ -1,0 +1,68 @@
+#include "Player/PlayerStateGroundSpin.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionGroundMoveControl.h"
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerInput.h"
+#include "Util/ObjUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateGroundSpin, GroundSpin);
+
+NERVES_MAKE_STRUCT(PlayerStateGroundSpin, GroundSpin);
+}  // namespace
+
+PlayerStateGroundSpin::PlayerStateGroundSpin(al::LiveActor* parent,
+                                             const IUsePlayerCollision* collision,
+                                             const PlayerInput* input,
+                                             const PlayerConst* pConst,
+                                             PlayerAnimator* animator)
+    : ActorStateBase("地上スピン", parent), mCollision(collision), mPlayerInput(input),
+      mPlayerConst(pConst), mPlayerAnimator(animator) {
+    mGroundMoveCtrl = new PlayerActionGroundMoveControl(parent, pConst, input, collision);
+    mGroundMoveCtrl->set_c4(true);
+    mGroundMoveCtrl->setup(0.0f, 0.0f, 0, 0, 0, 0.0f, 0.0f, 0);
+    initNerve(&NrvPlayerStateGroundSpin.GroundSpin, 0);
+}
+
+void PlayerStateGroundSpin::appear() {
+    al::ActorStateBase::appear();
+    mGroundMoveCtrl->appear();
+    mIsSpinClockwise = mPlayerInput->isSpinClockwise();
+    al::setNerve(this, &NrvPlayerStateGroundSpin.GroundSpin);
+}
+
+void PlayerStateGroundSpin::exeGroundSpin() {
+    if (al::isFirstStep(this))
+        mPlayerAnimator->startAnim(mIsSpinClockwise ? "SpinGroundR" : "SpinGroundL");
+
+    sead::Vector3f velocity = {0.0f, 0.0f, 0.0f};
+    mGroundMoveCtrl->updateNormalAndSnap(&velocity);
+
+    sead::Vector3f input = {0.0f, 0.0f, 0.0f};
+    mPlayerInput->calcMoveInput(&input, mGroundMoveCtrl->getGroundNormal());
+
+    velocity *= mPlayerConst->getGroundSpinBrakeRate();
+    f32 maxSpeed =
+        sead::Mathf::max(velocity.length(), mPlayerConst->getGroundSpinMoveSpeedMax());
+    velocity += mPlayerConst->getGroundSpinAccelRate() * input;
+    al::limitLength(&velocity, velocity, maxSpeed);
+
+    al::setVelocity(mActor,
+                    velocity - mGroundMoveCtrl->getGroundNormal() * mPlayerConst->getGravityMove());
+
+    sead::Vector3f frontDir = {0.0f, 0.0f, 0.0f};
+    if (!al::tryNormalizeOrZero(&frontDir, velocity))
+        al::calcFrontDir(&frontDir, mActor);
+
+    rs::slerpUpFront(mActor, sead::Vector3f::ey, frontDir, mPlayerConst->getSlerpQuatRate(), 0.0f);
+
+    if (!al::isLessStep(this, mPlayerConst->getGroundSpinFrame()))
+        kill();
+}

--- a/src/Player/PlayerStateGroundSpin.cpp
+++ b/src/Player/PlayerStateGroundSpin.cpp
@@ -20,8 +20,7 @@ NERVES_MAKE_STRUCT(PlayerStateGroundSpin, GroundSpin);
 
 PlayerStateGroundSpin::PlayerStateGroundSpin(al::LiveActor* parent,
                                              const IUsePlayerCollision* collision,
-                                             const PlayerInput* input,
-                                             const PlayerConst* pConst,
+                                             const PlayerInput* input, const PlayerConst* pConst,
                                              PlayerAnimator* animator)
     : ActorStateBase("地上スピン", parent), mCollision(collision), mPlayerInput(input),
       mPlayerConst(pConst), mPlayerAnimator(animator) {
@@ -49,8 +48,7 @@ void PlayerStateGroundSpin::exeGroundSpin() {
     mPlayerInput->calcMoveInput(&input, mGroundMoveCtrl->getGroundNormal());
 
     velocity *= mPlayerConst->getGroundSpinBrakeRate();
-    f32 maxSpeed =
-        sead::Mathf::max(velocity.length(), mPlayerConst->getGroundSpinMoveSpeedMax());
+    f32 maxSpeed = sead::Mathf::max(velocity.length(), mPlayerConst->getGroundSpinMoveSpeedMax());
     velocity += mPlayerConst->getGroundSpinAccelRate() * input;
     al::limitLength(&velocity, velocity, maxSpeed);
 

--- a/src/Player/PlayerStateGroundSpin.h
+++ b/src/Player/PlayerStateGroundSpin.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class IUsePlayerCollision;
+class PlayerInput;
+class PlayerConst;
+class PlayerAnimator;
+class PlayerActionGroundMoveControl;
+
+class PlayerStateGroundSpin : public al::ActorStateBase {
+public:
+    PlayerStateGroundSpin(al::LiveActor* parent, const IUsePlayerCollision* collision,
+                          const PlayerInput* input, const PlayerConst* pConst,
+                          PlayerAnimator* animator);
+
+    void appear() override;
+    void exeGroundSpin();
+
+private:
+    const IUsePlayerCollision* mCollision;
+    const PlayerInput* mPlayerInput;
+    const PlayerConst* mPlayerConst;
+    PlayerAnimator* mPlayerAnimator;
+    PlayerActionGroundMoveControl* mGroundMoveCtrl = nullptr;
+    bool mIsSpinClockwise = false;
+};


### PR DESCRIPTION
The name is pretty clear on what this state is doing: Spin the player while grounded.

Its implementation is also mostly straight-forward. Only one notable thing:
- the direction of a spin (clockwise/counter-clockwise) only changes the animation and does not affect anything else

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/646)
<!-- Reviewable:end -->
