### PR TITLE
Library/Clipping: Implement `ClippingGroupHolder`

### DIFF
--- a/lib/al/Library/Clipping/ClippingGroupHolder.cpp
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.cpp
@@ -79,8 +79,6 @@ void ClippingInfoGroup::endClippedAll() {
 }
 
 ClippingGroupHolder::ClippingGroupHolder() {
-    mGroupCount = 0;
-
     mGroups = new ClippingInfoGroup*[0x40];
 
     for (s32 i = 0; i < 0x40; i++)
@@ -91,9 +89,9 @@ void ClippingGroupHolder::update(const ClippingJudge* clippingJudge) {
     for (s32 i = 0; i < mGroupCount; i++) {
         ClippingInfoGroup* group = mGroups[i];
         if (!group->judgeClippingAll(clippingJudge)) {
-            if (group->isClipped != 0)
+            if (group->isClipped)
                 group->endClippedAll();
-        } else if (group->isClipped == 0)
+        } else if (!group->isClipped)
             group->startClippedAll();
     }
 }
@@ -121,8 +119,6 @@ ClippingInfoGroup* ClippingGroupHolder::tryFindGroup(const ClippingActorInfo* cl
 }
 
 void ClippingGroupHolder::allocBuffer() {
-    if (mGroupCount < 0)
-        return;
     for (s32 i = 0; i < mGroupCount; i++)
         mGroups[i]->allocBuffer();
 }

--- a/lib/al/Library/Clipping/ClippingGroupHolder.cpp
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.cpp
@@ -7,48 +7,59 @@
 
 namespace al {
 
-ClippingInfoGroup::ClippingInfoGroup() : mGroupId(new PlacementId()) {}
+ClippingInfoGroup::ClippingInfoGroup() : groupId(new PlacementId()) {}
 
 // BUG: no bounds check
 void ClippingInfoGroup::registerInfo(ClippingActorInfo* clippingActorInfo) {
-    mClippingInfos[mSize] = clippingActorInfo;
-    mSize++;
+    clippingInfos[size] = clippingActorInfo;
+    size++;
 }
 
 void ClippingInfoGroup::removeInfo(ClippingActorInfo* clippingActorInfo) {
-    for (s32 i = 0; i < mSize; i++) {
-        if (mClippingInfos[i] == clippingActorInfo) {
-            mClippingInfos[i] = mClippingInfos[mSize - 1];
-            mSize--;
+    for (s32 i = 0; i < size; i++) {
+        if (clippingInfos[i] == clippingActorInfo) {
+            clippingInfos[i] = clippingInfos[size - 1];
+            size--;
             return;
         }
     }
 }
 
 void ClippingInfoGroup::addCount() {
-    mCount++;
+    count++;
 }
 
 void ClippingInfoGroup::allocBuffer() {
-    mClippingInfos = new ClippingActorInfo*[mCount];
+    clippingInfos = new ClippingActorInfo*[count];
 
-    for (s32 i = 0; i < mCount; i++)
-        mClippingInfos[i] = nullptr;
+    for (s32 i = 0; i < count; i++)
+        clippingInfos[i] = nullptr;
 }
 
 void ClippingInfoGroup::setGroupId(const ClippingActorInfo* clippingActorInfo) {
+<<<<<<< HEAD
     *mGroupId = *clippingActorInfo->getPlacementId();
+=======
+    *groupId = *clippingActorInfo->placementId;
+>>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
 }
 
 bool ClippingInfoGroup::isEqualGroupId(const PlacementId* placementId) const {
-    return mGroupId->isEqual(*placementId);
+    return groupId->isEqual(*placementId);
 }
 
 bool ClippingInfoGroup::judgeClippingAll(const ClippingJudge* clippingJudge) const {
+<<<<<<< HEAD
     for (s32 i = 0; i < mSize; i++) {
         if (!isDead(mClippingInfos[i]->getLiveActor()) &&
             (isInvalidClipping(mClippingInfos[i]->getLiveActor()) ||
              !mClippingInfos[i]->judgeClipping(clippingJudge))) {
+=======
+    for (s32 i = 0; i < size; i++) {
+        if (!isDead(clippingInfos[i]->liveActor) &&
+            (isInvalidClipping(clippingInfos[i]->liveActor) ||
+             !clippingInfos[i]->judgeClipping(clippingJudge))) {
+>>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
             return false;
         }
     }
@@ -56,15 +67,80 @@ bool ClippingInfoGroup::judgeClippingAll(const ClippingJudge* clippingJudge) con
 }
 
 void ClippingInfoGroup::startClippedAll() {
-    mIsClipped = true;
-    for (s32 i = 0; i < mSize; i++)
-        mClippingInfos[i]->startClipped();
+    isClipped = true;
+    for (s32 i = 0; i < size; i++)
+        clippingInfos[i]->startClipped();
 }
 
 void ClippingInfoGroup::endClippedAll() {
-    mIsClipped = false;
-    for (s32 i = 0; i < mSize; i++)
-        mClippingInfos[i]->endClipped();
+    isClipped = false;
+    for (s32 i = 0; i < size; i++)
+        clippingInfos[i]->endClipped();
+}
+
+ClippingGroupHolder::ClippingGroupHolder() {
+    mGroupCount = 0;
+
+    mGroups = new ClippingInfoGroup*[0x40];
+
+    for (s32 i = 0; i < 0x40; i++)
+        mGroups[i] = nullptr;
+}
+
+void ClippingGroupHolder::update(const ClippingJudge* clippingJudge) {
+    for (s32 i = 0; i < mGroupCount; i++) {
+        ClippingInfoGroup* group = mGroups[i];
+        if (!group->judgeClippingAll(clippingJudge)) {
+            if (group->isClipped != 0)
+                group->endClippedAll();
+        } else if (group->isClipped == 0)
+            group->startClippedAll();
+    }
+}
+
+void ClippingGroupHolder::createAndCount(ClippingActorInfo* clippingActorInfo) {
+    if (!clippingActorInfo->isGroupClippingInit())
+        return;
+
+    ClippingInfoGroup* clippingInfoGroup = tryFindGroup(clippingActorInfo);
+    if (!clippingInfoGroup) {
+        clippingInfoGroup = new ClippingInfoGroup();
+
+        clippingInfoGroup->setGroupId(clippingActorInfo);
+        mGroups[mGroupCount] = clippingInfoGroup;
+        mGroupCount++;
+    }
+    clippingInfoGroup->count++;
+}
+
+ClippingInfoGroup* ClippingGroupHolder::tryFindGroup(const ClippingActorInfo* clippingActorInfo) {
+    for (s32 i = 0; i < mGroupCount; i++)
+        if (mGroups[i]->isEqualGroupId(clippingActorInfo->placementId))
+            return mGroups[i];
+    return nullptr;
+}
+
+void ClippingGroupHolder::allocBuffer() {
+    if (mGroupCount < 0)
+        return;
+    for (s32 i = 0; i < mGroupCount; i++)
+        mGroups[i]->allocBuffer();
+}
+
+void ClippingGroupHolder::registerInfo(ClippingActorInfo* clippingActorInfo) {
+    ClippingInfoGroup* group = tryFindGroup(clippingActorInfo);
+    if (group)
+        group->registerInfo(clippingActorInfo);
+}
+
+void ClippingGroupHolder::leave(ClippingActorInfo* clippingActorInfo) {
+    ClippingInfoGroup* clippingInfoGroup = tryFindGroup(clippingActorInfo);
+    if (clippingInfoGroup)
+        clippingInfoGroup->removeInfo(clippingActorInfo);
+}
+
+void ClippingGroupHolder::reentry(ClippingActorInfo* clippingActorInfo) {
+    registerInfo(clippingActorInfo);
 }
 
 }  // namespace al

--- a/lib/al/Library/Clipping/ClippingGroupHolder.cpp
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.cpp
@@ -37,11 +37,7 @@ void ClippingInfoGroup::allocBuffer() {
 }
 
 void ClippingInfoGroup::setGroupId(const ClippingActorInfo* clippingActorInfo) {
-<<<<<<< HEAD
-    *mGroupId = *clippingActorInfo->getPlacementId();
-=======
-    *groupId = *clippingActorInfo->placementId;
->>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
+    *groupId = *clippingActorInfo->getPlacementId();
 }
 
 bool ClippingInfoGroup::isEqualGroupId(const PlacementId* placementId) const {
@@ -49,17 +45,10 @@ bool ClippingInfoGroup::isEqualGroupId(const PlacementId* placementId) const {
 }
 
 bool ClippingInfoGroup::judgeClippingAll(const ClippingJudge* clippingJudge) const {
-<<<<<<< HEAD
-    for (s32 i = 0; i < mSize; i++) {
-        if (!isDead(mClippingInfos[i]->getLiveActor()) &&
-            (isInvalidClipping(mClippingInfos[i]->getLiveActor()) ||
-             !mClippingInfos[i]->judgeClipping(clippingJudge))) {
-=======
     for (s32 i = 0; i < size; i++) {
-        if (!isDead(clippingInfos[i]->liveActor) &&
-            (isInvalidClipping(clippingInfos[i]->liveActor) ||
+        if (!isDead(clippingInfos[i]->getLiveActor()) &&
+            (isInvalidClipping(clippingInfos[i]->getLiveActor()) ||
              !clippingInfos[i]->judgeClipping(clippingJudge))) {
->>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
             return false;
         }
     }
@@ -113,7 +102,7 @@ void ClippingGroupHolder::createAndCount(ClippingActorInfo* clippingActorInfo) {
 
 ClippingInfoGroup* ClippingGroupHolder::tryFindGroup(const ClippingActorInfo* clippingActorInfo) {
     for (s32 i = 0; i < mGroupCount; i++)
-        if (mGroups[i]->isEqualGroupId(clippingActorInfo->placementId))
+        if (mGroups[i]->isEqualGroupId(clippingActorInfo->getPlacementId()))
             return mGroups[i];
     return nullptr;
 }

--- a/lib/al/Library/Clipping/ClippingGroupHolder.h
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.h
@@ -2,12 +2,37 @@
 
 #include <basis/seadTypes.h>
 
+#include "Library/Clipping/ClippingActorInfo.h"
+#include "Library/Placement/PlacementId.h"
+
 namespace al {
 class PlacementId;
-class ClippingInfoGroup;
 class ClippingJudge;
+<<<<<<< HEAD
 
 class ClippingActorInfo;
+=======
+struct ClippingActorInfo;
+>>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
+
+struct ClippingInfoGroup {
+    ClippingInfoGroup();
+    void registerInfo(ClippingActorInfo* clippingActorInfo);
+    void removeInfo(ClippingActorInfo* clippingActorInfo);
+    void addCount();
+    void allocBuffer();
+    void setGroupId(const ClippingActorInfo* clippingActorInfo);
+    bool isEqualGroupId(const PlacementId* placementId) const;
+    bool judgeClippingAll(const ClippingJudge* clippingJudge) const;
+    void startClippedAll();
+    void endClippedAll();
+
+    s32 count = 0;
+    s32 size = 0;
+    ClippingActorInfo** clippingInfos = nullptr;
+    PlacementId* groupId;
+    bool isClipped = false;
+};
 
 class ClippingGroupHolder {
 public:
@@ -21,28 +46,8 @@ public:
     void reentry(ClippingActorInfo* clippingActorInfo);
 
 private:
-    void* filler[0x2];
-};
-
-class ClippingInfoGroup {
-public:
-    ClippingInfoGroup();
-    void registerInfo(ClippingActorInfo* clippingActorInfo);
-    void removeInfo(ClippingActorInfo* clippingActorInfo);
-    void addCount();
-    void allocBuffer();
-    void setGroupId(const ClippingActorInfo* clippingActorInfo);
-    bool isEqualGroupId(const PlacementId* placementId) const;
-    bool judgeClippingAll(const ClippingJudge* clippingJudge) const;
-    void startClippedAll();
-    void endClippedAll();
-
-private:
-    s32 mCount = 0;
-    s32 mSize = 0;
-    ClippingActorInfo** mClippingInfos = nullptr;
-    PlacementId* mGroupId;
-    bool mIsClipped = false;
+    s32 mGroupCount = 0;
+    ClippingInfoGroup** mGroups = nullptr;
 };
 
 }  // namespace al

--- a/lib/al/Library/Clipping/ClippingGroupHolder.h
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.h
@@ -5,12 +5,7 @@
 namespace al {
 class PlacementId;
 class ClippingJudge;
-<<<<<<< HEAD
-
 class ClippingActorInfo;
-=======
-struct ClippingActorInfo;
->>>>>>> a77f7900 (Implemented: ClippingGroupHolder)
 
 struct ClippingInfoGroup {
     ClippingInfoGroup();

--- a/lib/al/Library/Clipping/ClippingGroupHolder.h
+++ b/lib/al/Library/Clipping/ClippingGroupHolder.h
@@ -2,9 +2,6 @@
 
 #include <basis/seadTypes.h>
 
-#include "Library/Clipping/ClippingActorInfo.h"
-#include "Library/Placement/PlacementId.h"
-
 namespace al {
 class PlacementId;
 class ClippingJudge;


### PR DESCRIPTION
It turns out that ClippingInfoGroup was a struct. Kinda makes sense based on the name. ClippingGroupHolder might be a struct but ill change that if I run into something that hints to that later on.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/686)
<!-- Reviewable:end -->
