### PR TITLE
workflow: Still fix `inline` functions for SensorMsg macros in OdysseyHeaders

### DIFF
--- a/.github/scripts/process-headers.py
+++ b/.github/scripts/process-headers.py
@@ -31,6 +31,12 @@ for root, _, files in os.walk(workdir):
                             # in this case: https://github.com/MonsterDruide1/OdysseyDecomp/blob/master/lib/al/Library/HitSensor/SensorMsgSetupUtil.h#L87
                             # (ending a macro definition with a function definition with no body)
                             break
+                        if line_inner_no_newline == "inline SensorMsg##Type(PARAM_LIST CtorParams);":
+                            # despite all special case handlings above, this macro line is still special
+                            # it is only declared in the class itself, so should according to all current rules be removed,
+                            # but is also defined immediately afterwards in the same macro, which means that it is
+                            # still inlined in all usages and should therefore be included in the headers repo
+                            break
                         if line_inner_no_newline.endswith("{") or line_inner_no_newline.endswith("}"):
                             break
                         if line_inner_no_newline.endswith(";"):


### PR DESCRIPTION
Another one. See the comment above the newly-added special case for a reasoning:
```py
# despite all special case handlings above, this macro line is still special
# it is only declared in the class itself, so should according to all current rules be removed,
# but is also defined immediately afterwards in the same macro, which means that it is
# still inlined in all usages and should therefore be included in the headers repo
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/706)
<!-- Reviewable:end -->
