### PR TITLE
build.py: Print recomendation to update tools if they are outdated

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 
 import argparse
-from colorama import Fore
 from setup import check_download_url_updated, get_build_dir
 import subprocess
 import os
-import time
 from common import setup_common as setup
 
 project_root = setup.ROOT
@@ -16,6 +14,7 @@ def touch_cmake_lists():
 
 def warn_outdated_tools():
     if check_download_url_updated(False):
+        from colorama import Fore
         print(f"{Fore.YELLOW}Found outdated tools, consider rerunning setup.py to update them{Fore.RESET}")
 
 build_sources_path = get_build_dir() / '.build_sources'

--- a/tools/build.py
+++ b/tools/build.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 
 import argparse
-from setup import get_build_dir
+from colorama import Fore
+from setup import check_download_url_updated, get_build_dir
 import subprocess
 import os
 import time
@@ -12,6 +13,10 @@ project_root = setup.ROOT
 def touch_cmake_lists():
     cmake_lists_path = project_root / 'CMakeLists.txt'
     os.utime(cmake_lists_path, times=None)
+
+def warn_outdated_tools():
+    if check_download_url_updated(False):
+        print(f"{Fore.YELLOW}Found outdated tools, consider rerunning setup.py to update them{Fore.RESET}")
 
 build_sources_path = get_build_dir() / '.build_sources'
 
@@ -27,6 +32,8 @@ def main():
     if not get_build_dir().is_dir():
         print("Please run setup.py first.")
         exit(1)
+
+    warn_outdated_tools()
 
     cmake_args = ['cmake', '--build', str(get_build_dir())]
     if args.clean:

--- a/tools/build.py
+++ b/tools/build.py
@@ -13,9 +13,9 @@ def touch_cmake_lists():
     os.utime(cmake_lists_path, times=None)
 
 def warn_outdated_tools():
-    if check_download_url_updated(False):
+    if check_download_url_updated():
         from colorama import Fore
-        print(f"{Fore.YELLOW}Found outdated tools, consider rerunning setup.py to update them{Fore.RESET}")
+        print(f"{Fore.YELLOW}Found unexpected version of tools, consider rerunning setup.py to fetch the version matching the current repository. Rebase onto latest master to work with the newest tools.{Fore.RESET}")
 
 build_sources_path = get_build_dir() / '.build_sources'
 


### PR DESCRIPTION
This PR makes it so that `build.py` prints a warning if the `CACHE_REPO_RELEASE_URL` in `setup.py` does not match the cached url

Fixes #678

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/679)
<!-- Reviewable:end -->
