### PR TITLE
Effect: Fix function signatures in `EffectKeeper`

### DIFF
--- a/lib/al/Library/Effect/EffectKeeper.h
+++ b/lib/al/Library/Effect/EffectKeeper.h
@@ -37,7 +37,7 @@ public:
     void tryUpdateMaterial(const char*);
     void updatePrefix(const EffectPrefixType&, bool);
     void emitEffectCurrentPos(const char*);
-    al::Effect* findEffect(const char*) const;
+    Effect* findEffect(const char*) const;
     void emitEffect(const char*, const sead::Vector3f*);
     bool tryEmitEffect(const char*, const sead::Vector3f*);
     void deleteEffect(const char*);
@@ -57,7 +57,7 @@ public:
     void setParticleColor(const char*, const sead::Color4f&);
     void setParticleLifeScale(const char*, f32);
     sead::Matrix34f* findMtxPtr(const char*);
-    al::Effect* tryFindEffect(const char*) const;
+    Effect* tryFindEffect(const char*) const;
 
     bool get_21() const { return field_21; }
 

--- a/lib/al/Library/Effect/EffectKeeper.h
+++ b/lib/al/Library/Effect/EffectKeeper.h
@@ -37,9 +37,9 @@ public:
     void tryUpdateMaterial(const char*);
     void updatePrefix(const EffectPrefixType&, bool);
     void emitEffectCurrentPos(const char*);
-    void findEffect(const char*);
+    al::Effect* findEffect(const char*) const;
     void emitEffect(const char*, const sead::Vector3f*);
-    void tryEmitEffect(const char*, const sead::Vector3f*);
+    bool tryEmitEffect(const char*, const sead::Vector3f*);
     void deleteEffect(const char*);
     void tryDeleteEffect(const char*);
     void tryKillEmitterAndParticleAll();
@@ -56,8 +56,8 @@ public:
     void setParticleAlpha(const char*, f32);
     void setParticleColor(const char*, const sead::Color4f&);
     void setParticleLifeScale(const char*, f32);
-    void findMtxPtr(const char*);
-    void tryFindEffect(const char*);
+    sead::Matrix34f* findMtxPtr(const char*);
+    al::Effect* tryFindEffect(const char*) const;
 
     bool get_21() const { return field_21; }
 


### PR DESCRIPTION
This file contains some wrong/missing return types, and two functions are not marked as `const` correctly.

Noticed by @mcanterogomez, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/709)
<!-- Reviewable:end -->
