### PR TITLE
`Layout/CoinCounter`: Fix nerve ordering

### DIFF
--- a/src/Layout/CoinCounter.cpp
+++ b/src/Layout/CoinCounter.cpp
@@ -20,7 +20,7 @@ NERVE_IMPL(CoinCounter, CountAnimAdd);
 NERVE_IMPL(CoinCounter, CountAnimSub);
 
 NERVES_MAKE_NOSTRUCT(CoinCounter, Wait);
-NERVES_MAKE_STRUCT(CoinCounter, End, Appear, Add, Sub, CountAnimAdd, CountAnimSub);
+NERVES_MAKE_STRUCT(CoinCounter, End, Appear, CountAnimAdd, CountAnimSub, Add, Sub);
 }  // namespace
 
 CoinCounter::CoinCounter(const char* name, const al::LayoutInitInfo& initInfo, bool isCoin)
@@ -96,9 +96,9 @@ void CoinCounter::startCountAnim(s32 coinNum) {
     mTotalCoins = getCountTotalFromData();
 
     if (coinNum < prevCoinCount)
-        al::setNerve(this, &NrvCoinCounter.Sub);
+        al::setNerve(this, &NrvCoinCounter.CountAnimSub);
     else
-        al::setNerve(this, &NrvCoinCounter.Add);
+        al::setNerve(this, &NrvCoinCounter.CountAnimAdd);
 }
 
 bool CoinCounter::tryUpdateCount() {
@@ -112,9 +112,9 @@ bool CoinCounter::tryUpdateCount() {
 
     al::Nerve* nerve;
     if (mTotalCoins < newTotalCoins)
-        nerve = &NrvCoinCounter.CountAnimAdd;
+        nerve = &NrvCoinCounter.Add;
     else
-        nerve = &NrvCoinCounter.CountAnimSub;
+        nerve = &NrvCoinCounter.Sub;
 
     mTotalCoins = newTotalCoins;
     mCoinNum = newCoinNum;


### PR DESCRIPTION
Currently our implementation of `CoinCounter` uses the `Appear` nerve where `End` is used in the original code and vice versa. The reason this doesn't mismatch is because those two nerves are also in the wrong order in the Nrv struct. I noticed this when @Krabbix on discord was trying to make a custom layout and based it off of our `CoinCounter` impl, since it had stuff like setting the `Appear` nerve in `kill` which doesn't make sense.

So this PR fixes that

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/720)
<!-- Reviewable:end -->
