### PR TITLE
dev: Run dev container using `amd64`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM --platform=linux/amd64 ubuntu:24.04
 WORKDIR /app
 
 # avoid errors/configuration issues while installing other packages


### PR DESCRIPTION
This pull request makes it possible to run the dev container on ARM-based Macs. It causes Docker to run the container using Rosetta (a type of x86 emulation) instead.

There are a few things stopping it from working on ARM natively. [This line](https://github.com/MonsterDruide1/OdysseyDecomp/blob/4acc352324a5b50553e4639d06a39aef324cd9f7/.devcontainer/Dockerfile#L21) in the `Dockerfile` for one. On top of that, some of the tools didn’t work and I even got some Rust compilation errors. This change just removes all the complexity of supporting ARM without (from what I understand) impacting anyone on x86_64.

It would be good if someone on PC is able to test it to double-check there is no impact.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/660)
<!-- Reviewable:end -->
