### PR TITLE
Library/HitSensor: Refactor `SensorMsg` related macros and functions

### DIFF
--- a/lib/al/Library/HitSensor/SensorMsgSetupUtil.h
+++ b/lib/al/Library/HitSensor/SensorMsgSetupUtil.h
@@ -177,18 +177,18 @@ of the target actor:
 */
 
 #define SEND_MSG_TO_ACTOR_IMPL_(Name, Type)                                                        \
-    bool sendMsg##Name(al::LiveActor* actor) {                                                     \
+    bool sendMsg##Name(al::LiveActor* receiver) {                                                  \
         SensorMsg##Type msg;                                                                       \
-        return alActorSensorFunction::sendMsgToActorUnusedSensor(msg, actor);                      \
+        return alActorSensorFunction::sendMsgToActorUnusedSensor(msg, receiver);                   \
     }
 
 #define SEND_MSG_TO_ACTOR_IMPL(Name) SEND_MSG_TO_ACTOR_IMPL_(Name, Name)
 
 // Same as SEND_MSG_TO_ACTOR_IMPL but also includes data like the macro above
 #define SEND_MSG_DATA_TO_ACTOR_IMPL(Name, DataType, DataName)                                      \
-    bool sendMsg##Name(al::LiveActor* actor, DataType DataName) {                                  \
+    bool sendMsg##Name(al::LiveActor* receiver, DataType DataName) {                               \
         SensorMsg##Name msg(DataName);                                                             \
-        return alActorSensorFunction::sendMsgToActorUnusedSensor(msg, actor);                      \
+        return alActorSensorFunction::sendMsgToActorUnusedSensor(msg, receiver);                   \
     }
 
 /*

--- a/lib/al/Library/LiveActor/ActorSensorUtil.h
+++ b/lib/al/Library/LiveActor/ActorSensorUtil.h
@@ -250,7 +250,7 @@ bool sendMsgHitVeryStrong(HitSensor* receiver, HitSensor* sender);
 bool sendMsgKnockDown(HitSensor* receiver, HitSensor* sender);
 bool sendMsgMapPush(HitSensor* receiver, HitSensor* sender);
 bool sendMsgVanish(HitSensor* receiver, HitSensor* sender);
-bool sendMsgChangeAlpha(LiveActor* actor, f32 pAlpha);
+bool sendMsgChangeAlpha(LiveActor* receiver, f32 pAlpha);
 bool sendMsgShowModel(HitSensor* receiver, HitSensor* sender);
 bool sendMsgHideModel(HitSensor* receiver, HitSensor* sender);
 bool sendMsgRestart(HitSensor* receiver, HitSensor* sender);
@@ -300,18 +300,19 @@ bool sendMsgFireBalCollide(HitSensor* receiver, HitSensor* sender);
 bool sendMsgFireBallFloorTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgDokanBazookaAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgRideAllPlayerItemGet(HitSensor* receiver, HitSensor* sender);
-bool sendMsgHideModel(LiveActor* actor);
-bool sendMsgShowModel(LiveActor* actor);
-bool sendMsgRestart(LiveActor* actor);
+bool sendMsgHideModel(LiveActor* receiver);
+bool sendMsgShowModel(LiveActor* receiver);
+bool sendMsgRestart(LiveActor* receiver);
+// TODO: rename parameters
 bool sendMsgCollisionImpulse(HitSensor* receiver, HitSensor* sender, sead::Vector3f* pVecPtr,
                              const sead::Vector3f& pConstVec, f32 pFloatVal,
                              const sead::Vector3f& pConstVec2, f32 pFloatVal2);
-bool sendMsgSwitchOn(LiveActor* actor);
-bool sendMsgSwitchOnInit(LiveActor* actor);
-bool sendMsgSwitchOffInit(LiveActor* actor);
-bool sendMsgSwitchKillOn(LiveActor* actor);
-bool sendMsgSwitchKillOnInit(LiveActor* actor);
-bool sendMsgSwitchKillOffInit(LiveActor* actor);
+bool sendMsgSwitchOn(LiveActor* receiver);
+bool sendMsgSwitchOnInit(LiveActor* receiver);
+bool sendMsgSwitchOffInit(LiveActor* receiver);
+bool sendMsgSwitchKillOn(LiveActor* receiver);
+bool sendMsgSwitchKillOnInit(LiveActor* receiver);
+bool sendMsgSwitchKillOffInit(LiveActor* receiver);
 bool sendMsgPlayerFloorTouchToColliderGround(LiveActor* receiver, HitSensor* sender);
 bool sendMsgPlayerUpperPunchToColliderCeiling(LiveActor* receiver, HitSensor* sender);
 bool sendMsgEnemyFloorTouchToColliderGround(LiveActor* receiver, HitSensor* sender);

--- a/lib/al/Library/LiveActor/ActorSensorUtil.h
+++ b/lib/al/Library/LiveActor/ActorSensorUtil.h
@@ -78,7 +78,7 @@ const sead::Vector3f& getOriginalSensorFollowPosOffset(const ActorSensorControll
 void resetActorSensorController(ActorSensorController*);
 void calcPosBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*, f32);
 f32 calcDistance(const HitSensor*, const HitSensor*);
-const sead::Vector3f& getSensorPos(const HitSensor*);
+const sead::Vector3f& getSensorPos(const HitSensor* sensor);
 f32 calcDistanceV(const sead::Vector3f&, const HitSensor*, const HitSensor*);
 f32 calcDistanceH(const sead::Vector3f&, const HitSensor*, const HitSensor*);
 bool calcDirBetweenSensors(sead::Vector3f*, const HitSensor*, const HitSensor*);
@@ -149,22 +149,24 @@ void invalidateHitSensorPlayerAll(LiveActor*);
 void invalidateHitSensorPlayerAttackAll(LiveActor*);
 bool isSensorPlayerAttack(const HitSensor*);
 
-bool sendMsgPlayerAttackTrample(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerAttackTrample(HitSensor* receiver, HitSensor* sender,
+                                ComboCounter* pComboCounter);
 bool sendMsgPlayerTrampleReflect(HitSensor* receiver, HitSensor* sender,
-                                 ComboCounter* comboCounter);
+                                 ComboCounter* pComboCounter);
 bool sendMsgPlayerReflectOrTrample(HitSensor* receiver, HitSensor* sender,
                                    ComboCounter* comboCounter);
-bool sendMsgPlayerHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgPlayerObjHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgPlayerObjHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPlayerObjHipDropReflect(HitSensor* receiver, HitSensor* sender,
-                                    ComboCounter* comboCounter);
+                                    ComboCounter* pComboCounter);
 bool sendMsgPlayerObjHipDropHighJump(HitSensor* receiver, HitSensor* sender,
-                                     ComboCounter* comboCounter);
+                                     ComboCounter* pComboCounter);
 bool sendMsgPlayerHipDropKnockDown(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerStatueDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgPlayerObjStatueDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerStatueDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgPlayerObjStatueDrop(HitSensor* receiver, HitSensor* sender,
+                                ComboCounter* pComboCounter);
 bool sendMsgPlayerObjStatueDropReflect(HitSensor* receiver, HitSensor* sender,
-                                       ComboCounter* comboCounter);
+                                       ComboCounter* pComboCounter);
 bool sendMsgPlayerObjStatueDropReflectNoCondition(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerStatueTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerUpperPunch(HitSensor* receiver, HitSensor* sender);
@@ -174,38 +176,39 @@ bool sendMsgPlayerRollingReflect(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerObjRollingAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerObjRollingAttackFailure(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerInvincibleAttack(HitSensor* receiver, HitSensor* sender,
-                                   ComboCounter* comboCounter);
+                                   ComboCounter* pComboCounter);
 bool sendMsgPlayerFireBallAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerRouteDokanFireBallAttack(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerTailAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerTailAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPlayerTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerKick(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerCatch(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerSlidingAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerSlidingAttack(HitSensor* receiver, HitSensor* sender,
+                                ComboCounter* pComboCounter);
 bool sendMsgPlayerBoomerangAttack(HitSensor* receiver, HitSensor* sender,
-                                  ComboCounter* comboCounter);
+                                  ComboCounter* pComboCounter);
 bool sendMsgPlayerBoomerangAttackCollide(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerBoomerangReflect(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerBoomerangBreak(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerBodyAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgPlayerBodyLanding(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerBodyAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgPlayerBodyLanding(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPlayerBodyAttackReflect(HitSensor* receiver, HitSensor* sender,
-                                    ComboCounter* comboCounter);
-bool sendMsgPlayerClimbAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgPlayerSpinAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgPlayerGiantAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+                                    ComboCounter* pComboCounter);
+bool sendMsgPlayerClimbAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgPlayerSpinAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgPlayerGiantAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPlayerCooperationHipDrop(HitSensor* receiver, HitSensor* sender,
-                                     ComboCounter* comboCounter);
+                                     ComboCounter* pComboCounter);
 bool sendMsgPlayerClimbSlidingAttack(HitSensor* receiver, HitSensor* sender,
-                                     ComboCounter* comboCounter);
+                                     ComboCounter* pComboCounter);
 bool sendMsgPlayerClimbRollingAttack(HitSensor* receiver, HitSensor* sender,
-                                     ComboCounter* comboCounter);
-bool sendMsgPlayerGiantHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+                                     ComboCounter* pComboCounter);
+bool sendMsgPlayerGiantHipDrop(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPlayerDisregard(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerItemGet(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerPutOnEquipment(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerReleaseEquipment(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerReleaseEquipmentGoal(HitSensor* receiver, HitSensor* sender, u32);
+bool sendMsgPlayerReleaseEquipmentGoal(HitSensor* receiver, HitSensor* sender, u32 pType);
 bool sendMsgPlayerFloorTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerDamageTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerCarryFront(HitSensor* receiver, HitSensor* sender);
@@ -221,10 +224,10 @@ bool sendMsgPlayerReleaseDead(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerReleaseDemo(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerToss(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerInvincibleTouch(HitSensor* receiver, HitSensor* sender,
-                                  ComboCounter* comboCounter);
+                                  ComboCounter* pComboCounter);
 bool sendMsgEnemyAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgEnemyAttackBoomerang(HitSensor* receiver, HitSensor* sender);
-bool sendMsgEnemyAttackFire(HitSensor* receiver, HitSensor* sender, const char*);
+bool sendMsgEnemyAttackFire(HitSensor* receiver, HitSensor* sender, const char* pMaterialCode);
 bool sendMsgEnemyAttackNeedle(HitSensor* receiver, HitSensor* sender);
 bool sendMsgEnemyFloorTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgEnemyItemGet(HitSensor* receiver, HitSensor* sender);
@@ -236,8 +239,8 @@ bool sendMsgEnemyTrample(HitSensor* receiver, HitSensor* sender);
 bool sendMsgMapObjTrample(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPressureDeath(HitSensor* receiver, HitSensor* sender);
 bool sendMsgNpcTouch(HitSensor* receiver, HitSensor* sender);
-bool sendMsgExplosion(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgExplosionCollide(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgExplosion(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgExplosionCollide(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgPush(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPushStrong(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPushVeryStrong(HitSensor* receiver, HitSensor* sender);
@@ -247,16 +250,16 @@ bool sendMsgHitVeryStrong(HitSensor* receiver, HitSensor* sender);
 bool sendMsgKnockDown(HitSensor* receiver, HitSensor* sender);
 bool sendMsgMapPush(HitSensor* receiver, HitSensor* sender);
 bool sendMsgVanish(HitSensor* receiver, HitSensor* sender);
-bool sendMsgChangeAlpha(LiveActor* receiver, f32 alpha);
+bool sendMsgChangeAlpha(LiveActor* actor, f32 pAlpha);
 bool sendMsgShowModel(HitSensor* receiver, HitSensor* sender);
 bool sendMsgHideModel(HitSensor* receiver, HitSensor* sender);
 bool sendMsgRestart(HitSensor* receiver, HitSensor* sender);
 bool sendMsgNeedleBallAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPunpunFloorTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgInvalidateFootPrint(HitSensor* receiver, HitSensor* sender);
-bool sendMsgKickKouraAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgKickKouraAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgKickKouraAttackCollide(HitSensor* receiver, HitSensor* sender,
-                                   ComboCounter* comboCounter);
+                                   ComboCounter* pComboCounter);
 bool sendMsgKickKouraGetItem(HitSensor* receiver, HitSensor* sender);
 bool sendMsgKickKouraReflect(HitSensor* receiver, HitSensor* sender);
 bool sendMsgKickKouraCollideNoReflect(HitSensor* receiver, HitSensor* sender);
@@ -277,54 +280,54 @@ bool sendMsgJumpInhibit(HitSensor* receiver, HitSensor* sender);
 bool sendMsgGoalKill(HitSensor* receiver, HitSensor* sender);
 bool sendMsgGoal(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindStart(HitSensor* receiver, HitSensor* sender);
-bool sendMsgBindInit(HitSensor* receiver, HitSensor* sender, u32);
+bool sendMsgBindInit(HitSensor* receiver, HitSensor* sender, u32 pBindType);
 bool sendMsgBindEnd(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindCancel(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindCancelByDemo(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindDamage(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindSteal(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBindGiant(HitSensor* receiver, HitSensor* sender);
-bool sendMsgBallAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgBallAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgBallRouteDokanAttack(HitSensor* receiver, HitSensor* sender,
-                                 ComboCounter* comboCounter);
+                                 ComboCounter* pComboCounter);
 bool sendMsgBallAttackHold(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBallAttackDRCHold(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBallAttackCollide(HitSensor* receiver, HitSensor* sender);
-bool sendMsgBallTrample(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgBallTrample(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgBallTrampleCollide(HitSensor* receiver, HitSensor* sender);
 bool sendMsgBallItemGet(HitSensor* receiver, HitSensor* sender);
 bool sendMsgFireBalCollide(HitSensor* receiver, HitSensor* sender);
 bool sendMsgFireBallFloorTouch(HitSensor* receiver, HitSensor* sender);
 bool sendMsgDokanBazookaAttack(HitSensor* receiver, HitSensor* sender);
 bool sendMsgRideAllPlayerItemGet(HitSensor* receiver, HitSensor* sender);
-bool sendMsgHideModel(LiveActor* receiver);
-bool sendMsgShowModel(LiveActor* receiver);
-bool sendMsgRestart(LiveActor* receiver);
-bool sendMsgCollisionImpulse(HitSensor* receiver, HitSensor* sender, sead::Vector3f*,
-                             const sead::Vector3f&, f32, const sead::Vector3f&, f32);
-bool sendMsgSwitchOn(LiveActor* receiver);
-bool sendMsgSwitchOnInit(LiveActor* receiver);
-bool sendMsgSwitchOffInit(LiveActor* receiver);
-bool sendMsgSwitchKillOn(LiveActor* receiver);
-bool sendMsgSwitchKillOnInit(LiveActor* receiver);
-bool sendMsgSwitchKillOffInit(LiveActor* receiver);
+bool sendMsgHideModel(LiveActor* actor);
+bool sendMsgShowModel(LiveActor* actor);
+bool sendMsgRestart(LiveActor* actor);
+bool sendMsgCollisionImpulse(HitSensor* receiver, HitSensor* sender, sead::Vector3f* pVecPtr,
+                             const sead::Vector3f& pConstVec, f32 pFloatVal,
+                             const sead::Vector3f& pConstVec2, f32 pFloatVal2);
+bool sendMsgSwitchOn(LiveActor* actor);
+bool sendMsgSwitchOnInit(LiveActor* actor);
+bool sendMsgSwitchOffInit(LiveActor* actor);
+bool sendMsgSwitchKillOn(LiveActor* actor);
+bool sendMsgSwitchKillOnInit(LiveActor* actor);
+bool sendMsgSwitchKillOffInit(LiveActor* actor);
 bool sendMsgPlayerFloorTouchToColliderGround(LiveActor* receiver, HitSensor* sender);
 bool sendMsgPlayerUpperPunchToColliderCeiling(LiveActor* receiver, HitSensor* sender);
 bool sendMsgEnemyFloorTouchToColliderGround(LiveActor* receiver, HitSensor* sender);
 bool sendMsgEnemyUpperPunchToColliderCeiling(LiveActor* receiver, HitSensor* sender);
-bool sendMsgAskSafetyPoint(HitSensor* receiver, HitSensor* sender,
-                           sead::Vector3f** safetyPointAccessor);
+bool sendMsgAskSafetyPoint(HitSensor* receiver, HitSensor* sender, sead::Vector3f** pSafetyPoint);
 bool sendMsgAskSafetyPointToColliderGround(LiveActor* receiver, HitSensor* sender,
                                            sead::Vector3f** safetyPointAccessor);
 bool sendMsgTouchAssist(HitSensor* receiver, HitSensor* sender);
 bool sendMsgTouchAssistTrig(HitSensor* receiver, HitSensor* sender);
 bool sendMsgTouchStroke(HitSensor* receiver, HitSensor* sender);
 bool sendMsgScreenPointInvalidCollisionParts(HitSensor* receiver, HitSensor* sender);
-bool sendMsgBlockUpperPunch(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
-bool sendMsgBlockLowerPunch(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgBlockUpperPunch(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
+bool sendMsgBlockLowerPunch(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgBlockItemGet(HitSensor* receiver, HitSensor* sender);
 bool sendMsgKillerItemGet(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerKouraAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* comboCounter);
+bool sendMsgPlayerKouraAttack(HitSensor* receiver, HitSensor* sender, ComboCounter* pComboCounter);
 bool sendMsgLightFlash(HitSensor* receiver, HitSensor* sender);
 bool sendMsgForceAbyss(HitSensor* receiver, HitSensor* sender);
 bool sendMsgIsNerveSupportFreeze(HitSensor* receiver, HitSensor* sender);
@@ -349,16 +352,16 @@ bool sendMsgPlayerTouchShadow(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerPullOutShadow(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerAttackShadow(HitSensor* receiver, HitSensor* sender);
 bool sendMsgPlayerAttackShadowStrong(HitSensor* receiver, HitSensor* sender);
-bool sendMsgPlayerAttackChangePos(HitSensor* receiver, HitSensor* sender, sead::Vector3f* pos);
+bool sendMsgPlayerAttackChangePos(HitSensor* receiver, HitSensor* sender, sead::Vector3f* pPos);
 bool sendMsgAtmosOnlineLight(HitSensor* receiver, HitSensor* sender);
 bool sendMsgLightBurn(HitSensor* receiver, HitSensor* sender);
 bool sendMsgMoonLightBurn(HitSensor* receiver, HitSensor* sender);
-bool sendMsgString(HitSensor* receiver, HitSensor* sender, const char* str);
-bool sendMsgStringV4fPtr(HitSensor* receiver, HitSensor* sender, const char* str,
-                         sead::Vector4f* vec);
+bool sendMsgString(HitSensor* receiver, HitSensor* sender, const char* pStr);
+bool sendMsgStringV4fPtr(HitSensor* receiver, HitSensor* sender, const char* pString,
+                         sead::Vector4f* pVec);
 bool sendMsgStringV4fSensorPtr(HitSensor* receiver, HitSensor* sender, const char* str,
                                sead::Vector4f* vec);
-bool sendMsgStringVoidPtr(HitSensor* receiver, HitSensor* sender, const char* str, void* ptr);
+bool sendMsgStringVoidPtr(HitSensor* receiver, HitSensor* sender, const char* pString, void* pPtr);
 
 bool isMsgPushAll(const SensorMsg* msg);
 bool isMsgPush(const SensorMsg* msg);
@@ -608,7 +611,7 @@ bool tryReceiveMsgPushAndAddVelocityH(LiveActor*, const SensorMsg*, const HitSen
                                       const HitSensor*, f32);
 bool tryReceiveMsgPushAndCalcPushTrans(sead::Vector3f*, const SensorMsg*, const LiveActor*,
                                        const HitSensor*, const HitSensor*, f32);
-bool sendMsgCollidePush(HitSensor*, HitSensor*, const sead::Vector3f&);
+bool sendMsgCollidePush(HitSensor* receiver, HitSensor* sender, const sead::Vector3f& pVec);
 bool tryReceiveMsgCollidePush(sead::Vector3f*, const SensorMsg*);
 f32 getChangeAlphaValue(const SensorMsg*);
 u32 getBindInitType(const SensorMsg*);
@@ -842,13 +845,12 @@ SENSOR_MSG_WITH_DATA_CUSTOM_CTOR(CollidePush, ((sead::Vector3f, Vec)),
 }
 
 // TODO: rename variables
-SENSOR_MSG_WITH_DATA_CUSTOM_CTOR(CollisionImpulse,
-                                 ((sead::Vector3f*, VecPtr), (const sead::Vector3f*, ConstVec),
-                                  (f32, FloatVal), (const sead::Vector3f*, ConstVec2),
-                                  (f32, FloatVal2)),
-                                 ((sead::Vector3f*, VecPtr), (const sead::Vector3f&, VecRef),
-                                  (f32, FloatVal), (const sead::Vector3f&, VecRef2),
-                                  (f32, FloatVal2))) {
+SENSOR_MSG_WITH_DATA_CUSTOM_CTOR_DIRECT_GETTERS(
+    CollisionImpulse,
+    ((sead::Vector3f*, VecPtr), (const sead::Vector3f*, ConstVec), (f32, FloatVal),
+     (const sead::Vector3f*, ConstVec2), (f32, FloatVal2)),
+    ((sead::Vector3f*, VecPtr), (const sead::Vector3f&, VecRef), (f32, FloatVal),
+     (const sead::Vector3f&, VecRef2), (f32, FloatVal2))) {
     mVecPtr = pVecPtr;
     mConstVec = &pVecRef;
     mFloatVal = pFloatVal;


### PR DESCRIPTION
This PR does some refactoring to the stuff added in #415 based on what I noticed while implementing game `SensorMsg` stuff.
The following changes were made:
* Since `SEND_MSG_WITH_DATA_MULTI_IMPL` already supports just giving it one data field, I renamed it to `SEND_MSG_WITH_DATA_IMPL` and removed the old `SEND_MSG_WITH_DATA_IMPL` macro. This forces all invocations of the macro to be given proper field names for the data even if there's only one field which is good for keeping the naming consistent between the header and cpp because we probably don't want to name the params in the header `data`
* Similarly I changed `SEND_MSG_DATA_TO_ACTOR` so that it now takes a name for the data field instead of just using `data` as the name
* Function param names now match between `ActorSensorUtil.h`/`.cpp`
* I made it so that `SENSOR_MSG_WITH_DATA_CUSTOM_CTOR` now gets the return types of the generated getters from the ctor params since for example it makes more sense for msgs that store a `sead::Vector3f` but take in a `const sead::Vector3f&` to have a getter that returns a `const sead::Vector3f&`. As discovered by @german77 this is also required to match some functions in `Util/SensorMsgFunction.o` that deal with vectors. This however does not work for msgs where the ctor has incompatible types with the stored types (for example input is a pointer and the stored value is a reference). For this edge case, I added the `SENSOR_MSG_WITH_CUSTOM_CTOR_DIRECT_GETTERS` macro which works like the other macro before this PR
* I noticed that `rs::sendMsgPushToPlayerAndKillVelocityToTarget`[`H`] are almost identical to `al::sendMsgPushAndKillVelocityToTarget`[`H`] with the only difference being that the two `rs` functions send a different msg than the `al` ones. However I also noticed that the `rs` ones used `al::getSensorPos(sensor)` instead of `sensor->getPos` like the `al` ones, but since the functions seem otherwise copied and `al::getSensorPos` is located in the same object as the two `al` functions, it is very likely that the `sensor->getPos` call in the `al` functions is actually inlined from `al::getSensorPos`, so I changed those two functions to use that and of course also implemented the function so that it can could get inlined

(Sorry I couldn't think of a better name for this PR)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/702)
<!-- Reviewable:end -->
