### PR TITLE
Player: Implement `PlayerJudgeWallKeep`

### DIFF
--- a/lib/al/Library/Collision/CollisionPartsKeeperUtil.h
+++ b/lib/al/Library/Collision/CollisionPartsKeeperUtil.h
@@ -7,6 +7,8 @@ class CollisionPartsFilterBase;
 class IUseCollision;
 class Triangle;
 class TriangleFilterBase;
+struct HitInfo;
+struct ArrowHitInfo;
 
 bool isFloorCode(const Triangle&, const char*);
 }  // namespace al
@@ -23,4 +25,11 @@ bool getHitPosOnArrow(const al::IUseCollision*, sead::Vector3f*, const sead::Vec
                       const al::TriangleFilterBase*);
 s32 checkStrikeArrow(const al::IUseCollision*, const sead::Vector3f&, const sead::Vector3f&,
                      const al::CollisionPartsFilterBase*, const al::TriangleFilterBase*);
+                     
+const sead::Vector3f& getCollisionHitPos(const al::HitInfo*);
+const sead::Vector3f& getCollisionHitNormal(const al::HitInfo*);
+
+bool getLastPolyOnArrow(const al::IUseCollision*, const al::ArrowHitInfo**, const sead::Vector3f&,
+                        const sead::Vector3f&, const al::CollisionPartsFilterBase*,
+                        const al::TriangleFilterBase*);
 }  // namespace alCollisionUtil

--- a/lib/al/Library/Collision/PartsInterpolator.h
+++ b/lib/al/Library/Collision/PartsInterpolator.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class Triangle;
+
+class TriangleFilterBase {
+public:
+    virtual bool isInvalidTriangle(const al::Triangle& triangle) const = 0;
+};
+
+class TriangleFilterWallOnly : public al::TriangleFilterBase {
+public:
+    TriangleFilterWallOnly(const sead::Vector3f& down) : mDown(down) {}
+    bool isInvalidTriangle(const al::Triangle& triangle) const override;
+
+private:
+    const sead::Vector3f& mDown;
+};
+
+}

--- a/src/Player/PlayerCarryKeeper.h
+++ b/src/Player/PlayerCarryKeeper.h
@@ -6,6 +6,7 @@ class PlayerCarryKeeper {
 public:
     bool isThrowHold() const;
     bool isCarry() const;
+    bool isCarryWallKeep() const;
 
 private:
     u8 padding[0x70];

--- a/src/Player/PlayerCounterAfterUpperPunch.h
+++ b/src/Player/PlayerCounterAfterUpperPunch.h
@@ -9,6 +9,8 @@ public:
     PlayerCounterAfterUpperPunch();
     void update(const PlayerTrigger* trigger);
 
+    u32 getCounter() const { return mCounter; }
+
 private:
     // yes, this is an u32, bounded by a signed s32
     u32 mCounter = sead::Mathi::maxNumber();

--- a/src/Player/PlayerJudgeWallKeep.cpp
+++ b/src/Player/PlayerJudgeWallKeep.cpp
@@ -1,0 +1,157 @@
+#include "Player/PlayerJudgeWallKeep.h"
+
+#include "Library/Collision/CollisionPartsTriangle.h"
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/Collision/PartsInterpolator.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/MathUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerCarryKeeper.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerCounterAfterUpperPunch.h"
+#include "Player/PlayerCounterForceRun.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+PlayerJudgeWallKeep::PlayerJudgeWallKeep(
+    const al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+    const IUsePlayerCollision* collider, const IPlayerModelChanger* modelChanger,
+    const IUsePlayerHeightCheck* heightCheck,
+    const PlayerCounterAfterUpperPunch* counterAfterUpperPunch,
+    const PlayerWallActionHistory* wallActionHistory, const PlayerCarryKeeper* carryKeeper,
+    const PlayerTrigger* trigger, const PlayerCounterForceRun* counterForceRun)
+    : mPlayer(player), mConst(pConst), mInput(input), mCollider(collider),
+      mModelChanger(modelChanger), mHeightCheck(heightCheck),
+      mCounterAfterUpperPunch(counterAfterUpperPunch), mWallActionHistory(wallActionHistory),
+      mCarryKeeper(carryKeeper), mTrigger(trigger), mCounterForceRun(counterForceRun) {}
+
+void PlayerJudgeWallKeep::reset() {
+    mIsJudge = false;
+}
+
+void PlayerJudgeWallKeep::update() {
+    mIsJudge = false;
+    if (mModelChanger->is2DModel() || mCounterForceRun->isForceRun() ||
+        mCounterAfterUpperPunch->getCounter() < (u32)mConst->getWallInhibitAfterPunch() ||
+        (rs::isAboveGround(mHeightCheck) &&
+         rs::getGroundHeight(mHeightCheck) < mConst->getWallHeightLowLimit()) ||
+        rs::isCollidedGround(mCollider) || !rs::isCollidedWall(mCollider) ||
+        rs::isActionCodeNoWallKeepWall(mCollider) || !mCarryKeeper->isCarryWallKeep())
+        return;
+
+    const sead::Vector3f& collidedWallNormal = rs::getCollidedWallNormal(mCollider);
+    if (!rs::judgeEnableWallKeepHistory(mPlayer, mWallActionHistory, al::getTrans(mPlayer),
+                                        collidedWallNormal, mConst->getTall(), true))
+        return;
+
+    // required to be explicit block for stack management
+    {
+        const PlayerInput* input = mInput;
+        const al::LiveActor* player = mPlayer;
+        f32 wallKeepDegree = mConst->getWallKeepDegree();
+        const PlayerTrigger* trigger = mTrigger;
+        sead::Vector3f velocity = al::getVelocity(player);
+        const sead::Vector3f* gravity = &al::getGravity(player);
+        if (!al::tryNormalizeOrZero(&velocity) || velocity.dot(*gravity) <= 0.0f)
+            return;
+
+        if (trigger->isOn(PlayerTrigger::EActionTrigger_val30)) {
+            if (!input->isMoveDeepDown())
+                return;
+            sead::Vector3f moveInput = {0.0f, 0.0f, 0.0f};
+            input->calcMoveInput(&moveInput, -*gravity);
+            al::normalize(&moveInput);
+            if ((-moveInput).dot(collidedWallNormal) <
+                sead::Mathf::cos(sead::Mathf::deg2rad(wallKeepDegree)))
+                return;
+        } else {
+            sead::Vector3f facingDir;
+            al::calcFrontDir(&facingDir, player);
+            f32 cosOfDegree = sead::Mathf::cos(sead::Mathf::deg2rad(wallKeepDegree));
+            if ((-facingDir).dot(collidedWallNormal) < cosOfDegree)
+                return;
+
+            sead::Vector3f moveDirection = {0.0f, 0.0f, 0.0f};
+            input->calcMoveDirection(&moveDirection, -*gravity);
+            f32 dot = collidedWallNormal.dot(moveDirection);
+            if (dot > 0.0f && dot < cosOfDegree)
+                return;
+        }
+
+        sead::Vector3f verticalVelocity = {0.0f, 0.0f, 0.0f};
+        al::verticalizeVec(&verticalVelocity, *gravity, al::getVelocity(player));
+        if (al::isNearZero(verticalVelocity, 0.001f))
+            return;
+
+        sead::Vector3f playerUp;
+        al::calcUpDir(&playerUp, player);
+        sead::Vector3f trans = al::getTrans(player) + playerUp * 120.0f;
+        if (!alCollisionUtil::checkStrikeArrow(player, trans, collidedWallNormal * -77.0f, nullptr,
+                                               nullptr))
+            return;
+    }
+
+    if (rs::isCollidedWallFace(mCollider)) {
+        mIsJudge = true;
+        return;
+    }
+
+    // required to be explicit block to match function return pattern
+    {
+        const sead::Vector3f& gravity2 = al::getGravity(mPlayer);
+        sead::Vector3f nearWallPosition =
+            rs::getCollidedWallPos(mCollider) - collidedWallNormal * 5.0f;
+        sead::Vector3f wallSide = {0.0f, 0.0f, 0.0f};
+        wallSide.setCross(collidedWallNormal, gravity2);
+        al::normalize(&wallSide);
+
+        sead::Vector3f sideOffset = wallSide * 50.0f;
+        al::TriangleFilterWallOnly filterWallOnly = {gravity2};
+
+        const al::ArrowHitInfo* hitInfo1 = nullptr;
+        if (alCollisionUtil::getLastPolyOnArrow(mPlayer, &hitInfo1, nearWallPosition + sideOffset,
+                                                -sideOffset, nullptr, &filterWallOnly)) {
+            const sead::Vector3f& hitPos =
+                alCollisionUtil::getCollisionHitPos(hitInfo1->hitInfo.data());
+            const sead::Vector3f& hitNormal =
+                alCollisionUtil::getCollisionHitNormal(hitInfo1->hitInfo.data());
+            if (!rs::calcExistCollisionBorder(mPlayer, hitPos, hitNormal)) {
+                if (sead::Mathf::abs(al::calcAngleOnPlaneDegree(
+                        hitNormal, collidedWallNormal, gravity2)) > mConst->getWallFollowAngleH())
+                    return;
+                else if (sead::Mathf::abs(
+                             al::calcAngleOnPlaneDegree(hitNormal, collidedWallNormal, wallSide)) >
+                         mConst->getWallFollowAngleV())
+                    return;
+            }
+        }
+
+        const al::ArrowHitInfo* hitInfo2 = nullptr;
+        if (alCollisionUtil::getLastPolyOnArrow(mPlayer, &hitInfo2, nearWallPosition - sideOffset,
+                                                sideOffset, nullptr, &filterWallOnly)) {
+            const sead::Vector3f& hitPos =
+                alCollisionUtil::getCollisionHitPos(hitInfo2->hitInfo.data());
+            const sead::Vector3f& hitNormal =
+                alCollisionUtil::getCollisionHitNormal(hitInfo2->hitInfo.data());
+            if (!rs::calcExistCollisionBorder(mPlayer, hitPos, hitNormal)) {
+                if (sead::Mathf::abs(al::calcAngleOnPlaneDegree(
+                        hitNormal, collidedWallNormal, gravity2)) > mConst->getWallFollowAngleH())
+                    return;
+                if (sead::Mathf::abs(al::calcAngleOnPlaneDegree(
+                        hitNormal, collidedWallNormal, wallSide)) > mConst->getWallFollowAngleV())
+                    return;
+            }
+        }
+    }
+
+    mIsJudge = true;
+}
+
+bool PlayerJudgeWallKeep::judge() const {
+    return mIsJudge;
+}

--- a/src/Player/PlayerJudgeWallKeep.h
+++ b/src/Player/PlayerJudgeWallKeep.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IJudge.h"
+
+namespace al {
+class LiveActor;
+}
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class IPlayerModelChanger;
+class IUsePlayerHeightCheck;
+class PlayerCounterAfterUpperPunch;
+class PlayerWallActionHistory;
+class PlayerCarryKeeper;
+class PlayerTrigger;
+class PlayerCounterForceRun;
+
+class PlayerJudgeWallKeep : public al::HioNode, public IJudge {
+public:
+    PlayerJudgeWallKeep(const al::LiveActor* player, const PlayerConst* pConst,
+                        const PlayerInput* input, const IUsePlayerCollision* collider,
+                        const IPlayerModelChanger* modelChanger,
+                        const IUsePlayerHeightCheck* heightCheck,
+                        const PlayerCounterAfterUpperPunch* counterAfterUpperPunch,
+                        const PlayerWallActionHistory* wallActionHistory,
+                        const PlayerCarryKeeper* carryKeeper, const PlayerTrigger* trigger,
+                        const PlayerCounterForceRun* counterForceRun);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const al::LiveActor* mPlayer;
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollider;
+    const IPlayerModelChanger* mModelChanger;
+    const IUsePlayerHeightCheck* mHeightCheck;
+    const PlayerCounterAfterUpperPunch* mCounterAfterUpperPunch;
+    const PlayerWallActionHistory* mWallActionHistory;
+    const PlayerCarryKeeper* mCarryKeeper;
+    const PlayerTrigger* mTrigger;
+    const PlayerCounterForceRun* mCounterForceRun;
+    bool mIsJudge = false;
+};

--- a/src/Player/PlayerTrigger.h
+++ b/src/Player/PlayerTrigger.h
@@ -26,7 +26,7 @@ public:
         EActionTrigger_val6 = 6,
         // used in PlayerJudgeForceLand
         EActionTrigger_val11 = 11,
-        // used in PlayerJudgeWallCatch
+        // used in PlayerJudgeWallCatch, PlayerJudgeWallKeep
         EActionTrigger_val30 = 30,
         EActionTrigger_QuickTurn = 34,
     };

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -6,7 +6,9 @@ namespace al {
 class CollisionParts;
 class HitSensor;
 class LiveActor;
+class IUseCollision;
 }  // namespace al
+class PlayerWallActionHistory;
 
 class IUsePlayerCollision;
 class PlayerConst;
@@ -19,6 +21,10 @@ bool trySendMsgPlayerReflectOrTrample(const al::LiveActor*, al::HitSensor*, al::
 bool findWallCatchPos(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
                       const al::LiveActor*, const sead::Vector3f&, const sead::Vector3f&,
                       const sead::Vector3f&, f32, f32, f32, f32, f32, f32, f32);
+bool judgeEnableWallKeepHistory(const al::LiveActor*, const PlayerWallActionHistory*,
+                                const sead::Vector3f&, const sead::Vector3f&, f32, bool);
+bool calcExistCollisionBorder(const al::IUseCollision*, const sead::Vector3f&,
+                              const sead::Vector3f&);
 
 bool findWallCatchPosWallHit(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
                              sead::Vector3f*, const al::LiveActor*, const sead::Vector3f&,

--- a/src/Util/PlayerCollisionUtil.h
+++ b/src/Util/PlayerCollisionUtil.h
@@ -16,6 +16,7 @@ class PlayerConst;
 namespace rs {
 
 f32 getGroundHeight(const IUsePlayerHeightCheck*);
+bool isAboveGround(const IUsePlayerHeightCheck*);
 
 const sead::Vector3f& getCollidedWallPos(const IUsePlayerCollision*);
 const sead::Vector3f& getCollidedWallNormal(const IUsePlayerCollision*);
@@ -44,9 +45,11 @@ void calcGroundNormalOrGravityDir(sead::Vector3f*, const al::LiveActor*,
                                   const IUsePlayerCollision*);
 bool isCollisionCodeSandSink(const IUsePlayerCollision*);
 bool isCollidedWall(const IUsePlayerCollision*);
+bool isCollidedWallFace(const IUsePlayerCollision*);
 bool isCollidedCeiling(const IUsePlayerCollision*);
 bool isActionCodeNoWallGrab(const IUsePlayerCollision*);
 bool isActionCodeNoActionWall(const IUsePlayerCollision*);
+bool isActionCodeNoWallKeepWall(const IUsePlayerCollision*);
 
 bool isCollisionCodeGrabCeilAny(const IUsePlayerCollision*);
 bool isCollisionCodeGrabCeilWall(const IUsePlayerCollision*);


### PR DESCRIPTION
Pretty close to one year after initially decompiling this (Jun 26, 2024), I finally cleaned up and PRed this.

However, due to how much time has passed, I don't know a lot about this code anymore either. It somehow checks the angle between player and wall to determine whether the player is allowed to slide on it.

I started decompiling this on request of some part of the Low%-community, who were trying to figure out why Mario refused to wall-jump after a specific jump in the Forks room - if I remember correctly. Maybe this helps then.