### PR TITLE
Library/LiveActor: Fix name of `LiveActorFlag->isModelHidden`

### DIFF
--- a/lib/al/Library/LiveActor/LiveActorFlag.h
+++ b/lib/al/Library/LiveActor/LiveActorFlag.h
@@ -8,7 +8,7 @@ struct LiveActorFlag {
     bool isClippingInvalid = true;
     bool isDrawClipped = false;
     bool isDisableCalcAnim = false;
-    bool isModelVisible = false;
+    bool isModelHidden = false;
     bool isCollideOff = true;
     bool field_07 = false;
     bool isMaterialCodeValid = false;


### PR DESCRIPTION
As it turns out, our logic is flipped here. This variable is not used anywhere yet, so it didn't become obvious in any function.

Found this in a debugging session in cooperation with @mcanterogomez.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/717)
<!-- Reviewable:end -->
