### PR TITLE
devcontainer: Fix `aarch64` and layering

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,20 +4,23 @@ WORKDIR /app
 # avoid errors/configuration issues while installing other packages
 ARG DEBIAN_FRONTEND=noninteractive
 ARG TZ=Etc/UTC
-RUN apt update
-RUN apt install -y tzdata
+RUN apt update && apt install -y tzdata
 
 # install git for collaboration management
-RUN apt install -y git
+RUN apt update && apt install -y git
 
 # install dependencies for building and running the project
-RUN apt install -y ccache cmake curl less libncurses6 libssl-dev llvm ninja-build pip pkg-config python3
+RUN apt update && apt install -y ccache cmake curl less libncurses6 libssl-dev ninja-build pip pkg-config python3
 RUN pip install --break-system-packages capstone colorama cxxfilt pyelftools python-Levenshtein toml watchdog
 
 # install dependencies for code environment
-RUN apt install -y clangd clang-format
+RUN apt update && apt install -y clangd clang-format llvm
 
 # install (outdated) libtinfo5, required for old clang version
-RUN curl -o libtinfo5_6.3-2_amd64.deb http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
+RUN if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
+        curl -o libtinfo5_6.3-2_amd64.deb http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && \
+        dpkg -i libtinfo5_6.3-2_amd64.deb && \
+        rm -f libtinfo5_6.3-2_amd64.deb; \
+    fi
 
 ENTRYPOINT ["bash"]


### PR DESCRIPTION
This pull request makes three changes to `.devcontainer/Dockerfile`:

## ARM support
When running on an ARM CPUs (aka `aarch64`), the Dockerfile now skips the installation of `libtinfo5`. The package URL for this is x64-specific, so it doesn’t work on ARM. Furthermore, it doesn’t seem to be required based in an ARM container (based on my experience).

## More `apt update`s
All `apt install` lines are now prefixed with `apt update &&` to avoid layering issues with outdated package feeds. See [best-practices#apt-get](https://docs.docker.com/build/building/best-practices/#apt-get).

As an example, when `llvm` was added to the list of packages recently, it was not possible for me to update the container without clearing my image cache first (or adding this subcommand). This is because Docker reused a layer from _ages_ ago so `apt update` was not run prior to installing the new list of packages.

## Move `llvm` further down
To my knowledge, the `llvm` package is only needed for asm-differ. I moved it to the “code environment” section since it’s more like `clangd` where you only need it during development. I don’t feel strongly on this though, happy to revert if needed.