### PR TITLE
Player: Implement `PlayerStateLongJump`

### DIFF
--- a/src/Player/PlayerStateLongJump.cpp
+++ b/src/Player/PlayerStateLongJump.cpp
@@ -18,12 +18,12 @@
 namespace {
 NERVE_IMPL(PlayerStateLongJump, Jump);
 
-NERVE_MAKE(PlayerStateLongJump, Jump);
+NERVES_MAKE_NOSTRUCT(PlayerStateLongJump, Jump);
 }  // namespace
 
-PlayerStateLongJump::PlayerStateLongJump(al::LiveActor* player, PlayerConst const* pConst,
-                                         PlayerInput const* input,
-                                         IUsePlayerCollision const* collider,
+PlayerStateLongJump::PlayerStateLongJump(al::LiveActor* player, const PlayerConst* pConst,
+                                         const PlayerInput* input,
+                                         const IUsePlayerCollision* collider,
                                          PlayerTrigger* trigger, PlayerAnimator* animator,
                                          PlayerContinuousLongJump* continuousLongJump,
                                          PlayerActionDiveInWater* actionDiveInWater)
@@ -32,8 +32,6 @@ PlayerStateLongJump::PlayerStateLongJump(al::LiveActor* player, PlayerConst cons
       mDiveInWater(actionDiveInWater) {
     initNerve(&Jump, 0);
 }
-
-PlayerStateLongJump::~PlayerStateLongJump() = default;
 
 void PlayerStateLongJump::appear() {
     al::ActorStateBase::appear();
@@ -44,7 +42,7 @@ void PlayerStateLongJump::appear() {
 void PlayerStateLongJump::exeJump() {
     al::LiveActor* actor = mActor;
     const sead::Vector3f& gravity = al::getGravity(actor);
-    
+
     if (al::isFirstStep(this)) {
         rs::setupLongJumpVelocity(mActor, mCollision, mConst->getJumpInertiaRate(),
                                   mConst->getLongJumpMovePow(), mConst->getLongJumpSpeedMin(),

--- a/src/Player/PlayerStateLongJump.cpp
+++ b/src/Player/PlayerStateLongJump.cpp
@@ -55,7 +55,7 @@ void PlayerStateLongJump::exeJump() {
     }
 
     if (mTrigger->isOnUpperPunchHit())
-        rs::reflectCeilingUpperPunch(mActor, mCollision, mInput, mConst, mTrigger, 0);
+        rs::reflectCeilingUpperPunch(mActor, mCollision, mInput, mConst, mTrigger, false);
 
     if (rs::isCollidedCeiling(mCollision))
         rs::reflectCeiling(mActor, 0.0f);

--- a/src/Player/PlayerStateLongJump.cpp
+++ b/src/Player/PlayerStateLongJump.cpp
@@ -1,0 +1,74 @@
+#include "Player/PlayerStateLongJump.h"
+
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionDiveInWater.h"
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerContinuousLongJump.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerTrigger.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/SpecialBuildUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateLongJump, Jump);
+
+NERVE_MAKE(PlayerStateLongJump, Jump);
+}  // namespace
+
+PlayerStateLongJump::PlayerStateLongJump(al::LiveActor* player, PlayerConst const* pConst,
+                                         PlayerInput const* input,
+                                         IUsePlayerCollision const* collider,
+                                         PlayerTrigger* trigger, PlayerAnimator* animator,
+                                         PlayerContinuousLongJump* continuousLongJump,
+                                         PlayerActionDiveInWater* actionDiveInWater)
+    : al::ActorStateBase("幅跳び", player), mConst(pConst), mInput(input), mCollision(collider),
+      mTrigger(trigger), mAnimator(animator), mContinuousLongJump(continuousLongJump),
+      mDiveInWater(actionDiveInWater) {
+    initNerve(&Jump, 0);
+}
+
+PlayerStateLongJump::~PlayerStateLongJump() = default;
+
+void PlayerStateLongJump::appear() {
+    al::ActorStateBase::appear();
+    rs::noticePlayerJumpStart(mTrigger, mActor);
+    al::setNerve(this, &Jump);
+}
+
+void PlayerStateLongJump::exeJump() {
+    al::LiveActor* actor = mActor;
+    const sead::Vector3f& gravity = al::getGravity(actor);
+    
+    if (al::isFirstStep(this)) {
+        rs::setupLongJumpVelocity(mActor, mCollision, mConst->getJumpInertiaRate(),
+                                  mConst->getLongJumpMovePow(), mConst->getLongJumpSpeedMin(),
+                                  mConst->getLongJumpInitSpeed(), mConst->getLongJumpJumpPow());
+        if (rs::isModeE3Rom())
+            mAnimator->startAnim("JumpBroad3");
+        else
+            mAnimator->startAnim(mContinuousLongJump->getLongJumpAnimName());
+        mContinuousLongJump->countUp();
+    }
+
+    if (mTrigger->isOnUpperPunchHit())
+        rs::reflectCeilingUpperPunch(mActor, mCollision, mInput, mConst, mTrigger, 0);
+
+    if (rs::isCollidedCeiling(mCollision))
+        rs::reflectCeiling(mActor, 0.0f);
+
+    sead::Vector3f moveInput = {0.0f, 0.0f, 0.0f};
+    mInput->calcMoveInput(&moveInput, -gravity);
+    rs::moveDivingJump(mActor, moveInput, mConst->getLongJumpAccel(), mConst->getLongJumpBrake(),
+                       mConst->getLongJumpSpeed(), mConst->getLongJumpSpeedMin(),
+                       mConst->getLongJumpSideAccel(), mConst->getLongJumpGravity(),
+                       mConst->getFallSpeedMax(), mConst->getSlerpQuatGrav());
+    mDiveInWater->tryChangeDiveInWaterAnim();
+    if (rs::isOnGround(actor, mCollision))
+        kill();
+}

--- a/src/Player/PlayerStateLongJump.h
+++ b/src/Player/PlayerStateLongJump.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class PlayerConst;
+class PlayerInput;
+class IUsePlayerCollision;
+class PlayerTrigger;
+class PlayerAnimator;
+class PlayerContinuousLongJump;
+class PlayerActionDiveInWater;
+
+class PlayerStateLongJump : public al::ActorStateBase {
+public:
+    PlayerStateLongJump(al::LiveActor*,const PlayerConst *,const PlayerInput *,
+                      const  IUsePlayerCollision *, PlayerTrigger*, PlayerAnimator*,
+                        PlayerContinuousLongJump*, PlayerActionDiveInWater*);
+    ~PlayerStateLongJump() override;
+
+    void appear() override;
+    void exeJump();
+
+private:
+    const PlayerConst* mConst;
+    const PlayerInput* mInput;
+    const IUsePlayerCollision* mCollision;
+    PlayerTrigger* mTrigger;
+    PlayerAnimator* mAnimator;
+    PlayerContinuousLongJump* mContinuousLongJump;
+    PlayerActionDiveInWater* mDiveInWater;
+};

--- a/src/Player/PlayerStateLongJump.h
+++ b/src/Player/PlayerStateLongJump.h
@@ -12,10 +12,10 @@ class PlayerActionDiveInWater;
 
 class PlayerStateLongJump : public al::ActorStateBase {
 public:
-    PlayerStateLongJump(al::LiveActor*,const PlayerConst *,const PlayerInput *,
-                      const  IUsePlayerCollision *, PlayerTrigger*, PlayerAnimator*,
-                        PlayerContinuousLongJump*, PlayerActionDiveInWater*);
-    ~PlayerStateLongJump() override;
+    PlayerStateLongJump(al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+                        const IUsePlayerCollision* collider, PlayerTrigger* trigger,
+                        PlayerAnimator* animator, PlayerContinuousLongJump* continuousLongJump,
+                        PlayerActionDiveInWater* actionDiveInWater);
 
     void appear() override;
     void exeJump();

--- a/src/Util/ObjUtil.h
+++ b/src/Util/ObjUtil.h
@@ -9,12 +9,22 @@ class LiveActor;
 class IUseCollision;
 }  // namespace al
 class PlayerWallActionHistory;
-
 class IUsePlayerCollision;
 class PlayerConst;
 class PlayerModelHolder;
+class PlayerInput;
+class PlayerTrigger;
 
 namespace rs {
+
+void reflectCeiling(al::LiveActor*, f32);
+
+void reflectCeilingUpperPunch(al::LiveActor*, const IUsePlayerCollision*, const PlayerInput*,
+                              const PlayerConst*, const PlayerTrigger*, bool);
+
+void setupLongJumpVelocity(al::LiveActor*, const IUsePlayerCollision*, f32, f32, f32, f32, f32);
+
+void noticePlayerJumpStart(PlayerTrigger*, const al::LiveActor*);
 
 bool trySendMsgPlayerReflectOrTrample(const al::LiveActor*, al::HitSensor*, al::HitSensor*);
 


### PR DESCRIPTION
Another player state. Interesting facts about this one:
- shares most of its movement code with the dive, so controls feel very similar on them
- For the `E3` demo, the jumping animation was hardcoded to `JumpBroad3`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/701)
<!-- Reviewable:end -->
