### PR TITLE
Project/Memory: Implement `MemorySystem`

### DIFF
--- a/lib/al/Library/Memory/HeapUtil.cpp
+++ b/lib/al/Library/Memory/HeapUtil.cpp
@@ -71,7 +71,7 @@ void freeAllSequenceHeap() {
     clearFileLoaderEntry();
 }
 
-bool printAllSequenceHeap() {
+void printAllSequenceHeap() {
     return alProjectInterface::getSystemKit()->getMemorySystem()->printSequenceHeap();
 }
 

--- a/lib/al/Library/Memory/HeapUtil.cpp
+++ b/lib/al/Library/Memory/HeapUtil.cpp
@@ -72,7 +72,7 @@ void freeAllSequenceHeap() {
 }
 
 void printAllSequenceHeap() {
-    return alProjectInterface::getSystemKit()->getMemorySystem()->printSequenceHeap();
+    alProjectInterface::getSystemKit()->getMemorySystem()->printSequenceHeap();
 }
 
 void createSceneHeap(const char* stageName, bool backwards) {

--- a/lib/al/Library/Memory/HeapUtil.h
+++ b/lib/al/Library/Memory/HeapUtil.h
@@ -18,7 +18,7 @@ void addNamedHeap(sead::Heap* heap, const char* heapName);
 void removeNamedHeap(const char* heapName);
 void createSequenceHeap();
 void freeAllSequenceHeap();
-bool printAllSequenceHeap();
+void printAllSequenceHeap();
 void createSceneHeap(const char* stageName, bool backwards);
 void createSceneResourceHeap(const char* stageName);
 bool isCreatedSceneResourceHeap();

--- a/lib/al/Project/Memory/MemorySystem.cpp
+++ b/lib/al/Project/Memory/MemorySystem.cpp
@@ -1,5 +1,6 @@
 #include "Project/Memory/MemorySystem.h"
 
+#include <basis/seadRawPrint.h>
 #include <filedevice/seadFileDeviceMgr.h>
 #include <heap/seadHeapMgr.h>
 
@@ -8,8 +9,6 @@
 #include "Library/Resource/ResourceUtil.h"
 #include "Library/Yaml/ByamlIter.h"
 #include "Project/Memory/SceneHeapSetter.h"
-#include "basis/seadRawPrint.h"
-#include "heap/seadFrameHeap.h"
 
 namespace al {
 
@@ -28,12 +27,12 @@ MemorySystem::MemorySystem(sead::Heap* heap)
         }
 
         mIsExistFileResource = sead::FileDeviceMgr::instance()->getMainFileDevice()->isExistFile(
-            al::StringTmp<64>("%s.szs", "SystemData/MemorySystem"));
+            StringTmp<64>("%s.szs", "SystemData/MemorySystem"));
     }
 }
 
 void MemorySystem::allocFailedCallbackFunc(const sead::HeapMgr::AllocFailedCallbackArg* arg) {
-    if (al::isEqualString(arg->heap->getName().cstr(), "gpu"))
+    if (isEqualString(arg->heap->getName().cstr(), "gpu"))
         return;
     arg->heap->dump();
     sead::system::Halt();
@@ -63,7 +62,7 @@ bool MemorySystem::createSceneHeap(const char* stageName, bool backwards) {
     sead::Heap::HeapDirection direction =
         backwards ? sead::Heap::cHeapDirection_Reverse : sead::Heap::cHeapDirection_Forward;
 
-    sead::Heap* currentHeap = al::getCurrentHeap();
+    sead::Heap* currentHeap = getCurrentHeap();
     if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
         size = currentHeap->getMaxAllocatableSize(8);
 
@@ -73,24 +72,25 @@ bool MemorySystem::createSceneHeap(const char* stageName, bool backwards) {
     return currentSceneResourceHeap == nullptr;
 }
 
-__attribute__((always_inline)) u64 MemorySystem::getSceneResourceHeapSize(const char* stageName) const {
-    bool isStaffRollOrDemoEnding = stageName && (al::isEqualString(stageName, "StaffRollStage") ||
-                                                 al::isEqualString(stageName, "DemoEndingStage"));
+__attribute__((always_inline)) u64
+MemorySystem::getSceneResourceHeapSize(const char* stageName) const {
+    bool isStaffRollOrDemoEnding = stageName && (isEqualString(stageName, "StaffRollStage") ||
+                                                 isEqualString(stageName, "DemoEndingStage"));
 
-    if (!isStaffRollOrDemoEnding && this->mWorldResourceHeap)
+    if (!isStaffRollOrDemoEnding && mWorldResourceHeap)
         return 0x80000LL;
 
     if (stageName && mIsExistFileResource) {
-        al::ByamlIter heapSizeMap =
-            al::findOrCreateResource("SystemData/MemorySystem", 0LL)->getByml("HeapSizeDefine");
+        ByamlIter heapSizeMap =
+            findOrCreateResource("SystemData/MemorySystem", 0LL)->getByml("HeapSizeDefine");
 
         for (s32 i = 0; i < heapSizeMap.getSize(); i++) {
-            al::ByamlIter heapSizeEntry;
+            ByamlIter heapSizeEntry;
             heapSizeMap.tryGetIterByIndex(&heapSizeEntry, i);
 
             const char* stage = nullptr;
             heapSizeEntry.tryGetStringByKey(&stage, "Stage");
-            if (al::isEqualString(stage, stageName)) {
+            if (isEqualString(stage, stageName)) {
                 f32 sceneResourceMB = 0.0;
                 if (!heapSizeEntry.tryGetFloatByKey(&sceneResourceMB, "SceneResourceNx"))
                     heapSizeEntry.tryGetFloatByKey(&sceneResourceMB, "SceneResource");
@@ -103,7 +103,8 @@ __attribute__((always_inline)) u64 MemorySystem::getSceneResourceHeapSize(const 
     return 0x6400000LL;
 }
 
-// NON_MATCHING: within getting size and saving to mSceneResourceHeap (https://decomp.me/scratch/Pqb4H)
+// NON_MATCHING: within getting size and saving to mSceneResourceHeap
+// (https://decomp.me/scratch/Pqb4H)
 void MemorySystem::createSceneResourceHeap(const char* stageName, bool backwards) {
     u64 size = getSceneResourceHeapSize(stageName);
 
@@ -111,7 +112,7 @@ void MemorySystem::createSceneResourceHeap(const char* stageName, bool backwards
         backwards ? sead::Heap::cHeapDirection_Reverse : sead::Heap::cHeapDirection_Forward;
 
     if (size != 0) {
-        sead::Heap* currentHeap = al::getCurrentHeap();
+        sead::Heap* currentHeap = getCurrentHeap();
         if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
             size = currentHeap->getMaxAllocatableSize(8);
     }
@@ -134,7 +135,7 @@ void MemorySystem::destroySceneResourceHeap() {
 void MemorySystem::createCourseSelectHeap() {
     {
         u64 size = 0xA00000;
-        sead::Heap* currentHeap = al::getCurrentHeap();
+        sead::Heap* currentHeap = getCurrentHeap();
         if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
             size = currentHeap->getMaxAllocatableSize(8);
 
@@ -144,7 +145,7 @@ void MemorySystem::createCourseSelectHeap() {
     }
     {
         u64 size = 0x2800000;
-        sead::Heap* currentHeap = al::getCurrentHeap();
+        sead::Heap* currentHeap = getCurrentHeap();
         if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
             size = currentHeap->getMaxAllocatableSize(8);
 

--- a/lib/al/Project/Memory/MemorySystem.cpp
+++ b/lib/al/Project/Memory/MemorySystem.cpp
@@ -103,7 +103,7 @@ __attribute__((always_inline)) u64 MemorySystem::getSceneResourceHeapSize(const 
     return 0x6400000LL;
 }
 
-// NON_MATCHING
+// NON_MATCHING: within getting size and saving to mSceneResourceHeap (https://decomp.me/scratch/Pqb4H)
 void MemorySystem::createSceneResourceHeap(const char* stageName, bool backwards) {
     u64 size = getSceneResourceHeapSize(stageName);
 

--- a/lib/al/Project/Memory/MemorySystem.cpp
+++ b/lib/al/Project/Memory/MemorySystem.cpp
@@ -1,0 +1,200 @@
+#include "Project/Memory/MemorySystem.h"
+
+#include <filedevice/seadFileDeviceMgr.h>
+#include <heap/seadHeapMgr.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Resource/Resource.h"
+#include "Library/Resource/ResourceUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Project/Memory/SceneHeapSetter.h"
+#include "basis/seadRawPrint.h"
+#include "heap/seadFrameHeap.h"
+
+namespace al {
+
+MemorySystem::MemorySystem(sead::Heap* heap)
+    : mDelegate(this, &MemorySystem::allocFailedCallbackFunc) {
+    sead::HeapMgr::instance()->setAllocFailedCallback(&mDelegate);
+    mStationedHeap =
+        sead::ExpHeap::tryCreate((u32)heap->getMaxAllocatableSize(8) - 0x1900000, "StationedHeap",
+                                 heap, 8, sead::Heap::cHeapDirection_Forward, false);
+
+    {
+        sead::ScopedCurrentHeapSetter setter(mStationedHeap);
+        {
+            sead::ScopedCurrentHeapSetter setter(mStationedHeap);
+            mHeapList.allocBuffer(32, nullptr);
+        }
+
+        mIsExistFileResource = sead::FileDeviceMgr::instance()->getMainFileDevice()->isExistFile(
+            al::StringTmp<64>("%s.szs", "SystemData/MemorySystem"));
+    }
+}
+
+void MemorySystem::allocFailedCallbackFunc(const sead::HeapMgr::AllocFailedCallbackArg* arg) {
+    if (al::isEqualString(arg->heap->getName().cstr(), "gpu"))
+        return;
+    arg->heap->dump();
+    sead::system::Halt();
+}
+
+void MemorySystem::createSequenceHeap() {
+    mSequenceHeap = sead::ExpHeap::tryCreate(0, "SequenceHeap", nullptr, 8,
+                                             sead::Heap::cHeapDirection_Forward, false);
+}
+
+void MemorySystem::freeAllSequenceHeap() {
+    mSequenceHeap->freeAll();
+}
+
+void MemorySystem::printSequenceHeap() {
+    mSequenceHeap->dumpFreeList();
+    mSequenceHeap->dumpUseList();
+    mSequenceHeap->dump();
+}
+
+bool MemorySystem::createSceneHeap(const char* stageName, bool backwards) {
+    sead::Heap* currentSceneResourceHeap = mSceneResourceHeap;
+    if (!currentSceneResourceHeap)
+        createSceneResourceHeap(stageName, backwards);
+
+    u64 size = 0x1EA00000;
+    sead::Heap::HeapDirection direction =
+        backwards ? sead::Heap::cHeapDirection_Reverse : sead::Heap::cHeapDirection_Forward;
+
+    sead::Heap* currentHeap = al::getCurrentHeap();
+    if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
+        size = currentHeap->getMaxAllocatableSize(8);
+
+    mSceneHeap = sead::ExpHeap::tryCreate(size, "SceneHeap", nullptr, 8, direction, false);
+    mSceneHeap->mFlag.reset(sead::Heap::Flag::cEnableDebugFillUser);
+
+    return currentSceneResourceHeap == nullptr;
+}
+
+__attribute__((always_inline)) u64 MemorySystem::getSceneResourceHeapSize(const char* stageName) const {
+    bool isStaffRollOrDemoEnding = stageName && (al::isEqualString(stageName, "StaffRollStage") ||
+                                                 al::isEqualString(stageName, "DemoEndingStage"));
+
+    if (!isStaffRollOrDemoEnding && this->mWorldResourceHeap)
+        return 0x80000LL;
+
+    if (stageName && mIsExistFileResource) {
+        al::ByamlIter heapSizeMap =
+            al::findOrCreateResource("SystemData/MemorySystem", 0LL)->getByml("HeapSizeDefine");
+
+        for (s32 i = 0; i < heapSizeMap.getSize(); i++) {
+            al::ByamlIter heapSizeEntry;
+            heapSizeMap.tryGetIterByIndex(&heapSizeEntry, i);
+
+            const char* stage = nullptr;
+            heapSizeEntry.tryGetStringByKey(&stage, "Stage");
+            if (al::isEqualString(stage, stageName)) {
+                f32 sceneResourceMB = 0.0;
+                if (!heapSizeEntry.tryGetFloatByKey(&sceneResourceMB, "SceneResourceNx"))
+                    heapSizeEntry.tryGetFloatByKey(&sceneResourceMB, "SceneResource");
+
+                return sceneResourceMB * 1024.0f * 1024.0f;
+            }
+        }
+    }
+
+    return 0x6400000LL;
+}
+
+// NON_MATCHING
+void MemorySystem::createSceneResourceHeap(const char* stageName, bool backwards) {
+    u64 size = getSceneResourceHeapSize(stageName);
+
+    sead::Heap::HeapDirection direction =
+        backwards ? sead::Heap::cHeapDirection_Reverse : sead::Heap::cHeapDirection_Forward;
+
+    if (size != 0) {
+        sead::Heap* currentHeap = al::getCurrentHeap();
+        if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
+            size = currentHeap->getMaxAllocatableSize(8);
+    }
+
+    mSceneResourceHeap =
+        sead::FrameHeap::tryCreate(size, "SceneHeapResource", nullptr, 8, direction, true);
+    mSceneResourceHeap->mFlag.reset(sead::Heap::Flag::cEnableDebugFillUser);
+}
+
+void MemorySystem::destroySceneHeap() {
+    mSceneHeap->destroy();
+    mSceneHeap = nullptr;
+}
+
+void MemorySystem::destroySceneResourceHeap() {
+    mSceneResourceHeap->destroy();
+    mSceneResourceHeap = nullptr;
+}
+
+void MemorySystem::createCourseSelectHeap() {
+    {
+        u64 size = 0xA00000;
+        sead::Heap* currentHeap = al::getCurrentHeap();
+        if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
+            size = currentHeap->getMaxAllocatableSize(8);
+
+        mCourseSelectResourceHeap = sead::ExpHeap::tryCreate(
+            size, "CourseSelectHeapResource", nullptr, 8, sead::Heap::cHeapDirection_Reverse, true);
+        mCourseSelectResourceHeap->mFlag.reset(sead::Heap::Flag::cEnableDebugFillUser);
+    }
+    {
+        u64 size = 0x2800000;
+        sead::Heap* currentHeap = al::getCurrentHeap();
+        if (currentHeap && currentHeap->getMaxAllocatableSize(8) < size)
+            size = currentHeap->getMaxAllocatableSize(8);
+
+        mCourseSelectHeap = sead::ExpHeap::tryCreate(size, "CourseSelectHeapScene", nullptr, 8,
+                                                     sead::Heap::cHeapDirection_Reverse, false);
+        mCourseSelectHeap->mFlag.reset(sead::Heap::Flag::cEnableDebugFillUser);
+    }
+}
+
+void MemorySystem::destroyCourseSelectHeap() {
+    mCourseSelectResourceHeap->destroy();
+    mCourseSelectResourceHeap = nullptr;
+    mCourseSelectHeap->destroy();
+    mCourseSelectHeap = nullptr;
+}
+
+void MemorySystem::createWorldResourceHeap() {
+    sead::Heap* parent = mSequenceHeap;
+    mWorldResourceHeap = sead::ExpHeap::create(0x35700000, "WorldHeapResource", parent, 8,
+                                               sead::Heap::cHeapDirection_Forward, true);
+}
+
+void MemorySystem::destroyWorldResourceHeap() {
+    mWorldResourceHeap->destroy();
+    mWorldResourceHeap = nullptr;
+}
+
+void MemorySystem::freeAllPlayerHeap() {
+    mPlayerResourceHeap->freeAll();
+}
+
+sead::Heap* MemorySystem::tryFindNamedHeap(const char* heapName) const {
+    sead::StrTreeMap<32, sead::Heap*>::Node* result = mHeapList.find(heapName);
+    if (!result)
+        return nullptr;
+    return result->value();
+}
+
+sead::Heap* MemorySystem::findNamedHeap(const char* heapName) const {
+    return tryFindNamedHeap(heapName);
+}
+
+void MemorySystem::addNamedHeap(sead::Heap* heap, const char* heapName) {
+    mHeapList.insert(heapName ?: heap->getName().cstr(), heap);
+}
+
+void MemorySystem::removeNamedHeap(const char* heapName) {
+    sead::SafeString name = heapName;
+    if (mHeapList.find(name))
+        mHeapList.erase(name);
+}
+
+}  // namespace al

--- a/lib/al/Project/Memory/MemorySystem.cpp
+++ b/lib/al/Project/Memory/MemorySystem.cpp
@@ -8,7 +8,7 @@
 #include "Library/Resource/Resource.h"
 #include "Library/Resource/ResourceUtil.h"
 #include "Library/Yaml/ByamlIter.h"
-#include "Project/Memory/SceneHeapSetter.h"
+#include "Project/Memory/Util.h"
 
 namespace al {
 

--- a/lib/al/Project/Memory/MemorySystem.h
+++ b/lib/al/Project/Memory/MemorySystem.h
@@ -2,6 +2,7 @@
 
 #include <container/seadStrTreeMap.h>
 #include <heap/seadExpHeap.h>
+#include <heap/seadFrameHeap.h>
 #include <heap/seadHeapMgr.h>
 
 namespace al {
@@ -14,7 +15,7 @@ public:
     void allocFailedCallbackFunc(const sead::HeapMgr::AllocFailedCallbackArg*);
     void createSequenceHeap();
     void freeAllSequenceHeap();
-    bool printSequenceHeap();
+    void printSequenceHeap();
     bool createSceneHeap(const char* stageName, bool backwards);
     void createSceneResourceHeap(const char* stageName, bool backwards);
     void destroySceneHeap();
@@ -24,26 +25,26 @@ public:
     void createWorldResourceHeap();
     void destroyWorldResourceHeap();
     void freeAllPlayerHeap();
-    sead::Heap* tryFindNamedHeap(const char* heapName);
-    sead::Heap* findNamedHeap(const char* heapName);
+    sead::Heap* tryFindNamedHeap(const char* heapName) const;
+    sead::Heap* findNamedHeap(const char* heapName) const;
     void addNamedHeap(sead::Heap* heap, const char* heapName);
     void removeNamedHeap(const char* heapName);
 
-    sead::ExpHeap* getStationedHeap() { return mStationedHeap; }
+    sead::Heap* getStationedHeap() { return mStationedHeap; }
 
-    sead::ExpHeap* getSequenceHeap() { return mSequenceHeap; }
+    sead::Heap* getSequenceHeap() { return mSequenceHeap; }
 
-    sead::ExpHeap* getSceneResourceHeap() { return mSceneResourceHeap; }
+    sead::Heap* getSceneResourceHeap() { return mSceneResourceHeap; }
 
-    sead::ExpHeap* getSceneHeap() { return mSceneHeap; }
+    sead::Heap* getSceneHeap() { return mSceneHeap; }
 
-    sead::ExpHeap* getPlayerResourceHeap() { return mPlayerResourceHeap; }
+    sead::Heap* getPlayerResourceHeap() { return mPlayerResourceHeap; }
 
-    sead::ExpHeap* getCourseSelectResourceHeap() { return mCourseSelectResourceHeap; }
+    sead::Heap* getCourseSelectResourceHeap() { return mCourseSelectResourceHeap; }
 
-    sead::ExpHeap* getCourseSelectHeap() { return mCourseSelectHeap; }
+    sead::Heap* getCourseSelectHeap() { return mCourseSelectHeap; }
 
-    sead::ExpHeap* getWorldResourceHeap() { return mWorldResourceHeap; }
+    sead::Heap* getWorldResourceHeap() { return mWorldResourceHeap; }
 
     AudioResourceDirector* getAudioResourceDirector() { return mAudioResourceDirector; }
 
@@ -52,17 +53,19 @@ public:
     }
 
 private:
-    sead::ExpHeap* mStationedHeap;
-    sead::ExpHeap* mSequenceHeap;
-    sead::ExpHeap* mSceneResourceHeap;
-    sead::ExpHeap* mSceneHeap;
-    sead::ExpHeap* mPlayerResourceHeap;
-    sead::ExpHeap* mCourseSelectResourceHeap;
-    sead::ExpHeap* mCourseSelectHeap;
-    sead::ExpHeap* mWorldResourceHeap;
+    inline u64 getSceneResourceHeapSize(const char* stageName) const;
+
+    sead::ExpHeap* mStationedHeap = nullptr;
+    sead::ExpHeap* mSequenceHeap = nullptr;
+    sead::FrameHeap* mSceneResourceHeap = nullptr;
+    sead::ExpHeap* mSceneHeap = nullptr;
+    sead::ExpHeap* mPlayerResourceHeap = nullptr;
+    sead::ExpHeap* mCourseSelectResourceHeap = nullptr;
+    sead::ExpHeap* mCourseSelectHeap = nullptr;
+    sead::ExpHeap* mWorldResourceHeap = nullptr;
     sead::StrTreeMap<32, sead::Heap*> mHeapList;
-    AudioResourceDirector* mAudioResourceDirector;
-    bool mIsExistFileResource;
+    AudioResourceDirector* mAudioResourceDirector = nullptr;
+    bool mIsExistFileResource = false;
     sead::Delegate1<MemorySystem, const sead::HeapMgr::AllocFailedCallbackArg*> mDelegate;
 };
 

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <heap/seadHeap.h>
+
+namespace al {
+
+class SceneHeapSetter {
+public:
+    SceneHeapSetter();
+};
+
+void copyMemoryFast(u32*, const u32*, u32);
+void copyMemory(void*, const void*, u32);
+bool tryCompressByZlib(u8*, u32*, const u8*, u32);
+bool tryDecompressByZlib(u8*, u32*, const u8*, u32);
+sead::Heap* getCurrentHeap();
+
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,19 +1,10 @@
 #pragma once
 
-#include <basis/seadTypes.h>
-#include <heap/seadHeap.h>
-
 namespace al {
 
 class SceneHeapSetter {
 public:
     SceneHeapSetter();
 };
-
-void copyMemoryFast(u32*, const u32*, u32);
-void copyMemory(void*, const void*, u32);
-bool tryCompressByZlib(u8*, u32*, const u8*, u32);
-bool tryDecompressByZlib(u8*, u32*, const u8*, u32);
-sead::Heap* getCurrentHeap();
 
 }  // namespace al

--- a/lib/al/Project/Memory/Util.h
+++ b/lib/al/Project/Memory/Util.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <heap/seadHeap.h>
+
+namespace al {
+
+void copyMemoryFast(u32*, const u32*, u32);
+void copyMemory(void*, const void*, u32);
+bool tryCompressByZlib(u8*, u32*, const u8*, u32);
+bool tryDecompressByZlib(u8*, u32*, const u8*, u32);
+sead::Heap* getCurrentHeap();
+
+}  // namespace al


### PR DESCRIPTION
This class is used to manage heaps for storing all data related to a specific scene, and clearing the heaps when unloading an area. Particularly notable are the hardcoded sizes for the different heap types. Replacing these functions would allow easy adjustment of these for modders.

One mismatch is introduced in this PR:
https://decomp.me/scratch/Pqb4H

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/648)
<!-- Reviewable:end -->
