### PR TITLE
All: Fix code styling things enforced by upcoming lints

### DIFF
--- a/lib/al/Library/Application/ApplicationMessageReceiver.cpp
+++ b/lib/al/Library/Application/ApplicationMessageReceiver.cpp
@@ -3,7 +3,7 @@
 #include <nn/am.h>
 
 namespace al {
-ApplicationMessageReceiver::ApplicationMessageReceiver() {}
+ApplicationMessageReceiver::ApplicationMessageReceiver() = default;
 
 nn::oe::OperationMode ApplicationMessageReceiver::getOperationMode() const {
     nn::oe::OperationMode operationMode = nn::oe::GetOperationMode();

--- a/lib/al/Library/Area/AreaObjDirector.cpp
+++ b/lib/al/Library/Area/AreaObjDirector.cpp
@@ -81,7 +81,7 @@ void AreaObjDirector::createAreaObjGroupBuffer() {
     s32 areaGroupCount = 0;
     s32 nEntries = mFactory->getNumFactoryEntries();
     for (s32 i = 0; i < nEntries; i++) {
-        if (mAreaGroups[i] == nullptr)
+        if (!mAreaGroups[i] )
             continue;
         mAreaGroups[i]->createBuffer();
         areaGroupCount++;
@@ -111,7 +111,7 @@ void AreaObjDirector::placementAreaObj(const AreaInitInfo& initInfo) {
 
         AreaCreatorFunction creatorFunc = nullptr;
         mFactory->getEntryIndex(&creatorFunc, pInfoName);
-        if (creatorFunc == nullptr)
+        if (!creatorFunc )
             continue;
 
         const char* displayName;

--- a/lib/al/Library/Area/AreaObjDirector.cpp
+++ b/lib/al/Library/Area/AreaObjDirector.cpp
@@ -81,7 +81,7 @@ void AreaObjDirector::createAreaObjGroupBuffer() {
     s32 areaGroupCount = 0;
     s32 nEntries = mFactory->getNumFactoryEntries();
     for (s32 i = 0; i < nEntries; i++) {
-        if (!mAreaGroups[i] )
+        if (!mAreaGroups[i])
             continue;
         mAreaGroups[i]->createBuffer();
         areaGroupCount++;
@@ -111,7 +111,7 @@ void AreaObjDirector::placementAreaObj(const AreaInitInfo& initInfo) {
 
         AreaCreatorFunction creatorFunc = nullptr;
         mFactory->getEntryIndex(&creatorFunc, pInfoName);
-        if (!creatorFunc )
+        if (!creatorFunc)
             continue;
 
         const char* displayName;

--- a/lib/al/Library/Area/AreaObjUtil.cpp
+++ b/lib/al/Library/Area/AreaObjUtil.cpp
@@ -17,7 +17,7 @@ AreaObj* tryFindAreaObj(const IUseAreaObj* areaUser, const char* name,
 AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
                                   const sead::Vector3f& position, AreaObjFilterBase* filter) {
     AreaObjGroup* areaObjGroup = tryFindAreaObjGroup(areaUser, name);
-    if (areaObjGroup == nullptr)
+    if (!areaObjGroup )
         return nullptr;
 
     AreaObj* currentAreaObj = nullptr;
@@ -25,7 +25,7 @@ AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
     for (s32 i = 0; i < size; i++) {
         AreaObj* areaObj = areaObjGroup->getAreaObj(i);
 
-        if ((currentAreaObj == nullptr ||
+        if ((!currentAreaObj  ||
              currentAreaObj->getPriority() <= areaObj->getPriority()) &&
             areaObj->isInVolume(position) && filter->isValidArea(areaObj)) {
             currentAreaObj = areaObj;
@@ -38,7 +38,7 @@ AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
 bool tryFindAreaObjAll(const IUseAreaObj* areaUser, const char* name,
                        const sead::Vector3f& position, AreaObjFindCallBack* callBack) {
     AreaObjGroup* areaObjGroup = tryFindAreaObjGroup(areaUser, name);
-    if (areaObjGroup == nullptr)
+    if (!areaObjGroup )
         return false;
 
     bool foundAnyArea = false;
@@ -64,7 +64,7 @@ bool isInAreaObj(const AreaObjGroup* group, const sead::Vector3f& position) {
 }
 
 AreaObj* tryGetAreaObj(const AreaObjGroup* group, const sead::Vector3f& position) {
-    if (group == nullptr)
+    if (!group )
         return nullptr;
 
     return group->getInVolumeAreaObj(position);
@@ -96,7 +96,7 @@ bool isInPlayerControlOffArea(const IUseAreaObj* areaUser, const sead::Vector3f&
 
 s32 calcAreaObjNum(const IUseAreaObj* areaUser, const char* name) {
     AreaObjGroup* group = tryFindAreaObjGroup(areaUser, name);
-    if (group == nullptr)
+    if (!group )
         return 0;
 
     return group->getSize();
@@ -125,21 +125,21 @@ bool tryGetAreaObjArg(s32* outArg, const AreaObj* areaObj, const char* key) {
 }
 
 bool tryGetAreaObjArg(f32* outArg, const AreaObj* areaObj, const char* key) {
-    if (areaObj->getPlacementInfo() == nullptr)
+    if (!areaObj->getPlacementInfo() )
         return false;
 
     return tryGetArg(outArg, *areaObj->getPlacementInfo(), key);
 }
 
 bool tryGetAreaObjArg(bool* outArg, const AreaObj* areaObj, const char* key) {
-    if (areaObj->getPlacementInfo() == nullptr)
+    if (!areaObj->getPlacementInfo() )
         return false;
 
     return tryGetArg(outArg, *areaObj->getPlacementInfo(), key);
 }
 
 bool tryGetAreaObjStringArg(const char** outArg, const AreaObj* areaObj, const char* key) {
-    if (areaObj->getPlacementInfo() == nullptr)
+    if (!areaObj->getPlacementInfo() )
         return false;
 
     return tryGetStringArg(outArg, *areaObj->getPlacementInfo(), key);

--- a/lib/al/Library/Area/AreaObjUtil.cpp
+++ b/lib/al/Library/Area/AreaObjUtil.cpp
@@ -17,7 +17,7 @@ AreaObj* tryFindAreaObj(const IUseAreaObj* areaUser, const char* name,
 AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
                                   const sead::Vector3f& position, AreaObjFilterBase* filter) {
     AreaObjGroup* areaObjGroup = tryFindAreaObjGroup(areaUser, name);
-    if (!areaObjGroup )
+    if (!areaObjGroup)
         return nullptr;
 
     AreaObj* currentAreaObj = nullptr;
@@ -25,8 +25,7 @@ AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
     for (s32 i = 0; i < size; i++) {
         AreaObj* areaObj = areaObjGroup->getAreaObj(i);
 
-        if ((!currentAreaObj  ||
-             currentAreaObj->getPriority() <= areaObj->getPriority()) &&
+        if ((!currentAreaObj || currentAreaObj->getPriority() <= areaObj->getPriority()) &&
             areaObj->isInVolume(position) && filter->isValidArea(areaObj)) {
             currentAreaObj = areaObj;
         }
@@ -38,7 +37,7 @@ AreaObj* tryFindAreaObjWithFilter(const IUseAreaObj* areaUser, const char* name,
 bool tryFindAreaObjAll(const IUseAreaObj* areaUser, const char* name,
                        const sead::Vector3f& position, AreaObjFindCallBack* callBack) {
     AreaObjGroup* areaObjGroup = tryFindAreaObjGroup(areaUser, name);
-    if (!areaObjGroup )
+    if (!areaObjGroup)
         return false;
 
     bool foundAnyArea = false;
@@ -64,7 +63,7 @@ bool isInAreaObj(const AreaObjGroup* group, const sead::Vector3f& position) {
 }
 
 AreaObj* tryGetAreaObj(const AreaObjGroup* group, const sead::Vector3f& position) {
-    if (!group )
+    if (!group)
         return nullptr;
 
     return group->getInVolumeAreaObj(position);
@@ -96,7 +95,7 @@ bool isInPlayerControlOffArea(const IUseAreaObj* areaUser, const sead::Vector3f&
 
 s32 calcAreaObjNum(const IUseAreaObj* areaUser, const char* name) {
     AreaObjGroup* group = tryFindAreaObjGroup(areaUser, name);
-    if (!group )
+    if (!group)
         return 0;
 
     return group->getSize();
@@ -125,21 +124,21 @@ bool tryGetAreaObjArg(s32* outArg, const AreaObj* areaObj, const char* key) {
 }
 
 bool tryGetAreaObjArg(f32* outArg, const AreaObj* areaObj, const char* key) {
-    if (!areaObj->getPlacementInfo() )
+    if (!areaObj->getPlacementInfo())
         return false;
 
     return tryGetArg(outArg, *areaObj->getPlacementInfo(), key);
 }
 
 bool tryGetAreaObjArg(bool* outArg, const AreaObj* areaObj, const char* key) {
-    if (!areaObj->getPlacementInfo() )
+    if (!areaObj->getPlacementInfo())
         return false;
 
     return tryGetArg(outArg, *areaObj->getPlacementInfo(), key);
 }
 
 bool tryGetAreaObjStringArg(const char** outArg, const AreaObj* areaObj, const char* key) {
-    if (!areaObj->getPlacementInfo() )
+    if (!areaObj->getPlacementInfo())
         return false;
 
     return tryGetStringArg(outArg, *areaObj->getPlacementInfo(), key);

--- a/lib/al/Library/Area/AreaShape.cpp
+++ b/lib/al/Library/Area/AreaShape.cpp
@@ -11,7 +11,7 @@
 
 namespace al {
 
-AreaShape::AreaShape() {}
+AreaShape::AreaShape() = default;
 
 void AreaShape::setBaseMtxPtr(const sead::Matrix34f* baseMtxPtr) {
     mBaseMtxPtr = baseMtxPtr;

--- a/lib/al/Library/Area/AreaShapeInfinite.cpp
+++ b/lib/al/Library/Area/AreaShapeInfinite.cpp
@@ -2,7 +2,7 @@
 
 namespace al {
 
-AreaShapeInfinite::AreaShapeInfinite() {}
+AreaShapeInfinite::AreaShapeInfinite() = default;
 
 bool AreaShapeInfinite::isInVolume(const sead::Vector3f&) const {
     return true;

--- a/lib/al/Library/Area/AreaShapeOval.cpp
+++ b/lib/al/Library/Area/AreaShapeOval.cpp
@@ -6,7 +6,7 @@
 
 namespace al {
 
-AreaShapeOval::AreaShapeOval() {}
+AreaShapeOval::AreaShapeOval() = default;
 
 bool AreaShapeOval::isInVolume(const sead::Vector3f& pos) const {
     sead::Vector3f localPos = sead::Vector3f::zero;

--- a/lib/al/Library/Area/AreaShapeSphere.cpp
+++ b/lib/al/Library/Area/AreaShapeSphere.cpp
@@ -4,7 +4,7 @@
 
 namespace al {
 
-AreaShapeSphere::AreaShapeSphere() {}
+AreaShapeSphere::AreaShapeSphere() = default;
 
 bool AreaShapeSphere::isInVolume(const sead::Vector3f& pos) const {
     sead::Vector3f baseTrans;

--- a/lib/al/Library/Base/StringUtil.cpp
+++ b/lib/al/Library/Base/StringUtil.cpp
@@ -103,7 +103,7 @@ void removeExtensionString(char* out, u32 len, const char* str) {
     char* dot = strchr(out, '.');
     char* dirSeparator = strchr(out, '/');
 
-    if (!dot  || dot < dirSeparator || ++dirSeparator == dot)
+    if (!dot || dot < dirSeparator || ++dirSeparator == dot)
         return;
 
     *dot = '\0';

--- a/lib/al/Library/Base/StringUtil.cpp
+++ b/lib/al/Library/Base/StringUtil.cpp
@@ -103,7 +103,7 @@ void removeExtensionString(char* out, u32 len, const char* str) {
     char* dot = strchr(out, '.');
     char* dirSeparator = strchr(out, '/');
 
-    if (dot == nullptr || dot < dirSeparator || ++dirSeparator == dot)
+    if (!dot  || dot < dirSeparator || ++dirSeparator == dot)
         return;
 
     *dot = '\0';

--- a/lib/al/Library/Bgm/BgmKeeper.cpp
+++ b/lib/al/Library/Bgm/BgmKeeper.cpp
@@ -11,7 +11,7 @@ namespace al {
 
 BgmKeeper::BgmKeeper(const AudioSystemInfo* audioInfo, BgmDirector* director, const char* string)
     : mBgmDirector(director) {
-    if (string != nullptr)
+    if (string )
         mBgmUserInfo = alBgmFunction::tryFindBgmUserInfo(audioInfo->bgmDataBase, string);
 }
 
@@ -25,7 +25,7 @@ BgmKeeper* BgmKeeper::create(const AudioSystemInfo* audioInfo, BgmDirector* dire
 void BgmKeeper::update() {}
 
 const char* BgmKeeper::getUserName() const {
-    if (mBgmUserInfo == nullptr)
+    if (!mBgmUserInfo )
         return nullptr;
     return mBgmUserInfo->name;
 }

--- a/lib/al/Library/Bgm/BgmKeeper.cpp
+++ b/lib/al/Library/Bgm/BgmKeeper.cpp
@@ -11,7 +11,7 @@ namespace al {
 
 BgmKeeper::BgmKeeper(const AudioSystemInfo* audioInfo, BgmDirector* director, const char* string)
     : mBgmDirector(director) {
-    if (string )
+    if (string)
         mBgmUserInfo = alBgmFunction::tryFindBgmUserInfo(audioInfo->bgmDataBase, string);
 }
 
@@ -25,7 +25,7 @@ BgmKeeper* BgmKeeper::create(const AudioSystemInfo* audioInfo, BgmDirector* dire
 void BgmKeeper::update() {}
 
 const char* BgmKeeper::getUserName() const {
-    if (!mBgmUserInfo )
+    if (!mBgmUserInfo)
         return nullptr;
     return mBgmUserInfo->name;
 }

--- a/lib/al/Library/Camera/CameraParamMoveLimit.cpp
+++ b/lib/al/Library/Camera/CameraParamMoveLimit.cpp
@@ -16,7 +16,7 @@ CameraParamMoveLimit* CameraParamMoveLimit::create(const CameraPoser* poser) {
     return result;
 }
 
-CameraParamMoveLimit::CameraParamMoveLimit() {}
+CameraParamMoveLimit::CameraParamMoveLimit() = default;
 
 void CameraParamMoveLimit::load(const ByamlIter& iter) {
     ByamlIter moveLimitIter;

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -117,7 +117,7 @@ public:
     static_assert(sizeof(OrthoProjectionParam) == 0xC);
 
     CameraPoser(const char* name);
-    virtual AreaObjDirector* getAreaObjDirector() const override;
+    AreaObjDirector* getAreaObjDirector() const override;
 
     virtual void init() {}
 
@@ -147,13 +147,13 @@ public:
 
     virtual const char* getName() const override { return mPoserName; }
 
-    virtual CollisionDirector* getCollisionDirector() const override;
+    CollisionDirector* getCollisionDirector() const override;
 
     virtual NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
 
     virtual AudioKeeper* getAudioKeeper() const override { return mAudioKeeper; }
 
-    virtual RailRider* getRailRider() const override;
+    RailRider* getRailRider() const override;
 
     virtual void load(const ByamlIter& iter);
     virtual void movement();  // TODO: implementation missing

--- a/lib/al/Library/Camera/CameraPoserActorRailParallel.h
+++ b/lib/al/Library/Camera/CameraPoserActorRailParallel.h
@@ -9,7 +9,7 @@ public:
 
     void init() override;
     void loadParam(const ByamlIter& iter) override;
-    void start(const CameraStartInfo& startInfo) override;
+    void start(const CameraStartInfo& info) override;
     void update() override;
 
 private:

--- a/lib/al/Library/Camera/CameraPoserFix.cpp
+++ b/lib/al/Library/Camera/CameraPoserFix.cpp
@@ -50,7 +50,7 @@ void CameraPoserFix::loadParam(const ByamlIter& iter) {
     tryGetByamlBool(&mIsCalcNearestAtFromPreAt, iter, "IsCalcNearestAtFromPreAt");
 }
 
-void CameraPoserFix::start(const CameraStartInfo& startInfo) {
+void CameraPoserFix::start(const CameraStartInfo& info) {
     mPreLookAtPos.set(alCameraPoserFunction::getPreLookAtPos(this));
     update();
 }

--- a/lib/al/Library/Camera/CameraPoserFix.h
+++ b/lib/al/Library/Camera/CameraPoserFix.h
@@ -17,7 +17,7 @@ public:
 
     void init() override;
     void loadParam(const ByamlIter& iter) override;
-    void start(const CameraStartInfo& startInfo) override;
+    void start(const CameraStartInfo& info) override;
     void update() override;
 
 private:

--- a/lib/al/Library/Camera/SpecialCameraHolder.cpp
+++ b/lib/al/Library/Camera/SpecialCameraHolder.cpp
@@ -6,7 +6,7 @@
 
 namespace al {
 
-SpecialCameraHolder::SpecialCameraHolder() {}
+SpecialCameraHolder::SpecialCameraHolder() = default;
 
 void SpecialCameraHolder::allocEntranceCameraBuffer(s32 maxEntries) {
     mMaxEntranceCameras = maxEntries;

--- a/lib/al/Library/Clipping/ClippingActorInfo.h
+++ b/lib/al/Library/Clipping/ClippingActorInfo.h
@@ -15,24 +15,24 @@ class ViewIdHolder;
 
 class ClippingActorInfo {
 public:
-    ClippingActorInfo(LiveActor*);
-    void setTypeToSphere(f32, const sead::Vector3f*);
+    ClippingActorInfo(LiveActor* actor);
+    void setTypeToSphere(f32 radius, const sead::Vector3f* pos);
     void startClipped();
     void endClipped();
-    void updateClipping(const ClippingJudge*);
-    bool judgeClipping(const ClippingJudge*) const;
-    void updateClipping(ClippingRequestKeeper*, const ClippingJudge*);
+    void updateClipping(const ClippingJudge* clippingJudge);
+    bool judgeClipping(const ClippingJudge* clippingJudge) const;
+    void updateClipping(ClippingRequestKeeper* clippingRequestKeeper, const ClippingJudge* clippingJudge);
     bool isGroupClipping() const;
     bool isGroupClippingInit() const;
-    void setTypeToObb(const sead::BoundBox3f&, const sead::Matrix34f*);
-    void setGroupClippingId(const ActorInitInfo&);
+    void setTypeToObb(const sead::BoundBox3f& boundBox, const sead::Matrix34f* matrix);
+    void setGroupClippingId(const ActorInitInfo& clippingId);
     void setFarClipLevel20M();
     void updateFarClipLevel();
     void setFarClipLevelMax();
     bool isFarClipLevelMax() const;
     bool checkActiveViewGroupAny() const;
-    void initViewGroup(const ViewIdHolder*);
-    void registerViewGroupFarClipFlag(const bool*);
+    void initViewGroup(const ViewIdHolder* viewIdHolder);
+    void registerViewGroupFarClipFlag(const bool* flag);
 
     LiveActor* getLiveActor() const { return mLiveActor; }
 

--- a/lib/al/Library/Clipping/ClippingActorInfo.h
+++ b/lib/al/Library/Clipping/ClippingActorInfo.h
@@ -21,7 +21,8 @@ public:
     void endClipped();
     void updateClipping(const ClippingJudge* clippingJudge);
     bool judgeClipping(const ClippingJudge* clippingJudge) const;
-    void updateClipping(ClippingRequestKeeper* clippingRequestKeeper, const ClippingJudge* clippingJudge);
+    void updateClipping(ClippingRequestKeeper* clippingRequestKeeper,
+                        const ClippingJudge* clippingJudge);
     bool isGroupClipping() const;
     bool isGroupClippingInit() const;
     void setTypeToObb(const sead::BoundBox3f& boundBox, const sead::Matrix34f* matrix);

--- a/lib/al/Library/Clipping/ClippingJudge.h
+++ b/lib/al/Library/Clipping/ClippingJudge.h
@@ -13,7 +13,8 @@ class ClippingFarAreaObserver;
 // TODO: rename `idx`, `idy` and `idz` across all functions
 class ClippingJudge {
 public:
-    ClippingJudge(const ClippingFarAreaObserver* clippingFarAreaObserver, const SceneCameraInfo* cameraInfo);
+    ClippingJudge(const ClippingFarAreaObserver* clippingFarAreaObserver,
+                  const SceneCameraInfo* cameraInfo);
 
     void update();
     bool isJudgedToClipFrustumUnUseFarLevel(const sead::Vector3f& pos, f32 idx, f32 idy) const;

--- a/lib/al/Library/Clipping/ClippingJudge.h
+++ b/lib/al/Library/Clipping/ClippingJudge.h
@@ -13,7 +13,7 @@ class ClippingFarAreaObserver;
 // TODO: rename `idx`, `idy` and `idz` across all functions
 class ClippingJudge {
 public:
-    ClippingJudge(const ClippingFarAreaObserver*, const SceneCameraInfo*);
+    ClippingJudge(const ClippingFarAreaObserver* clippingFarAreaObserver, const SceneCameraInfo* cameraInfo);
 
     void update();
     bool isJudgedToClipFrustumUnUseFarLevel(const sead::Vector3f& pos, f32 idx, f32 idy) const;

--- a/lib/al/Library/Clipping/ClippingRequestKeeper.h
+++ b/lib/al/Library/Clipping/ClippingRequestKeeper.h
@@ -29,7 +29,7 @@ class ClippingRequestKeeper {
 public:
     ClippingRequestKeeper(s32 capacity);
     void executeRequest();
-    void request(LiveActor* actor, ClippingRequestType requestType);
+    void request(LiveActor* actor, ClippingRequestType clippingRequestType);
 
 private:
     ClippingRequestTable* mRequestTable;

--- a/lib/al/Library/Clipping/ViewIdHolder.cpp
+++ b/lib/al/Library/Clipping/ViewIdHolder.cpp
@@ -5,7 +5,7 @@
 #include "Library/Placement/PlacementInfo.h"
 
 namespace al {
-ViewIdHolder::ViewIdHolder() {}
+ViewIdHolder::ViewIdHolder() = default;
 
 ViewIdHolder* ViewIdHolder::tryCreate(const PlacementInfo& placementInfo) {
     if (calcLinkChildNum(placementInfo, "ViewGroup") < 1) {

--- a/lib/al/Library/Collision/CollisionPartsTriangle.cpp
+++ b/lib/al/Library/Collision/CollisionPartsTriangle.cpp
@@ -208,7 +208,7 @@ const sead::Matrix34f& Triangle::getPrevBaseMtx() const {
     return mCollisionParts->getPrevBaseMtx();
 }
 
-HitInfo::HitInfo() {}
+HitInfo::HitInfo() = default;
 
 bool HitInfo::isCollisionAtFace() const {
     return collisionLocation == CollisionLocation::Face;

--- a/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
+++ b/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
@@ -10,6 +10,7 @@ public:
     public:
         void calcHistory(const sead::Vector3f&, const sead::Vector3f&, f32);
 
+    private:
         unsigned char padding_0[0x60];
         f32 mHist0;
         unsigned char padding_1[0x70 - 0x64];
@@ -21,6 +22,7 @@ public:
     public:
         void calcHistory(const sead::Vector3f&, const sead::Vector3f&);
 
+    private:
         unsigned char padding_1[0x88];
         sead::Vector2f unkVec0;
         unsigned char padding_0[0x98 - (0x88 + 0x8)];
@@ -38,6 +40,7 @@ public:
     void update();
     JoyPadAccelPoseAnalyzer getSwingDirDoubleHandSameDir() const;
 
+private:
     s32 mControllerPort;               // port of the controller
     s32 mAccelDeviceNum;               // number of accelerometers
     bool gap00;                        // unknown

--- a/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
+++ b/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
@@ -11,9 +11,9 @@ public:
         void calcHistory(const sead::Vector3f&, const sead::Vector3f&, f32);
 
         unsigned char padding_0[0x60];
-        f32 hist0;
+        f32 mHist0;
         unsigned char padding_1[0x70 - 0x64];
-        f32 hist1;
+        f32 mHist1;
         unsigned char padding_2[0x1c];
     };
 
@@ -41,9 +41,9 @@ public:
     s32 mControllerPort;               // port of the controller
     s32 mAccelDeviceNum;               // number of accelerometers
     bool gap00;                        // unknown
-    bool mSwingLeft;                   // shaking the left joycon
-    bool mSwingRight;                  // shaking the right joycon
-    bool mSwingAny;                    // shaking anything
+    bool mIsSwingLeft;                   // shaking the left joycon
+    bool mIsSwingRight;                  // shaking the right joycon
+    bool mIsSwingAny;                    // shaking anything
     sead::Vector2f mSwingBorder;       // Border to trigger a motion shake
     sead::Vector2f mAccelLeftVel;      // Accelerometer of the Left Joycon
     sead::Vector2f mAccelRightVel;     // Accelerometer of the Right Joycon

--- a/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
+++ b/lib/al/Library/Controller/JoyPadAccelPoseAnalyzer.h
@@ -41,9 +41,9 @@ public:
     s32 mControllerPort;               // port of the controller
     s32 mAccelDeviceNum;               // number of accelerometers
     bool gap00;                        // unknown
-    bool mIsSwingLeft;                   // shaking the left joycon
-    bool mIsSwingRight;                  // shaking the right joycon
-    bool mIsSwingAny;                    // shaking anything
+    bool mIsSwingLeft;                 // shaking the left joycon
+    bool mIsSwingRight;                // shaking the right joycon
+    bool mIsSwingAny;                  // shaking anything
     sead::Vector2f mSwingBorder;       // Border to trigger a motion shake
     sead::Vector2f mAccelLeftVel;      // Accelerometer of the Left Joycon
     sead::Vector2f mAccelRightVel;     // Accelerometer of the Right Joycon

--- a/lib/al/Library/Demo/DemoFunction.h
+++ b/lib/al/Library/Demo/DemoFunction.h
@@ -19,7 +19,7 @@ void setDemoInfoDemoName(const LiveActor* actor, const char* name);
 void killForceBeforeDemo(LiveActor* actor);
 void prepareSkip(LiveActor* actor, s32);
 void invalidateLODWithSubActor(LiveActor*);
-bool isActiveDemo(const Scene*);
+bool isActiveDemo(const Scene* scene);
 
 }  // namespace al
 

--- a/lib/al/Library/Draw/GraphicsQualityController.h
+++ b/lib/al/Library/Draw/GraphicsQualityController.h
@@ -14,7 +14,7 @@ public:
     bool isChangedGraphicsQualityMode() const { return mIsChangedGraphicsQualityMode; }
 
 private:
-    void* _0[1];
+    void* _10[1];
     GraphicsQualityInfo* mGraphicsQualityInfo;
     void* _20[17];
     bool mIsChangedGraphicsQualityMode;

--- a/lib/al/Library/Draw/SubCameraRenderer.h
+++ b/lib/al/Library/Draw/SubCameraRenderer.h
@@ -34,7 +34,7 @@ public:
     void calcOnScreenPos(sead::Vector3f*, const sead::Vector3f&) const;
 
 private:
-    void* _padding[0x4a];
+    void* _10[0x4a];
 };
 
 static_assert(sizeof(SubCameraRenderer) == 0x260);

--- a/lib/al/Library/Event/SceneEventFlowMsg.cpp
+++ b/lib/al/Library/Event/SceneEventFlowMsg.cpp
@@ -3,7 +3,7 @@
 #include "Library/Base/StringUtil.h"
 
 namespace al {
-SceneEventFlowMsg::SceneEventFlowMsg() {}
+SceneEventFlowMsg::SceneEventFlowMsg() = default;
 
 bool SceneEventFlowMsg::isReceiveCommand(const char* cmd) const {
     if (mCmd.isEmpty())

--- a/lib/al/Library/Execute/LayoutExecuteInfo.cpp
+++ b/lib/al/Library/Execute/LayoutExecuteInfo.cpp
@@ -1,7 +1,7 @@
 #include "Library/Execute/LayoutExecuteInfo.h"
 
 namespace al {
-LayoutExecuteInfo::LayoutExecuteInfo() {}
+LayoutExecuteInfo::LayoutExecuteInfo() = default;
 
 void LayoutExecuteInfo::addUpdater(ExecutorListLayoutUpdate* updater) {
     mUpdaters[mUpdaterCount] = updater;

--- a/lib/al/Library/KeyPose/KeyPoseKeeper.cpp
+++ b/lib/al/Library/KeyPose/KeyPoseKeeper.cpp
@@ -5,7 +5,7 @@
 #include "Project/Joint/KeyPose.h"
 
 namespace al {
-KeyPoseKeeper::KeyPoseKeeper() {}
+KeyPoseKeeper::KeyPoseKeeper() = default;
 
 void KeyPoseKeeper::init(const PlacementInfo& info) {
     mKeyPoseCount = calcLinkNestNum(info, "KeyMoveNext") + 1;

--- a/lib/al/Library/KeyPose/KeyPoseKeeperUtil.cpp
+++ b/lib/al/Library/KeyPose/KeyPoseKeeperUtil.cpp
@@ -31,10 +31,10 @@ void restartKeyPose(KeyPoseKeeper* keyPoseKeeper, sead::Vector3f* pos, sead::Qua
 
     const KeyPose& keyPose = keyPoseKeeper->getKeyPose(0);
 
-    if (pos != nullptr)
+    if (pos )
         pos->set(keyPose.getTrans());
 
-    if (orientation != nullptr)
+    if (orientation )
         orientation->set(keyPose.getQuat());
 }
 

--- a/lib/al/Library/KeyPose/KeyPoseKeeperUtil.cpp
+++ b/lib/al/Library/KeyPose/KeyPoseKeeperUtil.cpp
@@ -31,10 +31,10 @@ void restartKeyPose(KeyPoseKeeper* keyPoseKeeper, sead::Vector3f* pos, sead::Qua
 
     const KeyPose& keyPose = keyPoseKeeper->getKeyPose(0);
 
-    if (pos )
+    if (pos)
         pos->set(keyPose.getTrans());
 
-    if (orientation )
+    if (orientation)
         orientation->set(keyPose.getQuat());
 }
 

--- a/lib/al/Library/Layout/LayoutActor.h
+++ b/lib/al/Library/Layout/LayoutActor.h
@@ -60,11 +60,11 @@ public:
 
     virtual LayoutKeeper* getLayoutKeeper() const override { return mLayoutKeeper; }
 
-    virtual CameraDirector* getCameraDirector() const override;
+    CameraDirector* getCameraDirector() const override;
 
-    virtual SceneObjHolder* getSceneObjHolder() const override;
+    SceneObjHolder* getSceneObjHolder() const override;
 
-    virtual const MessageSystem* getMessageSystem() const override;
+    const MessageSystem* getMessageSystem() const override;
 
     virtual void control() {}
 

--- a/lib/al/Library/LiveActor/ActorInitUtil.cpp
+++ b/lib/al/Library/LiveActor/ActorInitUtil.cpp
@@ -157,7 +157,7 @@ __attribute__((always_inline)) void initActorModel(LiveActor* actor, const Actor
     initModel.tryGetStringByKey(&displayRootJointName, "DisplayRootJointName");
 
     initActorModelKeeper(actor, initInfo, actorResource, blendAnimMax);
-    if (displayRootJointName )
+    if (displayRootJointName)
         actor->getModelKeeper()->setDisplayRootJointMtxPtr(
             getJointMtxPtr(actor, displayRootJointName));
 
@@ -318,7 +318,7 @@ __attribute__((always_inline)) void initActorCollision(LiveActor* actor,
     initCollision.tryGetStringByKey(&name, "Name");
     sead::FixedSafeString<256> unused;
 
-    if (!name )
+    if (!name)
         name = getBaseName(modelRes->getArchiveName());
 
     const char* sensorName = nullptr;
@@ -329,7 +329,7 @@ __attribute__((always_inline)) void initActorCollision(LiveActor* actor,
     const char* joint = nullptr;
     initCollision.tryGetStringByKey(&joint, "Joint");
     sead::Matrix34f* jointMtx = nullptr;
-    if (joint )
+    if (joint)
         jointMtx = getJointMtxPtr(actor, joint);
 
     initActorCollisionWithResource(actor, modelRes, name, sensor, jointMtx, suffix);
@@ -380,7 +380,7 @@ __attribute__((always_inline)) void initActorSound(LiveActor* actor, const Actor
     } else
         return;
 
-    if (seName )
+    if (seName)
         initActorSeKeeper(actor, initInfo, seName);
     if (initSound.isExistKey("BgmUserName"))
         initActorBgmKeeper(actor, initInfo, bgmName);
@@ -526,7 +526,7 @@ void initActorImpl(LiveActor* actor, const ActorInitInfo& initInfo,
     ActorResource* actorResource =
         findOrCreateActorResource(initInfo.actorResourceHolder, path.cstr(), suffix);
     Resource* modelRes = actorResource->getModelRes();
-    if (!actor->getSceneInfo() )
+    if (!actor->getSceneInfo())
         initActorSceneInfo(actor, initInfo);
 
     initActorPose(actor, initInfo, modelRes, suffix);
@@ -745,7 +745,7 @@ createActorFromFactory(const ActorInitInfo& childInitInfo, const PlacementInfo* 
 
     ActorCreatorFunction creationFunction = nullptr;
     factory->getEntryIndex(&creationFunction, className);
-    if (!creationFunction )
+    if (!creationFunction)
         return nullptr;
 
     const char* displayName;

--- a/lib/al/Library/LiveActor/ActorInitUtil.cpp
+++ b/lib/al/Library/LiveActor/ActorInitUtil.cpp
@@ -157,7 +157,7 @@ __attribute__((always_inline)) void initActorModel(LiveActor* actor, const Actor
     initModel.tryGetStringByKey(&displayRootJointName, "DisplayRootJointName");
 
     initActorModelKeeper(actor, initInfo, actorResource, blendAnimMax);
-    if (displayRootJointName != nullptr)
+    if (displayRootJointName )
         actor->getModelKeeper()->setDisplayRootJointMtxPtr(
             getJointMtxPtr(actor, displayRootJointName));
 
@@ -318,7 +318,7 @@ __attribute__((always_inline)) void initActorCollision(LiveActor* actor,
     initCollision.tryGetStringByKey(&name, "Name");
     sead::FixedSafeString<256> unused;
 
-    if (name == nullptr)
+    if (!name )
         name = getBaseName(modelRes->getArchiveName());
 
     const char* sensorName = nullptr;
@@ -329,7 +329,7 @@ __attribute__((always_inline)) void initActorCollision(LiveActor* actor,
     const char* joint = nullptr;
     initCollision.tryGetStringByKey(&joint, "Joint");
     sead::Matrix34f* jointMtx = nullptr;
-    if (joint != nullptr)
+    if (joint )
         jointMtx = getJointMtxPtr(actor, joint);
 
     initActorCollisionWithResource(actor, modelRes, name, sensor, jointMtx, suffix);
@@ -380,7 +380,7 @@ __attribute__((always_inline)) void initActorSound(LiveActor* actor, const Actor
     } else
         return;
 
-    if (seName != nullptr)
+    if (seName )
         initActorSeKeeper(actor, initInfo, seName);
     if (initSound.isExistKey("BgmUserName"))
         initActorBgmKeeper(actor, initInfo, bgmName);
@@ -526,7 +526,7 @@ void initActorImpl(LiveActor* actor, const ActorInitInfo& initInfo,
     ActorResource* actorResource =
         findOrCreateActorResource(initInfo.actorResourceHolder, path.cstr(), suffix);
     Resource* modelRes = actorResource->getModelRes();
-    if (actor->getSceneInfo() == nullptr)
+    if (!actor->getSceneInfo() )
         initActorSceneInfo(actor, initInfo);
 
     initActorPose(actor, initInfo, modelRes, suffix);
@@ -745,7 +745,7 @@ createActorFromFactory(const ActorInitInfo& childInitInfo, const PlacementInfo* 
 
     ActorCreatorFunction creationFunction = nullptr;
     factory->getEntryIndex(&creationFunction, className);
-    if (creationFunction == nullptr)
+    if (!creationFunction )
         return nullptr;
 
     const char* displayName;

--- a/lib/al/Library/LiveActor/HitReactionKeeper.h
+++ b/lib/al/Library/LiveActor/HitReactionKeeper.h
@@ -44,7 +44,7 @@ struct HitReactionInfo {
     f32 radialBlurStrengthEnd;
     f32 radialBlurAlphaBegin;
     f32 radialBlurAlphaEnd;
-    bool radialBlurScreenSpace;
+    bool isRadialBlurScreenSpace;
     sead::Vector2f radialBlurScreenPos;
 };
 

--- a/lib/al/Library/LiveActor/LiveActor.h
+++ b/lib/al/Library/LiveActor/LiveActor.h
@@ -93,13 +93,13 @@ public:
 
     virtual StageSwitchKeeper* getStageSwitchKeeper() const override { return mStageSwitchKeeper; }
 
-    virtual RailRider* getRailRider() const override;
-    virtual SceneObjHolder* getSceneObjHolder() const override;
-    virtual CollisionDirector* getCollisionDirector() const override;
-    virtual AreaObjDirector* getAreaObjDirector() const override;
-    virtual CameraDirector* getCameraDirector() const override;
+    RailRider* getRailRider() const override;
+    SceneObjHolder* getSceneObjHolder() const override;
+    CollisionDirector* getCollisionDirector() const override;
+    AreaObjDirector* getAreaObjDirector() const override;
+    CameraDirector* getCameraDirector() const override;
     NatureDirector* getNatureDirector() const;
-    virtual void initStageSwitchKeeper() override;
+    void initStageSwitchKeeper() override;
 
     virtual void control() {}
 

--- a/lib/al/Library/LiveActor/LiveActorFlag.h
+++ b/lib/al/Library/LiveActor/LiveActorFlag.h
@@ -10,7 +10,7 @@ struct LiveActorFlag {
     bool isDisableCalcAnim = false;
     bool isModelHidden = false;
     bool isCollideOff = true;
-    bool field_07 = false;
+    bool field_7 = false;
     bool isMaterialCodeValid = false;
     bool isPuddleMaterialValid = false;
     bool isAreaTargetOn = true;

--- a/lib/al/Library/MapObj/BreakMapPartsBase.cpp
+++ b/lib/al/Library/MapObj/BreakMapPartsBase.cpp
@@ -49,7 +49,7 @@ void BreakMapPartsBase::init(const ActorInitInfo& info) {
     const char* suffix = nullptr;
     tryGetStringArg(&suffix, info, "SuffixName");
 
-    if (suffix != nullptr && isEqualString(suffix, "None"))
+    if (suffix  && isEqualString(suffix, "None"))
         suffix = nullptr;
 
     initMapPartsActor(this, info, suffix);
@@ -78,7 +78,7 @@ void BreakMapPartsBase::init(const ActorInitInfo& info) {
 }
 
 void BreakMapPartsBase::initAfterPlacement() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -91,36 +91,36 @@ void BreakMapPartsBase::kill() {
 }
 
 void BreakMapPartsBase::movement() {
-    if (!isNerve(this, &NrvBreakMapPartsBase.Wait) || mMtxConnector != nullptr) {
+    if (!isNerve(this, &NrvBreakMapPartsBase.Wait) || mMtxConnector ) {
         LiveActor::movement();
 
         return;
     }
 
-    if (getEffectKeeper() != nullptr && getEffectKeeper()->get_21())
+    if (getEffectKeeper()  && getEffectKeeper()->get_21())
         getEffectKeeper()->update();
 }
 
 void BreakMapPartsBase::calcAnim() {
-    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && mMtxConnector == nullptr)
+    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && !mMtxConnector )
         return;
 
     LiveActor::calcAnim();
 }
 
 void BreakMapPartsBase::exeWait() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         connectPoseQT(this, mMtxConnector);
 }
 
 void BreakMapPartsBase::exeBreak() {
     if (isFirstStep(this)) {
         LiveActor* subActor = tryGetSubActor(this, "壊れモデル");
-        if (subActor != nullptr)
+        if (subActor )
             subActor->appear();
 
         subActor = tryGetSubActor(this, "残留モデル");
-        if (subActor != nullptr) {
+        if (subActor ) {
             subActor->appear();
 
             if (isTraceModelRandomRotate(subActor))
@@ -130,7 +130,7 @@ void BreakMapPartsBase::exeBreak() {
         if (mIsExistHitReactionBreak)
             startHitReaction(this, "破壊");
 
-        if (mAudioKeeper != nullptr)
+        if (mAudioKeeper )
             startSe(mAudioKeeper, "Riddle");
 
         if (!isExistAction(this, "Break")) {

--- a/lib/al/Library/MapObj/BreakMapPartsBase.cpp
+++ b/lib/al/Library/MapObj/BreakMapPartsBase.cpp
@@ -49,7 +49,7 @@ void BreakMapPartsBase::init(const ActorInitInfo& info) {
     const char* suffix = nullptr;
     tryGetStringArg(&suffix, info, "SuffixName");
 
-    if (suffix  && isEqualString(suffix, "None"))
+    if (suffix && isEqualString(suffix, "None"))
         suffix = nullptr;
 
     initMapPartsActor(this, info, suffix);
@@ -78,7 +78,7 @@ void BreakMapPartsBase::init(const ActorInitInfo& info) {
 }
 
 void BreakMapPartsBase::initAfterPlacement() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -91,36 +91,36 @@ void BreakMapPartsBase::kill() {
 }
 
 void BreakMapPartsBase::movement() {
-    if (!isNerve(this, &NrvBreakMapPartsBase.Wait) || mMtxConnector ) {
+    if (!isNerve(this, &NrvBreakMapPartsBase.Wait) || mMtxConnector) {
         LiveActor::movement();
 
         return;
     }
 
-    if (getEffectKeeper()  && getEffectKeeper()->get_21())
+    if (getEffectKeeper() && getEffectKeeper()->get_21())
         getEffectKeeper()->update();
 }
 
 void BreakMapPartsBase::calcAnim() {
-    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && !mMtxConnector )
+    if (isNerve(this, &NrvBreakMapPartsBase.Wait) && !mMtxConnector)
         return;
 
     LiveActor::calcAnim();
 }
 
 void BreakMapPartsBase::exeWait() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         connectPoseQT(this, mMtxConnector);
 }
 
 void BreakMapPartsBase::exeBreak() {
     if (isFirstStep(this)) {
         LiveActor* subActor = tryGetSubActor(this, "壊れモデル");
-        if (subActor )
+        if (subActor)
             subActor->appear();
 
         subActor = tryGetSubActor(this, "残留モデル");
-        if (subActor ) {
+        if (subActor) {
             subActor->appear();
 
             if (isTraceModelRandomRotate(subActor))
@@ -130,7 +130,7 @@ void BreakMapPartsBase::exeBreak() {
         if (mIsExistHitReactionBreak)
             startHitReaction(this, "破壊");
 
-        if (mAudioKeeper )
+        if (mAudioKeeper)
             startSe(mAudioKeeper, "Riddle");
 
         if (!isExistAction(this, "Break")) {

--- a/lib/al/Library/MapObj/ClockMapParts.cpp
+++ b/lib/al/Library/MapObj/ClockMapParts.cpp
@@ -93,7 +93,7 @@ void ClockMapParts::init(const ActorInitInfo& info) {
     if (isExistModel(this)) {
         mRippleCtrl = RippleCtrl::tryCreate(this);
 
-        if (mRippleCtrl != nullptr)
+        if (mRippleCtrl )
             mRippleCtrl->init(info);
     }
 
@@ -209,7 +209,7 @@ void ClockMapParts::setRestartNerve() {
 }
 
 void ClockMapParts::control() {
-    if (mRippleCtrl == nullptr)
+    if (!mRippleCtrl )
         return;
 
     mRippleCtrl->update();

--- a/lib/al/Library/MapObj/ClockMapParts.cpp
+++ b/lib/al/Library/MapObj/ClockMapParts.cpp
@@ -93,7 +93,7 @@ void ClockMapParts::init(const ActorInitInfo& info) {
     if (isExistModel(this)) {
         mRippleCtrl = RippleCtrl::tryCreate(this);
 
-        if (mRippleCtrl )
+        if (mRippleCtrl)
             mRippleCtrl->init(info);
     }
 
@@ -209,7 +209,7 @@ void ClockMapParts::setRestartNerve() {
 }
 
 void ClockMapParts::control() {
-    if (!mRippleCtrl )
+    if (!mRippleCtrl)
         return;
 
     mRippleCtrl->update();

--- a/lib/al/Library/MapObj/ConveyerStep.cpp
+++ b/lib/al/Library/MapObj/ConveyerStep.cpp
@@ -33,7 +33,7 @@ void ConveyerStep::init(const ActorInitInfo& info) {
 }
 
 bool ConveyerStep::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
-    if (mHost )
+    if (mHost)
         return mHost->receiveMsg(message, other, self);
 
     return false;
@@ -66,12 +66,11 @@ void ConveyerStep::setTransByCoord(f32 coord, bool isForwards, bool isForceReset
 
         if (tryGetStringArg(&keyHitReactionName, *conveyerKey.placementInfo,
                             "KeyHitReactionName") &&
-            (!mKeyHitReactionName  ||
-             !isEqualString(mKeyHitReactionName, keyHitReactionName)))
+            (!mKeyHitReactionName || !isEqualString(mKeyHitReactionName, keyHitReactionName)))
             startHitReaction(this, keyHitReactionName);
 
         if (tryGetStringArg(&actionName, *conveyerKey.placementInfo, "ActionName") &&
-            (!mActionName  || !isEqualString(mActionName, actionName)))
+            (!mActionName || !isEqualString(mActionName, actionName)))
             startAction(this, actionName);
     }
 
@@ -85,14 +84,14 @@ void ConveyerStep::setTransByCoord(f32 coord, bool isForwards, bool isForceReset
     if (newCoord > mConveyerKeyKeeper->getTotalMoveDistance()) {
         if (mIsExist) {
             mIsExist = false;
-            if (getModelKeeper()  && !isHideModel(this))
+            if (getModelKeeper() && !isHideModel(this))
                 hideModel(this);
             if (isExistCollisionParts(this))
                 invalidateCollisionParts(this);
         }
     } else if (!mIsExist) {
         mIsExist = true;
-        if (getModelKeeper()  && isHideModel(this))
+        if (getModelKeeper() && isHideModel(this))
             showModel(this);
         if (isExistCollisionParts(this))
             validateCollisionParts(this);

--- a/lib/al/Library/MapObj/ConveyerStep.cpp
+++ b/lib/al/Library/MapObj/ConveyerStep.cpp
@@ -33,7 +33,7 @@ void ConveyerStep::init(const ActorInitInfo& info) {
 }
 
 bool ConveyerStep::receiveMsg(const SensorMsg* message, HitSensor* other, HitSensor* self) {
-    if (mHost != nullptr)
+    if (mHost )
         return mHost->receiveMsg(message, other, self);
 
     return false;
@@ -66,12 +66,12 @@ void ConveyerStep::setTransByCoord(f32 coord, bool isForwards, bool isForceReset
 
         if (tryGetStringArg(&keyHitReactionName, *conveyerKey.placementInfo,
                             "KeyHitReactionName") &&
-            (mKeyHitReactionName == nullptr ||
+            (!mKeyHitReactionName  ||
              !isEqualString(mKeyHitReactionName, keyHitReactionName)))
             startHitReaction(this, keyHitReactionName);
 
         if (tryGetStringArg(&actionName, *conveyerKey.placementInfo, "ActionName") &&
-            (mActionName == nullptr || !isEqualString(mActionName, actionName)))
+            (!mActionName  || !isEqualString(mActionName, actionName)))
             startAction(this, actionName);
     }
 
@@ -85,14 +85,14 @@ void ConveyerStep::setTransByCoord(f32 coord, bool isForwards, bool isForceReset
     if (newCoord > mConveyerKeyKeeper->getTotalMoveDistance()) {
         if (mIsExist) {
             mIsExist = false;
-            if (getModelKeeper() != nullptr && !isHideModel(this))
+            if (getModelKeeper()  && !isHideModel(this))
                 hideModel(this);
             if (isExistCollisionParts(this))
                 invalidateCollisionParts(this);
         }
     } else if (!mIsExist) {
         mIsExist = true;
-        if (getModelKeeper() != nullptr && isHideModel(this))
+        if (getModelKeeper()  && isHideModel(this))
             showModel(this);
         if (isExistCollisionParts(this))
             validateCollisionParts(this);

--- a/lib/al/Library/MapObj/FixMapParts.cpp
+++ b/lib/al/Library/MapObj/FixMapParts.cpp
@@ -18,7 +18,7 @@ void FixMapParts::init(const ActorInitInfo& info) {
     trySyncStageSwitchAppearAndKill(this);
     registActorToDemoInfo(this, info);
 
-    if (getModelKeeper() != nullptr && !isExistAction(this) && !isViewDependentModel(this))
+    if (getModelKeeper()  && !isExistAction(this) && !isViewDependentModel(this))
         mIsStatic = true;
 }
 

--- a/lib/al/Library/MapObj/FixMapParts.cpp
+++ b/lib/al/Library/MapObj/FixMapParts.cpp
@@ -18,7 +18,7 @@ void FixMapParts::init(const ActorInitInfo& info) {
     trySyncStageSwitchAppearAndKill(this);
     registActorToDemoInfo(this, info);
 
-    if (getModelKeeper()  && !isExistAction(this) && !isViewDependentModel(this))
+    if (getModelKeeper() && !isExistAction(this) && !isViewDependentModel(this))
         mIsStatic = true;
 }
 

--- a/lib/al/Library/MapObj/GateMapParts.cpp
+++ b/lib/al/Library/MapObj/GateMapParts.cpp
@@ -88,7 +88,7 @@ void GateMapParts::exeOpen() {
             return;
         }
 
-        if (mSuccessSeObj != nullptr)
+        if (mSuccessSeObj )
             startSe(mSuccessSeObj, "Riddle");
 
         startNerveAction(this, "End");
@@ -129,7 +129,7 @@ void GateMapParts::exeBound() {
             return;
         }
 
-        if (mSuccessSeObj != nullptr)
+        if (mSuccessSeObj )
             startSe(mSuccessSeObj, "Riddle");
 
         startNerveAction(this, "End");

--- a/lib/al/Library/MapObj/GateMapParts.cpp
+++ b/lib/al/Library/MapObj/GateMapParts.cpp
@@ -88,7 +88,7 @@ void GateMapParts::exeOpen() {
             return;
         }
 
-        if (mSuccessSeObj )
+        if (mSuccessSeObj)
             startSe(mSuccessSeObj, "Riddle");
 
         startNerveAction(this, "End");
@@ -129,7 +129,7 @@ void GateMapParts::exeBound() {
             return;
         }
 
-        if (mSuccessSeObj )
+        if (mSuccessSeObj)
             startSe(mSuccessSeObj, "Riddle");
 
         startNerveAction(this, "End");

--- a/lib/al/Library/MapObj/KeyMoveMapParts.cpp
+++ b/lib/al/Library/MapObj/KeyMoveMapParts.cpp
@@ -86,7 +86,7 @@ void KeyMoveMapParts::init(const ActorInitInfo& info) {
         return;
 
     mRippleCtrl = RippleCtrl::tryCreate(this);
-    if (mRippleCtrl )
+    if (mRippleCtrl)
         mRippleCtrl->init(info);
 }
 
@@ -113,7 +113,7 @@ void KeyMoveMapParts::stop() {
     else
         startNerveAction(this, "Stop");
 
-    if (mSeMoveName ) {
+    if (mSeMoveName) {
         tryStopSe(this, mSeMoveName, -1, nullptr);
         mSeMoveName = nullptr;
     }
@@ -174,13 +174,13 @@ bool KeyMoveMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, Hit
 }
 
 void KeyMoveMapParts::control() {
-    if (mSwitchKeepOnAreaGroup )
+    if (mSwitchKeepOnAreaGroup)
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup )
+    if (mSwitchOnAreaGroup)
         mSwitchOnAreaGroup->update(getTrans(this));
 
-    if (mRippleCtrl )
+    if (mRippleCtrl)
         mRippleCtrl->update();
 }
 
@@ -254,7 +254,7 @@ void KeyMoveMapParts::exeMove() {
         mKeyMoveMoveTime = calcKeyMoveMoveTime(mKeyPoseKeeper);
 
         mSeMoveName = getSeNameByIndex(mKeyPoseKeeper->getKeyPoseCurrentIdx());
-        if (mSeMoveName )
+        if (mSeMoveName)
             tryStartSe(this, mSeMoveName);
     }
 
@@ -270,7 +270,7 @@ void KeyMoveMapParts::exeMove() {
             setWaitEndNerve();
         else {
             startNerveAction(this, "Wait");
-            if (mSeMoveName ) {
+            if (mSeMoveName) {
                 tryStopSe(this, mSeMoveName, -1, nullptr);
                 mSeMoveName = nullptr;
             }

--- a/lib/al/Library/MapObj/KeyMoveMapParts.cpp
+++ b/lib/al/Library/MapObj/KeyMoveMapParts.cpp
@@ -86,7 +86,7 @@ void KeyMoveMapParts::init(const ActorInitInfo& info) {
         return;
 
     mRippleCtrl = RippleCtrl::tryCreate(this);
-    if (mRippleCtrl != nullptr)
+    if (mRippleCtrl )
         mRippleCtrl->init(info);
 }
 
@@ -113,7 +113,7 @@ void KeyMoveMapParts::stop() {
     else
         startNerveAction(this, "Stop");
 
-    if (mSeMoveName != nullptr) {
+    if (mSeMoveName ) {
         tryStopSe(this, mSeMoveName, -1, nullptr);
         mSeMoveName = nullptr;
     }
@@ -174,13 +174,13 @@ bool KeyMoveMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, Hit
 }
 
 void KeyMoveMapParts::control() {
-    if (mSwitchKeepOnAreaGroup != nullptr)
+    if (mSwitchKeepOnAreaGroup )
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup != nullptr)
+    if (mSwitchOnAreaGroup )
         mSwitchOnAreaGroup->update(getTrans(this));
 
-    if (mRippleCtrl != nullptr)
+    if (mRippleCtrl )
         mRippleCtrl->update();
 }
 
@@ -254,7 +254,7 @@ void KeyMoveMapParts::exeMove() {
         mKeyMoveMoveTime = calcKeyMoveMoveTime(mKeyPoseKeeper);
 
         mSeMoveName = getSeNameByIndex(mKeyPoseKeeper->getKeyPoseCurrentIdx());
-        if (mSeMoveName != nullptr)
+        if (mSeMoveName )
             tryStartSe(this, mSeMoveName);
     }
 
@@ -270,7 +270,7 @@ void KeyMoveMapParts::exeMove() {
             setWaitEndNerve();
         else {
             startNerveAction(this, "Wait");
-            if (mSeMoveName != nullptr) {
+            if (mSeMoveName ) {
                 tryStopSe(this, mSeMoveName, -1, nullptr);
                 mSeMoveName = nullptr;
             }

--- a/lib/al/Library/MapObj/KeyMoveMapPartsGenerator.cpp
+++ b/lib/al/Library/MapObj/KeyMoveMapPartsGenerator.cpp
@@ -80,7 +80,7 @@ void KeyMoveMapPartsGenerator::exeDelay() {
 void KeyMoveMapPartsGenerator::exeGenerate() {
     if (isIntervalStep(this, mGenerateInterval, 0)) {
         KeyMoveMapParts* keyMoveMapParts = mKeyMoveMapPartsGroup->tryFindDeadDeriveActor();
-        if (keyMoveMapParts )
+        if (keyMoveMapParts)
             keyMoveMapParts->appearAndSetStart();
     }
 }

--- a/lib/al/Library/MapObj/KeyMoveMapPartsGenerator.cpp
+++ b/lib/al/Library/MapObj/KeyMoveMapPartsGenerator.cpp
@@ -80,7 +80,7 @@ void KeyMoveMapPartsGenerator::exeDelay() {
 void KeyMoveMapPartsGenerator::exeGenerate() {
     if (isIntervalStep(this, mGenerateInterval, 0)) {
         KeyMoveMapParts* keyMoveMapParts = mKeyMoveMapPartsGroup->tryFindDeadDeriveActor();
-        if (keyMoveMapParts != nullptr)
+        if (keyMoveMapParts )
             keyMoveMapParts->appearAndSetStart();
     }
 }

--- a/lib/al/Library/MapObj/RailMoveMapParts.cpp
+++ b/lib/al/Library/MapObj/RailMoveMapParts.cpp
@@ -86,10 +86,10 @@ bool RailMoveMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, Hi
 }
 
 void RailMoveMapParts::control() {
-    if (mSwitchKeepOnAreaGroup != nullptr)
+    if (mSwitchKeepOnAreaGroup )
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup != nullptr)
+    if (mSwitchOnAreaGroup )
         mSwitchOnAreaGroup->update(getTrans(this));
 }
 

--- a/lib/al/Library/MapObj/RailMoveMapParts.cpp
+++ b/lib/al/Library/MapObj/RailMoveMapParts.cpp
@@ -86,10 +86,10 @@ bool RailMoveMapParts::receiveMsg(const SensorMsg* message, HitSensor* other, Hi
 }
 
 void RailMoveMapParts::control() {
-    if (mSwitchKeepOnAreaGroup )
+    if (mSwitchKeepOnAreaGroup)
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup )
+    if (mSwitchOnAreaGroup)
         mSwitchOnAreaGroup->update(getTrans(this));
 }
 

--- a/lib/al/Library/MapObj/RollingCubeMapParts.cpp
+++ b/lib/al/Library/MapObj/RollingCubeMapParts.cpp
@@ -106,7 +106,7 @@ bool RollingCubeMapParts::receiveMsg(const SensorMsg* message, HitSensor* other,
 }
 
 void RollingCubeMapParts::control() {
-    if (mMoveLimitMtx != nullptr)
+    if (mMoveLimitMtx )
         mMoveLimitMtx->makeQT(mInitialPoseQuat, getTrans(this));
 
     calcMtxLandEffect(&mLandEffectMtx, mRollingCubePoseKeeper, getQuat(this), getTrans(this));

--- a/lib/al/Library/MapObj/RollingCubeMapParts.cpp
+++ b/lib/al/Library/MapObj/RollingCubeMapParts.cpp
@@ -106,7 +106,7 @@ bool RollingCubeMapParts::receiveMsg(const SensorMsg* message, HitSensor* other,
 }
 
 void RollingCubeMapParts::control() {
-    if (mMoveLimitMtx )
+    if (mMoveLimitMtx)
         mMoveLimitMtx->makeQT(mInitialPoseQuat, getTrans(this));
 
     calcMtxLandEffect(&mLandEffectMtx, mRollingCubePoseKeeper, getQuat(this), getTrans(this));

--- a/lib/al/Library/MapObj/SubActorLodExecutor.cpp
+++ b/lib/al/Library/MapObj/SubActorLodExecutor.cpp
@@ -16,7 +16,7 @@ SubActorLodExecutor::SubActorLodExecutor(LiveActor* actor, const ActorInitInfo& 
     const char* cubeMapUnitName = nullptr;
     tryGetStringArg(&cubeMapUnitName, info, "CubeMapUnitName");
 
-    if (cubeMapUnitName )
+    if (cubeMapUnitName)
         forceApplyCubeMap(subActor, cubeMapUnitName);
 
     subActor->makeActorDead();

--- a/lib/al/Library/MapObj/SubActorLodExecutor.cpp
+++ b/lib/al/Library/MapObj/SubActorLodExecutor.cpp
@@ -16,7 +16,7 @@ SubActorLodExecutor::SubActorLodExecutor(LiveActor* actor, const ActorInitInfo& 
     const char* cubeMapUnitName = nullptr;
     tryGetStringArg(&cubeMapUnitName, info, "CubeMapUnitName");
 
-    if (cubeMapUnitName != nullptr)
+    if (cubeMapUnitName )
         forceApplyCubeMap(subActor, cubeMapUnitName);
 
     subActor->makeActorDead();

--- a/lib/al/Library/MapObj/SubActorLodMapParts.cpp
+++ b/lib/al/Library/MapObj/SubActorLodMapParts.cpp
@@ -16,7 +16,7 @@ void SubActorLodMapParts::init(const ActorInitInfo& info) {
     initMapPartsActor(this, info, suffix);
 
     mSubActorLodExecutor = new SubActorLodExecutor(this, info, 0);
-    if (getModelKeeper() != nullptr && !isExistAction(this) && !isViewDependentModel(this))
+    if (getModelKeeper()  && !isExistAction(this) && !isViewDependentModel(this))
         mIsControlled = true;
 
     trySyncStageSwitchAppearAndKill(this);

--- a/lib/al/Library/MapObj/SubActorLodMapParts.cpp
+++ b/lib/al/Library/MapObj/SubActorLodMapParts.cpp
@@ -16,7 +16,7 @@ void SubActorLodMapParts::init(const ActorInitInfo& info) {
     initMapPartsActor(this, info, suffix);
 
     mSubActorLodExecutor = new SubActorLodExecutor(this, info, 0);
-    if (getModelKeeper()  && !isExistAction(this) && !isViewDependentModel(this))
+    if (getModelKeeper() && !isExistAction(this) && !isViewDependentModel(this))
         mIsControlled = true;
 
     trySyncStageSwitchAppearAndKill(this);

--- a/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
+++ b/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
@@ -33,7 +33,7 @@ void SupportFreezeSyncGroupHolder::movement() {
 
 void SupportFreezeSyncGroupHolder::regist(LiveActor* actor, const ActorInitInfo& info) {
     SupportFreezeSyncGroup* supportFreezeSyncGroup = tryFindGroup(info);
-    if (!supportFreezeSyncGroup ) {
+    if (!supportFreezeSyncGroup) {
         supportFreezeSyncGroup = new SupportFreezeSyncGroup();
         supportFreezeSyncGroup->init(info);
 

--- a/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
+++ b/lib/al/Library/MapObj/SupportFreezeSyncGroupHolder.cpp
@@ -33,7 +33,7 @@ void SupportFreezeSyncGroupHolder::movement() {
 
 void SupportFreezeSyncGroupHolder::regist(LiveActor* actor, const ActorInitInfo& info) {
     SupportFreezeSyncGroup* supportFreezeSyncGroup = tryFindGroup(info);
-    if (supportFreezeSyncGroup == nullptr) {
+    if (!supportFreezeSyncGroup ) {
         supportFreezeSyncGroup = new SupportFreezeSyncGroup();
         supportFreezeSyncGroup->init(info);
 

--- a/lib/al/Library/MapObj/VisibleSwitchMapParts.cpp
+++ b/lib/al/Library/MapObj/VisibleSwitchMapParts.cpp
@@ -101,7 +101,7 @@ void VisibleSwitchMapParts::startSuddenDisappear() {
 }
 
 void VisibleSwitchMapParts::initAfterPlacement() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     sead::Vector3f dir;
@@ -132,7 +132,7 @@ void VisibleSwitchMapParts::initAfterPlacement() {
 }
 
 void VisibleSwitchMapParts::control() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     connectPoseQT(this, mMtxConnector);

--- a/lib/al/Library/MapObj/VisibleSwitchMapParts.cpp
+++ b/lib/al/Library/MapObj/VisibleSwitchMapParts.cpp
@@ -29,7 +29,7 @@ VisibleSwitchMapParts::VisibleSwitchMapParts(const char* name) : LiveActor(name)
 
 void VisibleSwitchMapParts::init(const ActorInitInfo& info) {
     using VisibleSwitchMapPartsFunctor =
-        FunctorV0M<al::VisibleSwitchMapParts*, void (al::VisibleSwitchMapParts::*)()>;
+        FunctorV0M<VisibleSwitchMapParts*, void (VisibleSwitchMapParts::*)()>;
 
     initMapPartsActor(this, info, nullptr);
     initNerve(this, &NrvVisibleSwitchMapParts.Show, 0);
@@ -101,7 +101,7 @@ void VisibleSwitchMapParts::startSuddenDisappear() {
 }
 
 void VisibleSwitchMapParts::initAfterPlacement() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     sead::Vector3f dir;
@@ -132,7 +132,7 @@ void VisibleSwitchMapParts::initAfterPlacement() {
 }
 
 void VisibleSwitchMapParts::control() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     connectPoseQT(this, mMtxConnector);

--- a/lib/al/Library/MapObj/WheelMapParts.cpp
+++ b/lib/al/Library/MapObj/WheelMapParts.cpp
@@ -56,10 +56,10 @@ void WheelMapParts::control() {
 
     makeMtxUpFrontPos(&mSurfaceEffectMtx, sead::Vector3f::ey, moveDir, getTrans(this));
 
-    if (mSwitchKeepOnAreaGroup )
+    if (mSwitchKeepOnAreaGroup)
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup )
+    if (mSwitchOnAreaGroup)
         mSwitchOnAreaGroup->update(getTrans(this));
 }
 

--- a/lib/al/Library/MapObj/WheelMapParts.cpp
+++ b/lib/al/Library/MapObj/WheelMapParts.cpp
@@ -56,10 +56,10 @@ void WheelMapParts::control() {
 
     makeMtxUpFrontPos(&mSurfaceEffectMtx, sead::Vector3f::ey, moveDir, getTrans(this));
 
-    if (mSwitchKeepOnAreaGroup != nullptr)
+    if (mSwitchKeepOnAreaGroup )
         mSwitchKeepOnAreaGroup->update(getTrans(this));
 
-    if (mSwitchOnAreaGroup != nullptr)
+    if (mSwitchOnAreaGroup )
         mSwitchOnAreaGroup->update(getTrans(this));
 }
 

--- a/lib/al/Library/Math/ParabolicPath.cpp
+++ b/lib/al/Library/Math/ParabolicPath.cpp
@@ -4,7 +4,7 @@
 
 namespace al {
 
-ParabolicPath::ParabolicPath() {}
+ParabolicPath::ParabolicPath() = default;
 
 void ParabolicPath::initFromUpVector(const sead::Vector3f& start, const sead::Vector3f& end,
                                      const sead::Vector3f& up) {

--- a/lib/al/Library/Movement/AnimScaleController.cpp
+++ b/lib/al/Library/Movement/AnimScaleController.cpp
@@ -2,7 +2,7 @@
 
 namespace al {
 
-AnimScaleParam::AnimScaleParam() {}
+AnimScaleParam::AnimScaleParam() = default;
 
 AnimScaleParam::AnimScaleParam(f32 a, f32 b, f32 c, f32 d, f32 e, f32 f, f32 g, s32 h, f32 i, f32 j,
                                f32 k, f32 l)

--- a/lib/al/Library/Movement/EnemyStateBlowDown.cpp
+++ b/lib/al/Library/Movement/EnemyStateBlowDown.cpp
@@ -60,7 +60,7 @@ void EnemyStateBlowDown::start(const LiveActor* attacker) {
 }
 
 void EnemyStateBlowDown::appear() {
-    al::NerveStateBase::appear();
+    NerveStateBase::appear();
     if (isInvalidClipping(mActor))
         mIsInvalidClipping = true;
     else {
@@ -71,7 +71,7 @@ void EnemyStateBlowDown::appear() {
 }
 
 void EnemyStateBlowDown::kill() {
-    al::NerveStateBase::kill();
+    NerveStateBase::kill();
     if (!mIsInvalidClipping)
         validateClipping(mActor);
 }
@@ -95,15 +95,15 @@ void EnemyStateBlowDown::control() {
     mBlowDownTimer++;
 }
 
-EnemyStateBlowDownParam::EnemyStateBlowDownParam() {}
+EnemyStateBlowDownParam::EnemyStateBlowDownParam() = default;
 
 EnemyStateBlowDownParam::EnemyStateBlowDownParam(const char* actionName) : actionName(actionName) {}
 
 EnemyStateBlowDownParam::EnemyStateBlowDownParam(const char* actionName, f32 velocityStrength,
                                                  f32 gravityStrength, f32 velocityMultiplier,
                                                  f32 velocityScale, s32 blowDownLength,
-                                                 bool faceAwayFromActor)
+                                                 bool isFaceAwayFromActor)
     : actionName(actionName), velocityStrength(velocityStrength), gravityStrength(gravityStrength),
       velocityMultiplier(velocityMultiplier), velocityScale(velocityScale),
-      blowDownLength(blowDownLength), faceAwayFromActor(faceAwayFromActor) {}
+      blowDownLength(blowDownLength), isFaceAwayFromActor(isFaceAwayFromActor) {}
 }  // namespace al

--- a/lib/al/Library/Movement/EnemyStateBlowDown.cpp
+++ b/lib/al/Library/Movement/EnemyStateBlowDown.cpp
@@ -31,7 +31,7 @@ void EnemyStateBlowDown::start(const HitSensor* other) {
 }
 
 void EnemyStateBlowDown::start(const sead::Vector3f& dir) {
-    if (mParam->faceAwayFromActor)
+    if (mParam->isFaceAwayFromActor)
         faceToDirection(mActor, -dir);
 
     auto* actor = mActor;

--- a/lib/al/Library/Movement/EnemyStateBlowDown.h
+++ b/lib/al/Library/Movement/EnemyStateBlowDown.h
@@ -14,7 +14,7 @@ public:
     EnemyStateBlowDownParam(const char* actionName);
     EnemyStateBlowDownParam(const char* actionName, f32 velocityStrength, f32 gravityStrength,
                             f32 velocityMultiplier, f32 velocityScale, s32 blowDownLength,
-                            bool faceAwayFromActor);
+                            bool isFaceAwayFromActor);
 
     const char* actionName = "BlowDown";
     f32 velocityStrength = 10.3f;
@@ -22,7 +22,7 @@ public:
     f32 velocityMultiplier = 1.1f;
     f32 velocityScale = 0.995f;
     s32 blowDownLength = 120;
-    bool faceAwayFromActor = true;
+    bool isFaceAwayFromActor = true;
 };
 
 class EnemyStateBlowDown : public ActorStateBase {

--- a/lib/al/Library/Nerve/NerveKeeper.cpp
+++ b/lib/al/Library/Nerve/NerveKeeper.cpp
@@ -15,7 +15,7 @@ void NerveKeeper::initNerveAction(NerveActionCtrl* actionCtrl) {
 }
 
 void NerveKeeper::setNerve(const Nerve* nextNerve) {
-    if (mStep >= 0 && mCurrentNerve != nullptr)
+    if (mStep >= 0 && mCurrentNerve )
         mCurrentNerve->executeOnEnd(this);
 
     mNextNerve = nextNerve;

--- a/lib/al/Library/Nerve/NerveKeeper.cpp
+++ b/lib/al/Library/Nerve/NerveKeeper.cpp
@@ -15,7 +15,7 @@ void NerveKeeper::initNerveAction(NerveActionCtrl* actionCtrl) {
 }
 
 void NerveKeeper::setNerve(const Nerve* nextNerve) {
-    if (mStep >= 0 && mCurrentNerve )
+    if (mStep >= 0 && mCurrentNerve)
         mCurrentNerve->executeOnEnd(this);
 
     mNextNerve = nextNerve;

--- a/lib/al/Library/Nfp/NfpDirector.h
+++ b/lib/al/Library/Nfp/NfpDirector.h
@@ -30,7 +30,7 @@ public:
     void start();
     void clearCommand();
     void resetError();
-    virtual void showError(const nn::Result&);
+    virtual void showError(const nn::Result& result);
     void executeCommandInitialize();
     void executeCommandFinalize();
     void executeCommandListDevices();

--- a/lib/al/Library/Obj/BreakModel.cpp
+++ b/lib/al/Library/Obj/BreakModel.cpp
@@ -27,8 +27,8 @@ BreakModel::BreakModel(const LiveActor* rootActor, const char* objName, const ch
     : LiveActor(objName), mParent(rootActor), mRootMtx(rootMtx), mModelName(modelName),
       mBreakAction(breakActionName), mInitSuffix(fileSuffixName) {}
 
-void BreakModel::init(const ActorInitInfo& initInfo) {
-    initActorWithArchiveName(this, initInfo, mModelName, mInitSuffix);
+void BreakModel::init(const ActorInitInfo& info) {
+    initActorWithArchiveName(this, info, mModelName, mInitSuffix);
     initNerve(this, &Wait, 0);
     invalidateClipping(this);
 

--- a/lib/al/Library/Obj/BreakModel.h
+++ b/lib/al/Library/Obj/BreakModel.h
@@ -9,7 +9,7 @@ public:
     BreakModel(const LiveActor* rootActor, const char* objName, const char* modelName,
                const char* fileSuffixName, const sead::Matrix34f* rootMtx,
                const char* breakActionName);
-    void init(const ActorInitInfo& initInfo);
+    void init(const ActorInitInfo& info);
     void appear();
     void exeWait();
     void exeBreak();

--- a/lib/al/Library/Obj/EffectObj.cpp
+++ b/lib/al/Library/Obj/EffectObj.cpp
@@ -50,7 +50,7 @@ void EffectObj::init(const ActorInitInfo& info) {
 }
 
 void EffectObj::initAfterPlacement() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -80,7 +80,7 @@ void EffectObj::control() {
             makeMtxFrontUpPos(&poseMtx, railDir, railUp, railTrans);
             updatePoseMtx(this, &poseMtx);
         }
-    } else if (mMtxConnector != nullptr)
+    } else if (mMtxConnector )
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Obj/EffectObj.cpp
+++ b/lib/al/Library/Obj/EffectObj.cpp
@@ -50,7 +50,7 @@ void EffectObj::init(const ActorInitInfo& info) {
 }
 
 void EffectObj::initAfterPlacement() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -80,7 +80,7 @@ void EffectObj::control() {
             makeMtxFrontUpPos(&poseMtx, railDir, railUp, railTrans);
             updatePoseMtx(this, &poseMtx);
         }
-    } else if (mMtxConnector )
+    } else if (mMtxConnector)
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Obj/EffectObjCameraEmit.cpp
+++ b/lib/al/Library/Obj/EffectObjCameraEmit.cpp
@@ -41,14 +41,14 @@ void EffectObjCameraEmit::switchOnKill() {
 }
 
 void EffectObjCameraEmit::initAfterPlacement() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
 void EffectObjCameraEmit::control() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Obj/EffectObjCameraEmit.cpp
+++ b/lib/al/Library/Obj/EffectObjCameraEmit.cpp
@@ -41,14 +41,14 @@ void EffectObjCameraEmit::switchOnKill() {
 }
 
 void EffectObjCameraEmit::initAfterPlacement() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
 void EffectObjCameraEmit::control() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Obj/EffectObjInterval.cpp
+++ b/lib/al/Library/Obj/EffectObjInterval.cpp
@@ -35,14 +35,14 @@ void EffectObjInterval::init(const ActorInitInfo& info) {
 }
 
 void EffectObjInterval::initAfterPlacement() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
 void EffectObjInterval::control() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Obj/EffectObjInterval.cpp
+++ b/lib/al/Library/Obj/EffectObjInterval.cpp
@@ -35,14 +35,14 @@ void EffectObjInterval::init(const ActorInitInfo& info) {
 }
 
 void EffectObjInterval::initAfterPlacement() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         return;
 
     attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
 void EffectObjInterval::control() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         connectPoseQT(this, mMtxConnector);
 
     makeMtxRT(&mBaseMtx, this);

--- a/lib/al/Library/Play/Area/CameraStartParamArea.h
+++ b/lib/al/Library/Play/Area/CameraStartParamArea.h
@@ -7,7 +7,7 @@ class CameraStartParamArea : public AreaObj {
 public:
     CameraStartParamArea(const char* name);
 
-    void init(const AreaInitInfo& areaInitInfo) override;
+    void init(const AreaInitInfo& info) override;
 
     void appear();
     void kill();

--- a/lib/al/Library/Play/Area/SeBarrierArea.h
+++ b/lib/al/Library/Play/Area/SeBarrierArea.h
@@ -7,7 +7,7 @@ class SeBarrierArea : public AreaObj {
 public:
     SeBarrierArea(const char* name);
 
-    void init(const AreaInitInfo& areaInitInfo) override;
+    void init(const AreaInitInfo& info) override;
 
 private:
     sead::Vector3f mTrans = {0.0, 0.0, 0.0};

--- a/lib/al/Library/Play/Area/SePlayArea.h
+++ b/lib/al/Library/Play/Area/SePlayArea.h
@@ -7,7 +7,7 @@ class SePlayArea : public AreaObj {
 public:
     SePlayArea(const char* name);
 
-    void init(const AreaInitInfo& areaInitInfo) override;
+    void init(const AreaInitInfo& info) override;
 
 private:
     const char* mSePlayName = nullptr;

--- a/lib/al/Library/Play/Area/ViewCtrlArea.h
+++ b/lib/al/Library/Play/Area/ViewCtrlArea.h
@@ -9,7 +9,7 @@ class ViewCtrlArea : public AreaObj {
 public:
     ViewCtrlArea(const char* name);
 
-    void init(const AreaInitInfo& areaInitInfo) override;
+    void init(const AreaInitInfo& info) override;
 
     PlacementId* getPlacementId() const { return mClippingViewId; }
 

--- a/lib/al/Library/Play/Camera/CameraPoserSubjective.h
+++ b/lib/al/Library/Play/Camera/CameraPoserSubjective.h
@@ -14,8 +14,8 @@ class CameraPoserSubjective : public CameraPoser {
 public:
     CameraPoserSubjective(const char*);
     void init() override;
-    void loadParam(const ByamlIter&) override;
-    void start(const CameraStartInfo&) override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
     void movement() override;
     void update() override;
     void startSnapShotMode() override;

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -43,7 +43,7 @@ void CameraVerticalAbsorber::start(const sead::Vector3f& pos, const CameraStartI
 
     mPrevTargetTrans = pos;
 
-    if (unk_unusedBool || mIsInvalidated ||
+    if (unk_unk_unusedbool || mIsInvalidated ||
         alCameraPoserFunction::isPlayerTypeNotTouchGround(mCameraPoser))
         return setNerve(this, &NrvCameraVerticalAbsorber.FollowAbsolute);
     if (alCameraPoserFunction::isTargetClimbPole(mCameraPoser))
@@ -92,7 +92,7 @@ void CameraVerticalAbsorber::update() {
     mLookAtCamera.getUp() = mCameraPoser->getCameraUp();
     if (mLookAtCamera.getUp().length() > 0.0f)
         mLookAtCamera.getUp().normalize();
-    if (!unk_unusedBool && !mIsInvalidated) {
+    if (!unk_unk_unusedbool && !mIsInvalidated) {
         mLookAtCamera.getAt() -= mTargetInterp;
         if (!mIsNoCameraPosAbsorb)
             mLookAtCamera.getPos() -= mTargetInterp;

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.h
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.h
@@ -52,7 +52,7 @@ private:
     sead::Vector3f mPrevTargetFront;
     bool mIsNoCameraPosAbsorb;
     bool mIsInvalidated;
-    bool unk_unusedBool;
+    bool unk_unk_unusedbool;
     bool mIsStopUpdate;
     bool mIsKeepInFrame;
 };

--- a/lib/al/Library/Resource/ActorResourceHolder.cpp
+++ b/lib/al/Library/Resource/ActorResourceHolder.cpp
@@ -54,7 +54,7 @@ void ActorResourceHolder::freeErasedActorResource() {
         // otherwise it assumes that res is not null
         __asm("" : "=r"(res) : "0"(res));
 
-        if (!res )
+        if (!res)
             continue;
         delete res;
     }

--- a/lib/al/Library/Resource/ActorResourceHolder.cpp
+++ b/lib/al/Library/Resource/ActorResourceHolder.cpp
@@ -54,7 +54,7 @@ void ActorResourceHolder::freeErasedActorResource() {
         // otherwise it assumes that res is not null
         __asm("" : "=r"(res) : "0"(res));
 
-        if (res == nullptr)
+        if (!res )
             continue;
         delete res;
     }

--- a/lib/al/Library/Resource/ResourceFunction.h
+++ b/lib/al/Library/Resource/ResourceFunction.h
@@ -20,9 +20,9 @@ void removeResourceCategory(const sead::SafeString& resourceName);
 const char* getResourceName(const Resource* resource);
 const char* getResourcePath(const Resource* resource);
 bool isExistResGraphicsFile(const Resource* resource);
-Resource* findResource(const sead::SafeString&);
-Resource* findOrCreateResource(const sead::SafeString& path, const char* ext);
-Resource* findOrCreateResourceCategory(const sead::SafeString& path,
+Resource* findResource(const sead::SafeString& resourceName);
+Resource* findOrCreateResource(const sead::SafeString& resourceName, const char* ext);
+Resource* findOrCreateResourceCategory(const sead::SafeString& resourceName,
                                        const sead::SafeString& category, const char* ext);
 Resource* findOrCreateResourceEventData(const char* eventDataName, const char* resourceName);
 Resource* findOrCreateResourceSystemData(const char* systemDataName, const char* resourceName);

--- a/lib/al/Library/Scene/ISceneObj.h
+++ b/lib/al/Library/Scene/ISceneObj.h
@@ -9,7 +9,7 @@ public:
 
     virtual ~ISceneObj() = default;
 
-    virtual void initAfterPlacementSceneObj(const ActorInitInfo&) {}
+    virtual void initAfterPlacementSceneObj(const ActorInitInfo& info) {}
 
     virtual void initSceneObj() {}
 };

--- a/lib/al/Library/Scene/Scene.h
+++ b/lib/al/Library/Scene/Scene.h
@@ -27,7 +27,7 @@ class Scene : public NerveExecutor,
 public:
     Scene(const char* name);
 
-    virtual ~Scene();
+    ~Scene() override;
 
     virtual void init(const SceneInitInfo& initInfo) {}
 

--- a/lib/al/Library/Scene/SceneStopCtrl.cpp
+++ b/lib/al/Library/Scene/SceneStopCtrl.cpp
@@ -1,7 +1,7 @@
 #include "Library/Scene/SceneStopCtrl.h"
 
 namespace al {
-SceneStopCtrl::SceneStopCtrl() {}
+SceneStopCtrl::SceneStopCtrl() = default;
 
 void SceneStopCtrl::reqeustStopScene(s32 stopFrames, s32 delayFrames) {
     if (mStopFrames <= 0 && mDelayFrames <= 0)

--- a/lib/al/Library/Screen/ScreenCoverCtrl.cpp
+++ b/lib/al/Library/Screen/ScreenCoverCtrl.cpp
@@ -1,7 +1,7 @@
 #include "Library/Screen/ScreenCoverCtrl.h"
 
 namespace al {
-ScreenCoverCtrl::ScreenCoverCtrl() {}
+ScreenCoverCtrl::ScreenCoverCtrl() = default;
 
 void ScreenCoverCtrl::requestCaptureScreenCover(s32 coverFrames) {
     if (mCoverFrames < coverFrames) {

--- a/lib/al/Library/Screen/ScreenPoint.h
+++ b/lib/al/Library/Screen/ScreenPoint.h
@@ -5,5 +5,5 @@ class LiveActor;
 }  // namespace al
 
 namespace alScreenPointFunction {
-void updateScreenPointAll(al::LiveActor*);
+void updateScreenPointAll(al::LiveActor* actor);
 }  // namespace alScreenPointFunction

--- a/lib/al/Library/Se/SeDirectorInitInfo.h
+++ b/lib/al/Library/Se/SeDirectorInitInfo.h
@@ -12,8 +12,8 @@ struct SeDirectorInitInfo {
     s32 listenerCount = 1;
     const char* defaultListenerName = "注視点";
     const char* defaultStageEffectName = nullptr;
-    bool useMeInfo = true;
-    bool useLoopSequencer = false;
+    bool isUseMeInfo = true;
+    bool isUseLoopSequencer = false;
     s32* field_28 = nullptr;
     s32 field_30 = -1;
     const sead::Vector3f* cameraPos = nullptr;

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -17,7 +17,7 @@ class Scene;
 class Sequence : public NerveExecutor, public IUseAudioKeeper, public IUseSceneCreator {
 public:
     Sequence(const char* name);
-    virtual ~Sequence() override;
+    ~Sequence() override;
 
     virtual void init(const SequenceInitInfo& initInfo);
 

--- a/lib/al/Library/Stage/StageRhythm.cpp
+++ b/lib/al/Library/Stage/StageRhythm.cpp
@@ -7,8 +7,8 @@ namespace al {
 
 StageSyncCounter::StageSyncCounter() = default;
 
-void StageSyncCounter::initAfterPlacementSceneObj(const ActorInitInfo& initInfo) {
-    registerExecutorUser(this, initInfo.executeDirector, getSceneObjName());
+void StageSyncCounter::initAfterPlacementSceneObj(const ActorInitInfo& info) {
+    registerExecutorUser(this, info.executeDirector, getSceneObjName());
 }
 
 }  // namespace al

--- a/lib/al/Library/Stage/StageRhythm.h
+++ b/lib/al/Library/Stage/StageRhythm.h
@@ -19,7 +19,7 @@ public:
 
     const char* getSceneObjName() const override { return "ステージ同期カウンタ"; }
 
-    void initAfterPlacementSceneObj(const ActorInitInfo& initInfo) override;
+    void initAfterPlacementSceneObj(const ActorInitInfo& info) override;
 
     s32 getCounter() const { return mCounter; }
 

--- a/lib/al/Library/Thread/FunctorV0M.h
+++ b/lib/al/Library/Thread/FunctorV0M.h
@@ -19,7 +19,7 @@ public:
     inline FunctorV0M(T objPointer, F functPointer)
         : mObjPointer(objPointer), mFunctPointer(functPointer) {}
 
-    inline FunctorV0M(const FunctorV0M<T, F>& copy) = default;
+    inline FunctorV0M(const FunctorV0M<T, F>& objPointer) = default;
 
     void operator()() const override { (mObjPointer->*mFunctPointer)(); }
 

--- a/lib/al/Library/Yaml/ByamlData.cpp
+++ b/lib/al/Library/Yaml/ByamlData.cpp
@@ -105,7 +105,7 @@ bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
         if (lowerBound >= upperBound)
             return false;
     }
-    if (!pair )
+    if (!pair)
         return false;
     data->set(pair, mIsRev);
     return true;

--- a/lib/al/Library/Yaml/ByamlData.cpp
+++ b/lib/al/Library/Yaml/ByamlData.cpp
@@ -105,7 +105,7 @@ bool ByamlHashIter::getDataByKey(ByamlData* data, s32 key) const {
         if (lowerBound >= upperBound)
             return false;
     }
-    if (pair == nullptr)
+    if (!pair )
         return false;
     data->set(pair, mIsRev);
     return true;

--- a/lib/al/Library/Yaml/Writer/ByamlWriterData.h
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterData.h
@@ -291,7 +291,7 @@ public:
     void addNull(const char* key) override;
 
     u8 getTypeCode() const override;
-    void writeContainer(sead::WriteStream*) const override;  // TODO implementation missing
+    void writeContainer(sead::WriteStream* stream) const override;  // TODO implementation missing
     void write(sead::WriteStream* stream) const override;
     void print(s32 recursionDepth) const override;  // TODO implementation missing
 

--- a/lib/al/Library/Yaml/Writer/ByamlWriterData.h
+++ b/lib/al/Library/Yaml/Writer/ByamlWriterData.h
@@ -21,7 +21,7 @@ public:
 
     virtual bool isContainer() const { return false; }
 
-    virtual void write(sead::WriteStream*) const;
+    virtual void write(sead::WriteStream* stream) const;
 
     virtual void print(s32 recursionDepth) const {}
 
@@ -104,7 +104,7 @@ public:
 
     virtual u32 calcBigDataSize() const { return 8; }
 
-    virtual void writeBigData(sead::WriteStream*) const {}
+    virtual void writeBigData(sead::WriteStream* stream) const {}
 
     void setOffset(s32 offset) { mOffset = offset; }
 
@@ -157,51 +157,51 @@ class ByamlWriterContainer : public ByamlWriterData {
 public:
     bool isContainer() const override { return true; }
 
-    virtual void addBool(const char*, bool) {}
+    virtual void addBool(const char* key, bool value) {}
 
-    virtual void addInt(const char*, s32) {}
+    virtual void addInt(const char* key, s32 value) {}
 
-    virtual void addUInt(const char*, u32) {}
+    virtual void addUInt(const char* key, u32 value) {}
 
-    virtual void addFloat(const char*, f32) {}
+    virtual void addFloat(const char* key, f32 value) {}
 
-    virtual void addInt64(const char*, s64, ByamlWriterBigDataList*) {}
+    virtual void addInt64(const char* key, s64, ByamlWriterBigDataList* value) {}
 
-    virtual void addUInt64(const char*, u64, ByamlWriterBigDataList*) {}
+    virtual void addUInt64(const char* key, u64, ByamlWriterBigDataList* value) {}
 
-    virtual void addDouble(const char*, f64, ByamlWriterBigDataList*) {}
+    virtual void addDouble(const char* key, f64, ByamlWriterBigDataList* value) {}
 
-    virtual void addString(const char*, const char*) {}
+    virtual void addString(const char* key, const char* value) {}
 
-    virtual void addHash(const char*, ByamlWriterHash*) {}
+    virtual void addHash(const char* key, ByamlWriterHash* value) {}
 
-    virtual void addArray(const char*, ByamlWriterArray*) {}
+    virtual void addArray(const char* key, ByamlWriterArray* value) {}
 
-    virtual void addNull(const char*) {}
+    virtual void addNull(const char* key) {}
 
-    virtual void addBool(bool) {}
+    virtual void addBool(bool value) {}
 
-    virtual void addInt(s32) {}
+    virtual void addInt(s32 value) {}
 
-    virtual void addUInt(u32) {}
+    virtual void addUInt(u32 value) {}
 
-    virtual void addFloat(f32) {}
+    virtual void addFloat(f32 value) {}
 
-    virtual void addInt64(s64, ByamlWriterBigDataList*) {}
+    virtual void addInt64(s64 value, ByamlWriterBigDataList* list) {}
 
-    virtual void addUInt64(u64, ByamlWriterBigDataList*) {}
+    virtual void addUInt64(u64 value, ByamlWriterBigDataList* list) {}
 
-    virtual void addDouble(f64, ByamlWriterBigDataList*) {}
+    virtual void addDouble(f64 value, ByamlWriterBigDataList* list) {}
 
-    virtual void addString(const char*) {}
+    virtual void addString(const char* value) {}
 
-    virtual void addHash(ByamlWriterHash*) {}
+    virtual void addHash(ByamlWriterHash* hash) {}
 
-    virtual void addArray(ByamlWriterArray*) {}
+    virtual void addArray(ByamlWriterArray* array) {}
 
     virtual void addNull() {}
 
-    virtual void writeContainer(sead::WriteStream*) const {}
+    virtual void writeContainer(sead::WriteStream* stream) const {}
 
     virtual bool isHash() const { return false; }
 

--- a/lib/al/Project/Action/ActionFunction.cpp
+++ b/lib/al/Project/Action/ActionFunction.cpp
@@ -7,7 +7,7 @@ namespace alActionFunction {
 const char* getAnimName(const al::ActionAnimCtrlInfo* infoCtrl,
                         const al::ActionAnimDataInfo* infoData) {
     const char* animName = infoData->actionName;
-    if (!animName )
+    if (!animName)
         animName = infoCtrl->actionName;
     return animName;
 }

--- a/lib/al/Project/Action/ActionFunction.cpp
+++ b/lib/al/Project/Action/ActionFunction.cpp
@@ -7,7 +7,7 @@ namespace alActionFunction {
 const char* getAnimName(const al::ActionAnimCtrlInfo* infoCtrl,
                         const al::ActionAnimDataInfo* infoData) {
     const char* animName = infoData->actionName;
-    if (animName == nullptr)
+    if (!animName )
         animName = infoCtrl->actionName;
     return animName;
 }

--- a/lib/al/Project/Bgm/BgmInfo.cpp
+++ b/lib/al/Project/Bgm/BgmInfo.cpp
@@ -3,7 +3,7 @@
 #include <cmath>
 
 namespace al {
-BgmChangeableParams::BgmChangeableParams() {}
+BgmChangeableParams::BgmChangeableParams() = default;
 
 void BgmChangeableParams::calcPitch(f32 value) {
     exp2f(value / 12);
@@ -24,7 +24,7 @@ void BgmChangeableParams::operator=(const BgmChangeableParams& value) {
     mTrackVolume5 = value.mTrackVolume5;
 }
 
-BgmUserInfo::BgmUserInfo() {}
+BgmUserInfo::BgmUserInfo() = default;
 
 s32 BgmUserInfo::compareInfo(const BgmUserInfo* info_1, const BgmUserInfo* info_2) {
     return strcmp(info_1->name, info_2->name);

--- a/lib/al/Project/Camera/CameraAngleVerticalRequester.cpp
+++ b/lib/al/Project/Camera/CameraAngleVerticalRequester.cpp
@@ -17,13 +17,13 @@ void CameraAngleVerticalRequester::initAfterPlacement() {
 }
 
 void CameraAngleVerticalRequester::update(const sead::Vector3f& position) {
-    if (mRequestAreaGroup == nullptr)
+    if (!mRequestAreaGroup )
         return;
     AreaObj* areaObj = tryGetAreaObj(mRequestAreaGroup, position);
     if (areaObj != mRequestArea) {
         mRequestArea = areaObj;
         mFramesUnchanged = -1;
-        if (areaObj != nullptr)
+        if (areaObj )
             getArg(&mAngleVertical, *mRequestArea->getPlacementInfo(), "AngleVertical");
     }
     mFramesUnchanged++;

--- a/lib/al/Project/Camera/CameraAngleVerticalRequester.cpp
+++ b/lib/al/Project/Camera/CameraAngleVerticalRequester.cpp
@@ -17,13 +17,13 @@ void CameraAngleVerticalRequester::initAfterPlacement() {
 }
 
 void CameraAngleVerticalRequester::update(const sead::Vector3f& position) {
-    if (!mRequestAreaGroup )
+    if (!mRequestAreaGroup)
         return;
     AreaObj* areaObj = tryGetAreaObj(mRequestAreaGroup, position);
     if (areaObj != mRequestArea) {
         mRequestArea = areaObj;
         mFramesUnchanged = -1;
-        if (areaObj )
+        if (areaObj)
             getArg(&mAngleVertical, *mRequestArea->getPlacementInfo(), "AngleVertical");
     }
     mFramesUnchanged++;

--- a/lib/al/Project/Camera/CameraObjectRequestInfo.h
+++ b/lib/al/Project/Camera/CameraObjectRequestInfo.h
@@ -12,8 +12,8 @@ struct CameraObjectRequestInfo {
     bool isUpToTargetAngleBySpeed;
     f32 targetAngleV;
     f32 angleSpeed;
-    bool moveDownAngle;
-    bool setAngleV;
+    bool isMoveDownAngle;
+    bool isSetAngleV;
     f32 angleV;
 };
 

--- a/lib/al/Project/Joint/RollingCubePoseKeeper.cpp
+++ b/lib/al/Project/Joint/RollingCubePoseKeeper.cpp
@@ -8,7 +8,7 @@
 
 namespace al {
 
-RollingCubePoseKeeper::RollingCubePoseKeeper() {}
+RollingCubePoseKeeper::RollingCubePoseKeeper() = default;
 
 void RollingCubePoseKeeper::setCubeSize(const sead::BoundBox3f& cubeSize) {
     mCubeSize = cubeSize;

--- a/lib/al/Project/LiveActor/SupportFreezeSyncGroup.cpp
+++ b/lib/al/Project/LiveActor/SupportFreezeSyncGroup.cpp
@@ -6,7 +6,7 @@
 #include "Library/Placement/PlacementFunction.h"
 
 namespace al {
-SupportFreezeSyncGroup::SupportFreezeSyncGroup() {}
+SupportFreezeSyncGroup::SupportFreezeSyncGroup() = default;
 
 void SupportFreezeSyncGroup::init(const ActorInitInfo& info) {
     alPlacementFunction::getLinkGroupId(mSupportFreezeSyncGroupId, info, "SupportFreezeSyncGroup");

--- a/lib/al/Project/Memory/MemorySystem.h
+++ b/lib/al/Project/Memory/MemorySystem.h
@@ -12,7 +12,7 @@ class MemorySystem {
 public:
     MemorySystem(sead::Heap* heap);
 
-    void allocFailedCallbackFunc(const sead::HeapMgr::AllocFailedCallbackArg*);
+    void allocFailedCallbackFunc(const sead::HeapMgr::AllocFailedCallbackArg* arg);
     void createSequenceHeap();
     void freeAllSequenceHeap();
     void printSequenceHeap();

--- a/src/Amiibo/AmiiboNpcDirector.cpp
+++ b/src/Amiibo/AmiiboNpcDirector.cpp
@@ -212,9 +212,9 @@ void AmiiboNpcDirector::trySetAmiiboCostumeName(s32 id) {
     ShopItem::ItemInfo* itemB = nullptr;
     rs::tryFindAmiiboCostumeItemInfo(&itemA, &itemB, charId, numberingId, mNpcLayout);
 
-    if (itemA != nullptr)
+    if (itemA )
         mClothName = rs::getDisplayName(mNpcLayout, *itemA);
-    if (itemB != nullptr)
+    if (itemB )
         mCapName = rs::getDisplayName(mNpcLayout, *itemB);
 }
 
@@ -231,7 +231,7 @@ void AmiiboNpcDirector::checkTimeReverseAndRestore() {
 
 al::NfpInfo* AmiiboNpcDirector::tryGetTriggerTouchNfpInfo() {
     al::NfpInfo* nfpInfo = mNfpDirector->tryGetTriggerTouchNfpInfo();
-    if (nfpInfo == nullptr)
+    if (!nfpInfo )
         return nullptr;
 
     *mNfpInfo = *nfpInfo;

--- a/src/Amiibo/AmiiboNpcDirector.cpp
+++ b/src/Amiibo/AmiiboNpcDirector.cpp
@@ -40,8 +40,8 @@ void AmiiboNpcDirector::init(ProjectNfpDirector* nfpDirector, al::AudioDirector*
     al::registerMessageTagDataString(mTagDataHolder, "CapName", &mCapName);
 }
 
-void AmiiboNpcDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) {
-    const al::LayoutInitInfo& layoutInitInfo = al::getLayoutInitInfo(initInfo);
+void AmiiboNpcDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    const al::LayoutInitInfo& layoutInitInfo = al::getLayoutInitInfo(info);
     mNpcLayout = new AmiiboNpcLayout(layoutInitInfo);
 
     mSearchDataTable = rs::getSearchAmiiboData(mNpcLayout);

--- a/src/Amiibo/AmiiboNpcDirector.cpp
+++ b/src/Amiibo/AmiiboNpcDirector.cpp
@@ -212,9 +212,9 @@ void AmiiboNpcDirector::trySetAmiiboCostumeName(s32 id) {
     ShopItem::ItemInfo* itemB = nullptr;
     rs::tryFindAmiiboCostumeItemInfo(&itemA, &itemB, charId, numberingId, mNpcLayout);
 
-    if (itemA )
+    if (itemA)
         mClothName = rs::getDisplayName(mNpcLayout, *itemA);
-    if (itemB )
+    if (itemB)
         mCapName = rs::getDisplayName(mNpcLayout, *itemB);
 }
 
@@ -231,7 +231,7 @@ void AmiiboNpcDirector::checkTimeReverseAndRestore() {
 
 al::NfpInfo* AmiiboNpcDirector::tryGetTriggerTouchNfpInfo() {
     al::NfpInfo* nfpInfo = mNfpDirector->tryGetTriggerTouchNfpInfo();
-    if (!nfpInfo )
+    if (!nfpInfo)
         return nullptr;
 
     *mNfpInfo = *nfpInfo;

--- a/src/Amiibo/AmiiboNpcDirector.h
+++ b/src/Amiibo/AmiiboNpcDirector.h
@@ -31,7 +31,7 @@ public:
     const char* getSceneObjName() const override { return "AmiiboNpc用データホルダ"; }
 
     void init(ProjectNfpDirector* nfpDirector, al::AudioDirector* audioDirector);
-    void initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
     void updateSearchAmiiboName();
     bool requestAppearAmiiboLayout();
     void requestDecideAmiiboLayout();

--- a/src/Amiibo/HelpAmiiboCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboCoinCollect.cpp
@@ -26,11 +26,11 @@ HelpAmiiboCoinCollect::HelpAmiiboCoinCollect(HelpAmiiboDirector* director,
                                              al::LiveActor* amiiboActor)
     : HelpAmiiboExecutor(director, amiiboActor, "コレクトコインお助け") {}
 
-void HelpAmiiboCoinCollect::initAfterPlacement(const al::ActorInitInfo& actorInitInfo) {
-    HelpAmiiboExecutor::initAfterPlacement(actorInitInfo);
+void HelpAmiiboCoinCollect::initAfterPlacement(const al::ActorInitInfo& initInfo) {
+    HelpAmiiboExecutor::initAfterPlacement(initInfo);
 
     mCoinCollectDummy = new CoinCollectDummy("コレクトコインお助け");
-    al::initCreateActorNoPlacementInfo(mCoinCollectDummy, actorInitInfo);
+    al::initCreateActorNoPlacementInfo(mCoinCollectDummy, initInfo);
 }
 
 bool HelpAmiiboCoinCollect::isTriggerTouch(const al::NfpInfo& nfpInfo) const {

--- a/src/Amiibo/HelpAmiiboCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboCoinCollect.cpp
@@ -39,24 +39,24 @@ bool HelpAmiiboCoinCollect::isTriggerTouch(const al::NfpInfo& nfpInfo) const {
 
 bool HelpAmiiboCoinCollect::isEnableUse() {
     CoinCollectHolder* coinHolder = al::tryGetSceneObj<CoinCollectHolder>(getActor());
-    if (!coinHolder )
+    if (!coinHolder)
         return false;
 
-    if (mCoinCollect2D  && al::isAlive(mCoinCollect2D))
+    if (mCoinCollect2D && al::isAlive(mCoinCollect2D))
         return false;
 
-    if (mCoinCollect  && al::isAlive(mCoinCollect))
+    if (mCoinCollect && al::isAlive(mCoinCollect))
         return false;
 
     const sead::Vector3f& playerPos = rs::getPlayerPos(getActor());
-    if (coinHolder->tryFindAliveCoinCollect(playerPos, true) )
+    if (coinHolder->tryFindAliveCoinCollect(playerPos, true))
         return true;
-    if (coinHolder->tryFindAliveCoinCollect2D(playerPos, true) )
+    if (coinHolder->tryFindAliveCoinCollect2D(playerPos, true))
         return true;
-    if (coinHolder->tryFindDeadButHintEnableCoinCollect() )
+    if (coinHolder->tryFindDeadButHintEnableCoinCollect())
         return true;
 
-    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) ) {
+    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos)) {
         sead::Vector3f stagePos = sead::Vector3f::zero;
         const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
@@ -80,7 +80,7 @@ bool HelpAmiiboCoinCollect::execute() {
         return true;
     }
 
-    if (mCoinCollect ) {
+    if (mCoinCollect) {
         if (mCoinCollect->isEnableHint()) {
             mCoinCollect = nullptr;
             return true;
@@ -88,7 +88,7 @@ bool HelpAmiiboCoinCollect::execute() {
         return false;
     }
 
-    if (mCoinCollect2D ) {
+    if (mCoinCollect2D) {
         if (mCoinCollect2D->isEnableHint()) {
             mCoinCollect2D = nullptr;
             return true;
@@ -110,7 +110,7 @@ void HelpAmiiboCoinCollect::activate() {
 
     CoinCollect* aliveCoinCollect =
         coinHolder->tryFindAliveCoinCollect(playerPos, 5000.0f, 10000.0f, true);
-    if (aliveCoinCollect ) {
+    if (aliveCoinCollect) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -125,7 +125,7 @@ void HelpAmiiboCoinCollect::activate() {
 
     CoinCollect2D* aliveCoinCollect2D =
         coinHolder->tryFindAliveCoinCollect2D(playerPos, 5000.0f, 10000.0f, true);
-    if (aliveCoinCollect2D ) {
+    if (aliveCoinCollect2D) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect2D)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -139,7 +139,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect* coinCollect = coinHolder->tryFindAliveCoinCollect(playerPos, true);
-    if (coinCollect ) {
+    if (coinCollect) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -153,7 +153,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect2D* coinCollect2D = coinHolder->tryFindAliveCoinCollect2D(playerPos, true);
-    if (coinCollect2D ) {
+    if (coinCollect2D) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect2D)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -167,7 +167,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect* deadCoinCollect = coinHolder->tryFindDeadButHintEnableCoinCollect();
-    if (deadCoinCollect ) {
+    if (deadCoinCollect) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(deadCoinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -180,7 +180,7 @@ void HelpAmiiboCoinCollect::activate() {
         return;
     }
 
-    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) ) {
+    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos)) {
         sead::Vector3f stagePos = sead::Vector3f::zero;
         const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
@@ -195,13 +195,13 @@ void HelpAmiiboCoinCollect::activate() {
 }
 
 void HelpAmiiboCoinCollect::deleteHintEffect() {
-    if (mCoinCollect ) {
+    if (mCoinCollect) {
         mCoinCollect->deleteHelpAmiiboEffect();
         mCoinCollect = nullptr;
         return;
     }
 
-    if (mCoinCollect2D ) {
+    if (mCoinCollect2D) {
         mCoinCollect2D->deleteHintEffect();
         mCoinCollect2D = nullptr;
         return;
@@ -212,12 +212,12 @@ void HelpAmiiboCoinCollect::deleteHintEffect() {
 }
 
 void HelpAmiiboCoinCollect::appearEffect() {
-    if (mCoinCollect ) {
+    if (mCoinCollect) {
         mCoinCollect->reappearHelpAmiiboEffect();
         return;
     }
 
-    if (mCoinCollect2D ) {
+    if (mCoinCollect2D) {
         mCoinCollect2D->reappearHintEffect();
         return;
     }
@@ -227,12 +227,12 @@ void HelpAmiiboCoinCollect::appearEffect() {
 }
 
 void HelpAmiiboCoinCollect::killEffect() {
-    if (mCoinCollect ) {
+    if (mCoinCollect) {
         mCoinCollect->deleteHelpAmiiboEffect();
         return;
     }
 
-    if (mCoinCollect2D )
+    if (mCoinCollect2D)
         mCoinCollect2D->deleteHintEffect();
 
     if (al::isAlive(mCoinCollectDummy))
@@ -251,6 +251,6 @@ bool HelpAmiiboCoinCollect::isUseDummyModel(al::LiveActor* actor) {
 
 void HelpAmiiboCoinCollect::getDummyEffectEmitPos(sead::Vector3f* position, al::LiveActor* actor) {
     al::AreaObj* areaObj = al::tryFindAreaObj(actor, "InvalidateStageMapArea", al::getTrans(actor));
-    if (areaObj )
+    if (areaObj)
         al::tryGetLinksTrans(position, *areaObj->getPlacementInfo(), "PlayerPoint");
 }

--- a/src/Amiibo/HelpAmiiboCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboCoinCollect.cpp
@@ -39,24 +39,24 @@ bool HelpAmiiboCoinCollect::isTriggerTouch(const al::NfpInfo& nfpInfo) const {
 
 bool HelpAmiiboCoinCollect::isEnableUse() {
     CoinCollectHolder* coinHolder = al::tryGetSceneObj<CoinCollectHolder>(getActor());
-    if (coinHolder == nullptr)
+    if (!coinHolder )
         return false;
 
-    if (mCoinCollect2D != nullptr && al::isAlive(mCoinCollect2D))
+    if (mCoinCollect2D  && al::isAlive(mCoinCollect2D))
         return false;
 
-    if (mCoinCollect != nullptr && al::isAlive(mCoinCollect))
+    if (mCoinCollect  && al::isAlive(mCoinCollect))
         return false;
 
     const sead::Vector3f& playerPos = rs::getPlayerPos(getActor());
-    if (coinHolder->tryFindAliveCoinCollect(playerPos, true) != nullptr)
+    if (coinHolder->tryFindAliveCoinCollect(playerPos, true) )
         return true;
-    if (coinHolder->tryFindAliveCoinCollect2D(playerPos, true) != nullptr)
+    if (coinHolder->tryFindAliveCoinCollect2D(playerPos, true) )
         return true;
-    if (coinHolder->tryFindDeadButHintEnableCoinCollect() != nullptr)
+    if (coinHolder->tryFindDeadButHintEnableCoinCollect() )
         return true;
 
-    if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
+    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) ) {
         sead::Vector3f stagePos = sead::Vector3f::zero;
         const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
@@ -80,7 +80,7 @@ bool HelpAmiiboCoinCollect::execute() {
         return true;
     }
 
-    if (mCoinCollect != nullptr) {
+    if (mCoinCollect ) {
         if (mCoinCollect->isEnableHint()) {
             mCoinCollect = nullptr;
             return true;
@@ -88,7 +88,7 @@ bool HelpAmiiboCoinCollect::execute() {
         return false;
     }
 
-    if (mCoinCollect2D != nullptr) {
+    if (mCoinCollect2D ) {
         if (mCoinCollect2D->isEnableHint()) {
             mCoinCollect2D = nullptr;
             return true;
@@ -110,7 +110,7 @@ void HelpAmiiboCoinCollect::activate() {
 
     CoinCollect* aliveCoinCollect =
         coinHolder->tryFindAliveCoinCollect(playerPos, 5000.0f, 10000.0f, true);
-    if (aliveCoinCollect != nullptr) {
+    if (aliveCoinCollect ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -125,7 +125,7 @@ void HelpAmiiboCoinCollect::activate() {
 
     CoinCollect2D* aliveCoinCollect2D =
         coinHolder->tryFindAliveCoinCollect2D(playerPos, 5000.0f, 10000.0f, true);
-    if (aliveCoinCollect2D != nullptr) {
+    if (aliveCoinCollect2D ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(aliveCoinCollect2D)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -139,7 +139,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect* coinCollect = coinHolder->tryFindAliveCoinCollect(playerPos, true);
-    if (coinCollect != nullptr) {
+    if (coinCollect ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -153,7 +153,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect2D* coinCollect2D = coinHolder->tryFindAliveCoinCollect2D(playerPos, true);
-    if (coinCollect2D != nullptr) {
+    if (coinCollect2D ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(coinCollect2D)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -167,7 +167,7 @@ void HelpAmiiboCoinCollect::activate() {
     }
 
     CoinCollect* deadCoinCollect = coinHolder->tryFindDeadButHintEnableCoinCollect();
-    if (deadCoinCollect != nullptr) {
+    if (deadCoinCollect ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         if (isUseDummyModel(deadCoinCollect)) {
             sead::Vector3f dummyEffectEmitPos = sead::Vector3f::zero;
@@ -180,7 +180,7 @@ void HelpAmiiboCoinCollect::activate() {
         return;
     }
 
-    if (al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) == nullptr) {
+    if (!al::tryFindAreaObj(mCoinCollectDummy, "InvalidateStageMapArea", playerPos) ) {
         sead::Vector3f stagePos = sead::Vector3f::zero;
         const char* stageName = nullptr;
         if (GameDataFunction::tryFindExistCoinCollectStagePosExcludeHomeStageInCurrentWorld(
@@ -195,13 +195,13 @@ void HelpAmiiboCoinCollect::activate() {
 }
 
 void HelpAmiiboCoinCollect::deleteHintEffect() {
-    if (mCoinCollect != nullptr) {
+    if (mCoinCollect ) {
         mCoinCollect->deleteHelpAmiiboEffect();
         mCoinCollect = nullptr;
         return;
     }
 
-    if (mCoinCollect2D != nullptr) {
+    if (mCoinCollect2D ) {
         mCoinCollect2D->deleteHintEffect();
         mCoinCollect2D = nullptr;
         return;
@@ -212,12 +212,12 @@ void HelpAmiiboCoinCollect::deleteHintEffect() {
 }
 
 void HelpAmiiboCoinCollect::appearEffect() {
-    if (mCoinCollect != nullptr) {
+    if (mCoinCollect ) {
         mCoinCollect->reappearHelpAmiiboEffect();
         return;
     }
 
-    if (mCoinCollect2D != nullptr) {
+    if (mCoinCollect2D ) {
         mCoinCollect2D->reappearHintEffect();
         return;
     }
@@ -227,12 +227,12 @@ void HelpAmiiboCoinCollect::appearEffect() {
 }
 
 void HelpAmiiboCoinCollect::killEffect() {
-    if (mCoinCollect != nullptr) {
+    if (mCoinCollect ) {
         mCoinCollect->deleteHelpAmiiboEffect();
         return;
     }
 
-    if (mCoinCollect2D != nullptr)
+    if (mCoinCollect2D )
         mCoinCollect2D->deleteHintEffect();
 
     if (al::isAlive(mCoinCollectDummy))
@@ -251,6 +251,6 @@ bool HelpAmiiboCoinCollect::isUseDummyModel(al::LiveActor* actor) {
 
 void HelpAmiiboCoinCollect::getDummyEffectEmitPos(sead::Vector3f* position, al::LiveActor* actor) {
     al::AreaObj* areaObj = al::tryFindAreaObj(actor, "InvalidateStageMapArea", al::getTrans(actor));
-    if (areaObj != nullptr)
+    if (areaObj )
         al::tryGetLinksTrans(position, *areaObj->getPlacementInfo(), "PlayerPoint");
 }

--- a/src/Amiibo/HelpAmiiboCoinCollect.h
+++ b/src/Amiibo/HelpAmiiboCoinCollect.h
@@ -20,7 +20,7 @@ class HelpAmiiboCoinCollect : public HelpAmiiboExecutor {
 public:
     HelpAmiiboCoinCollect(HelpAmiiboDirector* director, al::LiveActor* amiiboActor);
 
-    void initAfterPlacement(const al::ActorInitInfo& actorInitInfo) override;
+    void initAfterPlacement(const al::ActorInitInfo& initInfo) override;
     bool isTriggerTouch(const al::NfpInfo& nfpInfo) const override;
     bool isEnableUse() override;
     bool execute() override;

--- a/src/Amiibo/HelpAmiiboDirector.h
+++ b/src/Amiibo/HelpAmiiboDirector.h
@@ -33,7 +33,7 @@ public:
     HelpAmiiboDirector();
     void init(ProjectNfpDirector* projectNfpDirector, const al::PlayerHolder* playerHolder,
               al::AudioDirector* audioDirector, const al::LayoutInitInfo& initInfo);
-    void initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
 
     bool isTriggerTouchAmiiboMario() const;
     bool isTriggerTouchAmiiboPeach() const;

--- a/src/Amiibo/HelpAmiiboExecutor.cpp
+++ b/src/Amiibo/HelpAmiiboExecutor.cpp
@@ -4,7 +4,7 @@ HelpAmiiboExecutor::HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveAct
                                        const char* amiiboName)
     : mHelpAmiiboDirector(director), mHelpAmiiboActor(amiiboActor) {}
 
-void HelpAmiiboExecutor::initAfterPlacement(const al::ActorInitInfo&) {}
+void HelpAmiiboExecutor::initAfterPlacement(const al::ActorInitInfo& initInfo) {}
 
 bool HelpAmiiboExecutor::tryTouch(const al::NfpInfo& nfpInfo) {
     if (mIsActivated || !isTriggerTouch(nfpInfo))

--- a/src/Amiibo/HelpAmiiboExecutor.h
+++ b/src/Amiibo/HelpAmiiboExecutor.h
@@ -25,7 +25,7 @@ public:
     HelpAmiiboExecutor(HelpAmiiboDirector* director, al::LiveActor* amiiboActor,
                        const char* amiiboName);
 
-    virtual void initAfterPlacement(const al::ActorInitInfo&);
+    virtual void initAfterPlacement(const al::ActorInitInfo& initInfo);
     virtual bool isTriggerTouch(const al::NfpInfo& nfpInfo) const = 0;
     virtual bool isEnableUse() = 0;
     virtual bool execute() = 0;

--- a/src/Amiibo/HelpAmiiboNavigateCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboNavigateCoinCollect.cpp
@@ -31,7 +31,7 @@ void HelpAmiiboNavigateCoinCollect::activate() {
     CoinCollect* coinCollect = al::getSceneObj<CoinCollectHolder>(getActor())
                                    ->tryFindAliveCoinCollect(sead::Vector3f::zero, true);
 
-    if (coinCollect == nullptr) {
+    if (!coinCollect ) {
         al::startSe(getDirector(), "AmiiboKoopa");
         return;
     }
@@ -43,7 +43,7 @@ void HelpAmiiboNavigateCoinCollect::activate() {
 }
 
 bool HelpAmiiboNavigateCoinCollect::execute() {
-    if (mHintedCoinCollect == nullptr)
+    if (!mHintedCoinCollect )
         return true;
 
     if (al::isDead(mHintedCoinCollect)) {

--- a/src/Amiibo/HelpAmiiboNavigateCoinCollect.cpp
+++ b/src/Amiibo/HelpAmiiboNavigateCoinCollect.cpp
@@ -31,7 +31,7 @@ void HelpAmiiboNavigateCoinCollect::activate() {
     CoinCollect* coinCollect = al::getSceneObj<CoinCollectHolder>(getActor())
                                    ->tryFindAliveCoinCollect(sead::Vector3f::zero, true);
 
-    if (!coinCollect ) {
+    if (!coinCollect) {
         al::startSe(getDirector(), "AmiiboKoopa");
         return;
     }
@@ -43,7 +43,7 @@ void HelpAmiiboNavigateCoinCollect::activate() {
 }
 
 bool HelpAmiiboNavigateCoinCollect::execute() {
-    if (!mHintedCoinCollect )
+    if (!mHintedCoinCollect)
         return true;
 
     if (al::isDead(mHintedCoinCollect)) {

--- a/src/Amiibo/HelpAmiiboYoshi.cpp
+++ b/src/Amiibo/HelpAmiiboYoshi.cpp
@@ -13,11 +13,11 @@
 HelpAmiiboYoshi::HelpAmiiboYoshi(HelpAmiiboDirector* director, al::LiveActor* amiiboActor)
     : HelpAmiiboExecutor(director, amiiboActor, "ヨッシーお助け") {}
 
-void HelpAmiiboYoshi::initAfterPlacement(const al::ActorInitInfo& actorInitInfo) {
-    HelpAmiiboExecutor::initAfterPlacement(actorInitInfo);
+void HelpAmiiboYoshi::initAfterPlacement(const al::ActorInitInfo& initInfo) {
+    HelpAmiiboExecutor::initAfterPlacement(initInfo);
 
     mYoshi = new Yoshi("amiiboヨッシー");
-    al::initCreateActorNoPlacementInfo(mYoshi, actorInitInfo);
+    al::initCreateActorNoPlacementInfo(mYoshi, initInfo);
     mYoshi->makeActorDead();
 }
 

--- a/src/Amiibo/HelpAmiiboYoshi.h
+++ b/src/Amiibo/HelpAmiiboYoshi.h
@@ -15,7 +15,7 @@ class HelpAmiiboYoshi : public HelpAmiiboExecutor {
 public:
     HelpAmiiboYoshi(HelpAmiiboDirector* director, al::LiveActor* amiiboActor);
 
-    void initAfterPlacement(const al::ActorInitInfo& actorInitInfo) override;
+    void initAfterPlacement(const al::ActorInitInfo& initInfo) override;
     bool isTriggerTouch(const al::NfpInfo& nfpInfo) const override;
     bool execute() override;
     void activate() override;

--- a/src/Amiibo/SearchAmiiboDataTable.cpp
+++ b/src/Amiibo/SearchAmiiboDataTable.cpp
@@ -57,11 +57,11 @@ void SearchAmiiboDataTable::write(al::ByamlWriter* writer) {
     writer->pop();
 }
 
-void SearchAmiiboDataTable::read(const al::ByamlIter& iter) {
+void SearchAmiiboDataTable::read(const al::ByamlIter& save) {
     init();
 
     al::ByamlIter dataIter;
-    iter.tryGetIterByKey(&dataIter, "SearchAmiiboData");
+    save.tryGetIterByKey(&dataIter, "SearchAmiiboData");
 
     for (s32 i = 0; i < dataIter.getSize(); i++) {
         al::ByamlIter indexIter;

--- a/src/Amiibo/SearchAmiiboDataTable.h
+++ b/src/Amiibo/SearchAmiiboDataTable.h
@@ -20,7 +20,7 @@ public:
 
     void init();
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& iter) override;
+    void read(const al::ByamlIter& save) override;
     s32 getDataNumMax() const;
     bool isInvalidId(s32 index) const;
     const SearchAmiiboData& getData(s32 index) const;

--- a/src/Area/BirdGatheringSpotArea.h
+++ b/src/Area/BirdGatheringSpotArea.h
@@ -20,7 +20,7 @@ public:
 
     BirdGatheringSpotArea(const char* name);
 
-    void init(const al::AreaInitInfo& initInfo) override;
+    void init(const al::AreaInitInfo& info) override;
 
     void calcRandomGroundTrans(sead::Vector3f* trans) const;
     f32 getSightDistance() const;

--- a/src/Area/ExtForceArea.h
+++ b/src/Area/ExtForceArea.h
@@ -6,7 +6,7 @@ class ExtForceArea : public al::AreaObj {
 public:
     ExtForceArea(const char* name);
 
-    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void init(const al::AreaInitInfo& info) override;
 
     void calcExtForce(sead::Vector3f*, const sead::Vector3f&, const sead::Vector3f&,
                       const sead::Vector3f&) const;

--- a/src/Area/ForceRecoveryKidsArea.h
+++ b/src/Area/ForceRecoveryKidsArea.h
@@ -8,7 +8,7 @@ class ForceRecoveryKidsArea : public al::AreaObj {
 public:
     ForceRecoveryKidsArea(const char* name);
 
-    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void init(const al::AreaInitInfo& info) override;
 
 private:
     sead::Vector3f mTargetPos;

--- a/src/Area/MoveArea2D.h
+++ b/src/Area/MoveArea2D.h
@@ -10,7 +10,7 @@ public:
 
     MoveArea2D(const char* name);
 
-    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void init(const al::AreaInitInfo& info) override;
 
     bool calcGravityCylinderCenterAxis(sead::Vector3f*, f32*, const sead::Vector3f&, bool) const;
     bool calcGravityDir(sead::Vector3f*, f32*, const sead::Vector3f&) const;

--- a/src/Area/NpcForceMaterialCodeArea.h
+++ b/src/Area/NpcForceMaterialCodeArea.h
@@ -6,7 +6,7 @@ class NpcForceMaterialCodeArea : public al::AreaObj {
 public:
     NpcForceMaterialCodeArea(const char* name);
 
-    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void init(const al::AreaInitInfo& info) override;
 
 private:
     const char* mMaterialCodeName = nullptr;

--- a/src/Area/RouteGuideArea.h
+++ b/src/Area/RouteGuideArea.h
@@ -8,7 +8,7 @@ class RouteGuideArea : public al::AreaObj {
 public:
     RouteGuideArea(const char* name);
 
-    void init(const al::AreaInitInfo& areaInitInfo) override;
+    void init(const al::AreaInitInfo& info) override;
     void calcGuidePos(sead::Vector3f* guidePos) const;
 
 private:

--- a/src/Enemy/EnemyStateHackStart.cpp
+++ b/src/Enemy/EnemyStateHackStart.cpp
@@ -99,7 +99,7 @@ void EnemyStateHackStart::exeHackStart() {
             al::offDepthShadowModel(actor);
             al::validateDepthShadowMap(actor);
         }
-        if (mParam->updateSubActorShadowMap) {
+        if (mParam->isUpdateSubActorShadowMap) {
             s32 subActorNum = al::getSubActorNum(mActor);
             for (s32 i = 0; i < subActorNum; i++) {
                 al::LiveActor* subActor = al::getSubActor(mActor, i);
@@ -125,7 +125,7 @@ void startHackSwitchShadow(al::LiveActor* actor, const EnemyStateHackStartParam*
         al::offDepthShadowModel(actor);
         al::validateDepthShadowMap(actor);
     }
-    if (param && param->updateSubActorShadowMap) {
+    if (param && param->isUpdateSubActorShadowMap) {
         s32 subActorNum = al::getSubActorNum(actor);
         for (s32 i = 0; i < subActorNum; i++) {
             al::LiveActor* subActor = al::getSubActor(actor, i);
@@ -144,7 +144,7 @@ void endHackSwitchShadow(al::LiveActor* actor, const EnemyStateHackStartParam* p
         al::onDepthShadowModel(actor);
         al::invalidateDepthShadowMap(actor);
     }
-    if (param && param->updateSubActorShadowMap) {
+    if (param && param->isUpdateSubActorShadowMap) {
         s32 subActorNum = al::getSubActorNum(actor);
         for (s32 i = 0; i < subActorNum; i++) {
             al::LiveActor* subActor = al::getSubActor(actor, i);

--- a/src/Enemy/EnemyStateHackStart.cpp
+++ b/src/Enemy/EnemyStateHackStart.cpp
@@ -22,9 +22,9 @@ NERVES_MAKE_NOSTRUCT(EnemyStateHackStart, DiveIn, HackStart);
 
 EnemyStateHackStartParam::EnemyStateHackStartParam(const char* actionName, const char* visAnimName,
                                                    const char* mtpAnimName, bool hasSubActors,
-                                                   bool updateSubActorShadowMap)
+                                                   bool isUpdateSubActorShadowMap)
     : actionName(actionName), visAnimName(visAnimName), mtpAnimName(mtpAnimName),
-      hasSubActors(hasSubActors), updateSubActorShadowMap(updateSubActorShadowMap) {}
+      hasSubActors(hasSubActors), isUpdateSubActorShadowMap(isUpdateSubActorShadowMap) {}
 
 static EnemyStateHackStartParam sEnemyStateHackStartParam("HackStart", 0, 0, 0, 0);
 

--- a/src/Enemy/EnemyStateHackStart.h
+++ b/src/Enemy/EnemyStateHackStart.h
@@ -14,13 +14,13 @@ struct PlayerHackStartShaderParam;
 struct EnemyStateHackStartParam {
     EnemyStateHackStartParam(const char* actionName, const char* visAnimName,
                              const char* mtpAnimName, bool hasSubActors,
-                             bool updateSubActorShadowMap);
+                             bool isUpdateSubActorShadowMap);
 
     const char* actionName;
     const char* visAnimName;
     const char* mtpAnimName;
     bool hasSubActors;
-    bool updateSubActorShadowMap;
+    bool isUpdateSubActorShadowMap;
 };
 
 class EnemyStateHackStart : public al::ActorStateBase {

--- a/src/Enemy/EnemyStateSwoon.cpp
+++ b/src/Enemy/EnemyStateSwoon.cpp
@@ -178,7 +178,7 @@ bool EnemyStateSwoon::requestTrampled() {
 
 void EnemyStateSwoon::initParams(s32 swoonDuration, const char* trampledAnimName) {
     mSwoonDuration = swoonDuration;
-    if (trampledAnimName )
+    if (trampledAnimName)
         mTrampledAnimName = trampledAnimName;
 }
 

--- a/src/Enemy/EnemyStateSwoon.cpp
+++ b/src/Enemy/EnemyStateSwoon.cpp
@@ -178,7 +178,7 @@ bool EnemyStateSwoon::requestTrampled() {
 
 void EnemyStateSwoon::initParams(s32 swoonDuration, const char* trampledAnimName) {
     mSwoonDuration = swoonDuration;
-    if (trampledAnimName != nullptr)
+    if (trampledAnimName )
         mTrampledAnimName = trampledAnimName;
 }
 

--- a/src/Enemy/Gamane.cpp
+++ b/src/Enemy/Gamane.cpp
@@ -112,7 +112,7 @@ void Gamane::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     if (al::isNerve(this, &NrvGamane.PressDown) || al::isNerve(this, &NrvGamane.BlowDown))
         return;
 
-    if (mPlayerHack != nullptr) {
+    if (mPlayerHack ) {
         mHackState->attackSensor(self, other);
         return;
     }
@@ -166,7 +166,7 @@ bool Gamane::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
             return true;
     }
 
-    if (mPlayerHack != nullptr) {
+    if (mPlayerHack ) {
         if (rs::isMsgHackMarioCheckpointFlagWarp(message)) {
             rs::endHack(&mPlayerHack);
             rs::endHackShadow(this);
@@ -217,7 +217,7 @@ bool Gamane::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     if (rs::isMsgBlowDown(message)) {
         if (rs::isMsgGamaneBullet(message)) {
             GamaneBullet* bullet = (GamaneBullet*)al::getSensorHost(other);
-            if (bullet != nullptr && bullet->getParent() == this)
+            if (bullet  && bullet->getParent() == this)
                 return false;
         }
 
@@ -251,7 +251,7 @@ void Gamane::control() {
         al::updateMaterialCodePuddle(this);
     }
 
-    if (al::isNerve(this, &NrvGamane.Hack) && mPlayerHack != nullptr)
+    if (al::isNerve(this, &NrvGamane.Hack) && mPlayerHack )
         mDepthShadowMapCtrl->update(nullptr);
 
     if (!al::isNerve(this, &NrvGamane.Hack) || al::isHideModel(this))
@@ -261,7 +261,7 @@ void Gamane::control() {
 
     if (al::isInDeathArea(this) || al::isInWaterArea(this) ||
         al::isCollidedFloorCode(this, "DamageFire") || al::isCollidedFloorCode(this, "Poison")) {
-        if (!al::isInDeathArea(this) && mPlayerHack != nullptr)
+        if (!al::isInDeathArea(this) && mPlayerHack )
             rs::endHack(&mPlayerHack);
 
         al::startHitReaction(this, "消滅");
@@ -314,7 +314,7 @@ void Gamane::updateRefract() {
                                      refractPercentage * 0.5);
     mRefractTransitionTime--;
 
-    if (mPlayerHack != nullptr)
+    if (mPlayerHack )
         return;
 
     f32 intensity = al::lerpValue(mShadowMaskIntensity, 1.0, refractPercentage);

--- a/src/Enemy/Gamane.cpp
+++ b/src/Enemy/Gamane.cpp
@@ -112,7 +112,7 @@ void Gamane::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     if (al::isNerve(this, &NrvGamane.PressDown) || al::isNerve(this, &NrvGamane.BlowDown))
         return;
 
-    if (mPlayerHack ) {
+    if (mPlayerHack) {
         mHackState->attackSensor(self, other);
         return;
     }
@@ -166,7 +166,7 @@ bool Gamane::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
             return true;
     }
 
-    if (mPlayerHack ) {
+    if (mPlayerHack) {
         if (rs::isMsgHackMarioCheckpointFlagWarp(message)) {
             rs::endHack(&mPlayerHack);
             rs::endHackShadow(this);
@@ -217,7 +217,7 @@ bool Gamane::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     if (rs::isMsgBlowDown(message)) {
         if (rs::isMsgGamaneBullet(message)) {
             GamaneBullet* bullet = (GamaneBullet*)al::getSensorHost(other);
-            if (bullet  && bullet->getParent() == this)
+            if (bullet && bullet->getParent() == this)
                 return false;
         }
 
@@ -251,7 +251,7 @@ void Gamane::control() {
         al::updateMaterialCodePuddle(this);
     }
 
-    if (al::isNerve(this, &NrvGamane.Hack) && mPlayerHack )
+    if (al::isNerve(this, &NrvGamane.Hack) && mPlayerHack)
         mDepthShadowMapCtrl->update(nullptr);
 
     if (!al::isNerve(this, &NrvGamane.Hack) || al::isHideModel(this))
@@ -261,7 +261,7 @@ void Gamane::control() {
 
     if (al::isInDeathArea(this) || al::isInWaterArea(this) ||
         al::isCollidedFloorCode(this, "DamageFire") || al::isCollidedFloorCode(this, "Poison")) {
-        if (!al::isInDeathArea(this) && mPlayerHack )
+        if (!al::isInDeathArea(this) && mPlayerHack)
             rs::endHack(&mPlayerHack);
 
         al::startHitReaction(this, "消滅");
@@ -314,7 +314,7 @@ void Gamane::updateRefract() {
                                      refractPercentage * 0.5);
     mRefractTransitionTime--;
 
-    if (mPlayerHack )
+    if (mPlayerHack)
         return;
 
     f32 intensity = al::lerpValue(mShadowMaskIntensity, 1.0, refractPercentage);

--- a/src/Enemy/Jango/JangoDirector.cpp
+++ b/src/Enemy/Jango/JangoDirector.cpp
@@ -1,6 +1,6 @@
 #include "Enemy/Jango/JangoDirector.h"
 
-JangoDirector::JangoDirector() {}
+JangoDirector::JangoDirector() = default;
 
 void JangoDirector::registerJango(Jango* jango) {
     mJangos[mJangoCount] = jango;

--- a/src/Enemy/Kuribo2D.cpp
+++ b/src/Enemy/Kuribo2D.cpp
@@ -32,10 +32,10 @@ NERVES_MAKE_STRUCT(Kuribo2D, Walk, Wait, PressDown, BlowDown, FallAfterGenerate)
 
 Kuribo2D::Kuribo2D(const char* name) : al::LiveActor(name) {}
 
-void Kuribo2D::init(const al::ActorInitInfo& initInfo) {
+void Kuribo2D::init(const al::ActorInitInfo& info) {
     using Kuribo2DFunctor = al::FunctorV0M<Kuribo2D*, void (Kuribo2D::*)()>;
 
-    al::initActorWithArchiveName(this, initInfo, "Kuribo2D", nullptr);
+    al::initActorWithArchiveName(this, info, "Kuribo2D", nullptr);
     al::initNerve(this, &NrvKuribo2D.Walk, 0);
     rs::createAndSetFilter2DOnly(this);
 

--- a/src/Enemy/Kuribo2D.h
+++ b/src/Enemy/Kuribo2D.h
@@ -12,7 +12,7 @@ class Kuribo2D : public al::LiveActor, public IUseDimension {
 public:
     Kuribo2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void startWalk();
     void reset();
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;

--- a/src/Enemy/Megane.cpp
+++ b/src/Enemy/Megane.cpp
@@ -90,10 +90,10 @@ struct {
 
 Megane::Megane(const char* name) : al::LiveActor(name) {}
 
-void Megane::init(const al::ActorInitInfo& initInfo) {
+void Megane::init(const al::ActorInitInfo& info) {
     using MeganeFunctor = al::FunctorV0M<Megane*, void (Megane::*)()>;
 
-    al::initActorWithArchiveName(this, initInfo, "Megane", nullptr);
+    al::initActorWithArchiveName(this, info, "Megane", nullptr);
     al::initNerve(this, &MeganeData.NrvMegane.Wait, 3);
     mStateSwoon = new EnemyStateSwoon(this, "SwoonStart", "Swoon", "SwoonEnd", false, true);
     mStateSwoon->initParams(180, nullptr);
@@ -127,14 +127,14 @@ void Megane::init(const al::ActorInitInfo& initInfo) {
     al::setActionFrame(subActor, al::getActionFrameMax(subActor, "SpectaclesOn") - 1.0f);
 
     mTestFilterGlasses =
-        new TestFilterGlasses("メガネーレイアウト", al::getLayoutInitInfo(initInfo), nullptr);
+        new TestFilterGlasses("メガネーレイアウト", al::getLayoutInitInfo(info), nullptr);
     mStartingQuat.set(al::getQuat(this));
     mStartingPos.set(al::getTrans(this));
 
     mCapTargetInfo = rs::createCapTargetInfo(this, nullptr);
     mCameraPoserSubjective = new al::CameraPoserSubjective("主観");
     mCameraTicket =
-        alCameraFunction::initCamera(mCameraPoserSubjective, this, initInfo, nullptr, 9);
+        alCameraFunction::initCamera(mCameraPoserSubjective, this, info, nullptr, 9);
     mSpectaclesNerveKeeper = new al::NerveKeeper(this, &MeganeData.NrvMegane.SpectaclesOn, 0);
 
     mPlayerHackStartShaderCtrl =

--- a/src/Enemy/Megane.cpp
+++ b/src/Enemy/Megane.cpp
@@ -133,8 +133,7 @@ void Megane::init(const al::ActorInitInfo& info) {
 
     mCapTargetInfo = rs::createCapTargetInfo(this, nullptr);
     mCameraPoserSubjective = new al::CameraPoserSubjective("主観");
-    mCameraTicket =
-        alCameraFunction::initCamera(mCameraPoserSubjective, this, info, nullptr, 9);
+    mCameraTicket = alCameraFunction::initCamera(mCameraPoserSubjective, this, info, nullptr, 9);
     mSpectaclesNerveKeeper = new al::NerveKeeper(this, &MeganeData.NrvMegane.SpectaclesOn, 0);
 
     mPlayerHackStartShaderCtrl =

--- a/src/Enemy/Megane.h
+++ b/src/Enemy/Megane.h
@@ -28,7 +28,7 @@ class Megane : public al::LiveActor {
 public:
     Megane(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;

--- a/src/Enemy/Nokonoko2D.cpp
+++ b/src/Enemy/Nokonoko2D.cpp
@@ -46,14 +46,14 @@ NERVES_MAKE_STRUCT(Nokonoko2D, Walk, KouraMove, KouraMoveNoTouch, Damage, Damage
 Nokonoko2D::Nokonoko2D(const char* name)
     : al::LiveActor(name), mCollisionPartsFilter{rs::createCollisionPartsFilter2DOnly()} {}
 
-void Nokonoko2D::init(const al::ActorInitInfo& initInfo) {
+void Nokonoko2D::init(const al::ActorInitInfo& info) {
     using Nokonoko2DFunctor = al::FunctorV0M<Nokonoko2D*, void (Nokonoko2D::*)()>;
 
-    mIsGreen = al::isObjectName(initInfo, "NokonokoGreen2D");
+    mIsGreen = al::isObjectName(info, "NokonokoGreen2D");
     if (mIsGreen)
-        al::initActorWithArchiveName(this, initInfo, "NokonokoGreen2D", nullptr);
+        al::initActorWithArchiveName(this, info, "NokonokoGreen2D", nullptr);
     else
-        al::initActorWithArchiveName(this, initInfo, "NokonokoRed2D", nullptr);
+        al::initActorWithArchiveName(this, info, "NokonokoRed2D", nullptr);
 
     al::initNerve(this, &NrvNokonoko2D.Walk, 0);
     rs::createAndSetFilter2DOnly(this);
@@ -73,15 +73,15 @@ void Nokonoko2D::init(const al::ActorInitInfo& initInfo) {
     mInitTrans = al::getTrans(this);
     mInitFront = al::getFront(this);
 
-    if (al::isExistLinkChild(initInfo, "Nokonoko2dResetArea", 0)) {
-        mResetArea = al::createLinkAreaGroup(this, initInfo, "Nokonoko2dResetArea",
+    if (al::isExistLinkChild(info, "Nokonoko2dResetArea", 0)) {
+        mResetArea = al::createLinkAreaGroup(this, info, "Nokonoko2dResetArea",
                                              "子供エリアグループ", "子供エリア");
         al::PlacementInfo placementInfo;
-        al::getLinksInfo(&placementInfo, initInfo, "Nokonoko2dResetArea");
+        al::getLinksInfo(&placementInfo, info, "Nokonoko2dResetArea");
         al::tryGetArg(&mIsResetForce, placementInfo, "IsResetForce");
     }
-    al::tryGetArg(&mClippingTime, initInfo, "ClippingTime");
-    al::tryGetArg(&mIsHeavyGravity, initInfo, "IsHeavyGravity");
+    al::tryGetArg(&mClippingTime, info, "ClippingTime");
+    al::tryGetArg(&mIsHeavyGravity, info, "IsHeavyGravity");
     al::listenStageSwitchOn(this, "SwitchReset", Nokonoko2DFunctor(this, &Nokonoko2D::reset));
 }
 

--- a/src/Enemy/Nokonoko2D.h
+++ b/src/Enemy/Nokonoko2D.h
@@ -14,7 +14,7 @@ class Nokonoko2D : public al::LiveActor, public IUseDimension {
 public:
     Nokonoko2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void reset();
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,

--- a/src/Enemy/Pecho.cpp
+++ b/src/Enemy/Pecho.cpp
@@ -46,8 +46,8 @@ const al::AnimScaleParam gAnimScaleParam = al::AnimScaleParam();
 
 Pecho::Pecho(const char* name) : al::LiveActor(name) {}
 
-void Pecho::init(const al::ActorInitInfo& initInfo) {
-    al::initActor(this, initInfo);
+void Pecho::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
     mStartingQuat = al::getQuat(this);
     mStartingTrans = al::getTrans(this);
     mBodyOrientation = al::getQuat(this);

--- a/src/Enemy/Pecho.h
+++ b/src/Enemy/Pecho.h
@@ -17,7 +17,7 @@ class Pecho : public al::LiveActor {
 public:
     Pecho(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;

--- a/src/Item/Coin.cpp
+++ b/src/Item/Coin.cpp
@@ -101,7 +101,7 @@ void Coin::init(const al::ActorInitInfo& info) {
     al::expandClippingRadiusByShadowLength(this, nullptr, mShadowSize);
     mWaterSurfaceShadow = rs::tryCreateWaterSurfaceCoinShadow(info);
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
 
     if (al::trySyncStageSwitchAppear(this))
@@ -125,7 +125,7 @@ void Coin::init(const al::ActorInitInfo& info) {
 }
 
 void Coin::initAfterPlacement() {
-    if (mMtxConnector ) {
+    if (mMtxConnector) {
         if (!mIsConnectToCollisionBack) {
             al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
         } else {
@@ -243,7 +243,7 @@ bool Coin::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::Hi
 }
 
 void Coin::tryCreateMtxConnector() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         mMtxConnector = al::createMtxConnector(this);
 }
 
@@ -470,7 +470,7 @@ void Coin::appearBlow(const sead::Vector3f& velocity, s32 timeLimit) {
     al::validateHitSensors(this);
     al::showModelIfHide(this);
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::disconnectMtxConnector(mMtxConnector);
 
     rotate();
@@ -483,7 +483,7 @@ void Coin::rotate() {
         return;
     }
 
-    if (mMtxConnector  && al::isMtxConnectorConnecting(mMtxConnector) &&
+    if (mMtxConnector && al::isMtxConnectorConnecting(mMtxConnector) &&
         (al::isNerve(this, &NrvCoin.Appear) || al::isNerve(this, &NrvCoin.WaitConnectMtx))) {
         al::connectPoseQT(this, mMtxConnector, mPoseQuat, mPoseTrans);
         al::getTransPtr(this)->add(mChameleonOffset);
@@ -682,7 +682,7 @@ void Coin::exePopUp() {
 
     if (al::getVelocity(this).y < 0.0f && al::isCollidedGround(this)) {
         if (al::calcSpeed(this) < 15.0f) {
-            if (mMtxConnector ) {
+            if (mMtxConnector) {
                 al::disconnectMtxConnector(mMtxConnector);
                 mPoseTrans = al::getTrans(this);
                 al::attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -766,12 +766,12 @@ void Coin::exeGot() {
 
         al::onStageSwitch(this, "SwitchGetOn");
         alPadRumbleFunction::startPadRumble(this, "コッ（最小）", 1000.0f, 5000.0f);
-        if (mWaterSurfaceShadow )
+        if (mWaterSurfaceShadow)
             mWaterSurfaceShadow->disappearShadow();
     }
 
     if (al::isActionEnd(this)) {
-        if (mSaveObjInfo )
+        if (mSaveObjInfo)
             rs::onSaveObjInfo(mSaveObjInfo);
         kill();
     }

--- a/src/Item/Coin.cpp
+++ b/src/Item/Coin.cpp
@@ -68,20 +68,20 @@ const sead::Vector3f sAppearAboveVelocity(0.0f, 25.0f, 0.0f);
 
 Coin::Coin(const char* name, bool isDemo) : al::LiveActor(name), mIsDemo(isDemo) {}
 
-void Coin::init(const al::ActorInitInfo& initInfo) {
+void Coin::init(const al::ActorInitInfo& info) {
     const char* modelName = "Coin";
-    if (al::isPlaced(initInfo)) {
+    if (al::isPlaced(info)) {
         mIsPlaced = true;
-        alPlacementFunction::tryGetModelName(&modelName, initInfo);
+        alPlacementFunction::tryGetModelName(&modelName, info);
     } else {
         mIsPlaced = false;
     }
 
     const char* suffix = mIsDemo ? "MoveDemo" : nullptr;
-    al::initActorWithArchiveName(this, initInfo, modelName, suffix);
+    al::initActorWithArchiveName(this, info, modelName, suffix);
 
     bool isConnectToCollision = false;
-    al::tryGetArg(&isConnectToCollision, initInfo, "IsConnectToCollision");
+    al::tryGetArg(&isConnectToCollision, info, "IsConnectToCollision");
     if (!isConnectToCollision)
         al::initNerve(this, &NrvCoin.Wait, 1);
 
@@ -93,24 +93,24 @@ void Coin::init(const al::ActorInitInfo& initInfo) {
     mRotateCalculator = new CoinRotateCalculator(this);
 
     mStartingQuat.set(al::getQuat(this));
-    al::tryAddDisplayOffset(this, initInfo);
-    al::tryGetDisplayOffset(&mDisplayOffset, initInfo);
+    al::tryAddDisplayOffset(this, info);
+    al::tryGetDisplayOffset(&mDisplayOffset, info);
     mMtxConnector = al::createMtxConnector(this);
 
-    mShadowSize = rs::setShadowDropLength(this, initInfo, "本体");
+    mShadowSize = rs::setShadowDropLength(this, info, "本体");
     al::expandClippingRadiusByShadowLength(this, nullptr, mShadowSize);
-    mWaterSurfaceShadow = rs::tryCreateWaterSurfaceCoinShadow(initInfo);
+    mWaterSurfaceShadow = rs::tryCreateWaterSurfaceCoinShadow(info);
 
-    if (mMtxConnector != nullptr)
-        al::tryGetArg(&mIsConnectToCollisionBack, initInfo, "IsConnectToCollisionBack");
+    if (mMtxConnector )
+        al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
 
     if (al::trySyncStageSwitchAppear(this))
         al::setNerve(this, &NrvCoin.Appear);
 
     bool isCoinSave = false;
-    al::tryGetArg(&isCoinSave, initInfo, "IsCoinSave");
+    al::tryGetArg(&isCoinSave, info, "IsCoinSave");
     if (isCoinSave) {
-        mSaveObjInfo = rs::createSaveObjInfoNoWriteSaveDataInSameWorldResetMiniGame(initInfo);
+        mSaveObjInfo = rs::createSaveObjInfoNoWriteSaveDataInSameWorldResetMiniGame(info);
         if (rs::isOnSaveObjInfo(mSaveObjInfo)) {
             kill();
             return;
@@ -121,11 +121,11 @@ void Coin::init(const al::ActorInitInfo& initInfo) {
     al::initNerveState(this, mStateAppearRotate, &NrvCoin.AppearCoinLead, "誘導コイン出現");
     mPoseTrans = al::getTrans(this);
     mPoseQuat = al::getQuat(this);
-    al::registActorToDemoInfo(this, initInfo);
+    al::registActorToDemoInfo(this, info);
 }
 
 void Coin::initAfterPlacement() {
-    if (mMtxConnector != nullptr) {
+    if (mMtxConnector ) {
         if (!mIsConnectToCollisionBack) {
             al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
         } else {
@@ -243,7 +243,7 @@ bool Coin::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::Hi
 }
 
 void Coin::tryCreateMtxConnector() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         mMtxConnector = al::createMtxConnector(this);
 }
 
@@ -470,7 +470,7 @@ void Coin::appearBlow(const sead::Vector3f& velocity, s32 timeLimit) {
     al::validateHitSensors(this);
     al::showModelIfHide(this);
 
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::disconnectMtxConnector(mMtxConnector);
 
     rotate();
@@ -483,7 +483,7 @@ void Coin::rotate() {
         return;
     }
 
-    if (mMtxConnector != nullptr && al::isMtxConnectorConnecting(mMtxConnector) &&
+    if (mMtxConnector  && al::isMtxConnectorConnecting(mMtxConnector) &&
         (al::isNerve(this, &NrvCoin.Appear) || al::isNerve(this, &NrvCoin.WaitConnectMtx))) {
         al::connectPoseQT(this, mMtxConnector, mPoseQuat, mPoseTrans);
         al::getTransPtr(this)->add(mChameleonOffset);
@@ -682,7 +682,7 @@ void Coin::exePopUp() {
 
     if (al::getVelocity(this).y < 0.0f && al::isCollidedGround(this)) {
         if (al::calcSpeed(this) < 15.0f) {
-            if (mMtxConnector != nullptr) {
+            if (mMtxConnector ) {
                 al::disconnectMtxConnector(mMtxConnector);
                 mPoseTrans = al::getTrans(this);
                 al::attachMtxConnectorToCollision(mMtxConnector, this, false);
@@ -766,12 +766,12 @@ void Coin::exeGot() {
 
         al::onStageSwitch(this, "SwitchGetOn");
         alPadRumbleFunction::startPadRumble(this, "コッ（最小）", 1000.0f, 5000.0f);
-        if (mWaterSurfaceShadow != nullptr)
+        if (mWaterSurfaceShadow )
             mWaterSurfaceShadow->disappearShadow();
     }
 
     if (al::isActionEnd(this)) {
-        if (mSaveObjInfo != nullptr)
+        if (mSaveObjInfo )
             rs::onSaveObjInfo(mSaveObjInfo);
         kill();
     }

--- a/src/Item/Coin.h
+++ b/src/Item/Coin.h
@@ -23,7 +23,7 @@ class Coin : public al::LiveActor {
 public:
     Coin(const char* name, bool isDemo = false);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void appear() override;
     void makeActorAlive() override;

--- a/src/Item/Coin2D.cpp
+++ b/src/Item/Coin2D.cpp
@@ -38,20 +38,20 @@ NERVES_MAKE_STRUCT(Coin2D, Wait, Appear, CountUp, Got);
 
 Coin2D::Coin2D(const char* name) : al::LiveActor(name) {}
 
-void Coin2D::init(const al::ActorInitInfo& initInfo) {
+void Coin2D::init(const al::ActorInitInfo& info) {
     using Coin2DFunctor = al::FunctorV0M<Coin2D*, void (Coin2D::*)()>;
 
-    al::initActorWithArchiveName(this, initInfo, "CoinDot", nullptr);
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
-    if (mMtxConnector != nullptr)
-        al::tryGetArg(&mIsConnectToCollisionBack, initInfo, "IsConnectToCollisionBack");
+    al::initActorWithArchiveName(this, info, "CoinDot", nullptr);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    if (mMtxConnector )
+        al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
 
     al::initNerve(this, &NrvCoin2D.Wait, 0);
-    al::tryAddDisplayOffset(this, initInfo);
+    al::tryAddDisplayOffset(this, info);
     mDimensionKeeper = rs::createDimensionKeeper(this);
     rs::updateDimensionKeeper(mDimensionKeeper);
 
-    mIsPlaced = al::isPlaced(initInfo);
+    mIsPlaced = al::isPlaced(info);
     if (mIsPlaced)
         rs::snap2DParallelizeFront(this, this, 500.0f);
 
@@ -64,7 +64,7 @@ void Coin2D::init(const al::ActorInitInfo& initInfo) {
 }
 
 void Coin2D::initAfterPlacement() {
-    if (mMtxConnector != nullptr) {
+    if (mMtxConnector ) {
         if (!mIsConnectToCollisionBack) {
             al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
             return;
@@ -78,12 +78,12 @@ void Coin2D::initAfterPlacement() {
 
 void Coin2D::appear() {
     al::LiveActor::appear();
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 }
 
 void Coin2D::control() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 }
 
@@ -132,7 +132,7 @@ void Coin2D::appearCountUp() {
     al::setVelocityToDirection(this, up, 16.0f);
 
     al::AreaObj* areaObj = rs::tryFind2DAreaObj(this, nullptr, nullptr);
-    if (areaObj != nullptr) {
+    if (areaObj ) {
         sead::Vector3f lockDir = sead::Vector3f::zero;
         rs::calc2DAreaLockDir(&lockDir, areaObj, al::getTrans(this));
         sead::Quatf quat = sead::Quatf::unit;

--- a/src/Item/Coin2D.cpp
+++ b/src/Item/Coin2D.cpp
@@ -43,7 +43,7 @@ void Coin2D::init(const al::ActorInitInfo& info) {
 
     al::initActorWithArchiveName(this, info, "CoinDot", nullptr);
     mMtxConnector = al::tryCreateMtxConnector(this, info);
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
 
     al::initNerve(this, &NrvCoin2D.Wait, 0);
@@ -64,7 +64,7 @@ void Coin2D::init(const al::ActorInitInfo& info) {
 }
 
 void Coin2D::initAfterPlacement() {
-    if (mMtxConnector ) {
+    if (mMtxConnector) {
         if (!mIsConnectToCollisionBack) {
             al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
             return;
@@ -78,12 +78,12 @@ void Coin2D::initAfterPlacement() {
 
 void Coin2D::appear() {
     al::LiveActor::appear();
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 }
 
 void Coin2D::control() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 }
 
@@ -132,7 +132,7 @@ void Coin2D::appearCountUp() {
     al::setVelocityToDirection(this, up, 16.0f);
 
     al::AreaObj* areaObj = rs::tryFind2DAreaObj(this, nullptr, nullptr);
-    if (areaObj ) {
+    if (areaObj) {
         sead::Vector3f lockDir = sead::Vector3f::zero;
         rs::calc2DAreaLockDir(&lockDir, areaObj, al::getTrans(this));
         sead::Quatf quat = sead::Quatf::unit;

--- a/src/Item/Coin2D.h
+++ b/src/Item/Coin2D.h
@@ -17,7 +17,7 @@ class Coin2D : public al::LiveActor, public IUseDimension {
 public:
     Coin2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void appear() override;
     void control() override;

--- a/src/Item/Coin2DCity.cpp
+++ b/src/Item/Coin2DCity.cpp
@@ -53,7 +53,7 @@ void Coin2DCity::init(const al::ActorInitInfo& info) {
 void Coin2DCity::control() {
     mSyncCounter = al::getSceneObj<al::StageSyncCounter>(this)->getCounter();
     if (mLightTime > -1 && mCityDirector->isTriggerBeat()) {
-        if (mNextCoin  && mLightTime == 1)
+        if (mNextCoin && mLightTime == 1)
             mNextCoin->startLight();
 
         if (mLightTime == mCityDirector->getLightTime())
@@ -83,7 +83,7 @@ void Coin2DCity::startLight() {
 
     al::StageSyncCounter* syncCounter = al::getSceneObj<al::StageSyncCounter>(this);
     if (mSyncCounter == syncCounter->getCounter() && mCityDirector->isTriggerBeat()) {
-        if (mNextCoin  && mLightTime == 1)
+        if (mNextCoin && mLightTime == 1)
             mNextCoin->startLight();
 
         if (mLightTime == mCityDirector->getLightTime())

--- a/src/Item/Coin2DCity.cpp
+++ b/src/Item/Coin2DCity.cpp
@@ -31,18 +31,18 @@ NERVES_MAKE_STRUCT(Coin2DCity, Got, Light, GotWait);
 Coin2DCity::Coin2DCity(const char* name, Coin2DCityDirector* director)
     : al::LiveActor(name), mCityDirector(director) {}
 
-void Coin2DCity::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "CoinDot", nullptr);
-    al::tryAddDisplayOffset(this, initInfo);
+void Coin2DCity::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "CoinDot", nullptr);
+    al::tryAddDisplayOffset(this, info);
     mDimensionKeeper = rs::createDimensionKeeper(this);
     rs::updateDimensionKeeper(mDimensionKeeper);
 
     mCityDirector->registerCoin(this);
     al::PlacementInfo placementInfo;
-    if (al::isExistLinkChild(initInfo, "NextCoin", 0)) {
-        al::getLinksInfo(&placementInfo, initInfo, "NextCoin");
+    if (al::isExistLinkChild(info, "NextCoin", 0)) {
+        al::getLinksInfo(&placementInfo, info, "NextCoin");
         mNextCoin = new Coin2DCity("コイン2D都市", mCityDirector);
-        al::initCreateActorWithPlacementInfo(mNextCoin, initInfo, placementInfo);
+        al::initCreateActorWithPlacementInfo(mNextCoin, info, placementInfo);
     }
 
     al::initNerve(this, &Wait, 0);
@@ -53,7 +53,7 @@ void Coin2DCity::init(const al::ActorInitInfo& initInfo) {
 void Coin2DCity::control() {
     mSyncCounter = al::getSceneObj<al::StageSyncCounter>(this)->getCounter();
     if (mLightTime > -1 && mCityDirector->isTriggerBeat()) {
-        if (mNextCoin != nullptr && mLightTime == 1)
+        if (mNextCoin  && mLightTime == 1)
             mNextCoin->startLight();
 
         if (mLightTime == mCityDirector->getLightTime())
@@ -83,7 +83,7 @@ void Coin2DCity::startLight() {
 
     al::StageSyncCounter* syncCounter = al::getSceneObj<al::StageSyncCounter>(this);
     if (mSyncCounter == syncCounter->getCounter() && mCityDirector->isTriggerBeat()) {
-        if (mNextCoin != nullptr && mLightTime == 1)
+        if (mNextCoin  && mLightTime == 1)
             mNextCoin->startLight();
 
         if (mLightTime == mCityDirector->getLightTime())

--- a/src/Item/Coin2DCity.h
+++ b/src/Item/Coin2DCity.h
@@ -17,7 +17,7 @@ class Coin2DCity : public al::LiveActor, public IUseDimension {
 public:
     Coin2DCity(const char* name, Coin2DCityDirector* director);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/Coin2DCityDirector.cpp
+++ b/src/Item/Coin2DCityDirector.cpp
@@ -21,17 +21,17 @@ NERVES_MAKE_STRUCT(Coin2DCityDirector, Wait);
 
 Coin2DCityDirector::Coin2DCityDirector(const char* name) : al::LiveActor(name) {}
 
-void Coin2DCityDirector::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "Coin2DCityDirector", nullptr);
-    if (!al::isExistLinkChild(initInfo, "FirstCoin", 0)) {
+void Coin2DCityDirector::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "Coin2DCityDirector", nullptr);
+    if (!al::isExistLinkChild(info, "FirstCoin", 0)) {
         kill();
         return;
     }
 
-    al::tryGetArg(&mNextCoinLightTime, initInfo, "NextCoinLightTime");
-    al::tryGetArg(&mLightTime, initInfo, "LightTime");
-    al::tryGetArg(&mLightInterval, initInfo, "LightInterval");
-    al::tryGetArg(&mDelayTime, initInfo, "DelayTime");
+    al::tryGetArg(&mNextCoinLightTime, info, "NextCoinLightTime");
+    al::tryGetArg(&mLightTime, info, "LightTime");
+    al::tryGetArg(&mLightInterval, info, "LightInterval");
+    al::tryGetArg(&mDelayTime, info, "DelayTime");
     if (mNextCoinLightTime <= -1 || mLightTime <= -1 || mLightInterval <= -1 || mDelayTime <= -1) {
         kill();
         return;
@@ -40,12 +40,12 @@ void Coin2DCityDirector::init(const al::ActorInitInfo& initInfo) {
     mCoinHolder.allocBuffer(100, nullptr);
 
     al::PlacementInfo placementInfo;
-    al::getLinksInfo(&placementInfo, initInfo, "FirstCoin");
+    al::getLinksInfo(&placementInfo, info, "FirstCoin");
     s32 linkNestNum = al::calcLinkNestNum(placementInfo, "NextCoin");
 
     Coin2DCity* coin = new Coin2DCity("コイン2D都市", this);
-    al::initCreateActorWithPlacementInfo(coin, initInfo, placementInfo);
-    al::initSubActorKeeperNoFile(this, initInfo, linkNestNum + 1);
+    al::initCreateActorWithPlacementInfo(coin, info, placementInfo);
+    al::initSubActorKeeperNoFile(this, info, linkNestNum + 1);
 
     mBgmBeatCounter = new al::BgmBeatCounter(this, -0.28f);
     al::initNerve(this, &NrvCoin2DCityDirector.Wait, 0);

--- a/src/Item/Coin2DCityDirector.h
+++ b/src/Item/Coin2DCityDirector.h
@@ -18,7 +18,7 @@ class Coin2DCityDirector : public al::LiveActor {
 public:
     Coin2DCityDirector(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void control() override;
 

--- a/src/Item/CoinBlow.cpp
+++ b/src/Item/CoinBlow.cpp
@@ -10,17 +10,17 @@
 
 CoinBlow::CoinBlow(const char* name) : al::LiveActor(name) {}
 
-void CoinBlow::init(const al::ActorInitInfo& initInfo) {
+void CoinBlow::init(const al::ActorInitInfo& info) {
     using CoinBlowFunctor = al::FunctorV0M<CoinBlow*, void (CoinBlow::*)()>;
 
-    al::initActorWithArchiveName(this, initInfo, "CoinBlow", nullptr);
+    al::initActorWithArchiveName(this, info, "CoinBlow", nullptr);
     al::listenStageSwitchOnStart(this, CoinBlowFunctor(this, &CoinBlow::listenStart));
-    al::tryGetStringArg(&mBlowSize, initInfo, "BlowSize");
+    al::tryGetStringArg(&mBlowSize, info, "BlowSize");
     makeActorDead();
 }
 
 void CoinBlow::listenStart() {
-    if (mBlowSize == nullptr) {
+    if (!mBlowSize ) {
         al::appearItemTiming(this, "小");
         return;
     }

--- a/src/Item/CoinBlow.cpp
+++ b/src/Item/CoinBlow.cpp
@@ -20,7 +20,7 @@ void CoinBlow::init(const al::ActorInitInfo& info) {
 }
 
 void CoinBlow::listenStart() {
-    if (!mBlowSize ) {
+    if (!mBlowSize) {
         al::appearItemTiming(this, "小");
         return;
     }

--- a/src/Item/CoinBlow.h
+++ b/src/Item/CoinBlow.h
@@ -10,7 +10,7 @@ class CoinBlow : public al::LiveActor {
 public:
     CoinBlow(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
 
     void listenStart();
 

--- a/src/Item/CoinChameleon.cpp
+++ b/src/Item/CoinChameleon.cpp
@@ -27,12 +27,12 @@ NERVES_MAKE_STRUCT(CoinChameleon, Wait, Appear, Visible);
 
 CoinChameleon::CoinChameleon(const char* name) : al::LiveActor(name) {}
 
-void CoinChameleon::init(const al::ActorInitInfo& initInfo) {
-    al::initActor(this, initInfo);
+void CoinChameleon::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
     al::initNerve(this, &NrvCoinChameleon.Wait, 1);
 
     Coin* coin = new Coin("コイン", false);
-    al::initCreateActorWithPlacementInfo(coin, initInfo);
+    al::initCreateActorWithPlacementInfo(coin, info);
     mCoin = coin;
     mCoin->makeActorDead();
 
@@ -42,26 +42,26 @@ void CoinChameleon::init(const al::ActorInitInfo& initInfo) {
     al::hideModel(this);
     al::setMaterialProgrammable(this);
 
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
-    if (mMtxConnector != nullptr)
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    if (mMtxConnector )
         mCoin->setMtxConnector(mMtxConnector);
 
-    al::tryAddDisplayOffset(this, initInfo);
-    al::tryGetDisplayOffset(&mDisplayOffset, initInfo);
+    al::tryAddDisplayOffset(this, info);
+    al::tryGetDisplayOffset(&mDisplayOffset, info);
 
     mStateAppearRotate = new CoinStateAppearRotate(this, mMtxConnector, mDisplayOffset, "出現");
     al::initNerveState(this, mStateAppearRotate, &NrvCoinChameleon.Appear, "出現");
 
-    if (al::isPlaced(initInfo)) {
+    if (al::isPlaced(info)) {
         f32 shadowLength = 1500.0f;
-        al::tryGetArg(&shadowLength, initInfo, "ShadowLength");
+        al::tryGetArg(&shadowLength, info, "ShadowLength");
         mCoin->setShadowDropLength(shadowLength);
     }
     makeActorAlive();
 }
 
 void CoinChameleon::initAfterPlacement() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -90,11 +90,11 @@ bool CoinChameleon::receiveMsg(const al::SensorMsg* message, al::HitSensor* othe
 }
 
 void CoinChameleon::rotate() {
-    if (mMtxConnector == nullptr)
+    if (!mMtxConnector )
         al::setQuat(this, mQuat);
 
     bool checkWater = false;
-    if (al::isNerve(this, &NrvCoinChameleon.Appear) || mMtxConnector != nullptr)
+    if (al::isNerve(this, &NrvCoinChameleon.Appear) || mMtxConnector )
         checkWater = true;
 
     mRotateCalculator->update(sead::Vector3f::zero, checkWater);
@@ -106,7 +106,7 @@ void CoinChameleon::exeWait() {
         al::validateClipping(this);
         mWaitTime = 0;
     }
-    if (mMtxConnector != nullptr) {
+    if (mMtxConnector ) {
         al::connectPoseQT(this, mMtxConnector);
         *al::getTransPtr(this) += mDisplayOffset;
     }
@@ -131,7 +131,7 @@ void CoinChameleon::exeVisible() {
         al::showModelIfHide(this);
     }
 
-    if (mMtxConnector != nullptr) {
+    if (mMtxConnector ) {
         al::connectPoseQT(this, mMtxConnector);
         *al::getTransPtr(this) += mDisplayOffset;
     }

--- a/src/Item/CoinChameleon.cpp
+++ b/src/Item/CoinChameleon.cpp
@@ -43,7 +43,7 @@ void CoinChameleon::init(const al::ActorInitInfo& info) {
     al::setMaterialProgrammable(this);
 
     mMtxConnector = al::tryCreateMtxConnector(this, info);
-    if (mMtxConnector )
+    if (mMtxConnector)
         mCoin->setMtxConnector(mMtxConnector);
 
     al::tryAddDisplayOffset(this, info);
@@ -61,7 +61,7 @@ void CoinChameleon::init(const al::ActorInitInfo& info) {
 }
 
 void CoinChameleon::initAfterPlacement() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -90,11 +90,11 @@ bool CoinChameleon::receiveMsg(const al::SensorMsg* message, al::HitSensor* othe
 }
 
 void CoinChameleon::rotate() {
-    if (!mMtxConnector )
+    if (!mMtxConnector)
         al::setQuat(this, mQuat);
 
     bool checkWater = false;
-    if (al::isNerve(this, &NrvCoinChameleon.Appear) || mMtxConnector )
+    if (al::isNerve(this, &NrvCoinChameleon.Appear) || mMtxConnector)
         checkWater = true;
 
     mRotateCalculator->update(sead::Vector3f::zero, checkWater);
@@ -106,7 +106,7 @@ void CoinChameleon::exeWait() {
         al::validateClipping(this);
         mWaitTime = 0;
     }
-    if (mMtxConnector ) {
+    if (mMtxConnector) {
         al::connectPoseQT(this, mMtxConnector);
         *al::getTransPtr(this) += mDisplayOffset;
     }
@@ -131,7 +131,7 @@ void CoinChameleon::exeVisible() {
         al::showModelIfHide(this);
     }
 
-    if (mMtxConnector ) {
+    if (mMtxConnector) {
         al::connectPoseQT(this, mMtxConnector);
         *al::getTransPtr(this) += mDisplayOffset;
     }

--- a/src/Item/CoinChameleon.h
+++ b/src/Item/CoinChameleon.h
@@ -21,7 +21,7 @@ class CoinChameleon : public al::LiveActor {
 public:
     CoinChameleon(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void endClipped() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,

--- a/src/Item/CoinCirclePlacement.cpp
+++ b/src/Item/CoinCirclePlacement.cpp
@@ -22,31 +22,31 @@ NERVES_MAKE_STRUCT(CoinCirclePlacement, Move);
 
 CoinCirclePlacement::CoinCirclePlacement(const char* name) : al::LiveActor(name) {}
 
-void CoinCirclePlacement::init(const al::ActorInitInfo& initInfo) {
+void CoinCirclePlacement::init(const al::ActorInitInfo& info) {
     using CoinCirclePlacementFunctor =
         al::FunctorV0M<CoinCirclePlacement*, void (CoinCirclePlacement::*)()>;
 
-    al::initActor(this, initInfo);
+    al::initActor(this, info);
     al::initNerve(this, &NrvCoinCirclePlacement.Move, 0);
-    al::getArg(&mCoinNum, initInfo, "CoinNum");
+    al::getArg(&mCoinNum, info, "CoinNum");
 
     if (mCoinNum <= 0) {
         kill();
         return;
     }
 
-    al::getArg(&mRotateVelocity, initInfo, "RotateVelocity");
-    al::tryGetArg(&mCircleXWidth, initInfo, "CircleXWidth");
-    al::tryGetArg(&mCircleZWidth, initInfo, "CircleZWidth");
-    al::tryGetSide(&mSide, initInfo);
-    al::tryGetUp(&mUp, initInfo);
-    al::tryGetFront(&mFront, initInfo);
+    al::getArg(&mRotateVelocity, info, "RotateVelocity");
+    al::tryGetArg(&mCircleXWidth, info, "CircleXWidth");
+    al::tryGetArg(&mCircleZWidth, info, "CircleZWidth");
+    al::tryGetSide(&mSide, info);
+    al::tryGetUp(&mUp, info);
+    al::tryGetFront(&mFront, info);
 
     s32 coinNum = mCoinNum;
     mCoinArray = new Coin*[mCoinNum];
     for (s32 i = 0; i < mCoinNum; i++) {
         Coin* coin = new Coin("コイン", false);
-        al::initCreateActorWithPlacementInfo(coin, initInfo);
+        al::initCreateActorWithPlacementInfo(coin, info);
         mCoinArray[i] = coin;
 
         f32 coinAngle = sead::Mathf::deg2rad((360.0f / coinNum) * i);
@@ -58,9 +58,9 @@ void CoinCirclePlacement::init(const al::ActorInitInfo& initInfo) {
 
         al::setTrans(mCoinArray[i], coinPos);
         al::setScale(mCoinArray[i], {1.0f, 1.0f, 1.0f});
-        al::tryAddDisplayOffset(mCoinArray[i], initInfo);
+        al::tryAddDisplayOffset(mCoinArray[i], info);
         al::expandClippingRadiusByShadowLength(
-            this, &_154, rs::setShadowDropLength(mCoinArray[i], initInfo, "本体"));
+            this, &_154, rs::setShadowDropLength(mCoinArray[i], info, "本体"));
         mCoinArray[i]->appearCirclePlacement();
     }
 

--- a/src/Item/CoinCirclePlacement.h
+++ b/src/Item/CoinCirclePlacement.h
@@ -15,7 +15,7 @@ class CoinCirclePlacement : public al::LiveActor {
 public:
     CoinCirclePlacement(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
 
     void listenAppear();
     void exeMove();

--- a/src/Item/CoinCollect.cpp
+++ b/src/Item/CoinCollect.cpp
@@ -105,7 +105,7 @@ void CoinCollect::init(const al::ActorInitInfo& info) {
 }
 
 void CoinCollect::initAfterPlacement() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -175,7 +175,7 @@ void CoinCollect::appear() {
 }
 
 void CoinCollect::makeActorAlive() {
-    if (!mCoinCollectEmpty  && !al::isNerve(this, &NrvCoinCollect.Got))
+    if (!mCoinCollectEmpty && !al::isNerve(this, &NrvCoinCollect.Got))
         al::LiveActor::makeActorAlive();
 }
 
@@ -188,7 +188,7 @@ void CoinCollect::listenAppear() {
 }
 
 const sead::Vector3f& CoinCollect::getTransForHint() const {
-    if (mCoinCollectEmpty )
+    if (mCoinCollectEmpty)
         return al::getTrans(mCoinCollectEmpty);
 
     return al::getTrans(this);
@@ -219,7 +219,7 @@ bool CoinCollect::isEnableHint() const {
 }
 
 void CoinCollect::rotate() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);
@@ -232,7 +232,7 @@ void CoinCollect::exeWait() {
         rs::tryUpdateWaterSurfaceCoinShadow(mWaterSurfaceShadow, this, mShadowLength);
     }
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     rotate();
@@ -242,7 +242,7 @@ void CoinCollect::exeWait() {
 }
 
 void CoinCollect::exeWaitAmiibo() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     rotate();
@@ -259,12 +259,12 @@ void CoinCollect::exeGot() {
         rs::tryShowCapMsgCollectCoinGetFirst(this);
         al::startAction(this, "Got");
         alPadRumbleFunction::startPadRumble(this, "コッ（微弱）", 1000.0f, 5000.0f);
-        if (mWaterSurfaceShadow )
+        if (mWaterSurfaceShadow)
             mWaterSurfaceShadow->disappearShadow();
         _198 = false;
     }
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     if (al::isActionEnd(this)) {
@@ -293,7 +293,7 @@ void CoinCollect::exeCountUp() {
         GameDataFunction::addCoinCollect(this, mPlacementId);
 
         rs::tryShowCapMsgCollectCoinGetFirst(this);
-        if (mWaterSurfaceShadow )
+        if (mWaterSurfaceShadow)
             mWaterSurfaceShadow->disappearShadow();
 
         al::startHitReaction(this, "釣り取得");
@@ -307,7 +307,7 @@ void CoinCollect::exeBlow() {
         al::onCollide(this);
     }
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);
@@ -317,7 +317,7 @@ void CoinCollect::exeBlow() {
 
     if (al::getVelocity(this).y < 0.0f && al::isCollidedGround(this)) {
         if (al::calcSpeed(this) < 15.0f) {
-            if (mMtxConnector )
+            if (mMtxConnector)
                 al::attachMtxConnectorToCollision(mMtxConnector, this, false);
             al::setVelocityZero(this);
             al::setNerve(this, &NrvCoinCollect.Wait);

--- a/src/Item/CoinCollect.cpp
+++ b/src/Item/CoinCollect.cpp
@@ -50,20 +50,20 @@ NERVES_MAKE_STRUCT(CoinCollect, Wait, CountUp, WaitAmiibo, Got, Blow);
 
 CoinCollect::CoinCollect(const char* name) : al::LiveActor(name) {}
 
-void CoinCollect::init(const al::ActorInitInfo& initInfo) {
+void CoinCollect::init(const al::ActorInitInfo& info) {
     using CoinCollectFunctor = al::FunctorV0M<CoinCollect*, void (CoinCollect::*)()>;
 
-    al::initActorSceneInfo(this, initInfo);
+    al::initActorSceneInfo(this, info);
     rs::createCoinCollectWatcher(this);
     rs::createCoinCollectHolder(this);
 
     al::getSceneObj<CoinCollectHolder>(this)->registerCoinCollect(this);
 
-    if (GameDataFunction::isGotCoinCollect(this, initInfo)) {
+    if (GameDataFunction::isGotCoinCollect(this, info)) {
         const char* archiveName = rs::getStageCoinCollectEmptyArchiveName(this);
         al::getSceneObj<CoinCollectWatcher>(this)->registerCoin(true);
         CoinCollectEmpty* coinCollectEmpty = new CoinCollectEmpty("コレクトコイン空", archiveName);
-        al::initCreateActorWithPlacementInfo(coinCollectEmpty, initInfo);
+        al::initCreateActorWithPlacementInfo(coinCollectEmpty, info);
         makeActorDead();
         mCoinCollectEmpty = coinCollectEmpty;
         _198 = false;
@@ -72,7 +72,7 @@ void CoinCollect::init(const al::ActorInitInfo& initInfo) {
 
     al::getSceneObj<CoinCollectWatcher>(this)->registerCoin(false);
     const char* archiveName = rs::getStageCoinCollectArchiveName(this);
-    al::initActorWithArchiveName(this, initInfo, archiveName, nullptr);
+    al::initActorWithArchiveName(this, info, archiveName, nullptr);
     al::initNerve(this, &NrvCoinCollect.Wait, 2);
 
     mStateCountUp = new CoinStateCountUp(this);
@@ -81,12 +81,12 @@ void CoinCollect::init(const al::ActorInitInfo& initInfo) {
     mHintState = new CoinCollectHintState(this);
     al::initNerveState(this, mHintState, &NrvCoinCollect.WaitAmiibo, "ヒント");
 
-    al::tryAddDisplayOffset(this, initInfo);
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+    al::tryAddDisplayOffset(this, info);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
 
     mQuat.set(al::getQuat(this));
 
-    mPlacementId = al::createPlacementId(initInfo);
+    mPlacementId = al::createPlacementId(info);
     mExternalForceKeeper = new ExternalForceKeeper();
 
     mRotateCalculator = new CoinRotateCalculator(this);
@@ -98,14 +98,14 @@ void CoinCollect::init(const al::ActorInitInfo& initInfo) {
         makeActorAlive();
 
     al::offCollide(this);
-    mShadowLength = rs::setShadowDropLength(this, initInfo, "本体");
+    mShadowLength = rs::setShadowDropLength(this, info, "本体");
     al::expandClippingRadiusByShadowLength(this, nullptr, mShadowLength);
-    mWaterSurfaceShadow = rs::tryCreateWaterSurfaceCoinShadow(initInfo);
+    mWaterSurfaceShadow = rs::tryCreateWaterSurfaceCoinShadow(info);
     al::setEffectNamedMtxPtr(this, "WaterSurface", &mSurfaceMatrix);
 }
 
 void CoinCollect::initAfterPlacement() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -175,7 +175,7 @@ void CoinCollect::appear() {
 }
 
 void CoinCollect::makeActorAlive() {
-    if (mCoinCollectEmpty == nullptr && !al::isNerve(this, &NrvCoinCollect.Got))
+    if (!mCoinCollectEmpty  && !al::isNerve(this, &NrvCoinCollect.Got))
         al::LiveActor::makeActorAlive();
 }
 
@@ -188,7 +188,7 @@ void CoinCollect::listenAppear() {
 }
 
 const sead::Vector3f& CoinCollect::getTransForHint() const {
-    if (mCoinCollectEmpty != nullptr)
+    if (mCoinCollectEmpty )
         return al::getTrans(mCoinCollectEmpty);
 
     return al::getTrans(this);
@@ -219,7 +219,7 @@ bool CoinCollect::isEnableHint() const {
 }
 
 void CoinCollect::rotate() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);
@@ -232,7 +232,7 @@ void CoinCollect::exeWait() {
         rs::tryUpdateWaterSurfaceCoinShadow(mWaterSurfaceShadow, this, mShadowLength);
     }
 
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     rotate();
@@ -242,7 +242,7 @@ void CoinCollect::exeWait() {
 }
 
 void CoinCollect::exeWaitAmiibo() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     rotate();
@@ -259,12 +259,12 @@ void CoinCollect::exeGot() {
         rs::tryShowCapMsgCollectCoinGetFirst(this);
         al::startAction(this, "Got");
         alPadRumbleFunction::startPadRumble(this, "コッ（微弱）", 1000.0f, 5000.0f);
-        if (mWaterSurfaceShadow != nullptr)
+        if (mWaterSurfaceShadow )
             mWaterSurfaceShadow->disappearShadow();
         _198 = false;
     }
 
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     if (al::isActionEnd(this)) {
@@ -293,7 +293,7 @@ void CoinCollect::exeCountUp() {
         GameDataFunction::addCoinCollect(this, mPlacementId);
 
         rs::tryShowCapMsgCollectCoinGetFirst(this);
-        if (mWaterSurfaceShadow != nullptr)
+        if (mWaterSurfaceShadow )
             mWaterSurfaceShadow->disappearShadow();
 
         al::startHitReaction(this, "釣り取得");
@@ -307,7 +307,7 @@ void CoinCollect::exeBlow() {
         al::onCollide(this);
     }
 
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);
@@ -317,7 +317,7 @@ void CoinCollect::exeBlow() {
 
     if (al::getVelocity(this).y < 0.0f && al::isCollidedGround(this)) {
         if (al::calcSpeed(this) < 15.0f) {
-            if (mMtxConnector != nullptr)
+            if (mMtxConnector )
                 al::attachMtxConnectorToCollision(mMtxConnector, this, false);
             al::setVelocityZero(this);
             al::setNerve(this, &NrvCoinCollect.Wait);

--- a/src/Item/CoinCollect.h
+++ b/src/Item/CoinCollect.h
@@ -25,7 +25,7 @@ class CoinCollect : public al::LiveActor {
 public:
     CoinCollect(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void control() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,

--- a/src/Item/CoinCollect2D.cpp
+++ b/src/Item/CoinCollect2D.cpp
@@ -34,15 +34,15 @@ NERVES_MAKE_STRUCT(CoinCollect2D, Wait, WaitHint, Got);
 
 CoinCollect2D::CoinCollect2D(const char* name) : al::LiveActor(name) {}
 
-void CoinCollect2D::init(const al::ActorInitInfo& initInfo) {
-    al::initActorSceneInfo(this, initInfo);
+void CoinCollect2D::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
     rs::createCoinCollectWatcher(this);
     rs::createCoinCollectHolder(this);
     CoinCollectHolder* holder = al::getSceneObj<CoinCollectHolder>(this);
     holder->registerCoinCollect2D(this);
 
-    if (!GameDataFunction::isGotCoinCollect(this, initInfo)) {
-        al::initActorWithArchiveName(this, initInfo, rs::getStageCoinCollect2DArchiveName(this),
+    if (!GameDataFunction::isGotCoinCollect(this, info)) {
+        al::initActorWithArchiveName(this, info, rs::getStageCoinCollect2DArchiveName(this),
                                      nullptr);
         makeActorAlive();
         CoinCollectWatcher* watcher = al::getSceneObj<CoinCollectWatcher>(this);
@@ -52,13 +52,13 @@ void CoinCollect2D::init(const al::ActorInitInfo& initInfo) {
         mHintState = new CoinCollectHintState(this);
         al::initNerveState(this, mHintState, &NrvCoinCollect2D.WaitHint, "ヒント");
 
-        al::tryAddDisplayOffset(this, initInfo);
-        mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+        al::tryAddDisplayOffset(this, info);
+        mMtxConnector = al::tryCreateMtxConnector(this, info);
         mDimensionKeeper = rs::createDimensionKeeper(this);
         rs::updateDimensionKeeper(mDimensionKeeper);
         rs::snap2DParallelizeFront(this, this, 500.0f);
         al::startAction(this, "Wait");
-        mPlacementId = al::createPlacementId(initInfo);
+        mPlacementId = al::createPlacementId(info);
 
     } else {
         makeActorDead();
@@ -68,12 +68,12 @@ void CoinCollect2D::init(const al::ActorInitInfo& initInfo) {
 
         CoinCollectEmpty2D* coinCollectEmpty2d =
             new CoinCollectEmpty2D("コレクトコイン空2D", archiveName);
-        al::initCreateActorWithPlacementInfo(coinCollectEmpty2d, initInfo);
+        al::initCreateActorWithPlacementInfo(coinCollectEmpty2d, info);
     }
 }
 
 void CoinCollect2D::initAfterPlacement() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -122,12 +122,12 @@ void CoinCollect2D::exeWait() {
     if (al::isFirstStep(this))
         al::validateClipping(this);
 
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 }
 
 void CoinCollect2D::exeWaitHint() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     if (al::updateNerveState(this))

--- a/src/Item/CoinCollect2D.cpp
+++ b/src/Item/CoinCollect2D.cpp
@@ -73,7 +73,7 @@ void CoinCollect2D::init(const al::ActorInitInfo& info) {
 }
 
 void CoinCollect2D::initAfterPlacement() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -122,12 +122,12 @@ void CoinCollect2D::exeWait() {
     if (al::isFirstStep(this))
         al::validateClipping(this);
 
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 }
 
 void CoinCollect2D::exeWaitHint() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     if (al::updateNerveState(this))

--- a/src/Item/CoinCollect2D.h
+++ b/src/Item/CoinCollect2D.h
@@ -19,7 +19,7 @@ class CoinCollect2D : public al::LiveActor, public IUseDimension {
 public:
     CoinCollect2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/CoinCollectDummy.cpp
+++ b/src/Item/CoinCollectDummy.cpp
@@ -20,9 +20,9 @@ NERVES_MAKE_STRUCT(CoinCollectDummy, Hint);
 
 CoinCollectDummy::CoinCollectDummy(const char* name) : al::LiveActor(name) {}
 
-void CoinCollectDummy::init(const al::ActorInitInfo& initInfo) {
-    al::initActorSceneInfo(this, initInfo);
-    al::initActorWithArchiveName(this, initInfo, rs::getStageCoinCollectArchiveName(this), nullptr);
+void CoinCollectDummy::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorWithArchiveName(this, info, rs::getStageCoinCollectArchiveName(this), nullptr);
     al::initNerve(this, &NrvCoinCollectDummy.Hint, 1);
     mHintState = new CoinCollectHintState(this);
     al::initNerveState(this, mHintState, &NrvCoinCollectDummy.Hint, "ヒント");

--- a/src/Item/CoinCollectDummy.h
+++ b/src/Item/CoinCollectDummy.h
@@ -10,7 +10,7 @@ class CoinCollectDummy : public al::LiveActor {
 public:
     CoinCollectDummy(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void appear() override;
 
     void appearHint(const sead::Vector3f& position);

--- a/src/Item/CoinCollectEmpty.cpp
+++ b/src/Item/CoinCollectEmpty.cpp
@@ -56,7 +56,7 @@ void CoinCollectEmpty::init(const al::ActorInitInfo& info) {
 }
 
 void CoinCollectEmpty::initAfterPlacement() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -101,7 +101,7 @@ void CoinCollectEmpty::control() {
 }
 
 void CoinCollectEmpty::rotate() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);

--- a/src/Item/CoinCollectEmpty.cpp
+++ b/src/Item/CoinCollectEmpty.cpp
@@ -34,18 +34,18 @@ NERVES_MAKE_STRUCT(CoinCollectEmpty, Wait, Got, CountUp);
 CoinCollectEmpty::CoinCollectEmpty(const char* name, const char* archiveName)
     : al::LiveActor(name), mArchiveName(archiveName) {}
 
-void CoinCollectEmpty::init(const al::ActorInitInfo& initInfo) {
-    al::initActorSceneInfo(this, initInfo);
-    al::initActorWithArchiveName(this, initInfo, mArchiveName, nullptr);
+void CoinCollectEmpty::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorWithArchiveName(this, info, mArchiveName, nullptr);
     al::initNerve(this, &NrvCoinCollectEmpty.Wait, 1);
     mStateCountUp = new CoinStateCountUp(this);
     al::initNerveState(this, mStateCountUp, &NrvCoinCollectEmpty.Got, "カウントアップ状態");
     mRotateCalculator = new CoinRotateCalculator(this);
-    al::tryAddDisplayOffset(this, initInfo);
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+    al::tryAddDisplayOffset(this, info);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
     mExternalForceKeeper = new ExternalForceKeeper();
     al::expandClippingRadiusByShadowLength(this, nullptr,
-                                           rs::setShadowDropLength(this, initInfo, "本体"));
+                                           rs::setShadowDropLength(this, info, "本体"));
 
     if (al::isExistDitherAnimator(this))
         al::stopDitherAnimAutoCtrl(this);
@@ -56,7 +56,7 @@ void CoinCollectEmpty::init(const al::ActorInitInfo& initInfo) {
 }
 
 void CoinCollectEmpty::initAfterPlacement() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 }
 
@@ -101,7 +101,7 @@ void CoinCollectEmpty::control() {
 }
 
 void CoinCollectEmpty::rotate() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 
     al::setQuat(this, sead::Quatf::unit);

--- a/src/Item/CoinCollectEmpty.h
+++ b/src/Item/CoinCollectEmpty.h
@@ -20,7 +20,7 @@ class CoinCollectEmpty : public al::LiveActor {
 public:
     CoinCollectEmpty(const char* name, const char* archiveName);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/CoinCollectEmpty2D.cpp
+++ b/src/Item/CoinCollectEmpty2D.cpp
@@ -45,7 +45,7 @@ void CoinCollectEmpty2D::init(const al::ActorInitInfo& info) {
 }
 
 void CoinCollectEmpty2D::initAfterPlacement() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 
     sead::Matrix44f matrix = sead::Matrix44f::ident;
@@ -78,7 +78,7 @@ void CoinCollectEmpty2D::endClipped() {
 }
 
 void CoinCollectEmpty2D::exeWait() {
-    if (mMtxConnector )
+    if (mMtxConnector)
         al::connectPoseQT(this, mMtxConnector);
 }
 

--- a/src/Item/CoinCollectEmpty2D.cpp
+++ b/src/Item/CoinCollectEmpty2D.cpp
@@ -31,11 +31,11 @@ NERVES_MAKE_STRUCT(CoinCollectEmpty2D, Wait, Got);
 CoinCollectEmpty2D::CoinCollectEmpty2D(const char* name, const char* archiveName)
     : al::LiveActor(name), mArchiveName(archiveName) {}
 
-void CoinCollectEmpty2D::init(const al::ActorInitInfo& initInfo) {
-    al::initActorSceneInfo(this, initInfo);
-    al::initActorWithArchiveName(this, initInfo, mArchiveName, nullptr);
-    al::tryAddDisplayOffset(this, initInfo);
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+void CoinCollectEmpty2D::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorWithArchiveName(this, info, mArchiveName, nullptr);
+    al::tryAddDisplayOffset(this, info);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
     mDimensionKeeper = rs::createDimensionKeeper(this);
     rs::updateDimensionKeeper(mDimensionKeeper);
     rs::snap2DParallelizeFront(this, this, 500.0f);
@@ -45,7 +45,7 @@ void CoinCollectEmpty2D::init(const al::ActorInitInfo& initInfo) {
 }
 
 void CoinCollectEmpty2D::initAfterPlacement() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::attachMtxConnectorToCollision(mMtxConnector, this, false);
 
     sead::Matrix44f matrix = sead::Matrix44f::ident;
@@ -78,7 +78,7 @@ void CoinCollectEmpty2D::endClipped() {
 }
 
 void CoinCollectEmpty2D::exeWait() {
-    if (mMtxConnector != nullptr)
+    if (mMtxConnector )
         al::connectPoseQT(this, mMtxConnector);
 }
 

--- a/src/Item/CoinCollectEmpty2D.h
+++ b/src/Item/CoinCollectEmpty2D.h
@@ -17,7 +17,7 @@ class CoinCollectEmpty2D : public al::LiveActor, public IUseDimension {
 public:
     CoinCollectEmpty2D(const char* name, const char* archiveName);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/CoinCollectWatcher.cpp
+++ b/src/Item/CoinCollectWatcher.cpp
@@ -11,8 +11,8 @@
 
 CoinCollectWatcher::CoinCollectWatcher() : al::ISceneObj() {}
 
-void CoinCollectWatcher::initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) {
-    mCoinCollectLayout = new CoinCollectLayout(al::getLayoutInitInfo(initInfo));
+void CoinCollectWatcher::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    mCoinCollectLayout = new CoinCollectLayout(al::getLayoutInitInfo(info));
 }
 
 void CoinCollectWatcher::registerCoin(bool isCountUpCoin) {

--- a/src/Item/CoinCollectWatcher.h
+++ b/src/Item/CoinCollectWatcher.h
@@ -23,7 +23,7 @@ public:
 
     const char* getSceneObjName() const override { return "コインコレクト監視者"; }
 
-    void initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
 
     void registerCoin(bool isCountUpCoin);
     void countup(const al::LiveActor* actor);

--- a/src/Item/CoinRail.cpp
+++ b/src/Item/CoinRail.cpp
@@ -63,15 +63,15 @@ __attribute__((always_inline)) void addCoinToRail(CoinRail* rail, const al::Acto
     al::getRailTotalLength(rail);
 }
 
-void CoinRail::init(const al::ActorInitInfo& initInfo) {
-    al::initActor(this, initInfo);
+void CoinRail::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
 
     if (!al::isExistRail(this)) {
         kill();
         return;
     }
 
-    al::getArg(&mCoinNum, initInfo, "CoinNum");
+    al::getArg(&mCoinNum, info, "CoinNum");
     if (mCoinNum <= 1) {
         kill();
         return;
@@ -83,24 +83,24 @@ void CoinRail::init(const al::ActorInitInfo& initInfo) {
         return;
     }
 
-    al::tryGetArg(&mMoveVelocity, initInfo, "MoveVelocity");
+    al::tryGetArg(&mMoveVelocity, info, "MoveVelocity");
     if (mMoveVelocity < 0.0f) {
         kill();
         return;
     }
 
-    al::tryGetDisplayOffset(&mDisplayOffset, initInfo);
+    al::tryGetDisplayOffset(&mDisplayOffset, info);
 
     mCoins = new Coin*[mCoinNum];
     mRailPos = new f32[mCoinNum];
 
     if (al::isNearZero(mMoveVelocity))
-        addStaticCoinToRail(this, initInfo, mCoins, mRailPos, mCoinNum, isLoop);
+        addStaticCoinToRail(this, info, mCoins, mRailPos, mCoinNum, isLoop);
     else
-        addCoinToRail(this, initInfo, mCoins, mRailPos, mCoinNum);
+        addCoinToRail(this, info, mCoins, mRailPos, mCoinNum);
 
     f32 shadowLength = 1500.0f;
-    al::tryGetArg(&shadowLength, initInfo, "ShadowLength");
+    al::tryGetArg(&shadowLength, info, "ShadowLength");
     for (s32 i = 0; i < mCoinNum; i++)
         mCoins[i]->setShadowDropLength(shadowLength);
 
@@ -110,7 +110,7 @@ void CoinRail::init(const al::ActorInitInfo& initInfo) {
     f32 clipInfo = 0.0f;
     al::calcRailClippingInfo(&mClippingInfo, &clipInfo, this, 100.0f, 100.0f);
     al::setClippingInfo(this, clipInfo, &mClippingInfo);
-    al::initSubActorKeeperNoFile(this, initInfo, mCoinNum);
+    al::initSubActorKeeperNoFile(this, info, mCoinNum);
 
     for (s32 i = 0; i < mCoinNum; i++) {
         al::invalidateClipping(mCoins[i]);

--- a/src/Item/CoinRail.h
+++ b/src/Item/CoinRail.h
@@ -17,7 +17,7 @@ class CoinRail : public al::LiveActor {
 public:
     CoinRail(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void appear() override;
     void kill() override;
     void makeActorDead() override;

--- a/src/Item/CoinStack.cpp
+++ b/src/Item/CoinStack.cpp
@@ -26,8 +26,8 @@ NERVES_MAKE_STRUCT(CoinStack, Wait, Fall, Float);
 
 CoinStack::CoinStack(const char* name) : al::LiveActor(name) {}
 
-void CoinStack::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "CoinStack", nullptr);
+void CoinStack::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "CoinStack", nullptr);
     al::initNerve(this, &NrvCoinStack.Wait, 0);
     al::setClippingNearDistance(this, -1.0f);
     makeActorDead();
@@ -100,7 +100,7 @@ void CoinStack::signalFall(u32 delay, f32 radius) {
     mClippingRadius = radius;
     mClippingPos.y += fallDistance * -0.5f;
 
-    if (mStackAbove != nullptr)
+    if (mStackAbove )
         mStackAbove->signalFall(delay + 1, radius);
 
     if (!al::isNerve(this, &NrvCoinStack.Float) && !al::isNerve(this, &NrvCoinStack.Fall)) {
@@ -121,7 +121,7 @@ void CoinStack::postInit(CoinStackGroup* coinStackGroup, const sead::Vector3f& t
     al::setTrans(this, transY);
     mLandHeight = transY.y;
     mTransY = transY.y;
-    if (mStackBelow != nullptr)
+    if (mStackBelow )
         mStackBelow->setAbove(this);
 }
 
@@ -147,7 +147,7 @@ void CoinStack::exeFall() {
         return;
     }
 
-    if (mStackBelow != nullptr && mTransY - mStackBelow->getTransY() < *mExternalFallDistance)
+    if (mStackBelow  && mTransY - mStackBelow->getTransY() < *mExternalFallDistance)
         al::setNerve(this, &Land);
     else
         al::setTransY(this, mTransY);
@@ -160,7 +160,7 @@ void CoinStack::exeLand() {
     }
 
     if (al::isActionEnd(this)) {
-        if (mStackAbove == nullptr)
+        if (!mStackAbove )
             mCoinStackGroup->validateClipping();
 
         al::setClippingInfo(this, mClippingRadius, &mClippingPos);
@@ -180,10 +180,10 @@ void CoinStack::exeCollected() {
     GameDataFunction::addCoin(this, 5);
     mClippingRadius = mCoinStackGroup->setStackAsCollected(this);
 
-    if (mStackBelow != nullptr)
+    if (mStackBelow )
         mStackBelow->setAbove(mStackAbove);
 
-    if (mStackAbove != nullptr) {
+    if (mStackAbove ) {
         mStackAbove->setBelow(mStackBelow);
         mStackAbove->signalFall(0, mClippingRadius);
     }

--- a/src/Item/CoinStack.cpp
+++ b/src/Item/CoinStack.cpp
@@ -100,7 +100,7 @@ void CoinStack::signalFall(u32 delay, f32 radius) {
     mClippingRadius = radius;
     mClippingPos.y += fallDistance * -0.5f;
 
-    if (mStackAbove )
+    if (mStackAbove)
         mStackAbove->signalFall(delay + 1, radius);
 
     if (!al::isNerve(this, &NrvCoinStack.Float) && !al::isNerve(this, &NrvCoinStack.Fall)) {
@@ -121,7 +121,7 @@ void CoinStack::postInit(CoinStackGroup* coinStackGroup, const sead::Vector3f& t
     al::setTrans(this, transY);
     mLandHeight = transY.y;
     mTransY = transY.y;
-    if (mStackBelow )
+    if (mStackBelow)
         mStackBelow->setAbove(this);
 }
 
@@ -147,7 +147,7 @@ void CoinStack::exeFall() {
         return;
     }
 
-    if (mStackBelow  && mTransY - mStackBelow->getTransY() < *mExternalFallDistance)
+    if (mStackBelow && mTransY - mStackBelow->getTransY() < *mExternalFallDistance)
         al::setNerve(this, &Land);
     else
         al::setTransY(this, mTransY);
@@ -160,7 +160,7 @@ void CoinStack::exeLand() {
     }
 
     if (al::isActionEnd(this)) {
-        if (!mStackAbove )
+        if (!mStackAbove)
             mCoinStackGroup->validateClipping();
 
         al::setClippingInfo(this, mClippingRadius, &mClippingPos);
@@ -180,10 +180,10 @@ void CoinStack::exeCollected() {
     GameDataFunction::addCoin(this, 5);
     mClippingRadius = mCoinStackGroup->setStackAsCollected(this);
 
-    if (mStackBelow )
+    if (mStackBelow)
         mStackBelow->setAbove(mStackAbove);
 
-    if (mStackAbove ) {
+    if (mStackAbove) {
         mStackAbove->setBelow(mStackBelow);
         mStackAbove->signalFall(0, mClippingRadius);
     }

--- a/src/Item/CoinStack.h
+++ b/src/Item/CoinStack.h
@@ -18,7 +18,7 @@ public:
     CoinStack(const char* name);
     virtual ~CoinStack() = default;
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
 

--- a/src/Item/CoinStackGroup.h
+++ b/src/Item/CoinStackGroup.h
@@ -18,7 +18,7 @@ class CoinStackGroup : public al::LiveActor {
 public:
     CoinStackGroup(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/CoinStateAppearRotate.cpp
+++ b/src/Item/CoinStateAppearRotate.cpp
@@ -46,7 +46,7 @@ void CoinStateAppearRotate::exeRotate() {
     al::calcUpDir(&upDir, actor);
     al::rotateVectorDegree(&frontDir, frontDir, upDir, 15.0f);
 
-    if (mMtxConnector == nullptr) {
+    if (!mMtxConnector ) {
         al::getTransPtr(actor)->y = mInitialTransY + mOffset.y;
 
         sead::Quatf quad = sead::Quatf::unit;

--- a/src/Item/CoinStateAppearRotate.cpp
+++ b/src/Item/CoinStateAppearRotate.cpp
@@ -46,7 +46,7 @@ void CoinStateAppearRotate::exeRotate() {
     al::calcUpDir(&upDir, actor);
     al::rotateVectorDegree(&frontDir, frontDir, upDir, 15.0f);
 
-    if (!mMtxConnector ) {
+    if (!mMtxConnector) {
         al::getTransPtr(actor)->y = mInitialTransY + mOffset.y;
 
         sead::Quatf quad = sead::Quatf::unit;

--- a/src/Item/LifeMaxUpItem.h
+++ b/src/Item/LifeMaxUpItem.h
@@ -14,7 +14,7 @@ class LifeMaxUpItem : public al::LiveActor {
 public:
     LifeMaxUpItem(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/LifeMaxUpItem2D.h
+++ b/src/Item/LifeMaxUpItem2D.h
@@ -20,7 +20,7 @@ class LifeMaxUpItem2D : public al::LiveActor, public IUseDimension {
 public:
     LifeMaxUpItem2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     ActorDimensionKeeper* getActorDimensionKeeper() const override;

--- a/src/Item/LifeUpItem.h
+++ b/src/Item/LifeUpItem.h
@@ -19,7 +19,7 @@ class LifeUpItem : public al::LiveActor {
 public:
     LifeUpItem(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Item/LifeUpItem2D.h
+++ b/src/Item/LifeUpItem2D.h
@@ -19,7 +19,7 @@ class LifeUpItem2D : public al::LiveActor, public IUseDimension {
 public:
     LifeUpItem2D(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     ActorDimensionKeeper* getActorDimensionKeeper() const override;

--- a/src/Item/Shine.h
+++ b/src/Item/Shine.h
@@ -10,7 +10,7 @@ class Shine : public al::LiveActor, public IUseDimension {
 public:
     Shine(const char*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     al::LiveActor* getCurrentModel();
     bool tryExpandShadowAndClipping();
     void initAppearDemo(const al::ActorInitInfo&);

--- a/src/Layout/Compass.cpp
+++ b/src/Layout/Compass.cpp
@@ -48,10 +48,10 @@ void Compass::appear() {
 
         al::LiveActor* player = al::tryGetPlayerActor(mPlayerHolder, 0);
 
-        if (player != nullptr) {
+        if (player ) {
             al::AreaObj* area = al::tryFindAreaObj(player, "CompassArea", al::getTrans(player));
 
-            if (area != nullptr && isAreaMadness(area))
+            if (area  && isAreaMadness(area))
                 return;
         }
 
@@ -74,7 +74,7 @@ void Compass::appear() {
     } else {
         al::LiveActor* player = al::tryGetPlayerActor(mPlayerHolder, 0);
 
-        if (player == nullptr || !al::isInAreaObj(player, "CompassArea", al::getTrans(player)))
+        if (!player  || !al::isInAreaObj(player, "CompassArea", al::getTrans(player)))
             return;
 
         al::LayoutActor::appear();

--- a/src/Layout/Compass.cpp
+++ b/src/Layout/Compass.cpp
@@ -48,10 +48,10 @@ void Compass::appear() {
 
         al::LiveActor* player = al::tryGetPlayerActor(mPlayerHolder, 0);
 
-        if (player ) {
+        if (player) {
             al::AreaObj* area = al::tryFindAreaObj(player, "CompassArea", al::getTrans(player));
 
-            if (area  && isAreaMadness(area))
+            if (area && isAreaMadness(area))
                 return;
         }
 
@@ -74,7 +74,7 @@ void Compass::appear() {
     } else {
         al::LiveActor* player = al::tryGetPlayerActor(mPlayerHolder, 0);
 
-        if (!player  || !al::isInAreaObj(player, "CompassArea", al::getTrans(player)))
+        if (!player || !al::isInAreaObj(player, "CompassArea", al::getTrans(player)))
             return;
 
         al::LayoutActor::appear();

--- a/src/Layout/KidsModeLayoutAccessor.cpp
+++ b/src/Layout/KidsModeLayoutAccessor.cpp
@@ -4,7 +4,7 @@
 
 #include "System/GameDataUtil.h"
 
-KidsModeLayoutAccessor::KidsModeLayoutAccessor() {}
+KidsModeLayoutAccessor::KidsModeLayoutAccessor() = default;
 
 namespace rs {
 void setKidsModeLayoutDisable(const al::IUseSceneObjHolder* user) {

--- a/src/MapObj/AnagramAlphabet.h
+++ b/src/MapObj/AnagramAlphabet.h
@@ -17,7 +17,7 @@ class SaveObjInfo;
 class AnagramAlphabet : public al::LiveActor {
 public:
     AnagramAlphabet(const char*);
-    void init(const al::ActorInitInfo&);
+    void init(const al::ActorInitInfo& info);
     bool testBase(AnagramAlphabetCharacter*);
     bool testEndHack();
     bool testComplete();

--- a/src/MapObj/AppearSwitchTimer.cpp
+++ b/src/MapObj/AppearSwitchTimer.cpp
@@ -87,7 +87,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
 
             al::ActorCreatorFunction creatorFunction = nullptr;
             switchFactory->getEntryIndex(&creatorFunction, className);
-            if (creatorFunction ) {
+            if (creatorFunction) {
                 const char* displayName;
                 al::getDisplayName(&displayName, targetInfo);
                 createdActor = creatorFunction(displayName);
@@ -100,7 +100,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
                 mShine = ((TreasureBoxKey*)createdActor)->getShine();
         }
 
-        if (createdActor  && createdActor->getHitSensorKeeper()  &&
+        if (createdActor && createdActor->getHitSensorKeeper() &&
             createdActor->getHitSensorKeeper()->getSensorNum() != 0) {
             if (al::isEqualString("Shine", linkActorName) ||
                 al::isEqualString("TreasureBoxKey", linkActorName)) {
@@ -111,7 +111,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
         }
     }
 
-    if (mShine )
+    if (mShine)
         rs::updateHintTrans(mShine, al::getTrans(mHost));
 
     mIsInvalidHideRouteGuide = al::tryGetBoolArgOrFalse(info, "IsInvalidHideRouteGuide");
@@ -156,7 +156,7 @@ void AppearSwitchTimer::onSwitch() {
     if (!mIsInvalidHideRouteGuide)
         rs::offRouteGuideByActor(mHost);
 
-    if (mShine )
+    if (mShine)
         rs::updateHintTrans(mShine, al::getTrans(mShine));
 
     if (mDemoCameraFrame != 0) {
@@ -195,7 +195,7 @@ void AppearSwitchTimer::offSwitch() {
     if (!mIsInvalidHideRouteGuide)
         rs::onRouteGuideByActor(mHost);
 
-    if (mShine )
+    if (mShine)
         rs::updateHintTrans(mShine, al::getTrans(mHost));
 
     if (isDemoPlaying()) {
@@ -220,7 +220,7 @@ void AppearSwitchTimer::exeWaitAppearDemoStart() {
         else
             al::startCamera(mCamera, mCameraTicket, mCameraStartInterpFrame);
 
-        if (mDemoInfo )
+        if (mDemoInfo)
             al::addDemoActorFromAddDemoInfo(mHost, mDemoInfo);
         al::setNerve(this, &NrvAppearSwitchTimer.WaitAppearDemoCameraInterpoling);
     }
@@ -288,7 +288,7 @@ void AppearSwitchTimer::procAppearDitherAnim(s32 offset) {
 void AppearSwitchTimer::exeOnWait() {
     procAppearDitherAnim(mDemoCameraFrame);
     al::AreaObj* area = mTimerValidArea;
-    if (area ) {
+    if (area) {
         al::LiveActor* player = al::tryFindNearestPlayerActor(mHost);
         if (player && !al::isInAreaPos(area, al::getTrans(player))) {
             offSwitch();
@@ -316,9 +316,9 @@ void AppearSwitchTimer::exeOnWaitBlink() {
         al::holdSe(mAudioKeeper, "TimerLoopFast");
 
     al::AreaObj* area = mTimerValidArea;
-    if (area ) {
+    if (area) {
         al::LiveActor* nearest = al::tryFindNearestPlayerActor(mHost);
-        if (nearest  && !al::isInAreaPos(area, al::getTrans(nearest))) {
+        if (nearest && !al::isInAreaPos(area, al::getTrans(nearest))) {
             offSwitch();
             return;
         }

--- a/src/MapObj/AppearSwitchTimer.cpp
+++ b/src/MapObj/AppearSwitchTimer.cpp
@@ -87,7 +87,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
 
             al::ActorCreatorFunction creatorFunction = nullptr;
             switchFactory->getEntryIndex(&creatorFunction, className);
-            if (creatorFunction != nullptr) {
+            if (creatorFunction ) {
                 const char* displayName;
                 al::getDisplayName(&displayName, targetInfo);
                 createdActor = creatorFunction(displayName);
@@ -100,7 +100,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
                 mShine = ((TreasureBoxKey*)createdActor)->getShine();
         }
 
-        if (createdActor != nullptr && createdActor->getHitSensorKeeper() != nullptr &&
+        if (createdActor  && createdActor->getHitSensorKeeper()  &&
             createdActor->getHitSensorKeeper()->getSensorNum() != 0) {
             if (al::isEqualString("Shine", linkActorName) ||
                 al::isEqualString("TreasureBoxKey", linkActorName)) {
@@ -111,7 +111,7 @@ void AppearSwitchTimer::init(const al::ActorInitInfo& info, const al::IUseAudioK
         }
     }
 
-    if (mShine != nullptr)
+    if (mShine )
         rs::updateHintTrans(mShine, al::getTrans(mHost));
 
     mIsInvalidHideRouteGuide = al::tryGetBoolArgOrFalse(info, "IsInvalidHideRouteGuide");
@@ -156,7 +156,7 @@ void AppearSwitchTimer::onSwitch() {
     if (!mIsInvalidHideRouteGuide)
         rs::offRouteGuideByActor(mHost);
 
-    if (mShine != nullptr)
+    if (mShine )
         rs::updateHintTrans(mShine, al::getTrans(mShine));
 
     if (mDemoCameraFrame != 0) {
@@ -195,7 +195,7 @@ void AppearSwitchTimer::offSwitch() {
     if (!mIsInvalidHideRouteGuide)
         rs::onRouteGuideByActor(mHost);
 
-    if (mShine != nullptr)
+    if (mShine )
         rs::updateHintTrans(mShine, al::getTrans(mHost));
 
     if (isDemoPlaying()) {
@@ -220,7 +220,7 @@ void AppearSwitchTimer::exeWaitAppearDemoStart() {
         else
             al::startCamera(mCamera, mCameraTicket, mCameraStartInterpFrame);
 
-        if (mDemoInfo != nullptr)
+        if (mDemoInfo )
             al::addDemoActorFromAddDemoInfo(mHost, mDemoInfo);
         al::setNerve(this, &NrvAppearSwitchTimer.WaitAppearDemoCameraInterpoling);
     }
@@ -288,7 +288,7 @@ void AppearSwitchTimer::procAppearDitherAnim(s32 offset) {
 void AppearSwitchTimer::exeOnWait() {
     procAppearDitherAnim(mDemoCameraFrame);
     al::AreaObj* area = mTimerValidArea;
-    if (area != nullptr) {
+    if (area ) {
         al::LiveActor* player = al::tryFindNearestPlayerActor(mHost);
         if (player && !al::isInAreaPos(area, al::getTrans(player))) {
             offSwitch();
@@ -316,9 +316,9 @@ void AppearSwitchTimer::exeOnWaitBlink() {
         al::holdSe(mAudioKeeper, "TimerLoopFast");
 
     al::AreaObj* area = mTimerValidArea;
-    if (area != nullptr) {
+    if (area ) {
         al::LiveActor* nearest = al::tryFindNearestPlayerActor(mHost);
-        if (nearest != nullptr && !al::isInAreaPos(area, al::getTrans(nearest))) {
+        if (nearest  && !al::isInAreaPos(area, al::getTrans(nearest))) {
             offSwitch();
             return;
         }

--- a/src/MapObj/AppearSwitchTimer.h
+++ b/src/MapObj/AppearSwitchTimer.h
@@ -21,7 +21,7 @@ class AppearSwitchTimer : public al::NerveExecutor {
 public:
     AppearSwitchTimer();
     void init(const al::ActorInitInfo& info, const al::IUseAudioKeeper* audioKeeper,
-              al::IUseStageSwitch* stageSwitch, al::IUseCamera* camera, al::LiveActor* actor);
+              al::IUseStageSwitch* stageSwitch, al::IUseCamera* camera, al::LiveActor* host);
     void onSwitch();
     bool isSwitchOn();
     void offSwitch();

--- a/src/MapObj/BlinkRateCalculator.cpp
+++ b/src/MapObj/BlinkRateCalculator.cpp
@@ -4,7 +4,7 @@
 
 BlinkRateCalculator::BlinkRateCalculator(s32 maxFrames) : mMaxFrames(maxFrames) {}
 
-BlinkRateCalculator::BlinkRateCalculator() {}
+BlinkRateCalculator::BlinkRateCalculator() = default;
 
 void BlinkRateCalculator::reset() {
     mCurrentFrame = 0;

--- a/src/MapObj/CapHanger.h
+++ b/src/MapObj/CapHanger.h
@@ -21,8 +21,8 @@ public:
     void initAfterPlacement() override;
     void kill() override;
     void control() override;
-    void attackSensor(al::HitSensor* other, al::HitSensor* self) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void exeWait();
     void exeKeep();
     void exeRelease();

--- a/src/MapObj/CapHanger.h
+++ b/src/MapObj/CapHanger.h
@@ -22,7 +22,8 @@ public:
     void kill() override;
     void control() override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void exeWait();
     void exeKeep();
     void exeRelease();

--- a/src/MapObj/CapSwitch.cpp
+++ b/src/MapObj/CapSwitch.cpp
@@ -76,25 +76,25 @@ void CapSwitch::listenReset() {
         al::setNerve(this, &NrvCapSwitch.ReturnOff);
 }
 
-bool CapSwitch::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
+bool CapSwitch::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
     if (al::isNerve(this, &NrvCapSwitch.OffWaitInvalid))
-        return rs::isMsgPlayerDisregardHomingAttack(msg);
+        return rs::isMsgPlayerDisregardHomingAttack(message);
 
-    if (rs::isMsgCapStartLockOn(msg) && al::isNerve(this, &NrvCapSwitch.OffWait))
+    if (rs::isMsgCapStartLockOn(message) && al::isNerve(this, &NrvCapSwitch.OffWait))
         return true;
 
-    if (rs::tryReceiveMsgInitCapTargetAndSetCapTargetInfo(msg, mCapTargetInfo)) {
+    if (rs::tryReceiveMsgInitCapTargetAndSetCapTargetInfo(message, mCapTargetInfo)) {
         rs::tryGetFlyingCapPos(&mFlyingCapPos, this);
         al::invalidateClipping(this);
         al::setNerve(this, &NrvCapSwitch.OffWaitCapHold);
         return true;
     }
 
-    if ((rs::isMsgCapKeepLockOn(msg) || rs::isMsgCapIgnoreCancelLockOn(msg)) &&
+    if ((rs::isMsgCapKeepLockOn(message) || rs::isMsgCapIgnoreCancelLockOn(message)) &&
         al::isNerve(this, &NrvCapSwitch.OffWaitCapHold))
         return true;
 
-    if (rs::isMsgCapCancelLockOn(msg))
+    if (rs::isMsgCapCancelLockOn(message))
         return true;
 
     return false;

--- a/src/MapObj/CapSwitch.cpp
+++ b/src/MapObj/CapSwitch.cpp
@@ -76,7 +76,8 @@ void CapSwitch::listenReset() {
         al::setNerve(this, &NrvCapSwitch.ReturnOff);
 }
 
-bool CapSwitch::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+bool CapSwitch::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                           al::HitSensor* self) {
     if (al::isNerve(this, &NrvCapSwitch.OffWaitInvalid))
         return rs::isMsgPlayerDisregardHomingAttack(message);
 

--- a/src/MapObj/CapSwitch.h
+++ b/src/MapObj/CapSwitch.h
@@ -13,7 +13,7 @@ public:
     CapSwitch(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void initAfterPlacement() override;
     void control() override;
 

--- a/src/MapObj/CapSwitch.h
+++ b/src/MapObj/CapSwitch.h
@@ -13,7 +13,8 @@ public:
     CapSwitch(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void initAfterPlacement() override;
     void control() override;
 

--- a/src/MapObj/ChurchDoor.cpp
+++ b/src/MapObj/ChurchDoor.cpp
@@ -52,16 +52,16 @@ void ChurchDoor::init(const al::ActorInitInfo& info) {
     makeActorAlive();
 }
 
-bool ChurchDoor::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
-    if (rs::isMsgPlayerDisregardTargetMarker(msg))
+bool ChurchDoor::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 
-    if (rs::isMsgCapTouchWall(msg)) {
+    if (rs::isMsgCapTouchWall(message)) {
         if ((al::isNerve(this, &Open1) || al::isNerve(this, &Open2)) &&
             al::isLessEqualStep(this, 10))
             return true;
 
-        rs::requestHitReactionToAttacker(msg, other, al::getSensorPos(other));
+        rs::requestHitReactionToAttacker(message, other, al::getSensorPos(other));
 
         if (al::isNerve(this, &CloseWait1)) {
             al::startHitReaction(this, "ヒット1回目");

--- a/src/MapObj/ChurchDoor.cpp
+++ b/src/MapObj/ChurchDoor.cpp
@@ -52,7 +52,8 @@ void ChurchDoor::init(const al::ActorInitInfo& info) {
     makeActorAlive();
 }
 
-bool ChurchDoor::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+bool ChurchDoor::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                            al::HitSensor* self) {
     if (rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 

--- a/src/MapObj/ChurchDoor.h
+++ b/src/MapObj/ChurchDoor.h
@@ -9,7 +9,8 @@ public:
     ChurchDoor(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     bool isOpenWait() const;
     bool isDemoEnterChurch() const;

--- a/src/MapObj/ChurchDoor.h
+++ b/src/MapObj/ChurchDoor.h
@@ -9,7 +9,7 @@ public:
     ChurchDoor(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
 
     bool isOpenWait() const;
     bool isDemoEnterChurch() const;

--- a/src/MapObj/Doshi.h
+++ b/src/MapObj/Doshi.h
@@ -25,7 +25,7 @@ class Doshi : public al::LiveActor {
 public:
     Doshi(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/MapObj/ElectricWire/ElectricWireRailKeeper.cpp
+++ b/src/MapObj/ElectricWire/ElectricWireRailKeeper.cpp
@@ -75,7 +75,7 @@ void ElectricWireRailKeeper::init(const al::ActorInitInfo& info) {
             id->format("%d(Entrance)", i);
             ticketHack = al::initEntranceCamera(mElectricWire, *info.placementInfo, id->cstr());
         }
-        if (ticket != nullptr || ticketHack != nullptr)
+        if (ticket  || ticketHack )
             mCameraTickets.pushBack(new TicketHolder{ticket, ticketHack, i});
     }
     al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");

--- a/src/MapObj/ElectricWire/ElectricWireRailKeeper.cpp
+++ b/src/MapObj/ElectricWire/ElectricWireRailKeeper.cpp
@@ -75,7 +75,7 @@ void ElectricWireRailKeeper::init(const al::ActorInitInfo& info) {
             id->format("%d(Entrance)", i);
             ticketHack = al::initEntranceCamera(mElectricWire, *info.placementInfo, id->cstr());
         }
-        if (ticket  || ticketHack )
+        if (ticket || ticketHack)
             mCameraTickets.pushBack(new TicketHolder{ticket, ticketHack, i});
     }
     al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");

--- a/src/MapObj/HackFork.cpp
+++ b/src/MapObj/HackFork.cpp
@@ -54,12 +54,12 @@ PlayerHackStartShaderParam sPlayerHackStartShaderParam(true, 100.0f, 10, 20);
 HackFork::HackFork(const char* name) : al::LiveActor(name) {}
 
 // NON_MATCHING: Regswap and missing instructions https://decomp.me/scratch/NeUHJ
-void HackFork::init(const al::ActorInitInfo& initInfo) {
+void HackFork::init(const al::ActorInitInfo& info) {
     const char* modelName = nullptr;
-    if (alPlacementFunction::tryGetModelName(&modelName, initInfo))
-        al::initActorWithArchiveName(this, initInfo, modelName, nullptr);
+    if (alPlacementFunction::tryGetModelName(&modelName, info))
+        al::initActorWithArchiveName(this, info, modelName, nullptr);
     else
-        al::initActor(this, initInfo);
+        al::initActor(this, info);
 
     al::calcSideDir(&mSideDir, this);
     al::initJointControllerKeeper(this, 10);
@@ -73,11 +73,11 @@ void HackFork::init(const al::ActorInitInfo& initInfo) {
     }
 
     al::initNerve(this, &NrvHackFork.Wait, 0);
-    al::tryGetArg(&mIsLimitterFree, initInfo, "LimitterFree");
+    al::tryGetArg(&mIsLimitterFree, info, "LimitterFree");
     bool hasCamera = false;
-    bool isValid = al::tryGetArg(&hasCamera, initInfo, "Camera");
+    bool isValid = al::tryGetArg(&hasCamera, info, "Camera");
     if (hasCamera && isValid)
-        mCameraTicket = al::initObjectCamera(this, initInfo, nullptr, nullptr);
+        mCameraTicket = al::initObjectCamera(this, info, nullptr, nullptr);
 
     mMatrixCameraTarget = al::createActorMatrixCameraTarget(this, &mCameraTargetMtx);
     if (!al::isEqualString(modelName, "HackBoard")) {
@@ -86,16 +86,16 @@ void HackFork::init(const al::ActorInitInfo& initInfo) {
     }
 
     bool hasBallon = false;
-    bool isBallonValid = al::tryGetArg(&hasBallon, initInfo, "Balloon");
+    bool isBallonValid = al::tryGetArg(&hasBallon, info, "Balloon");
     if (hasBallon && isBallonValid && !rs::isSequenceTimeBalloonOrRace(this)) {
-        mEventFlowExecutor = rs::initEventFlow(this, initInfo, nullptr, nullptr);
+        mEventFlowExecutor = rs::initEventFlow(this, info, nullptr, nullptr);
         rs::startEventFlow(mEventFlowExecutor, "Init");
     }
     if (al::isMtpAnimExist(this)) {
-        rs::setNpcMaterialAnimFromPlacementInfo(this, initInfo);
+        rs::setNpcMaterialAnimFromPlacementInfo(this, info);
         al::tryStartMclAnimIfExist(this, al::getPlayingMtpAnimName(this));
     }
-    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
     makeActorAlive();
     mCapTargetInfo = rs::createCapTargetInfo(this, nullptr);
 

--- a/src/MapObj/HackFork.h
+++ b/src/MapObj/HackFork.h
@@ -27,7 +27,7 @@ class PlayerHackStartShaderCtrl;
 class HackFork : public al::LiveActor {
 public:
     HackFork(const char* name);
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/MapObj/HipDropSwitch.h
+++ b/src/MapObj/HipDropSwitch.h
@@ -16,7 +16,8 @@ public:
     void reset();
     void control() override;
     bool isOn() const;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void startClipped() override;
     bool isOnWait() const;
     void writeSave();

--- a/src/MapObj/HipDropSwitch.h
+++ b/src/MapObj/HipDropSwitch.h
@@ -12,11 +12,11 @@ class SensorMsg;
 class HipDropSwitch : public al::LiveActor {
 public:
     HipDropSwitch(const char*);
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void reset();
     void control() override;
     bool isOn() const;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void startClipped() override;
     bool isOnWait() const;
     void writeSave();

--- a/src/MapObj/PictureNoStageChange.h
+++ b/src/MapObj/PictureNoStageChange.h
@@ -8,7 +8,7 @@ public:
 
     void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
-                            al::HitSensor* self) override;
+                    al::HitSensor* self) override;
 
     void exeWait();
 

--- a/src/MapObj/PictureNoStageChange.h
+++ b/src/MapObj/PictureNoStageChange.h
@@ -6,8 +6,8 @@ class PictureNoStageChange : public al::LiveActor {
 public:
     PictureNoStageChange(const char* actorName, const char* archiveName);
 
-    virtual void init(const al::ActorInitInfo& info) override;
-    virtual bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                             al::HitSensor* self) override;
 
     void exeWait();

--- a/src/MapObj/RiseMapPartsHolder.h
+++ b/src/MapObj/RiseMapPartsHolder.h
@@ -14,7 +14,7 @@ class RiseMapParts;
 class RiseMapPartsHolder : public al::LiveActor {
 public:
     RiseMapPartsHolder(const char*);
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void startRise();
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/MapObj/RouletteSwitch.cpp
+++ b/src/MapObj/RouletteSwitch.cpp
@@ -22,39 +22,39 @@ NERVES_MAKE_STRUCT(RouletteSwitch, Wait);
 
 RouletteSwitch::RouletteSwitch(const char* name) : al::LiveActor(name) {}
 
-void RouletteSwitch::init(const al::ActorInitInfo& actorInitInfo) {
-    al::initActorSceneInfo(this, actorInitInfo);
+void RouletteSwitch::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
     al::initActorPoseTRSV(this);
-    al::initActorSRT(this, actorInitInfo);
-    al::initActorClipping(this, actorInitInfo);
-    al::initExecutorUpdate(this, actorInitInfo, "地形オブジェ[Movement]");
-    al::initStageSwitch(this, actorInitInfo);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");
+    al::initStageSwitch(this, info);
     al::initNerve(this, &NrvRouletteSwitch.Wait, 0);
-    al::initGroupClipping(this, actorInitInfo);
+    al::initGroupClipping(this, info);
 
     for (s32 i = 0; i < mButtons.capacity(); i++) {
         sead::FixedSafeString<0x80>* string = new sead::FixedSafeString<0x80>();
         string->format("Button%d", i + 1);
         al::PlacementInfo placementInfo;
-        if (!al::tryGetLinksInfo(&placementInfo, actorInitInfo, string->cstr()))
+        if (!al::tryGetLinksInfo(&placementInfo, info, string->cstr()))
             break;
 
         TrampleSwitch* trampleSwitch = new TrampleSwitch(string->cstr());
         al::ActorInitInfo switchInitInfo;
-        switchInitInfo.initViewIdHost(&placementInfo, actorInitInfo);
+        switchInitInfo.initViewIdHost(&placementInfo, info);
         trampleSwitch->init(switchInitInfo);
 
         mButtons.pushBack(trampleSwitch);
     }
 
     al::PlacementInfo placementInfo;
-    if (!al::tryGetLinksInfo(&placementInfo, actorInitInfo, "ButtonReset")) {
+    if (!al::tryGetLinksInfo(&placementInfo, info, "ButtonReset")) {
         makeActorDead();
         return;
     }
     mResetButton = new HipDropSwitch("リセットボタン");
     al::ActorInitInfo switchInitInfo;
-    switchInitInfo.initViewIdHost(&placementInfo, actorInitInfo);
+    switchInitInfo.initViewIdHost(&placementInfo, info);
     mResetButton->init(switchInitInfo);
     mIsPressReset = mResetButton->isOnWait();
     makeActorAlive();

--- a/src/MapObj/RouletteSwitch.h
+++ b/src/MapObj/RouletteSwitch.h
@@ -14,7 +14,7 @@ struct ActorInitInfo;
 class RouletteSwitch : public al::LiveActor {
 public:
     RouletteSwitch(const char* name);
-    void init(const al::ActorInitInfo& actorInitInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     void exeWait();
 

--- a/src/MapObj/RouteGuideDirector.h
+++ b/src/MapObj/RouteGuideDirector.h
@@ -35,7 +35,7 @@ static_assert(sizeof(RouteGuideAreaFinder) == 0x30);
 class RouteGuideDirector : public al::LiveActor, public al::ISceneObj {
 public:
     RouteGuideDirector();
-    void initAfterPlacementSceneObj(const al::ActorInitInfo&) override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
     bool isValidate() const;
     void offGuideSystem();
     void deactivateGuide();

--- a/src/MapObj/RouteGuideDirector.h
+++ b/src/MapObj/RouteGuideDirector.h
@@ -21,7 +21,7 @@ class RouteGuideAreaFinder : public al::AreaObjFindCallBack {
 public:
     RouteGuideAreaFinder();
     void reset(sead::Vector3f);
-    void findArea(const al::AreaObj*) override;
+    void findArea(const al::AreaObj* areaObj) override;
 
 private:
     const al::AreaObj* _8;

--- a/src/MapObj/SignBoardBlow.h
+++ b/src/MapObj/SignBoardBlow.h
@@ -14,7 +14,8 @@ class SignBoardBlow : public al::LiveActor {
 public:
     SignBoardBlow(const char* actorName, const char* signBoardBlowName);
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void startBlow(const sead::Vector3f&);
     void exeWait();
     void exeBlow();

--- a/src/MapObj/SignBoardBlow.h
+++ b/src/MapObj/SignBoardBlow.h
@@ -14,7 +14,7 @@ class SignBoardBlow : public al::LiveActor {
 public:
     SignBoardBlow(const char* actorName, const char* signBoardBlowName);
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void startBlow(const sead::Vector3f&);
     void exeWait();
     void exeBlow();

--- a/src/MapObj/SignBoardDanger.cpp
+++ b/src/MapObj/SignBoardDanger.cpp
@@ -85,11 +85,11 @@ void SignBoardDanger::init(const al::ActorInitInfo& info) {
     mCapHanger->makeActorAlive();
 }
 
-bool SignBoardDanger::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
+bool SignBoardDanger::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                                  al::HitSensor* self) {
     if (al::isNerve(this, &NrvSignBoardDanger.Dead)) {
-        if (rs::isMsgPlayerDisregardHomingAttack(msg) ||
-            rs::isMsgPlayerDisregardTargetMarker(msg) || al::isMsgPlayerDisregard(msg)) {
+        if (rs::isMsgPlayerDisregardHomingAttack(message) ||
+            rs::isMsgPlayerDisregardTargetMarker(message) || al::isMsgPlayerDisregard(message)) {
             return true;
         }
 
@@ -99,10 +99,10 @@ bool SignBoardDanger::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
         return false;
     }
 
-    if (rs::isMsgPlayerDisregardHomingAttack(msg) || rs::isMsgPlayerDisregardTargetMarker(msg))
+    if (rs::isMsgPlayerDisregardHomingAttack(message) || rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 
-    if (rs::isMsgBreakSignBoard(msg)) {
+    if (rs::isMsgBreakSignBoard(message)) {
         SignBoardBlow* signBlow = mSignBoardBlow;
         sead::Vector3f upDir = sead::Vector3f::ey;
         sead::Vector3f rightDir;
@@ -127,8 +127,8 @@ bool SignBoardDanger::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
         return true;
     }
 
-    if (al::isSensorCollision(self) && rs::isMsgCapReflectCollide(msg) && isCanStartReaction()) {
-        rs::requestHitReactionToAttacker(msg, self, other);
+    if (al::isSensorCollision(self) && rs::isMsgCapReflectCollide(message) && isCanStartReaction()) {
+        rs::requestHitReactionToAttacker(message, self, other);
         al::setNerve(this, &NrvSignBoardDanger.Reaction);
         return true;
     }
@@ -141,10 +141,10 @@ bool SignBoardDanger::isCanStartReaction() {
     return al::isNerve(this, &NrvSignBoardDanger.Reaction) && al::isGreaterEqualStep(this, 30);
 }
 
-void SignBoardDanger::attackSensor(al::HitSensor* other, al::HitSensor* self) {
+void SignBoardDanger::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     if (al::isNerve(this, &NrvSignBoardDanger.Dead) && (u32)mRespawnTimer < 5 &&
-        al::isSensorName(other, "Cap")) {
-        al::sendMsgPush(self, other);
+        al::isSensorName(self, "Cap")) {
+        al::sendMsgPush(other, self);
     }
 }
 

--- a/src/MapObj/SignBoardDanger.cpp
+++ b/src/MapObj/SignBoardDanger.cpp
@@ -99,7 +99,8 @@ bool SignBoardDanger::receiveMsg(const al::SensorMsg* message, al::HitSensor* ot
         return false;
     }
 
-    if (rs::isMsgPlayerDisregardHomingAttack(message) || rs::isMsgPlayerDisregardTargetMarker(message))
+    if (rs::isMsgPlayerDisregardHomingAttack(message) ||
+        rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 
     if (rs::isMsgBreakSignBoard(message)) {
@@ -127,7 +128,8 @@ bool SignBoardDanger::receiveMsg(const al::SensorMsg* message, al::HitSensor* ot
         return true;
     }
 
-    if (al::isSensorCollision(self) && rs::isMsgCapReflectCollide(message) && isCanStartReaction()) {
+    if (al::isSensorCollision(self) && rs::isMsgCapReflectCollide(message) &&
+        isCanStartReaction()) {
         rs::requestHitReactionToAttacker(message, self, other);
         al::setNerve(this, &NrvSignBoardDanger.Reaction);
         return true;

--- a/src/MapObj/SignBoardDanger.h
+++ b/src/MapObj/SignBoardDanger.h
@@ -16,9 +16,9 @@ class SignBoardDanger : public al::LiveActor {
 public:
     SignBoardDanger(const char* name);
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     bool isCanStartReaction();
-    void attackSensor(al::HitSensor* other, al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     void exeWait();
     void exeReaction();
     void exeDead();

--- a/src/MapObj/SignBoardDanger.h
+++ b/src/MapObj/SignBoardDanger.h
@@ -16,7 +16,8 @@ class SignBoardDanger : public al::LiveActor {
 public:
     SignBoardDanger(const char* name);
     void init(const al::ActorInitInfo& info) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     bool isCanStartReaction();
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     void exeWait();

--- a/src/MapObj/Souvenir.cpp
+++ b/src/MapObj/Souvenir.cpp
@@ -25,13 +25,13 @@ NERVES_MAKE_STRUCT(Souvenir, Wait, ReactionCap);
 Souvenir::Souvenir(const char* name) : al::LiveActor(name) {}
 
 // Non-matching: regswap (https://decomp.me/scratch/8qJEm)
-void Souvenir::init(const al::ActorInitInfo& actorInitInfo) {
+void Souvenir::init(const al::ActorInitInfo& info) {
     const char* suffix = nullptr;
-    al::tryGetStringArg(&suffix, actorInitInfo, "Suffix");
-    al::initMapPartsActor(this, actorInitInfo, suffix);
-    al::tryGetArg(&mIsReactionPlayerUpperPunch, actorInitInfo, "IsReactionPlayerUpperPunch");
-    al::tryGetArg(&mIsThroughCapAttack, actorInitInfo, "IsThroughCapAttack");
-    al::tryGetArg(&mRotateYSpeed, actorInitInfo, "RotateYSpeed");
+    al::tryGetStringArg(&suffix, info, "Suffix");
+    al::initMapPartsActor(this, info, suffix);
+    al::tryGetArg(&mIsReactionPlayerUpperPunch, info, "IsReactionPlayerUpperPunch");
+    al::tryGetArg(&mIsThroughCapAttack, info, "IsThroughCapAttack");
+    al::tryGetArg(&mRotateYSpeed, info, "RotateYSpeed");
     al::initNerve(this, &NrvSouvenir.Wait, 0);
     makeActorAlive();
 }
@@ -48,20 +48,20 @@ void Souvenir::attackSensor(al::HitSensor* self, al::HitSensor* other) {
         rs::sendMsgPushToPlayer(other, self);
 }
 
-bool Souvenir::receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other) {
-    if (al::isMsgPlayerDisregard(msg) || rs::isMsgPlayerDisregardHomingAttack(msg) ||
-        rs::isMsgPlayerDisregardTargetMarker(msg))
+bool Souvenir::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message) || rs::isMsgPlayerDisregardHomingAttack(message) ||
+        rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 
-    if (rs::isMsgCapTouchWall(msg) || rs::isMsgCapAttack(msg) || al::isMsgPlayerTrample(msg) ||
-        rs::isMsgPlayerAndCapHipDropAll(msg) || rs::isMsgPlayerAndCapObjHipDropAll(msg) ||
-        (al::isMsgPlayerObjUpperPunch(msg) && mIsReactionPlayerUpperPunch) ||
-        al::isMsgPlayerRollingAttack(msg) || al::isMsgPlayerObjRollingAttack(msg)) {
+    if (rs::isMsgCapTouchWall(message) || rs::isMsgCapAttack(message) || al::isMsgPlayerTrample(message) ||
+        rs::isMsgPlayerAndCapHipDropAll(message) || rs::isMsgPlayerAndCapObjHipDropAll(message) ||
+        (al::isMsgPlayerObjUpperPunch(message) && mIsReactionPlayerUpperPunch) ||
+        al::isMsgPlayerRollingAttack(message) || al::isMsgPlayerObjRollingAttack(message)) {
         if (!al::isExistAction(this, "ReactionCap"))
             return false;
 
-        const sead::Vector3f& velocity = al::getVelocity(al::getSensorHost(self));
-        if (!rs::isMsgCapAttack(msg) && velocity.length() < 5.0f)
+        const sead::Vector3f& velocity = al::getVelocity(al::getSensorHost(other));
+        if (!rs::isMsgCapAttack(message) && velocity.length() < 5.0f)
             return false;
 
         if (!al::isNerve(this, &NrvSouvenir.Wait) &&
@@ -70,15 +70,15 @@ bool Souvenir::receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::Hit
 
         al::setNerve(this, &NrvSouvenir.ReactionCap);
         if (mIsThroughCapAttack &&
-            (rs::isMsgCapAttack(msg) || al::isMsgPlayerObjUpperPunch(msg) ||
-             al::isMsgPlayerTrample(msg) || rs::isMsgPlayerAndCapHipDropAll(msg) ||
-             rs::isMsgPlayerAndCapObjHipDropAll(msg)))
+            (rs::isMsgCapAttack(message) || al::isMsgPlayerObjUpperPunch(message) ||
+             al::isMsgPlayerTrample(message) || rs::isMsgPlayerAndCapHipDropAll(message) ||
+             rs::isMsgPlayerAndCapObjHipDropAll(message)))
             return false;
 
-        if (!rs::isMsgPlayerAndCapHipDropAll(msg) && !rs::isMsgPlayerAndCapObjHipDropAll(msg))
-            al::startHitReactionHitEffect(this, "ヒット[小]", self, other);
+        if (!rs::isMsgPlayerAndCapHipDropAll(message) && !rs::isMsgPlayerAndCapObjHipDropAll(message))
+            al::startHitReactionHitEffect(this, "ヒット[小]", other, self);
         else
-            al::startHitReactionHitEffect(this, "ヒット", self, other);
+            al::startHitReactionHitEffect(this, "ヒット", other, self);
         return true;
     }
 
@@ -96,7 +96,7 @@ void Souvenir::exeWait() {
               al::isActionPlaying(this, "ReactionCap3")) ||
              (al::isExistAction(this, "ReactionCap4") &&
               al::isActionPlaying(this, "ReactionCap4"))) &&
-            getNextAction() != nullptr)
+            getNextAction() )
             return;
 
         if (mIsWait) {

--- a/src/MapObj/Souvenir.cpp
+++ b/src/MapObj/Souvenir.cpp
@@ -53,8 +53,9 @@ bool Souvenir::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al
         rs::isMsgPlayerDisregardTargetMarker(message))
         return true;
 
-    if (rs::isMsgCapTouchWall(message) || rs::isMsgCapAttack(message) || al::isMsgPlayerTrample(message) ||
-        rs::isMsgPlayerAndCapHipDropAll(message) || rs::isMsgPlayerAndCapObjHipDropAll(message) ||
+    if (rs::isMsgCapTouchWall(message) || rs::isMsgCapAttack(message) ||
+        al::isMsgPlayerTrample(message) || rs::isMsgPlayerAndCapHipDropAll(message) ||
+        rs::isMsgPlayerAndCapObjHipDropAll(message) ||
         (al::isMsgPlayerObjUpperPunch(message) && mIsReactionPlayerUpperPunch) ||
         al::isMsgPlayerRollingAttack(message) || al::isMsgPlayerObjRollingAttack(message)) {
         if (!al::isExistAction(this, "ReactionCap"))
@@ -75,7 +76,8 @@ bool Souvenir::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al
              rs::isMsgPlayerAndCapObjHipDropAll(message)))
             return false;
 
-        if (!rs::isMsgPlayerAndCapHipDropAll(message) && !rs::isMsgPlayerAndCapObjHipDropAll(message))
+        if (!rs::isMsgPlayerAndCapHipDropAll(message) &&
+            !rs::isMsgPlayerAndCapObjHipDropAll(message))
             al::startHitReactionHitEffect(this, "ヒット[小]", other, self);
         else
             al::startHitReactionHitEffect(this, "ヒット", other, self);
@@ -96,7 +98,7 @@ void Souvenir::exeWait() {
               al::isActionPlaying(this, "ReactionCap3")) ||
              (al::isExistAction(this, "ReactionCap4") &&
               al::isActionPlaying(this, "ReactionCap4"))) &&
-            getNextAction() )
+            getNextAction())
             return;
 
         if (mIsWait) {

--- a/src/MapObj/Souvenir.h
+++ b/src/MapObj/Souvenir.h
@@ -13,10 +13,10 @@ class SensorMsg;
 class Souvenir : public al::LiveActor {
 public:
     Souvenir(const char* name);
-    void init(const al::ActorInitInfo& actorInitInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
 
     void exeWait();
     inline const char* getNextAction();

--- a/src/MapObj/Souvenir.h
+++ b/src/MapObj/Souvenir.h
@@ -16,7 +16,8 @@ public:
     void init(const al::ActorInitInfo& info) override;
     void control() override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void exeWait();
     inline const char* getNextAction();

--- a/src/MapObj/TreasureBoxKey.cpp
+++ b/src/MapObj/TreasureBoxKey.cpp
@@ -48,13 +48,13 @@ void TreasureBoxKey::init(const al::ActorInitInfo& info) {
     }
 
     mShine = rs::initLinkShine(info, "ShineActor", 0);
-    if (mShine ) {
+    if (mShine) {
         al::updatePoseRotate(mShine, sead::Vector3f::zero);
         sead::Vector3f trans = al::getTrans(this);
         trans.y = al::getTrans(mShine).y;
         al::setTrans(mShine, trans);
 
-        if (mShine )
+        if (mShine)
             rs::updateHintTrans(mShine, al::getTrans(mTreasureBoxKeyOpener));
     }
 
@@ -71,20 +71,20 @@ void TreasureBoxKey::init(const al::ActorInitInfo& info) {
 
 void TreasureBoxKey::makeActorDead() {
     al::LiveActor::makeActorDead();
-    if (mTreasureBoxKeyOpener )
+    if (mTreasureBoxKeyOpener)
         mTreasureBoxKeyOpener->makeActorDead();
 
-    if (mShine )
+    if (mShine)
         mShine->makeActorDead();
 
-    if (mCameraTicket  && al::isActiveCamera(mCameraTicket))
+    if (mCameraTicket && al::isActiveCamera(mCameraTicket))
         al::endCamera(this, mCameraTicket, -1, false);
 }
 
 void TreasureBoxKey::makeActorAlive() {
     al::LiveActor::makeActorAlive();
     al::validateClipping(this);
-    if (mShine )
+    if (mShine)
         al::validateClipping(mShine);
 }
 
@@ -171,7 +171,7 @@ void TreasureBoxKey::exeOpen() {
         al::invalidateClipping(mShine);
         mShine->appearPopupWithoutDemo();
         al::sendMsgShowModel(mShine);
-        if (mCameraTicket )
+        if (mCameraTicket)
             al::startHitReaction(this, "シャイン出現デモ演出");
     }
 
@@ -181,7 +181,7 @@ void TreasureBoxKey::exeOpen() {
         al::startAction(this, "Wait");
     }
 
-    if (mCameraTicket ) {
+    if (mCameraTicket) {
         if (!al::isGreaterEqualStep(this, 150))
             return;
 

--- a/src/MapObj/TreasureBoxKey.cpp
+++ b/src/MapObj/TreasureBoxKey.cpp
@@ -48,13 +48,13 @@ void TreasureBoxKey::init(const al::ActorInitInfo& info) {
     }
 
     mShine = rs::initLinkShine(info, "ShineActor", 0);
-    if (mShine != nullptr) {
+    if (mShine ) {
         al::updatePoseRotate(mShine, sead::Vector3f::zero);
         sead::Vector3f trans = al::getTrans(this);
         trans.y = al::getTrans(mShine).y;
         al::setTrans(mShine, trans);
 
-        if (mShine != nullptr)
+        if (mShine )
             rs::updateHintTrans(mShine, al::getTrans(mTreasureBoxKeyOpener));
     }
 
@@ -71,38 +71,38 @@ void TreasureBoxKey::init(const al::ActorInitInfo& info) {
 
 void TreasureBoxKey::makeActorDead() {
     al::LiveActor::makeActorDead();
-    if (mTreasureBoxKeyOpener != nullptr)
+    if (mTreasureBoxKeyOpener )
         mTreasureBoxKeyOpener->makeActorDead();
 
-    if (mShine != nullptr)
+    if (mShine )
         mShine->makeActorDead();
 
-    if (mCameraTicket != nullptr && al::isActiveCamera(mCameraTicket))
+    if (mCameraTicket  && al::isActiveCamera(mCameraTicket))
         al::endCamera(this, mCameraTicket, -1, false);
 }
 
 void TreasureBoxKey::makeActorAlive() {
     al::LiveActor::makeActorAlive();
     al::validateClipping(this);
-    if (mShine != nullptr)
+    if (mShine )
         al::validateClipping(mShine);
 }
 
-bool TreasureBoxKey::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
+bool TreasureBoxKey::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                                 al::HitSensor* self) {
     if (al::isSensorName(self, "PlayerRegard")) {
-        if (al::isMsgPlayerDisregard(msg) && al::isNerve(this, &NrvTreasureBoxKey.OpenWait))
+        if (al::isMsgPlayerDisregard(message) && al::isNerve(this, &NrvTreasureBoxKey.OpenWait))
             return true;
-        return rs::isMsgPlayerDisregardHomingAttack(msg);
+        return rs::isMsgPlayerDisregardHomingAttack(message);
     }
 
-    if (al::isMsgRestart(msg)) {
+    if (al::isMsgRestart(message)) {
         restart();
         return true;
     }
 
-    if (al::isMsgChangeAlpha(msg)) {
-        f32 alpha = al::getChangeAlphaValue(msg);
+    if (al::isMsgChangeAlpha(message)) {
+        f32 alpha = al::getChangeAlphaValue(message);
         al::setModelAlphaMask(this, alpha);
         al::setModelAlphaMask(mTreasureBoxKeyOpener, alpha);
         if (!al::sendMsgChangeAlpha(mShine, alpha))
@@ -110,7 +110,7 @@ bool TreasureBoxKey::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
         return true;
     }
 
-    if (rs::isMsgTimerAthleticDemoStart(msg)) {
+    if (rs::isMsgTimerAthleticDemoStart(message)) {
         al::addDemoActor(this);
         al::addDemoActor(mTreasureBoxKeyOpener);
         return true;
@@ -171,7 +171,7 @@ void TreasureBoxKey::exeOpen() {
         al::invalidateClipping(mShine);
         mShine->appearPopupWithoutDemo();
         al::sendMsgShowModel(mShine);
-        if (mCameraTicket != nullptr)
+        if (mCameraTicket )
             al::startHitReaction(this, "シャイン出現デモ演出");
     }
 
@@ -181,7 +181,7 @@ void TreasureBoxKey::exeOpen() {
         al::startAction(this, "Wait");
     }
 
-    if (mCameraTicket != nullptr) {
+    if (mCameraTicket ) {
         if (!al::isGreaterEqualStep(this, 150))
             return;
 

--- a/src/MapObj/TreasureBoxKey.h
+++ b/src/MapObj/TreasureBoxKey.h
@@ -19,7 +19,7 @@ public:
     void init(const al::ActorInitInfo& info) override;
     void makeActorDead() override;
     void makeActorAlive() override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void restart();
     void exeCloseWait();
     void exeWaitStartDemo();

--- a/src/MapObj/TreasureBoxKey.h
+++ b/src/MapObj/TreasureBoxKey.h
@@ -19,7 +19,8 @@ public:
     void init(const al::ActorInitInfo& info) override;
     void makeActorDead() override;
     void makeActorAlive() override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void restart();
     void exeCloseWait();
     void exeWaitStartDemo();

--- a/src/MapObj/TreasureBoxKeyOpener.h
+++ b/src/MapObj/TreasureBoxKeyOpener.h
@@ -17,7 +17,8 @@ public:
     void initAfterPlacement() override;
     void appear() override;
     void makeActorAlive() override;
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void control() override;
     bool isGot();
     void exeAppear();

--- a/src/MapObj/TreasureBoxKeyOpener.h
+++ b/src/MapObj/TreasureBoxKeyOpener.h
@@ -13,11 +13,11 @@ class SensorMsg;
 class TreasureBoxKeyOpener : public al::LiveActor {
 public:
     TreasureBoxKeyOpener(const char*);
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void appear() override;
     void makeActorAlive() override;
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
     void control() override;
     bool isGot();
     void exeAppear();

--- a/src/MapObj/VolleyballBase.cpp
+++ b/src/MapObj/VolleyballBase.cpp
@@ -14,8 +14,8 @@ NERVES_MAKE_NOSTRUCT(VolleyballBase, Wait, Reaction);
 
 VolleyballBase::VolleyballBase(const char* name) : al::LiveActor(name) {}
 
-void VolleyballBase::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "VolleyballBase", nullptr);
+void VolleyballBase::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "VolleyballBase", nullptr);
     al::initNerve(this, &Wait, 0);
     makeActorAlive();
 }

--- a/src/MapObj/VolleyballBase.h
+++ b/src/MapObj/VolleyballBase.h
@@ -11,7 +11,7 @@ struct ActorInitInfo;
 class VolleyballBase : public al::LiveActor {
 public:
     VolleyballBase(const char* name);
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void startReaction();
 
     void exeWait();

--- a/src/MapObj/VolleyballNet.cpp
+++ b/src/MapObj/VolleyballNet.cpp
@@ -17,8 +17,8 @@ NERVES_MAKE_NOSTRUCT(VolleyballNet, Wait, Reaction);
 
 VolleyballNet::VolleyballNet(const char* name) : al::LiveActor(name) {}
 
-void VolleyballNet::init(const al::ActorInitInfo& initInfo) {
-    al::initActor(this, initInfo);
+void VolleyballNet::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
     al::initNerve(this, &Wait, 0);
     makeActorAlive();
 }

--- a/src/MapObj/VolleyballNet.h
+++ b/src/MapObj/VolleyballNet.h
@@ -13,7 +13,7 @@ class SensorMsg;
 class VolleyballNet : public al::LiveActor {
 public:
     VolleyballNet(const char* name);
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     void exeWait();

--- a/src/MapObj/WorldMapEarth.cpp
+++ b/src/MapObj/WorldMapEarth.cpp
@@ -6,8 +6,8 @@
 
 WorldMapEarth::WorldMapEarth(const char* name) : al::LiveActor(name) {}
 
-void WorldMapEarth::init(const al::ActorInitInfo& initInfo) {
-    al::initMapPartsActor(this, initInfo, nullptr);
+void WorldMapEarth::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
     makeActorAlive();
 }
 

--- a/src/MapObj/WorldMapEarth.h
+++ b/src/MapObj/WorldMapEarth.h
@@ -5,6 +5,6 @@
 class WorldMapEarth : public al::LiveActor {
 public:
     WorldMapEarth(const char* name);
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
 };

--- a/src/ModeBalloon/TimeBalloonHintArrow.h
+++ b/src/ModeBalloon/TimeBalloonHintArrow.h
@@ -14,7 +14,7 @@ class TimeBalloonHintArrow : public al::LiveActor {
 public:
     TimeBalloonHintArrow();
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
     void appear() override;

--- a/src/Npc/Bird.h
+++ b/src/Npc/Bird.h
@@ -11,7 +11,7 @@ public:
     void tryStartFlyAway();
 
 private:
-    void* _padding[0x19];
+    void* _108[0x19];
 };
 
 static_assert(sizeof(Bird) == 0x1d0);

--- a/src/Npc/KuriboGirl.cpp
+++ b/src/Npc/KuriboGirl.cpp
@@ -55,16 +55,16 @@ NERVES_MAKE_NOSTRUCT(KuriboGirl, Disappear, Hide, LoveFind, AppearShineStart, Ap
 
 KuriboGirl::KuriboGirl(const char* name) : al::LiveActor(name) {}
 
-void KuriboGirl::init(const al::ActorInitInfo& actorInitInfo) {
-    al::initActorWithArchiveName(this, actorInitInfo, "KuriboGirl", nullptr);
-    mAreaObjGroup = al::createLinkAreaGroup(this, actorInitInfo, "FindArea", "子供エリアグループ",
+void KuriboGirl::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "KuriboGirl", nullptr);
+    mAreaObjGroup = al::createLinkAreaGroup(this, info, "FindArea", "子供エリアグループ",
                                             "子供エリア");
-    mCamera = al::initObjectCamera(this, actorInitInfo, nullptr, nullptr);
+    mCamera = al::initObjectCamera(this, info, nullptr, nullptr);
     mCameraTarget = al::createActorCameraTarget(this, 0.0f);
 
-    al::tryGetArg(&mIsMoveShine, actorInitInfo, "isMoveShine");
-    mShineActor = rs::tryInitLinkShine(actorInitInfo, "ShineActor", 0);
-    if (mShineActor == nullptr) {
+    al::tryGetArg(&mIsMoveShine, info, "isMoveShine");
+    mShineActor = rs::tryInitLinkShine(info, "ShineActor", 0);
+    if (!mShineActor ) {
         mIsAfterShineAppear = true;
         al::initNerve(this, &NrvKuriboGirl.WaitLoveAfter, 0);
     } else {
@@ -73,7 +73,7 @@ void KuriboGirl::init(const al::ActorInitInfo& actorInitInfo) {
     }
 
     al::setHitSensorPosPtr(this, "WatchStart", &mHitSensorPos);
-    if (mAreaObjGroup == nullptr) {
+    if (!mAreaObjGroup ) {
         mHitSensorPos.set(al::getTrans(this));
         al::setSensorRadius(this, "WatchStart", 900.0f);
     } else {
@@ -119,9 +119,9 @@ void KuriboGirl::exeWait() {
     lookFront();
 
     al::LiveActor* nearestPlayerActor = al::tryFindNearestPlayerActor(this);
-    if (nearestPlayerActor != nullptr) {
+    if (nearestPlayerActor ) {
         if (rs::isPlayerHack(this) && !rs::isPlayerHackKuriboAny(this)) {
-            if (mAreaObjGroup == nullptr) {
+            if (!mAreaObjGroup ) {
                 sead::Vector3f distance = al::getTrans(nearestPlayerActor) - al::getTrans(this);
                 if (distance.length() < 900.0f) {
                     al::setNerve(this, &NrvKuriboGirl.Surprise);
@@ -397,7 +397,7 @@ void KuriboGirl::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 }
 
 bool KuriboGirl::isWatchStart(sead::Vector3f pos) {
-    if (mAreaObjGroup != nullptr) {
+    if (mAreaObjGroup ) {
         if (al::isInAreaObj(mAreaObjGroup, pos))
             return true;
     } else {
@@ -415,21 +415,21 @@ bool KuriboGirl::isNrvWait() {
            al::isNerve(this, &NrvKuriboGirl.WaitLoveAfter);
 }
 
-bool KuriboGirl::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
-    if (rs::isMsgPlayerDisregardHomingAttack(msg) || rs::isMsgPlayerDisregardTargetMarker(msg) ||
-        al::isMsgPlayerDisregard(msg))
+bool KuriboGirl::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(message) || rs::isMsgPlayerDisregardTargetMarker(message) ||
+        al::isMsgPlayerDisregard(message))
         return true;
 
-    if ((al::isSensorPlayerAttack(other) || rs::isMsgHosuiAttack(msg)) &&
+    if ((al::isSensorPlayerAttack(other) || rs::isMsgHosuiAttack(message)) &&
         al::isSensorName(self, "EyeWarning")) {
         mIsPlayerFar = false;
         if (isNrvWait())
             al::setNerve(this, &NrvKuriboGirl.Surprise);
         return false;
     }
-    if (al::isMsgPush(msg) && al::isSensorName(self, "Body"))
+    if (al::isMsgPush(message) && al::isSensorName(self, "Body"))
         return true;
-    if (rs::isMsgCapAttack(msg) && al::isSensorName(self, "EyeWarning")) {
+    if (rs::isMsgCapAttack(message) && al::isSensorName(self, "EyeWarning")) {
         mIsPlayerFar = false;
         if (isNrvWait())
             al::setNerve(this, &NrvKuriboGirl.Surprise);

--- a/src/Npc/KuriboGirl.cpp
+++ b/src/Npc/KuriboGirl.cpp
@@ -57,14 +57,14 @@ KuriboGirl::KuriboGirl(const char* name) : al::LiveActor(name) {}
 
 void KuriboGirl::init(const al::ActorInitInfo& info) {
     al::initActorWithArchiveName(this, info, "KuriboGirl", nullptr);
-    mAreaObjGroup = al::createLinkAreaGroup(this, info, "FindArea", "子供エリアグループ",
-                                            "子供エリア");
+    mAreaObjGroup =
+        al::createLinkAreaGroup(this, info, "FindArea", "子供エリアグループ", "子供エリア");
     mCamera = al::initObjectCamera(this, info, nullptr, nullptr);
     mCameraTarget = al::createActorCameraTarget(this, 0.0f);
 
     al::tryGetArg(&mIsMoveShine, info, "isMoveShine");
     mShineActor = rs::tryInitLinkShine(info, "ShineActor", 0);
-    if (!mShineActor ) {
+    if (!mShineActor) {
         mIsAfterShineAppear = true;
         al::initNerve(this, &NrvKuriboGirl.WaitLoveAfter, 0);
     } else {
@@ -73,7 +73,7 @@ void KuriboGirl::init(const al::ActorInitInfo& info) {
     }
 
     al::setHitSensorPosPtr(this, "WatchStart", &mHitSensorPos);
-    if (!mAreaObjGroup ) {
+    if (!mAreaObjGroup) {
         mHitSensorPos.set(al::getTrans(this));
         al::setSensorRadius(this, "WatchStart", 900.0f);
     } else {
@@ -119,9 +119,9 @@ void KuriboGirl::exeWait() {
     lookFront();
 
     al::LiveActor* nearestPlayerActor = al::tryFindNearestPlayerActor(this);
-    if (nearestPlayerActor ) {
+    if (nearestPlayerActor) {
         if (rs::isPlayerHack(this) && !rs::isPlayerHackKuriboAny(this)) {
-            if (!mAreaObjGroup ) {
+            if (!mAreaObjGroup) {
                 sead::Vector3f distance = al::getTrans(nearestPlayerActor) - al::getTrans(this);
                 if (distance.length() < 900.0f) {
                     al::setNerve(this, &NrvKuriboGirl.Surprise);
@@ -397,7 +397,7 @@ void KuriboGirl::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 }
 
 bool KuriboGirl::isWatchStart(sead::Vector3f pos) {
-    if (mAreaObjGroup ) {
+    if (mAreaObjGroup) {
         if (al::isInAreaObj(mAreaObjGroup, pos))
             return true;
     } else {
@@ -415,9 +415,10 @@ bool KuriboGirl::isNrvWait() {
            al::isNerve(this, &NrvKuriboGirl.WaitLoveAfter);
 }
 
-bool KuriboGirl::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
-    if (rs::isMsgPlayerDisregardHomingAttack(message) || rs::isMsgPlayerDisregardTargetMarker(message) ||
-        al::isMsgPlayerDisregard(message))
+bool KuriboGirl::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                            al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(message) ||
+        rs::isMsgPlayerDisregardTargetMarker(message) || al::isMsgPlayerDisregard(message))
         return true;
 
     if ((al::isSensorPlayerAttack(other) || rs::isMsgHosuiAttack(message)) &&

--- a/src/Npc/KuriboGirl.h
+++ b/src/Npc/KuriboGirl.h
@@ -41,7 +41,8 @@ public:
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool isWatchStart(sead::Vector3f pos);
     bool isNrvWait();
-    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
 private:
     al::AreaObjGroup* mAreaObjGroup = nullptr;

--- a/src/Npc/KuriboGirl.h
+++ b/src/Npc/KuriboGirl.h
@@ -19,7 +19,7 @@ class Shine;
 class KuriboGirl : public al::LiveActor {
 public:
     KuriboGirl(const char* name);
-    void init(const al::ActorInitInfo& actorInitInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     void exeWait();
     void lookFront();
@@ -41,7 +41,7 @@ public:
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool isWatchStart(sead::Vector3f pos);
     bool isNrvWait();
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) override;
 
 private:
     al::AreaObjGroup* mAreaObjGroup = nullptr;

--- a/src/Npc/RabbitGraphRailKeeper.cpp
+++ b/src/Npc/RabbitGraphRailKeeper.cpp
@@ -25,35 +25,35 @@ RabbitGraphRailKeeper::RabbitGraphRailKeeper(const char* name) : al::LiveActor(n
 RabbitGraphRailKeeper::RabbitGraphRailKeeper(const char* name, al::LiveActor* actor)
     : al::LiveActor(name) {}
 
-void RabbitGraphRailKeeper::init(const al::ActorInitInfo& initInfo) {
+void RabbitGraphRailKeeper::init(const al::ActorInitInfo& info) {
     using RabbitGraphRailKeeperFunctor =
         al::FunctorV0M<RabbitGraphRailKeeper*, void (RabbitGraphRailKeeper::*)()>;
 
-    al::initActorSceneInfo(this, initInfo);
+    al::initActorSceneInfo(this, info);
     al::initActorPoseTRSV(this);
-    al::initActorSRT(this, initInfo);
-    al::initActorClipping(this, initInfo);
-    al::initStageSwitch(this, initInfo);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::initStageSwitch(this, info);
 
     const char* objectName;
-    al::tryGetObjectName(&objectName, initInfo);
+    al::tryGetObjectName(&objectName, info);
 
-    if (al::isObjectName(initInfo, "RailRabbit")) {
+    if (al::isObjectName(info, "RailRabbit")) {
         mRail = new al::Rail();
-        mRail->init(*initInfo.placementInfo);
+        mRail->init(*info.placementInfo);
         mRailRider = new al::RailRider(mRail);
     } else {
-        if (!al::isExistRail(initInfo, "Rail")) {
+        if (!al::isExistRail(info, "Rail")) {
             makeActorDead();
             return;
         }
 
-        initRailKeeper(initInfo, "Rail");
+        initRailKeeper(info, "Rail");
     }
 
-    al::initExecutorUpdate(this, initInfo, "地形オブジェ[Movement]");
+    al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");
     al::initNerve(this, &NrvRabbitGraphRailKeeper.Wait, 0);
-    al::tryGetArg(&mIsJump, initInfo, "IsJump");
+    al::tryGetArg(&mIsJump, info, "IsJump");
     makeActorAlive();
 
     if (al::listenStageSwitchOnAppear(

--- a/src/Npc/RabbitGraphRailKeeper.h
+++ b/src/Npc/RabbitGraphRailKeeper.h
@@ -15,7 +15,7 @@ public:
     RabbitGraphRailKeeper(const char* name);
     RabbitGraphRailKeeper(const char* name, al::LiveActor* actor);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void appearBySwitch();
     void killBySwitch();
     bool isRailPointIgnore(s32 index) const;

--- a/src/Npc/ShineTowerNpc.cpp
+++ b/src/Npc/ShineTowerNpc.cpp
@@ -26,10 +26,10 @@ NERVES_MAKE_NOSTRUCT(ShineTowerNpc, NoBalloon);
 
 ShineTowerNpc::ShineTowerNpc(const char* name) : al::LiveActor(name) {}
 
-void ShineTowerNpc::init(const al::ActorInitInfo& actorInitInfo) {
-    al::initActorWithArchiveName(this, actorInitInfo, "NpcCap", nullptr);
+void ShineTowerNpc::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "NpcCap", nullptr);
     al::initNerve(this, &NrvShineTowerNpc.Wait, 0);
-    mEventFlowExecutor = rs::initEventFlow(this, actorInitInfo, "HomeMechanicNpc", nullptr);
+    mEventFlowExecutor = rs::initEventFlow(this, info, "HomeMechanicNpc", nullptr);
     al::MessageTagDataHolder* msgTagDataHolder = al::initMessageTagDataHolder(1);
     al::registerMessageTagDataScore(msgTagDataHolder, "Score", &mRemainingShineCount);
     rs::initEventMessageTagDataHolder(mEventFlowExecutor, msgTagDataHolder);

--- a/src/Npc/ShineTowerNpc.h
+++ b/src/Npc/ShineTowerNpc.h
@@ -12,7 +12,7 @@ class EventFlowExecutor;
 class ShineTowerNpc : public al::LiveActor {
 public:
     ShineTowerNpc(const char* name);
-    void init(const al::ActorInitInfo& actorInitInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void noBalloon();
     void startBalloon();
     void exeWait();

--- a/src/Npc/VolleyballBall.cpp
+++ b/src/Npc/VolleyballBall.cpp
@@ -41,8 +41,8 @@ const sead::Vector3f sCoinDropOffset = {0.0f, 200.0f, 200.0f};
 
 VolleyballBall::VolleyballBall(const char* name) : al::LiveActor(name) {}
 
-void VolleyballBall::init(const al::ActorInitInfo& initInfo) {
-    al::initActorWithArchiveName(this, initInfo, "VolleyballBall", nullptr);
+void VolleyballBall::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "VolleyballBall", nullptr);
     al::initNerve(this, &NrvVolleyballBall.Wait, 0);
     mAttackPath = new al::ParabolicPath();
     mReturnPath = new al::ParabolicPath();

--- a/src/Npc/VolleyballBall.h
+++ b/src/Npc/VolleyballBall.h
@@ -19,7 +19,7 @@ class VolleyballBall : public al::LiveActor {
 public:
     VolleyballBall(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Npc/VolleyballNpc.h
+++ b/src/Npc/VolleyballNpc.h
@@ -26,7 +26,7 @@ class VolleyballNpc : public al::LiveActor, public al::IEventFlowEventReceiver {
 public:
     VolleyballNpc(const char* name);
 
-    void init(const al::ActorInitInfo& initInfo) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;

--- a/src/Player/CapTargetInfo.cpp
+++ b/src/Player/CapTargetInfo.cpp
@@ -7,7 +7,7 @@
 #include "Library/Math/MathUtil.h"
 #include "Library/Matrix/MatrixUtil.h"
 
-CapTargetInfo::CapTargetInfo() {}
+CapTargetInfo::CapTargetInfo() = default;
 
 void CapTargetInfo::init(const al::LiveActor* actor, const char* name) {
     mActor = actor;

--- a/src/Player/CollisionShapeInfo.h
+++ b/src/Player/CollisionShapeInfo.h
@@ -57,7 +57,7 @@ public:
     void calcRelativeShapeInfo(const sead::Matrix34f&) override;
 
 private:
-    void* _18[20];
+    void* _10[20];
 };
 
 static_assert(sizeof(CollisionShapeInfoArrow) == 0xb8);

--- a/src/Player/HackerStateWingFly.cpp
+++ b/src/Player/HackerStateWingFly.cpp
@@ -64,7 +64,7 @@ void HackerStateWingFly::goFlyRise() {
 }
 
 void HackerStateWingFly::attackSensor(al::HitSensor* self, al::HitSensor* other) {
-    if (mParam.actionTrample != nullptr &&
+    if (mParam.actionTrample  &&
         rs::trySendMsgPlayerReflectOrTrample(mActor, self, other)) {
         al::setNerve(this, &NrvHostType.Trample);
         return;
@@ -79,7 +79,7 @@ void HackerStateWingFly::attackSensor(al::HitSensor* self, al::HitSensor* other)
 }
 
 bool HackerStateWingFly::canUpperPunch(al::HitSensor* self, al::HitSensor* other) const {
-    if (mParam.actionUpperPunch == nullptr)
+    if (!mParam.actionUpperPunch )
         return false;
     if (al::isNerve(this, &NrvHostType.Fall))
         return false;
@@ -134,7 +134,7 @@ void HackerStateWingFly::updateMove() {
     rs::addHackActorAccelStick(actor, *mHacker, &dir, mAccel, sead::Vector3f::ey);
     al::turnToDirection(actor, dir, mParam.turnAngle);
 
-    if (mCollision != nullptr) {
+    if (mCollision ) {
         rs::reboundVelocityFromCollision(actor, mCollision, 0.0f, 0.0f, 1.0f);
         return;
     }
@@ -156,7 +156,7 @@ void HackerStateWingFly::updateMove() {
 
 bool HackerStateWingFly::isOnGround() const {
     al::LiveActor* actor = mActor;
-    if (mCollision != nullptr)
+    if (mCollision )
         return rs::isOnGround(actor, mCollision);
 
     return al::isOnGround(actor, 0);

--- a/src/Player/HackerStateWingFly.cpp
+++ b/src/Player/HackerStateWingFly.cpp
@@ -64,8 +64,7 @@ void HackerStateWingFly::goFlyRise() {
 }
 
 void HackerStateWingFly::attackSensor(al::HitSensor* self, al::HitSensor* other) {
-    if (mParam.actionTrample  &&
-        rs::trySendMsgPlayerReflectOrTrample(mActor, self, other)) {
+    if (mParam.actionTrample && rs::trySendMsgPlayerReflectOrTrample(mActor, self, other)) {
         al::setNerve(this, &NrvHostType.Trample);
         return;
     }
@@ -79,7 +78,7 @@ void HackerStateWingFly::attackSensor(al::HitSensor* self, al::HitSensor* other)
 }
 
 bool HackerStateWingFly::canUpperPunch(al::HitSensor* self, al::HitSensor* other) const {
-    if (!mParam.actionUpperPunch )
+    if (!mParam.actionUpperPunch)
         return false;
     if (al::isNerve(this, &NrvHostType.Fall))
         return false;
@@ -134,7 +133,7 @@ void HackerStateWingFly::updateMove() {
     rs::addHackActorAccelStick(actor, *mHacker, &dir, mAccel, sead::Vector3f::ey);
     al::turnToDirection(actor, dir, mParam.turnAngle);
 
-    if (mCollision ) {
+    if (mCollision) {
         rs::reboundVelocityFromCollision(actor, mCollision, 0.0f, 0.0f, 1.0f);
         return;
     }
@@ -156,7 +155,7 @@ void HackerStateWingFly::updateMove() {
 
 bool HackerStateWingFly::isOnGround() const {
     al::LiveActor* actor = mActor;
-    if (mCollision )
+    if (mCollision)
         return rs::isOnGround(actor, mCollision);
 
     return al::isOnGround(actor, 0);

--- a/src/Player/PlayerActorHakoniwa.h
+++ b/src/Player/PlayerActorHakoniwa.h
@@ -141,7 +141,7 @@ public:
                     al::HitSensor* self) override;
     void control() override;
     void updateCollider() override;
-    void initPlayer(const al::ActorInitInfo&, const PlayerInitInfo&) override;
+    void initPlayer(const al::ActorInitInfo& actorInitInfo, const PlayerInitInfo& playerInitInfo) override;
     u32 getPortNo() const override;
     IUsePlayerCollision* getPlayerCollision() const override;
     PlayerHackKeeper* getPlayerHackKeeper() const override;

--- a/src/Player/PlayerActorHakoniwa.h
+++ b/src/Player/PlayerActorHakoniwa.h
@@ -141,7 +141,8 @@ public:
                     al::HitSensor* self) override;
     void control() override;
     void updateCollider() override;
-    void initPlayer(const al::ActorInitInfo& actorInitInfo, const PlayerInitInfo& playerInitInfo) override;
+    void initPlayer(const al::ActorInitInfo& actorInitInfo,
+                    const PlayerInitInfo& playerInitInfo) override;
     u32 getPortNo() const override;
     IUsePlayerCollision* getPlayerCollision() const override;
     PlayerHackKeeper* getPlayerHackKeeper() const override;

--- a/src/Player/PlayerBindableSensorList.h
+++ b/src/Player/PlayerBindableSensorList.h
@@ -12,7 +12,7 @@ public:
 
     void clear();
     void append(al::HitSensor* bindSensor, u32 type, f32 distance, s32 priority);
-    void remove(al::HitSensor* bindSensor);
+    void remove(al::HitSensor* toRemove);
     void sort();
 
     u32 getNum() const;

--- a/src/Player/PlayerCounterAfterUpperPunch.cpp
+++ b/src/Player/PlayerCounterAfterUpperPunch.cpp
@@ -2,7 +2,7 @@
 
 #include "Player/PlayerTrigger.h"
 
-PlayerCounterAfterUpperPunch::PlayerCounterAfterUpperPunch() {}
+PlayerCounterAfterUpperPunch::PlayerCounterAfterUpperPunch() = default;
 
 void PlayerCounterAfterUpperPunch::update(const PlayerTrigger* trigger) {
     if (mCounter <= (u32)sead::Mathi::maxNumber() - 1)

--- a/src/Player/PlayerCounterForceRun.cpp
+++ b/src/Player/PlayerCounterForceRun.cpp
@@ -2,7 +2,7 @@
 
 #include "Library/Math/MathUtil.h"
 
-PlayerCounterForceRun::PlayerCounterForceRun() {}
+PlayerCounterForceRun::PlayerCounterForceRun() = default;
 
 void PlayerCounterForceRun::setupForceRun(s32 frames, f32 speed) {
     mCounter = frames;

--- a/src/Player/PlayerJudgeLongFall.cpp
+++ b/src/Player/PlayerJudgeLongFall.cpp
@@ -21,9 +21,9 @@ bool PlayerJudgeLongFall::judge() const {
 
     if (mModelChanger->is2DModel())
         return false;
-    if (mBindKeeper->getBindSensor() != nullptr)
+    if (mBindKeeper->getBindSensor() )
         return false;
-    if (mHackKeeper->getUnkHitSensor() != nullptr)
+    if (mHackKeeper->getUnkHitSensor() )
         return false;
 
     f32 fallen = mFallDistanceCheck->getFallDistance();

--- a/src/Player/PlayerJudgeLongFall.cpp
+++ b/src/Player/PlayerJudgeLongFall.cpp
@@ -21,9 +21,9 @@ bool PlayerJudgeLongFall::judge() const {
 
     if (mModelChanger->is2DModel())
         return false;
-    if (mBindKeeper->getBindSensor() )
+    if (mBindKeeper->getBindSensor())
         return false;
-    if (mHackKeeper->getUnkHitSensor() )
+    if (mHackKeeper->getUnkHitSensor())
         return false;
 
     f32 fallen = mFallDistanceCheck->getFallDistance();

--- a/src/Player/PlayerJumpMessageRequest.cpp
+++ b/src/Player/PlayerJumpMessageRequest.cpp
@@ -1,6 +1,6 @@
 #include "Player/PlayerJumpMessageRequest.h"
 
-PlayerJumpMessageRequest::PlayerJumpMessageRequest() {}
+PlayerJumpMessageRequest::PlayerJumpMessageRequest() = default;
 
 void PlayerJumpMessageRequest::clear() {
     jumpType = PlayerJumpType::Standard;

--- a/src/Player/PlayerWallActionHistory.cpp
+++ b/src/Player/PlayerWallActionHistory.cpp
@@ -2,7 +2,7 @@
 
 #include "Util/PlayerCollisionUtil.h"
 
-PlayerWallActionHistory::PlayerWallActionHistory() {}
+PlayerWallActionHistory::PlayerWallActionHistory() = default;
 
 void PlayerWallActionHistory::update(const IUsePlayerCollision* collider) {
     if (rs::isCollidedGround(collider))

--- a/src/Scene/HintPhotoLayoutHolder.cpp
+++ b/src/Scene/HintPhotoLayoutHolder.cpp
@@ -20,7 +20,7 @@ DecideIconLayout* HintPhotoLayoutHolder::getDecideIcon() const {
 }
 
 void HintPhotoLayoutHolder::init(const al::LayoutInitInfo& initInfo) {
-    if (mLayoutActor == nullptr) {
+    if (!mLayoutActor ) {
         mLayoutActor = new al::LayoutActor("ヒント写真");
         al::initLayoutActor(mLayoutActor, initInfo, "HintPhoto", nullptr);
         mDecideIconLayout = new DecideIconLayout("決定アイコン", initInfo);

--- a/src/Scene/HintPhotoLayoutHolder.cpp
+++ b/src/Scene/HintPhotoLayoutHolder.cpp
@@ -20,7 +20,7 @@ DecideIconLayout* HintPhotoLayoutHolder::getDecideIcon() const {
 }
 
 void HintPhotoLayoutHolder::init(const al::LayoutInitInfo& initInfo) {
-    if (!mLayoutActor ) {
+    if (!mLayoutActor) {
         mLayoutActor = new al::LayoutActor("ヒント写真");
         al::initLayoutActor(mLayoutActor, initInfo, "HintPhoto", nullptr);
         mDecideIconLayout = new DecideIconLayout("決定アイコン", initInfo);

--- a/src/Scene/StageScene.h
+++ b/src/Scene/StageScene.h
@@ -22,7 +22,7 @@ class StageScene : public al::Scene {
 public:
     StageScene();
     ~StageScene() override;
-    void init(const al::SceneInitInfo&) override;
+    void init(const al::SceneInitInfo& initInfo) override;
     void appear() override;
     void kill() override;
 
@@ -36,7 +36,7 @@ public:
     unsigned char padding_d8[0x1F8];
     GameDataHolderAccessor* mHolder;
     unsigned char padding_2f8[0x20];
-    StageSceneLayout* stageSceneLayout;
+    StageSceneLayout* mStageSceneLayout;
 };
 
 namespace rs {

--- a/src/Scene/StageScene.h
+++ b/src/Scene/StageScene.h
@@ -31,8 +31,8 @@ public:
 
     bool isEnableSave() const;
 
+private:
     // somewhere here at 0xE0: stageName
-
     unsigned char padding_d8[0x1F8];
     GameDataHolderAccessor* mHolder;
     unsigned char padding_2f8[0x20];

--- a/src/Scene/TitleMenuScene.cpp
+++ b/src/Scene/TitleMenuScene.cpp
@@ -73,13 +73,13 @@ TitleMenuScene::~TitleMenuScene() {
         mChromakeyDrawer->finalize();
 }
 
-void TitleMenuScene::init(const al::SceneInitInfo& info) {
-    initDrawSystemInfo(info);
+void TitleMenuScene::init(const al::SceneInitInfo& initInfo) {
+    initDrawSystemInfo(initInfo);
     initAndLoadStageResource("SandWorldHomeStage", 1);
     al::SceneObjHolder* sceneObjHolder = SceneObjFactory::createSceneObjHolder();
     initSceneObjHolder(sceneObjHolder);
 
-    al::setSceneObj(this, GameDataFunction::getGameDataHolder(info.gameDataHolder),
+    al::setSceneObj(this, GameDataFunction::getGameDataHolder(initInfo.gameDataHolder),
                     SceneObjID_GameDataHolder);
 
     initSceneStopCtrl();
@@ -90,7 +90,7 @@ void TitleMenuScene::init(const al::SceneInitInfo& info) {
     graphicsInitArg._10 = 1 << graphicsInitArg.atmosScatterViewNum;
     graphicsInitArg._6 = true;
 
-    initLiveActorKitWithGraphics(graphicsInitArg, info, 1024, 1, 1);
+    initLiveActorKitWithGraphics(graphicsInitArg, initInfo, 1024, 1, 1);
     al::initGraphicsSystemInfo(this, "SandWorldHomeStage", 1);
 
     getLiveActorKit()->getGraphicsSystemInfo()->set_2f4(2);
@@ -101,10 +101,10 @@ void TitleMenuScene::init(const al::SceneInitInfo& info) {
         getLiveActorKit()->getPlayerHolder(), getLiveActorKit()->getGraphicsSystemInfo()));
 
     al::AudioDirectorInitInfo audioDirectorInitInfo;
-    al::initAudioDirector3D(this, info, audioDirectorInitInfo);
+    al::initAudioDirector3D(this, initInfo, audioDirectorInitInfo);
 
-    al::initSceneAudioKeeper(this, info, nullptr);
-    alAudioSystemFunction::disableAudioMaximizer(info.gameSysInfo);
+    al::initSceneAudioKeeper(this, initInfo, nullptr);
+    alAudioSystemFunction::disableAudioMaximizer(initInfo.gameSysInfo);
 
     ProjectCameraPoserFactory* projectCameraPoserFactory = new ProjectCameraPoserFactory();
     al::initCameraDirectorWithoutStageResource(this, projectCameraPoserFactory);
@@ -115,11 +115,11 @@ void TitleMenuScene::init(const al::SceneInitInfo& info) {
     ProjectAreaFactory* projectAreaFactory = new ProjectAreaFactory();
     areaObjDirector->init(projectAreaFactory);
 
-    al::initPadRumble(this, info);
+    al::initPadRumble(this, initInfo);
 
-    initLayoutKit(info);
+    initLayoutKit(initInfo);
     al::LayoutInitInfo layoutInitInfo;
-    al::initLayoutInitInfo(&layoutInitInfo, this, info);
+    al::initLayoutInitInfo(&layoutInitInfo, this, initInfo);
 
     al::PlacementInfo placementInfo;
     al::ActorInitInfo actorInitInfo;
@@ -127,7 +127,7 @@ void TitleMenuScene::init(const al::SceneInitInfo& info) {
     ProjectActorFactory* projectActorFactory = new ProjectActorFactory();
 
     al::initActorInitInfo(&actorInitInfo, this, &placementInfo, &layoutInitInfo,
-                          projectActorFactory, nullptr, info.gameDataHolder);
+                          projectActorFactory, nullptr, initInfo.gameDataHolder);
 
     initNerve(&NrvTitleMenuScene.Appear, 1);
 
@@ -151,7 +151,7 @@ void TitleMenuScene::init(const al::SceneInitInfo& info) {
                                                      layoutInitInfo, nullptr);
 
     mStatePauseMenu = new StageSceneStatePauseMenu(
-        "ポーズメニュー", this, mLayoutMenu, (GameDataHolder*)info.gameDataHolder, info,
+        "ポーズメニュー", this, mLayoutMenu, (GameDataHolder*)initInfo.gameDataHolder, initInfo,
         actorInitInfo, layoutInitInfo, mWindowConfirm, nullptr, true, nullptr);
 
     al::initNerveState(this, mStatePauseMenu, &NrvTitleMenuScene.Menu, "ポーズメニュー");

--- a/src/Scene/TitleMenuScene.h
+++ b/src/Scene/TitleMenuScene.h
@@ -16,7 +16,7 @@ public:
     TitleMenuScene();
     ~TitleMenuScene() override;
 
-    void init(const al::SceneInitInfo& info) override;
+    void init(const al::SceneInitInfo& initInfo) override;
     void appear() override;
     void control() override;
     void drawMain() const override;

--- a/src/Sequence/HakoniwaSequence.h
+++ b/src/Sequence/HakoniwaSequence.h
@@ -40,7 +40,7 @@ class HakoniwaSequence : public al::Sequence {
 public:
     HakoniwaSequence(const char* name);
 
-    void init(const al::SequenceInitInfo& info) override;
+    void init(const al::SequenceInitInfo& initInfo) override;
     void update() override;
     void drawMain() const override;
 

--- a/src/System/ByamlSave.h
+++ b/src/System/ByamlSave.h
@@ -9,6 +9,6 @@ class ByamlWriter;
 
 class ByamlSave : public al::HioNode {
 public:
-    virtual void write(al::ByamlWriter*) = 0;
-    virtual void read(const al::ByamlIter&) = 0;
+    virtual void write(al::ByamlWriter* writer) = 0;
+    virtual void read(const al::ByamlIter& save) = 0;
 };

--- a/src/System/GameConfigData.cpp
+++ b/src/System/GameConfigData.cpp
@@ -111,7 +111,7 @@ void GameConfigData::write(al::ByamlWriter* writer) {
     writer->pop();
 }
 
-void GameConfigData::read(const al::ByamlIter& conf) {
+void GameConfigData::read(const al::ByamlIter& save) {
     mCameraStickSensitivityLevel = -1;
     mIsCameraReverseInputH = false;
     mIsCameraReverseInputV = false;
@@ -122,7 +122,7 @@ void GameConfigData::read(const al::ByamlIter& conf) {
     mPadRumbleLevel = 0;
 
     al::ByamlIter iter;
-    al::tryGetByamlIterByKey(&iter, conf, "GameConfigData");
+    al::tryGetByamlIterByKey(&iter, save, "GameConfigData");
     al::tryGetByamlS32(&mCameraStickSensitivityLevel, iter, "CameraStickSensitivityLevel");
     al::tryGetByamlBool(&mIsCameraReverseInputH, iter, "IsCameraReverseInputH");
     al::tryGetByamlBool(&mIsCameraReverseInputV, iter, "IsCameraReverseInputV");

--- a/src/System/GameConfigData.h
+++ b/src/System/GameConfigData.h
@@ -37,7 +37,7 @@ public:
     s32 getPadRumbleLevel() const;
     void setPadRumbleLevel(s32 value);
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& conf) override;
+    void read(const al::ByamlIter& save) override;
 
 private:
     s32 mCameraStickSensitivityLevel = -1;

--- a/src/System/GameProgressData.cpp
+++ b/src/System/GameProgressData.cpp
@@ -374,11 +374,11 @@ void GameProgressData::write(al::ByamlWriter* writer) {
     writer->pop();
 }
 
-void GameProgressData::read(const al::ByamlIter& iter) {
+void GameProgressData::read(const al::ByamlIter& save) {
     init();
 
     al::ByamlIter hash;
-    iter.tryGetIterByKey(&hash, "GameProgressData");
+    save.tryGetIterByKey(&hash, "GameProgressData");
     hash.tryGetIntByKey((s32*)&mHomeStatus, "HomeStatus");
     hash.tryGetIntByKey(&mHomeLevel, "HomeLevel");
     hash.tryGetIntByKey(&mUnlockWorldNum, "UnlockWorldNum");

--- a/src/System/GameProgressData.h
+++ b/src/System/GameProgressData.h
@@ -38,7 +38,7 @@ public:
     };
 
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& iter) override;
+    void read(const al::ByamlIter& save) override;
 
     GameProgressData(const WorldList* worldList);
     void init();

--- a/src/System/PlayerHitPointData.cpp
+++ b/src/System/PlayerHitPointData.cpp
@@ -4,7 +4,7 @@
 #include "Library/Yaml/ByamlIter.h"
 #include "Library/Yaml/Writer/ByamlWriter.h"
 
-PlayerHitPointData::PlayerHitPointData() {}
+PlayerHitPointData::PlayerHitPointData() = default;
 
 void PlayerHitPointData::setKidsModeFlag(bool kidsMode) {
     mIsKidsMode = kidsMode;

--- a/src/System/PlayerHitPointData.cpp
+++ b/src/System/PlayerHitPointData.cpp
@@ -105,11 +105,11 @@ void PlayerHitPointData::write(al::ByamlWriter* writer) {
     writer->pop();
 }
 
-void PlayerHitPointData::read(const al::ByamlIter& reader) {
+void PlayerHitPointData::read(const al::ByamlIter& save) {
     init();
 
     al::ByamlIter hitPointData{};
-    reader.tryGetIterByKey(&hitPointData, "PlayerHitPointData");
+    save.tryGetIterByKey(&hitPointData, "PlayerHitPointData");
     hitPointData.tryGetBoolByKey(&mIsHaveMaxUpItem, "IsHaveMaxUpItem");
 
     recoverMax();

--- a/src/System/PlayerHitPointData.h
+++ b/src/System/PlayerHitPointData.h
@@ -30,7 +30,7 @@ public:
     void endForceNormalMode();
     bool isForceNormalMode() const;
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& reader) override;
+    void read(const al::ByamlIter& save) override;
 
 private:
     bool mIsKidsMode = false;

--- a/src/System/RaceRecord.cpp
+++ b/src/System/RaceRecord.cpp
@@ -52,7 +52,7 @@ void RaceRecord::write(al::ByamlWriter* writer) {
     writer->pop();
 }
 
-void RaceRecord::read(const al::ByamlIter& reader) {
+void RaceRecord::read(const al::ByamlIter& save) {
     mRecord = RaceTimeFunction::getRaceTimeMaxCsec();
     mBestRecord = RaceTimeFunction::getRaceTimeMaxCsec();
     mLapRecord = RaceTimeFunction::getRaceTimeMaxCsec();
@@ -62,7 +62,7 @@ void RaceRecord::read(const al::ByamlIter& reader) {
 
     al::ByamlIter recordData{};
 
-    reader.tryGetIterByKey(&recordData, mName.cstr());
+    save.tryGetIterByKey(&recordData, mName.cstr());
     recordData.tryGetIntByKey(&mRecord, "Record");
     recordData.tryGetIntByKey(&mLapRecord, "LapRecord");
     recordData.tryGetBoolByKey(&mIsWin, "IsWin");

--- a/src/System/RaceRecord.h
+++ b/src/System/RaceRecord.h
@@ -21,7 +21,7 @@ public:
     bool isEqualName(const char* name);
     void setRecord(s32 record, s32 bestRecord, s32 lapRecord, bool isWin);
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& reader) override;
+    void read(const al::ByamlIter& save) override;
 
 private:
     s32 mRecord = RaceTimeFunction::getRaceTimeMaxCsec();

--- a/src/System/SphinxQuizData.cpp
+++ b/src/System/SphinxQuizData.cpp
@@ -42,12 +42,12 @@ void SphinxQuizData::write(al::ByamlWriter* writer) {
     }
 }
 
-void SphinxQuizData::read(const al::ByamlIter& reader) {
+void SphinxQuizData::read(const al::ByamlIter& save) {
     init();
 
     for (s32 i = 0; i < mArraySize; i++) {
         al::ByamlIter sphinxData{};
-        reader.tryGetIterByIndex(&sphinxData, i);
+        save.tryGetIterByIndex(&sphinxData, i);
         sphinxData.tryGetBoolByKey(&mIsAnswerCorrectSphinxQuiz[i], "IsAnswerCorrectSphinxQuiz");
         sphinxData.tryGetBoolByKey(&mIsAnswerCorrectSphinxQuizAll[i],
                                    "IsAnswerCorrectSphinxQuizAll");

--- a/src/System/SphinxQuizData.h
+++ b/src/System/SphinxQuizData.h
@@ -18,7 +18,7 @@ public:
     bool isAnswerCorrectSphinxQuiz(s32 index) const;
     bool isAnswerCorrectSphinxQuizAll(s32 index) const;
     void write(al::ByamlWriter* writer) override;
-    void read(const al::ByamlIter& reader) override;
+    void read(const al::ByamlIter& save) override;
 
 private:
     bool* mIsAnswerCorrectSphinxQuiz;

--- a/src/Util/ExternalForceKeeper.cpp
+++ b/src/Util/ExternalForceKeeper.cpp
@@ -2,7 +2,7 @@
 
 #include "Util/SensorMsgFunction.h"
 
-ExternalForceKeeper::ExternalForceKeeper() {}
+ExternalForceKeeper::ExternalForceKeeper() = default;
 
 bool ExternalForceKeeper::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                                      al::HitSensor* self) {

--- a/src/Util/ItemGenerator.cpp
+++ b/src/Util/ItemGenerator.cpp
@@ -12,7 +12,7 @@
 #include "Enemy/KuriboMini.h"
 #include "Util/ItemUtil.h"
 
-ItemGenerator::ItemGenerator() {}
+ItemGenerator::ItemGenerator() = default;
 
 ItemGenerator::ItemGenerator(al::LiveActor* creator, const al::ActorInitInfo& info)
     : mCreator(creator) {


### PR DESCRIPTION
This PR fixes code styling stuff that will be dissallowed by the upcoming linter. As well as improving code styling, this PR also aims to document the process of working with the linter which will hopefully help with reviewing/improving MonsterDruide1/OdysseyDecompLinter#1 (Note that this PR also adds fixes for lints that will be added in later PRs after that one is merged). 
To achieve this, I've intentionally split this PR into 5 commits:
  * "Automatic fixes":
    * Fixes made by the linter automatically
    * Most of the changes in this PR
  * "Run clang-format":
    * `clang-format` the files after the automatic fixes
    * Shows how automatic fixes sometimes doing weird formatting is preferred over causing compiler errors with edge-cases
  *  "Manually fix compiling after automatic fixes (by renaming the usages of two struct variables)"
    * Shows that automatic lint fixes causing compiler errors is rare, but can happen
  * "Manual fixes for lints with no automatic ones (visibility checks and base function unnamed param check)"
    * Shows that for a few (currently two) lints, automatic fixes aren't made because either there is no easy way to automatically fix something, or the automatic fix would involve a decision we want to leave to the user
  * "More automatic fixes, caused by manual fixes (renaming params of overriding functions after base param names were added)"
    * Shows that sometimes making manual fixes can open up more automatic fixes