### PR TITLE
Project/LiveActor: Implement `ConveyerKeyKeeper`

### DIFF
--- a/lib/al/Library/MapObj/ConveyerStep.cpp
+++ b/lib/al/Library/MapObj/ConveyerStep.cpp
@@ -62,15 +62,15 @@ void ConveyerStep::setTransByCoord(f32 coord, bool isForwards, bool isForceReset
     const char* actionName = nullptr;
 
     if (index > -1) {
-        const ConveyerKey* conveyerKey = mConveyerKeyKeeper->getConveyerKey(index);
+        const ConveyerKey& conveyerKey = mConveyerKeyKeeper->getConveyerKey(index);
 
-        if (tryGetStringArg(&keyHitReactionName, conveyerKey->placementInfo,
+        if (tryGetStringArg(&keyHitReactionName, *conveyerKey.placementInfo,
                             "KeyHitReactionName") &&
             (mKeyHitReactionName == nullptr ||
              !isEqualString(mKeyHitReactionName, keyHitReactionName)))
             startHitReaction(this, keyHitReactionName);
 
-        if (tryGetStringArg(&actionName, conveyerKey->placementInfo, "ActionName") &&
+        if (tryGetStringArg(&actionName, *conveyerKey.placementInfo, "ActionName") &&
             (mActionName == nullptr || !isEqualString(mActionName, actionName)))
             startAction(this, actionName);
     }

--- a/lib/al/Project/LiveActor/ConveyerKeyKeeper.cpp
+++ b/lib/al/Project/LiveActor/ConveyerKeyKeeper.cpp
@@ -1,0 +1,175 @@
+#include "Project/LiveActor/ConveyerKeyKeeper.h"
+
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+
+namespace al {
+void ConveyerKey::init(const sead::Vector3f& keeperTrans, const sead::Vector3f& keeperDir,
+                       const PlacementInfo& placement) {
+    sead::Vector3f trans;
+    tryGetTrans(&trans, placement);
+    moveDistance = (trans - keeperTrans).dot(keeperDir);
+    totalMoveDistance = 0.0f;
+
+    interpolateType = 0;
+    tryGetArg(&interpolateType, placement, "InterpolateType");
+
+    quat.set(sead::Quatf::unit);
+    placementInfo = new PlacementInfo(placement);
+    tryGetQuat(&quat, placement);
+    verticalizeVec(&moveDistanceVertical, keeperDir, trans - keeperTrans);
+}
+
+ConveyerKeyKeeper::ConveyerKeyKeeper() = default;
+
+void ConveyerKeyKeeper::init(const ActorInitInfo& info) {
+    tryGetQuat(&mQuat, info);
+    tryGetTrans(&mTrans, info);
+    s32 moveAxis = 2;
+    tryGetArg(&moveAxis, info, "MoveAxis");
+    tryGetLocalAxis(&mMoveDirection, info, moveAxis);
+    mConveyerKeyCount = calcLinkNestNum(info, "KeyMoveNext") + 1;
+
+    mConveyerKeys = new ConveyerKey[mConveyerKeyCount];
+
+    mConveyerKeys[0].init(mTrans, mMoveDirection, *info.placementInfo);
+
+    PlacementInfo linkPlacementSource = *info.placementInfo;
+    PlacementInfo linkPlacement;
+
+    for (s32 i = 0; i < mConveyerKeyCount - 1; i++) {
+        getLinksInfo(&linkPlacement, linkPlacementSource, "KeyMoveNext");
+        mConveyerKeys[i + 1].init(mTrans, mMoveDirection, linkPlacement);
+        linkPlacementSource = linkPlacement;
+    }
+
+    mTotalMoveDistance = 0.0f;
+
+    for (s32 i = 1; i < mConveyerKeyCount; i++) {
+        ConveyerKey* key = &mConveyerKeys[i - 1];
+        ConveyerKey* nextKey = &mConveyerKeys[i];
+
+        f32 distance = sead::Mathf::abs(nextKey->moveDistance - key->moveDistance);
+        mTotalMoveDistance += distance;
+        nextKey->totalMoveDistance = mTotalMoveDistance;
+    }
+}
+
+// Mismatch: Same as calcPosAndQuatByKeyIndex
+// https://decomp.me/scratch/kmQvB
+void ConveyerKeyKeeper::calcPosAndQuat(sead::Vector3f* pos, sead::Quatf* quat, s32* index,
+                                       f32 coord) const {
+    if (coord <= 0.0f) {
+        if (pos)
+            pos->set(mTrans);
+
+        if (quat)
+            quat->set(mQuat);
+
+        if (index)
+            *index = -1;
+        return;
+    }
+
+    if (coord >= mTotalMoveDistance) {
+        // Pretty sure this should be a call to calcPosAndQuatByKeyIndex, but the match becomes
+        // worse
+        const ConveyerKey& key = getConveyerKey(mConveyerKeyCount - 1);
+        if (pos)
+            pos->set(key.moveDistanceVertical + key.moveDistance * mMoveDirection + mTrans);
+
+        if (quat)
+            quat->set(getConveyerKey(mConveyerKeyCount - 1).quat);
+
+        if (index)
+            *index = -1;
+        return;
+    }
+
+    s32 keyIndex = 0;
+    for (s32 i = 0; i < mConveyerKeyCount; i++) {
+        if (getConveyerKey(i).totalMoveDistance > coord) {
+            keyIndex = i;
+            break;
+        }
+    }
+
+    sead::Vector3f moveDistanceVertical = sead::Vector3f::zero;
+    sead::Quatf q = sead::Quatf::unit;
+    f32 moveDistance;
+    if (keyIndex < 1) {
+        const ConveyerKey& key = getConveyerKey(0);
+        moveDistanceVertical.set(key.moveDistanceVertical);
+        q.set(key.quat);
+        moveDistance = 0.0f;
+    } else {
+        const ConveyerKey& key = getConveyerKey(keyIndex);
+        const ConveyerKey& prevKey = getConveyerKey(keyIndex - 1);
+        sead::Vector3f prevKeyVec = prevKey.moveDistanceVertical;
+        sead::Vector3f keyVec = key.moveDistanceVertical;
+        f32 totalMoveDistance = key.totalMoveDistance - prevKey.totalMoveDistance;
+        f32 t;
+
+        if (isNearZero(totalMoveDistance))
+            t = 0.0f;
+        else
+            t = (coord - prevKey.totalMoveDistance) / totalMoveDistance;
+
+        f32 ease = easeByType(t, getConveyerKey(keyIndex - 1).interpolateType);
+        lerpVec(&moveDistanceVertical, prevKeyVec, keyVec, ease);
+        moveDistance = lerpValue(getConveyerKey(keyIndex - 1).moveDistance,
+                                 getConveyerKey(keyIndex).moveDistance, t);
+
+        sead::Quatf prevKeyQuat = getConveyerKey(keyIndex - 1).quat;
+        sead::Quatf keyQuat = getConveyerKey(keyIndex).quat;
+        slerpQuat(&q, prevKeyQuat, keyQuat, ease);
+    }
+
+    if (pos)
+        pos->set(moveDistance * mMoveDirection + mTrans + moveDistanceVertical);
+
+    if (quat)
+        quat->set(q);
+
+    if (index)
+        *index = keyIndex - 1;
+    return;
+}
+
+// Mismatch: The math is right, but the registers don't match
+// probably inlined (and optimized) in a few other places
+// https://decomp.me/scratch/kmQvB
+void ConveyerKeyKeeper::calcPosAndQuatByKeyIndex(sead::Vector3f* pos, sead::Quatf* quat,
+                                                 s32 index) const {
+    const ConveyerKey& key = getConveyerKey(index);
+    if (pos)
+        pos->set(key.moveDistance * mMoveDirection + mTrans + key.moveDistanceVertical);
+
+    if (quat)
+        quat->set(getConveyerKey(index).quat);
+}
+
+// Mismatch: Same as calcPosAndQuatByKeyIndex
+// https://decomp.me/scratch/kmQvB
+void ConveyerKeyKeeper::calcClippingSphere(sead::Vector3f* clippingTrans, f32* clippingRadius,
+                                           f32 offset) const {
+    if (clippingTrans) {
+        const ConveyerKey& key = getConveyerKey(0);
+        clippingTrans->set(key.moveDistance * mMoveDirection + mTrans + key.moveDistanceVertical);
+    }
+    *clippingRadius = offset;
+
+    for (s32 i = 1; i < mConveyerKeyCount; i++) {
+        const ConveyerKey& key = getConveyerKey(i);
+        sead::Vector3f pos = key.moveDistance * mMoveDirection + mTrans + key.moveDistanceVertical;
+        calcSphereMargeSpheres(clippingTrans, clippingRadius, *clippingTrans, *clippingRadius, pos,
+                               offset);
+    }
+}
+
+const ConveyerKey& ConveyerKeyKeeper::getConveyerKey(s32 index) const {
+    return mConveyerKeys[index];
+}
+}  // namespace al

--- a/lib/al/Project/LiveActor/ConveyerKeyKeeper.h
+++ b/lib/al/Project/LiveActor/ConveyerKeyKeeper.h
@@ -7,10 +7,16 @@ namespace al {
 struct ActorInitInfo;
 class PlacementInfo;
 
-// TODO: I'm not sure about this
 struct ConveyerKey {
-    void* _0[5];
-    const PlacementInfo& placementInfo;
+    f32 moveDistance;
+    f32 totalMoveDistance;
+    sead::Quatf quat;
+    sead::Vector3f moveDistanceVertical;
+    s32 interpolateType;
+    const PlacementInfo* placementInfo;
+
+    void init(const sead::Vector3f& keeperTrans, const sead::Vector3f& keeperDir,
+              const PlacementInfo& placement);
 };
 
 class ConveyerKeyKeeper {
@@ -21,18 +27,21 @@ public:
     void calcPosAndQuat(sead::Vector3f* pos, sead::Quatf* quat, s32* index, f32 coord) const;
     void calcPosAndQuatByKeyIndex(sead::Vector3f* pos, sead::Quatf* quat, s32 index) const;
     void calcClippingSphere(sead::Vector3f* clippingTrans, f32* clippingRadius, f32 offset) const;
-    const ConveyerKey* getConveyerKey(s32 index) const;  // return type depends on the type of _0
+    const ConveyerKey& getConveyerKey(s32 index) const;
 
     s32 getConveyerKeyCount() const { return mConveyerKeyCount; }
 
     f32 getTotalMoveDistance() const { return mTotalMoveDistance; }
 
 private:
-    ConveyerKey* mConveyerKeys;  // array of a struct/class with a size of 0x30?
-    s32 mConveyerKeyCount;
-    sead::Quatf mQuat;
-    sead::Vector3f mTrans;
-    sead::Vector3f mMoveDirection;
-    f32 mTotalMoveDistance;
+    ConveyerKey* mConveyerKeys = nullptr;
+    s32 mConveyerKeyCount = 0;
+    sead::Quatf mQuat = sead::Quatf::unit;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    sead::Vector3f mMoveDirection = sead::Vector3f::ez;
+    f32 mTotalMoveDistance = 0.0f;
 };
+
+static_assert(sizeof(ConveyerKeyKeeper) == 0x38);
+
 }  // namespace al


### PR DESCRIPTION
`al::ConveyerKeyKeeper::calcPosAndQuat`, `al::ConveyerKeyKeeper::calcPosAndQuatByIndex` and `al::ConveyerKeyKeeper::calcClippingSphere` all share the same mismatch: https://decomp.me/scratch/4dAST

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/680)
<!-- Reviewable:end -->
