### PR TITLE
Library/Area: Implement `SwitchOnAreaGroup`

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,10 +1,10 @@
 ---
-Language:        Cpp
+Language: Cpp
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
 AlignConsecutiveAssignments: false
 AlignConsecutiveDeclarations: false
-AlignOperands:   true
+AlignOperands: true
 AlignTrailingComments: true
 AllowAllParametersOfDeclarationOnNextLine: true
 AllowShortBlocksOnASingleLine: Never
@@ -22,29 +22,30 @@ BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Attach
 BreakBeforeTernaryOperators: false
 BreakConstructorInitializersBeforeComma: false
-ColumnLimit:     100
-CommentPragmas:  '^ (IWYU pragma:|NOLINT)'
+ColumnLimit: 100
+CommentPragmas: '^ (IWYU pragma:|NOLINT)'
 ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
-DisableFormat:   false
-ForEachMacros:   []
+DisableFormat: false
+ForEachMacros: [ ]
 IncludeCategories:
-  - Regex:           '^<[Ww]indows\.h>$'
-    Priority:        1
-  - Regex:           '^<'
-    Priority:        2
-  - Regex:           '^"'
-    Priority:        3
+  - Regex: '^<[Ww]indows\.h>$'
+    Priority: 1
+  - Regex: '^<'
+    Priority: 2
+  - Regex: '^"'
+    Priority: 3
 IndentCaseLabels: false
-IndentWidth:     4
+IndentWidth: 4
 IndentWrappedFunctionNames: false
+InsertNewlineAtEOF: true
 KeepEmptyLinesAtTheStartOfBlocks: false
 LineEnding: LF
 MacroBlockBegin: ''
-MacroBlockEnd:   ''
+MacroBlockEnd: ''
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: None
 ObjCBlockIndentWidth: 4
@@ -58,22 +59,22 @@ PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 60
 PointerAlignment: Left
 QualifierAlignment: Left
-ReflowComments:  true
+ReflowComments: true
 RemoveBracesLLVM: true
 SeparateDefinitionBlocks: Always
-SortIncludes:    true
+SortIncludes: true
 SpaceAfterCStyleCast: false
 SpaceBeforeAssignmentOperators: true
 SpaceBeforeParens: ControlStatements
 SpaceInEmptyParentheses: false
 SpacesBeforeTrailingComments: 2
-SpacesInAngles:  false
+SpacesInAngles: false
 SpacesInContainerLiterals: true
 SpacesInCStyleCastParentheses: false
 SpacesInParentheses: false
 SpacesInSquareBrackets: false
 Standard: c++17
-TabWidth:        4
-UseTab:          Never
-WhitespaceSensitiveMacros: ["SEAD_ENUM", "SEAD_ENUM_EX", "SEAD_ENUM_EX_VALUES"]
+TabWidth: 4
+UseTab: Never
+WhitespaceSensitiveMacros: [ "SEAD_ENUM", "SEAD_ENUM_EX", "SEAD_ENUM_EX_VALUES" ]
 ...

--- a/lib/al/Library/Area/SwitchOnAreaGroup.cpp
+++ b/lib/al/Library/Area/SwitchOnAreaGroup.cpp
@@ -1,0 +1,44 @@
+#include "Library/Area/SwitchOnAreaGroup.h"
+
+#include "Library/Area/AreaObj.h"
+#include "Library/Area/AreaObjGroup.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+namespace al {
+SwitchOnAreaGroup::SwitchOnAreaGroup(AreaObjGroup* areaObjGroup) : mAreaObjGroup(areaObjGroup) {}
+
+void SwitchOnAreaGroup::update(const sead::Vector3f* positions, s32 posCount) {
+    s32 size = mAreaObjGroup->getSize();
+    for (s32 i = 0; i < size; i++) {
+        AreaObj* areaObj = mAreaObjGroup->getAreaObj(i);
+        if (isOnStageSwitch(areaObj, "SwitchAreaOn"))
+            continue;
+
+        for (s32 j = 0; j < posCount; j++) {
+            if (!areaObj->isInVolume(positions[j]) || !isExternalCondition())
+                continue;
+
+            onStageSwitch(areaObj, "SwitchAreaOn");
+
+            break;
+        }
+    }
+}
+
+void SwitchOnAreaGroup::update(const sead::Vector3f& position) {
+    sead::Vector3f pos = position;  // wtf are they trying to do here?
+    s32 size = mAreaObjGroup->getSize();
+    for (s32 i = 0; i < size; i++) {
+        AreaObj* areaObj = mAreaObjGroup->getAreaObj(i);
+        if (isOnStageSwitch(areaObj, "SwitchAreaOn") || !areaObj->isInVolume(pos) ||
+            !isExternalCondition())
+            continue;
+
+        onStageSwitch(areaObj, "SwitchAreaOn");
+    }
+}
+
+bool SwitchOnAreaGroup::isExternalCondition() const {
+    return true;
+}
+}  // namespace al

--- a/lib/al/Library/Area/SwitchOnAreaGroup.h
+++ b/lib/al/Library/Area/SwitchOnAreaGroup.h
@@ -4,16 +4,15 @@
 
 namespace al {
 class AreaObjGroup;
-class PlayerHolder;
 
 class SwitchOnAreaGroup {
 public:
     SwitchOnAreaGroup(AreaObjGroup* areaObjGroup);
 
-    void update(const sead::Vector3f* trans, s32);
-    void update(const sead::Vector3f& trans);
-
     virtual bool isExternalCondition() const;
+
+    void update(const sead::Vector3f* positions, s32 posCount);
+    void update(const sead::Vector3f& position);
 
 private:
     AreaObjGroup* mAreaObjGroup;


### PR DESCRIPTION
This PR adds:
- `SwitchOnAreaGroup` functions.
- `InsertNewlineAtEOF: true` in `.clang-format` to ensure a new line will be added at the end of the file. This option has been added in clang-format 16.0.0