### PR TITLE
workflow: Fix `inline` functions for macro definitions in OdysseyHeaders

### DIFF
--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -24,6 +24,8 @@ for root, _, files in os.walk(workdir):
                 if "inline " in lines[i] and "(" in lines[i] and not "= default" in lines[i]:
                     for j, line_inner in enumerate(lines[i:]):
                         line_inner_no_newline = line_inner.strip("\n")
+                        if line_inner_no_newline.endswith("\\"):  # part of a macro definition => cut out relevant parts of the line to decide whether to delete it
+                            line_inner_no_newline = line_inner_no_newline[:-1].strip()
                         if line_inner_no_newline.endswith("{") or line_inner_no_newline.endswith("}"):
                             break
                         if line_inner_no_newline.endswith(";"):


### PR DESCRIPTION
We're currently generating broken headers, due to macro definitions being cut off half-way, when the `inline` keyword is found on any function.
Example: https://github.com/MonsterDruide1/OdysseyHeaders/blob/10ef705bf9c1f5df7e305252364440929af9a181/al/Library/HitSensor/SensorMsgSetupUtil.h#L47

The correct way to handle those is removing them from the macro definition - so let's refine the code for cutting out that part of the macro.