### PR TITLE
workflows: Fix more `inline` functions for macro definitions in OdysseyHeaders

### DIFF
--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -26,6 +26,11 @@ for root, _, files in os.walk(workdir):
                         line_inner_no_newline = line_inner.strip("\n")
                         if line_inner_no_newline.endswith("\\"):  # part of a macro definition => cut out relevant parts of the line to decide whether to delete it
                             line_inner_no_newline = line_inner_no_newline[:-1].strip()
+                        if line_inner_no_newline.strip() == "":
+                            # should not happen if everything is correct, but there's still broken stuff for macro definitions
+                            # in this case: https://github.com/MonsterDruide1/OdysseyDecomp/blob/master/lib/al/Library/HitSensor/SensorMsgSetupUtil.h#L87
+                            # (ending a macro definition with a function definition with no body)
+                            break
                         if line_inner_no_newline.endswith("{") or line_inner_no_newline.endswith("}"):
                             break
                         if line_inner_no_newline.endswith(";"):


### PR DESCRIPTION
More stuff being broken: The workflow doesn't like if macros end with a `inline` function definition, without body. In that case, it apparently keeps searching until the next "ending token" is found (semicolon or some brace type at the end of a line).

This fix is not particularly nice, but works: Just stop and ignore if an empty line is found. This should never happen in function declarations, which is all we're searching for here. The better option would be to find the closing parenthesis of the function parameters, but ... that's annoying, especially given that more parentheses might be used within the function parameter types (function pointers, ...).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/705)
<!-- Reviewable:end -->
