### PR TITLE
all: Improvements based on `listsym`

### DIFF
--- a/lib/al/Library/Yaml/MacroUtil.cpp
+++ b/lib/al/Library/Yaml/MacroUtil.cpp
@@ -127,8 +127,6 @@ void YamlParamGroup::readParam(const al::ByamlIter& iter) {
     }
 }
 
-YamlParam_YamlString::YamlParam_YamlString(const char* name) : YamlParamBase(name) {}
-
 YamlClassId YamlParam_YamlString::getClassId() const {
     return YamlClassId::String;
 }
@@ -136,8 +134,6 @@ YamlClassId YamlParam_YamlString::getClassId() const {
 void YamlParam_YamlString::setPtr_YamlString(const char** value) {
     setParamPtr(value);
 }
-
-YamlParam_V3f::YamlParam_V3f(const char* name) : YamlParamBase(name) {}
 
 YamlClassId YamlParam_V3f::getClassId() const {
     return YamlClassId::V3f;
@@ -147,8 +143,6 @@ void YamlParam_V3f::setPtr_V3f(sead::Vector3f* value) {
     setParamPtr(value);
 }
 
-YamlParam_YamlColor::YamlParam_YamlColor(const char* name) : YamlParamBase(name) {}
-
 YamlClassId YamlParam_YamlColor::getClassId() const {
     return YamlClassId::Color;
 }
@@ -156,8 +150,6 @@ YamlClassId YamlParam_YamlColor::getClassId() const {
 void YamlParam_YamlColor::setPtr_YamlColor(sead::Color4f* value) {
     setParamPtr(value);
 }
-
-YamlParam_bool::YamlParam_bool(const char* name) : YamlParamBase(name) {}
 
 YamlClassId YamlParam_bool::getClassId() const {
     return YamlClassId::Bool;
@@ -167,8 +159,6 @@ void YamlParam_bool::setPtr_bool(bool* value) {
     setParamPtr(value);
 }
 
-YamlParam_u8::YamlParam_u8(const char* name) : YamlParamBase(name) {}
-
 YamlClassId YamlParam_u8::getClassId() const {
     return YamlClassId::U8;
 }
@@ -177,8 +167,6 @@ void YamlParam_u8::setPtr_u8(u8* value) {
     setParamPtr(value);
 }
 
-YamlParam_f32::YamlParam_f32(const char* name) : YamlParamBase(name) {}
-
 YamlClassId YamlParam_f32::getClassId() const {
     return YamlClassId::F32;
 }
@@ -186,8 +174,6 @@ YamlClassId YamlParam_f32::getClassId() const {
 void YamlParam_f32::setPtr_f32(f32* value) {
     setParamPtr(value);
 }
-
-YamlParam_V2f::YamlParam_V2f(const char* name) : YamlParamBase(name) {}
 
 YamlClassId YamlParam_V2f::getClassId() const {
     return YamlClassId::V2f;

--- a/lib/al/Library/Yaml/MacroUtil.h
+++ b/lib/al/Library/Yaml/MacroUtil.h
@@ -102,7 +102,7 @@ private:
 
 class YamlParam_YamlString : public YamlParamBase<const char*> {
 public:
-    YamlParam_YamlString(const char* name);
+    YamlParam_YamlString(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_YamlString(const char** value) override;
@@ -110,7 +110,7 @@ public:
 
 class YamlParam_V3f : public YamlParamBase<sead::Vector3f> {
 public:
-    YamlParam_V3f(const char* name);
+    YamlParam_V3f(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_V3f(sead::Vector3f* value) override;
@@ -118,7 +118,7 @@ public:
 
 class YamlParam_YamlColor : public YamlParamBase<sead::Color4f> {
 public:
-    YamlParam_YamlColor(const char* name);
+    YamlParam_YamlColor(const char* name): YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_YamlColor(sead::Color4f* value) override;
@@ -126,7 +126,7 @@ public:
 
 class YamlParam_bool : public YamlParamBase<bool> {
 public:
-    YamlParam_bool(const char* name);
+    YamlParam_bool(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_bool(bool* value) override;
@@ -134,7 +134,7 @@ public:
 
 class YamlParam_u8 : public YamlParamBase<u8> {
 public:
-    YamlParam_u8(const char* name);
+    YamlParam_u8(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_u8(u8* value) override;
@@ -142,7 +142,7 @@ public:
 
 class YamlParam_f32 : public YamlParamBase<f32> {
 public:
-    YamlParam_f32(const char* name);
+    YamlParam_f32(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_f32(f32* value) override;
@@ -150,7 +150,7 @@ public:
 
 class YamlParam_V2f : public YamlParamBase<sead::Vector2f> {
 public:
-    YamlParam_V2f(const char* name);
+    YamlParam_V2f(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_V2f(sead::Vector2f* value) override;

--- a/lib/al/Library/Yaml/MacroUtil.h
+++ b/lib/al/Library/Yaml/MacroUtil.h
@@ -118,7 +118,7 @@ public:
 
 class YamlParam_YamlColor : public YamlParamBase<sead::Color4f> {
 public:
-    YamlParam_YamlColor(const char* name): YamlParamBase(name) {}
+    YamlParam_YamlColor(const char* name) : YamlParamBase(name) {}
 
     YamlClassId getClassId() const override;
     void setPtr_YamlColor(sead::Color4f* value) override;

--- a/lib/al/Project/File/FileLoader.cpp
+++ b/lib/al/Project/File/FileLoader.cpp
@@ -14,7 +14,7 @@
 #include "Project/File/SoundItemHolder.h"
 
 namespace al {
-static sead::FixedSafeString<256> sDeviceName{"main"};
+static sead::SafeString sDeviceName{"main"};
 
 FileLoader::FileLoader(s32 threadPriority) {
     mLoaderThread = new FileLoaderThread(threadPriority);

--- a/src/Sequence/WorldResourceLoader.cpp
+++ b/src/Sequence/WorldResourceLoader.cpp
@@ -9,7 +9,8 @@
 #include "Library/Yaml/ByamlIter.h"
 #include "Library/Yaml/ByamlUtil.h"
 
-const s32 priority = sead::Thread::cDefaultPriority;
+const s32 cDefaultPriority = sead::Thread::cDefaultPriority;
+const s32 cPriority = cDefaultPriority + 6;
 
 WorldResourceLoader::WorldResourceLoader(GameDataHolder* dataHolder) : mDataHolder(dataHolder) {
     using WorldResourceLoaderFunctor =
@@ -17,7 +18,7 @@ WorldResourceLoader::WorldResourceLoader(GameDataHolder* dataHolder) : mDataHold
 
     mWorldResourceLoader = new al::AsyncFunctorThread(
         "WorldResourceLoader", WorldResourceLoaderFunctor{this, &WorldResourceLoader::loadResource},
-        priority, 0x100000, sead::CoreId::cMain);
+        cPriority, 0x100000, sead::CoreId::cMain);
 }
 
 WorldResourceLoader::~WorldResourceLoader() {


### PR DESCRIPTION
Some random changes because I decided to look at `listsym` for a bit.
In this context, three PRs on other repos have also been created, which will be merged independently:
- https://github.com/open-ead/sead/pull/209
- https://github.com/open-ead/sead/pull/210
- https://github.com/open-ead/nnheaders/pull/46

In this PR specifically, the following things have been changed/fixed:
- Add more file initializers to `file_list.yml`
- All `YamlParam`s within `MacroUtil` have header-defined constructors
- `FileLoader::sDeviceName` has the non-specific type `SafeString`, so it can be fully evaluated at compile-time and only placed correctly in `.data` (instead of creating a file initializer to set up the `FixedSafeString<256>` it was before)
- `WorldResourceLoader` has an unused static variable which is just set to `sead::Thread::cDefaultPriority` - clang likes to optimize it away, which I was able to prevent by referencing this variable itself during the creation of `cPriority`, which is actually used in the constructor.