### PR TITLE
Library/LiveActor: Implement `ActorInitFunction`

### DIFF
--- a/lib/al/Library/Audio/System/AudioKeeper.h
+++ b/lib/al/Library/Audio/System/AudioKeeper.h
@@ -59,5 +59,6 @@ static_assert(sizeof(AudioKeeper) == 0x38);
 }  // namespace al
 
 namespace alAudioKeeperFunction {
+al::AudioKeeper* createAudioKeeper(const al::AudioDirector*);
 al::AudioKeeper* createAudioKeeper(const al::AudioDirector*, const char*, const char*);
-}
+}  // namespace alAudioKeeperFunction

--- a/lib/al/Library/Collision/CollisionDirector.h
+++ b/lib/al/Library/Collision/CollisionDirector.h
@@ -49,6 +49,8 @@ public:
     void invalidateCollisionPartsPtrArray();
     sead::PtrArray<CollisionParts>* getCollisionPartsPtrArray();
 
+    ICollisionPartsKeeper* getActivePartsKeeper() const { return mActivePartsKeeper; }
+
 private:
     ICollisionPartsKeeper* mActivePartsKeeper;
     CollisionPartsKeeperOctree* mRootOctree;

--- a/lib/al/Library/Collision/CollisionParts.h
+++ b/lib/al/Library/Collision/CollisionParts.h
@@ -11,9 +11,13 @@ class HitSensor;
 
 class CollisionParts {
 public:
+    CollisionParts(void* kcl, const void* byml);
+
     const LiveActor* getConnectedHost() const;
     void calcForceMovePower(sead::Vector3f*, const sead::Vector3f&) const;
     void calcForceRotatePower(sead::Quatf*) const;
+    void initParts(const sead::Matrix34f&);
+    void invalidateBySystem();
 
     const sead::Matrix34f& getBaseMtx() const { return mBaseMtx; }
 
@@ -29,11 +33,23 @@ public:
 
     const HitSensor* getConnectedSensor() const { return mConnectedSensor; }
 
+    void set_16e(bool val) { _16e = val; }
+
+    void setSpecialPurpose(const char* specialPurpose) { mSpecialPurpose = specialPurpose; }
+
+    void setOptionalPurpose(const char* optionalPurpose) { mOptionalPurpose = optionalPurpose; }
+
+    void setPriority(s32 priority) { mPriority = priority; }
+
+    void setConnectedSensor(HitSensor* sensor) { mConnectedSensor = sensor; }
+
+    void setJointMtx(const sead::Matrix34f* jointMtx) { mJointMtx = jointMtx; }
+
 private:
     void* unk[2];
     CollisionParts* _10;  // self-reference
     sead::TList<CollisionParts*>* mPartsList;
-    sead::Matrix34f* mJointMtx;
+    const sead::Matrix34f* mJointMtx;
     sead::Matrix34f mSyncMtx;
     sead::Matrix34f mBaseMtx;
     sead::Matrix34f mBaseInvMtx;

--- a/lib/al/Library/Draw/GraphicsSystemInfo.h
+++ b/lib/al/Library/Draw/GraphicsSystemInfo.h
@@ -192,6 +192,20 @@ public:
 
     PostProcessingFilter* getPostProcessingFilter() const { return mPostProcessingFilter; }
 
+    GpuMemAllocator* getGpuMemAllocator() const { return mGpuMemAllocator; }
+
+    ModelShaderHolder* getModelShaderHolder() const { return mModelShaderHolder; }
+
+    ModelOcclusionCullingDirector* getModelOcclusionCullingDirector() const {
+        return mModelOcclusionCullingDirector;
+    }
+
+    ShadowDirector* getShadowDirector() const { return mShadowDirector; }
+
+    PrepassTriangleCulling* getPrepassTriangleCulling() const { return mPrepassTriangleCulling; }
+
+    RadialBlurDirector* getRadialBlurDirector() const { return mRadialBlurDirector; }
+
 private:
     sead::StrTreeMap<128, const sead::PtrArray<UniformBlock>*> mViewIndexedUboArrayTree;
     GraphicsInitArg mInitArg;

--- a/lib/al/Library/LiveActor/ActorInitFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorInitFunction.cpp
@@ -1,0 +1,742 @@
+#include "Library/LiveActor/ActorInitFunction.h"
+
+#include <nn/g3d/ModelObj.h>
+
+#include "Library/Action/ActorActionKeeper.h"
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Camera/CameraDirector.h"
+#include "Library/Camera/CameraViewInfo.h"
+#include "Library/Camera/SceneCameraInfo.h"
+#include "Library/Collision/CollisionDirector.h"
+#include "Library/Collision/CollisionParts.h"
+#include "Library/Collision/ICollisionPartsKeeper.h"
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/Collision/PartsMtxConnector.h"
+#include "Library/Draw/GraphicsSystemInfo.h"
+#include "Library/Effect/EffectKeeper.h"
+#include "Library/Execute/ExecuteDirector.h"
+#include "Library/Execute/ExecuteUtil.h"
+#include "Library/Item/ItemUtil.h"
+#include "Library/Light/ModelMaterialCategory.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorParamHolder.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorResourceFunction.h"
+#include "Library/LiveActor/ActorSceneInfo.h"
+#include "Library/LiveActor/HitReactionKeeper.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/LiveActor/LiveActorInfo.h"
+#include "Library/LiveActor/LiveActorKeeper.h"
+#include "Library/Model/ModelCtrl.h"
+#include "Library/Model/ModelGroup.h"
+#include "Library/Model/ModelKeeper.h"
+#include "Library/Model/ModelShapeUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Play/Graphics/PrepassTriangleCulling.h"
+#include "Library/Resource/Resource.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/Screen/ScreenPointKeeper.h"
+#include "Library/Shader/ActorOcclusionKeeper.h"
+#include "Library/Shadow/DepthShadowMapCtrl.h"
+#include "Library/Shadow/DepthShadowMapDirector.h"
+#include "Library/Shadow/ShadowDirector.h"
+#include "Library/Shadow/ShadowKeeper.h"
+#include "Library/Shadow/ShadowMaskCastOvalCylinder.h"
+#include "Library/Shadow/ShadowMaskCtrl.h"
+#include "Library/Shadow/ShadowMaskCube.h"
+#include "Library/Shadow/ShadowMaskCylinder.h"
+#include "Library/Shadow/ShadowMaskDirector.h"
+#include "Library/Shadow/ShadowMaskSphere.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/ByamlUtil.h"
+#include "Project/Light/ActorPrepassLightKeeper.h"
+
+namespace al {
+
+void initActorSceneInfo(LiveActor* actor, const ActorInitInfo& info) {
+    auto* sceneInfo = new ActorSceneInfo();
+    *sceneInfo = info.actorSceneInfo;
+    actor->initSceneInfo(sceneInfo);
+    info.allActorsGroup->registerActor(actor);
+}
+
+void initExecutorUpdate(LiveActor* actor, const ActorInitInfo& info, const char* listName) {
+    registerExecutorActorUpdate(actor, info.executeDirector, listName);
+}
+
+void initExecutorDraw(LiveActor* actor, const ActorInitInfo& info, const char* listName) {
+    registerExecutorActorDraw(actor, info.executeDirector, listName);
+}
+
+void initExecutorPlayer(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "プレイヤー");
+    initExecutorDraw(actor, info, "プレイヤー");
+};
+
+void initExecutorPlayerPreMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "プレイヤー[PreMovement]");
+}
+
+void initExecutorPlayerMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "プレイヤー[Movement]");
+}
+
+void initExecutorPlayerModel(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "プレイヤーモデル");
+    initExecutorDraw(actor, info, "プレイヤーモデル");
+}
+
+void initExecutorPlayerDecoration(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "プレイヤー装飾");
+    initExecutorDraw(actor, info, "プレイヤー装飾");
+}
+
+void initExecutorEnemy(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "敵");
+    initExecutorDraw(actor, info, "敵");
+}
+
+void initExecutorEnemyMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "敵[Movement]");
+}
+
+void initExecutorEnemyDecoration(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "敵装飾");
+    initExecutorDraw(actor, info, "敵装飾");
+}
+
+void initExecutorEnemyDecorationMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "敵装飾[Movement]");
+}
+
+void initExecutorMapObj(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "地形オブジェ");
+    initExecutorDraw(actor, info, "地形オブジェ");
+}
+
+void initExecutorMapObjMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "地形オブジェ[Movement]");
+}
+
+void initExecutorMapObjDecoration(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "地形オブジェ装飾");
+    initExecutorDraw(actor, info, "地形オブジェ装飾");
+}
+
+void initExecutorNpcDecoration(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "ＮＰＣ装飾");
+    initExecutorDraw(actor, info, "ＮＰＣ");
+}
+
+void initExecutorShadowVolume(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "影ボリューム");
+    initExecutorDraw(actor, info, "影ボリューム");
+}
+
+void initExecutorShadowVolumeFillStencil(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "影ボリュームのフィル");
+    initExecutorDraw(actor, info, "影ボリュームのフィル");
+}
+
+void initExecutorCollisionMapObjDecorationMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "コリジョン地形装飾[Movement]");
+}
+
+void initExecutorWatchObj(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "監視オブジェ");
+}
+
+void initExecutorDebugMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "デバッグ[ActorMovement]");
+}
+
+// TODO: stores `calcViewCore` onto stack and immediately reads again
+// (https://decomp.me/scratch/FIy2O)
+void initExecutorModelUpdate(LiveActor* actor, const ActorInitInfo& info) {
+    s32 calcViewCore = actor->getModelKeeper()->getModelCtrl()->getCalcViewCore();
+    // mismatch here ^
+
+    const char* table;
+    if (calcViewCore == 1)
+        table = "ビュー更新(コア1)";
+    else if (calcViewCore == 2)
+        table = "ビュー更新(コア2)";
+    else if (actor->getModelKeeper()->getModelCtrl()->getModelObj()->get_8c() > 1)
+        table = "ビュー更新(コア1)";
+    else
+        table = "ビュー更新(コア2)";
+
+    initExecutorDraw(actor, info, "モデル描画バッファ更新");
+    if (isUsingPrepassTriangleCulling() && isIncludePrepassCullingShape(actor))
+        initExecutorDraw(actor, info, "カリング");
+    initExecutorUpdate(actor, info, table);
+}
+
+void initExecutorDrcAssistMovement(LiveActor* actor, const ActorInitInfo& info) {
+    initExecutorUpdate(actor, info, "DRCアシスト[Movement]");
+}
+
+void initActorPoseTRSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTRSV());
+}
+
+void initActorPoseTRMSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTRMSV());
+}
+
+void initActorPoseTRGMSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTRGMSV());
+}
+
+void initActorPoseTFSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTFSV());
+}
+
+void initActorPoseTFUSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTFUSV());
+}
+
+void initActorPoseTFGSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTFGSV());
+}
+
+void initActorPoseTQSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTQSV());
+}
+
+void initActorPoseTQGSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTQGSV());
+}
+
+void initActorPoseTQGMSV(LiveActor* actor) {
+    actor->initPoseKeeper(new ActorPoseKeeperTQGMSV());
+}
+
+void initActorSRT(LiveActor* actor, const ActorInitInfo& info) {
+    sead::Vector3f trans = {0.0f, 0.0f, 0.0f};
+    tryGetTrans(&trans, info);
+    setTrans(actor, trans);
+
+    sead::Vector3f rotate = {0.0f, 0.0f, 0.0f};
+    tryGetRotate(&rotate, info);
+    updatePoseRotate(actor, rotate);
+
+    sead::Vector3f scale = {1.0f, 1.0f, 1.0f};
+    tryGetScale(&scale, info);
+    setScale(actor, scale);
+}
+
+void initActorModelKeeper(LiveActor* actor, const ActorInitInfo& info,
+                          const ActorResource* resource, s32 blendAnimMax) {
+    auto* modelKeeper = new ModelKeeper();
+    modelKeeper->initResource(resource);
+
+    SceneCameraInfo* sceneCameraInfo = info.actorSceneInfo.cameraDirector->getSceneCameraInfo();
+
+    if (sceneCameraInfo->getViewNumMax() >= 2) {
+        modelKeeper->getModelCtrl()->setCameraInfo(
+            &sceneCameraInfo->getViewAt(0)->getLookAtCam().getMatrix(),
+            &sceneCameraInfo->getViewAt(1)->getLookAtCam().getMatrix(),
+            &sceneCameraInfo->getViewAt(0)->getProjMtx(),
+            &sceneCameraInfo->getViewAt(1)->getProjMtx());
+    } else {
+        modelKeeper->getModelCtrl()->setCameraInfo(
+            &sceneCameraInfo->getViewAt(0)->getLookAtCam().getMatrix(),
+            &sceneCameraInfo->getViewAt(0)->getLookAtCam().getMatrix(),
+            &sceneCameraInfo->getViewAt(0)->getProjMtx(),
+            &sceneCameraInfo->getViewAt(0)->getProjMtx());
+    }
+
+    modelKeeper->initModel(
+        blendAnimMax, info.actorSceneInfo.graphicsSystemInfo->getGpuMemAllocator(),
+        info.actorSceneInfo.graphicsSystemInfo->getModelShaderHolder(),
+        info.actorSceneInfo.graphicsSystemInfo->getModelOcclusionCullingDirector(),
+        info.actorSceneInfo.graphicsSystemInfo->getShadowDirector(),
+        info.actorSceneInfo.graphicsSystemInfo->getPrepassTriangleCulling());
+
+    {
+        const char* cubeMapName = nullptr;
+        tryGetStringArg(&cubeMapName, info, "CubeMapUnitName");
+        if (cubeMapName)
+            forceApplyCubeMap(modelKeeper, info.actorSceneInfo.graphicsSystemInfo, cubeMapName);
+    }
+
+    actor->initModelKeeper(modelKeeper);
+    info.actorSceneInfo.modelGroup->registerModel(modelKeeper);
+
+    sead::Matrix34f baseMtx;
+    actor->getPoseKeeper()->calcBaseMtx(&baseMtx);
+    setBaseMtxAndCalcAnim(actor, baseMtx, actor->getPoseKeeper()->getScale());
+}
+
+void initActorModelKeeper(LiveActor* actor, const ActorInitInfo& info, const char* actorResource,
+                          s32 blendAnimMax, const char* animResource) {
+    initActorModelKeeper(actor, info,
+                         findOrCreateActorResourceWithAnimResource(
+                             info.actorResourceHolder, actorResource, animResource, nullptr, false),
+                         blendAnimMax);
+}
+
+void initActorModelKeeperByHost(LiveActor* actor, const LiveActor* host) {
+    actor->initModelKeeper(host->getModelKeeper());
+}
+
+void initActorModelForceCubeMap(LiveActor* actor, const ActorInitInfo& info) {
+    const char* cubeMapName = nullptr;
+    tryGetStringArg(&cubeMapName, info, "CubeMapUnitName");
+    if (cubeMapName && actor->getModelKeeper())
+        forceApplyCubeMap(actor, cubeMapName);
+}
+
+void initActorActionKeeper(LiveActor* actor, const ActorInitInfo& info,
+                           const char* modelArchiveName, const char* suffix) {
+    ActorResource* resource = nullptr;
+    if (actor->getModelKeeper()) {
+        resource = findOrCreateActorResource(info.actorResourceHolder,
+                                             getModelResource(actor)->getPath(), suffix);
+    }
+
+    initActorActionKeeper(actor, resource, modelArchiveName, suffix);
+}
+
+void initActorActionKeeper(LiveActor* actor, const ActorResource* resource,
+                           const char* modelArchiveName, const char* suffix) {
+    auto* actionKeeper = ActorActionKeeper::tryCreate(actor, resource, modelArchiveName, suffix);
+    actor->initActionKeeper(actionKeeper);
+    if (actionKeeper)
+        actionKeeper->init();
+}
+
+void initActorEffectKeeper(LiveActor* actor, const ActorInitInfo& info, const char* name) {
+    auto* effectKeeper = new EffectKeeper(info.effectSystemInfo, name, getTransPtr(actor),
+                                          tryGetScalePtr(actor), actor->getBaseMtx());
+    actor->initEffectKeeper(effectKeeper);
+}
+
+void initActorSeKeeper(LiveActor* actor, const ActorInitInfo& info, const char* seName,
+                       const sead::Vector3f* transPtr, const sead::Matrix34f* baseMtx) {
+    AudioDirector* audioDirector = info.audioDirector;
+    AudioKeeper* audioKeeper;
+    if (actor->getAudioKeeper())
+        audioKeeper = actor->getAudioKeeper();
+    else {
+        audioKeeper = alAudioKeeperFunction::createAudioKeeper(audioDirector);
+        actor->initAudioKeeper(audioKeeper);
+    }
+    audioKeeper->initSeKeeper(audioDirector, seName, transPtr, baseMtx, actor->getModelKeeper(),
+                              info.actorSceneInfo.cameraDirector);
+}
+
+void initActorSeKeeper(LiveActor* actor, const ActorInitInfo& info, const char* seName) {
+    initActorSeKeeper(actor, info, seName, getTransPtr(actor), actor->getBaseMtx());
+}
+
+void initActorSeKeeperWithout3D(LiveActor* actor, const ActorInitInfo& info, const char* seName) {
+    initActorSeKeeper(actor, info, seName, nullptr, nullptr);
+}
+
+void initActorBgmKeeper(LiveActor* actor, const ActorInitInfo& info, const char* bgmName) {
+    AudioDirector* audioDirector = info.audioDirector;
+    AudioKeeper* audioKeeper;
+    if (actor->getAudioKeeper())
+        audioKeeper = actor->getAudioKeeper();
+    else {
+        audioKeeper = alAudioKeeperFunction::createAudioKeeper(audioDirector);
+        actor->initAudioKeeper(audioKeeper);
+    }
+    audioKeeper->initBgmKeeper(info.audioDirector, bgmName);
+}
+
+bool isInitializedBgmKeeper(LiveActor* actor) {
+    AudioKeeper* audioKeeper = actor->getAudioKeeper();
+    return audioKeeper && audioKeeper->getBgmKeeper();
+}
+
+void initHitReactionKeeper(LiveActor* actor, const char* suffix) {
+    initHitReactionKeeper(actor, getModelResource(actor), suffix);
+}
+
+void initHitReactionKeeper(LiveActor* actor, const Resource* resource, const char* suffix) {
+    HitReactionKeeper* hitReactionKeeper = HitReactionKeeper::tryCreate(
+        actor->getName(), getTransPtr(actor), actor, actor, actor,
+        actor->getSceneInfo()->padRumbleDirector, actor->getSceneInfo()->sceneStopCtrl,
+        actor->getSceneInfo()->graphicsSystemInfo->getRadialBlurDirector(),
+        actor->getSceneInfo()->playerHolder, resource, suffix);
+    if (hitReactionKeeper)
+        actor->setHitReactionKeeper(hitReactionKeeper);
+}
+
+void initActorParamHolder(LiveActor* actor, const char* suffix) {
+    initActorParamHolder(actor, getModelResource(actor), suffix);
+}
+
+void initActorParamHolder(LiveActor* actor, const Resource* resource, const char* suffix) {
+    ActorParamHolder* paramHolder = ActorParamHolder::tryCreate(actor, resource, suffix);
+    if (paramHolder)
+        actor->setActorParamHolder(paramHolder);
+}
+
+void initDepthShadowMapCtrl(LiveActor* actor, const Resource* resource, const ActorInitInfo& info,
+                            const char* suffix) {
+    ByamlIter fileIter;
+    sead::FixedSafeString<256> fileName;
+    if (!tryGetActorInitFileIterAndName(&fileIter, &fileName, resource, "InitDepthShadowMap",
+                                        suffix))
+        return;
+
+    DepthShadowMapCtrl* depthShadowMapCtrl = new DepthShadowMapCtrl(resource);
+    depthShadowMapCtrl->init(actor, fileIter);
+    actor->getShadowKeeper()->setDepthShadowMapCtrl(depthShadowMapCtrl);
+}
+
+void initDepthShadowMapCtrlWithoutIter(LiveActor* actor, s32 size, bool isAppendSubActor) {
+    DepthShadowMapCtrl* depthShadowMapCtrl = new DepthShadowMapCtrl(nullptr);
+    depthShadowMapCtrl->initWithoutIter(actor, size);
+    actor->getShadowKeeper()->setDepthShadowMapCtrl(depthShadowMapCtrl);
+    actor->getShadowKeeper()->getDepthShadowMapCtrl()->setAppendSubActor(isAppendSubActor);
+}
+
+// TODO: assign proper parameter names
+void addDepthShadowMapInfo(const LiveActor* actor, const char* a1, s32 a2, s32 a3, s32 a4, f32 a5,
+                           bool a6, const sead::Vector3f& a7, bool a8, const sead::Vector3f& a9,
+                           const sead::Vector3f& a10, bool a11, const char* a12, s32 a13, bool a14,
+                           f32 a15, f32 a16, f32 a17, bool a18, bool a19, f32 a20, s32 a21,
+                           bool a22) {
+    actor->getShadowKeeper()->getDepthShadowMapCtrl()->appendDepthShadowMapInfo(
+        a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15, a16, a17, a18, a19, a20,
+        a21, a22, false, 1.0f);
+}
+
+void declareUseDepthShadowMap(const LiveActor* actor, s32 num) {
+    actor->getSceneInfo()
+        ->graphicsSystemInfo->getShadowDirector()
+        ->getDepthShadowMapDirector()
+        ->declareUseDepthShadowMap(num);
+}
+
+// TODO: assign proper parameter names
+void createDepthShadowMap(const LiveActor* actor, const char* a1, s32 a2, s32 a3, s32 a4) {
+    actor->getSceneInfo()
+        ->graphicsSystemInfo->getShadowDirector()
+        ->getDepthShadowMapDirector()
+        ->createDepthShadowMap(actor->getShadowKeeper()->getDepthShadowMapCtrl(),
+                               actor->getModelKeeper(), a1, a2, a3, a4);
+}
+
+void initShadowMaskCtrl(LiveActor* actor, const ActorInitInfo& info, const ByamlIter& iter,
+                        const char* unused) {
+    bool isIgnoreShadowMaskYaml = false;
+    tryGetArg(&isIgnoreShadowMaskYaml, info, "IsIgnoreShadowMaskYaml");
+
+    ShadowMaskCtrl* shadowMaskCtrl = new ShadowMaskCtrl(isIgnoreShadowMaskYaml);
+    shadowMaskCtrl->init(actor, info, iter);
+
+    ShadowMaskDirector* shadowMaskDirector =
+        info.actorSceneInfo.graphicsSystemInfo->getShadowDirector()->getShadowMaskDirector();
+    s32 numShadowMasks = shadowMaskCtrl->getShadowMaskNum();
+    for (s32 i = 0; i < numShadowMasks; i++)
+        shadowMaskDirector->registerShadowMask(shadowMaskCtrl->getShadowMask(i));
+
+    actor->getShadowKeeper()->setShadowMaskCtrl(shadowMaskCtrl);
+}
+
+void initShadowMaskCtrlWithoutInitFile(LiveActor* actor, const ActorInitInfo& info, s32 numMasks) {
+    ShadowMaskCtrl* shadowMaskCtrl = new ShadowMaskCtrl(false);
+    shadowMaskCtrl->init(actor, numMasks);
+
+    ShadowMaskDirector* shadowMaskDirector =
+        info.actorSceneInfo.graphicsSystemInfo->getShadowDirector()->getShadowMaskDirector();
+    s32 numShadowMasks = shadowMaskCtrl->getShadowMaskNum();
+    for (s32 i = 0; i < numShadowMasks; i++)
+        shadowMaskDirector->registerShadowMask(shadowMaskCtrl->getShadowMask(i));
+
+    actor->getShadowKeeper()->setShadowMaskCtrl(shadowMaskCtrl);
+}
+
+void createShadowMaskSphere(LiveActor* actor, const char* name, const char* jointName,
+                            const char* drawCategory) {
+    ShadowMaskSphere* shadowMaskSphere = new ShadowMaskSphere(name);
+    shadowMaskSphere->createMtxConnector();
+    shadowMaskSphere->setDrawCategory(drawCategory);
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    shadowMaskSphere->setHost(actor);
+    shadowMaskSphere->declare(shadowMaskSphere->getDrawCategory());
+
+    MtxConnector* mtxConnector = shadowMaskSphere->getMtxConnector();
+    if (jointName && !isEqualString(jointName, "") && isExistJoint(actor, jointName))
+        attachMtxConnectorToJoint(mtxConnector, actor, jointName);
+    else
+        attachMtxConnectorToActor(mtxConnector, actor);
+
+    shadowMaskCtrl->appendShadowMask(shadowMaskSphere);
+}
+
+// TODO: assign proper parameter names
+void createShadowMaskCube(LiveActor* actor, const char* name, const char* jointName,
+                          const char* drawCategory, const sead::Color4f& color,
+                          const sead::Vector3f& offset, f32 a2, f32 a3, f32 dropLength,
+                          const sead::Vector3f& a5, f32 a6) {
+    ShadowMaskCube* shadowMaskCube = new ShadowMaskCube(name);
+    shadowMaskCube->createMtxConnector();
+    shadowMaskCube->init(a2, a3, dropLength, a5, a6, offset, color);
+    shadowMaskCube->setDrawCategory(drawCategory);
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    shadowMaskCube->setHost(actor);
+    shadowMaskCube->declare(shadowMaskCube->getDrawCategory());
+
+    MtxConnector* mtxConnector = shadowMaskCube->getMtxConnector();
+    if (jointName && !isEqualString(jointName, "") && isExistJoint(actor, jointName))
+        attachMtxConnectorToJoint(mtxConnector, actor, jointName);
+    else
+        attachMtxConnectorToActor(mtxConnector, actor);
+
+    shadowMaskCtrl->appendShadowMask(shadowMaskCube);
+}
+
+// TODO: assign proper parameter names
+void createShadowMaskCylinder(LiveActor* actor, const char* name, const char* jointName,
+                              const char* drawCategory, const sead::Color4f& color,
+                              const sead::Vector3f& offset, f32 a2, f32 dropLength, f32 a3, f32 a5,
+                              f32 a6) {
+    ShadowMaskCylinder* shadowMaskCylinder = new ShadowMaskCylinder(name);
+    shadowMaskCylinder->createMtxConnector();
+    shadowMaskCylinder->init(a2, dropLength, a3, a5, a6, offset, color);
+    shadowMaskCylinder->setDrawCategory(drawCategory);
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    shadowMaskCylinder->setHost(actor);
+    shadowMaskCylinder->declare(shadowMaskCylinder->getDrawCategory());
+
+    MtxConnector* mtxConnector = shadowMaskCylinder->getMtxConnector();
+    if (jointName && !isEqualString(jointName, "") && isExistJoint(actor, jointName))
+        attachMtxConnectorToJoint(mtxConnector, actor, jointName);
+    else
+        attachMtxConnectorToActor(mtxConnector, actor);
+
+    shadowMaskCtrl->appendShadowMask(shadowMaskCylinder);
+}
+
+void createShadowMaskCastOvalCylinder(LiveActor* actor, const char* name, const char* jointName,
+                                      const char* drawCategory, const sead::Color4f& color,
+                                      const sead::Vector3f& offset, const sead::Vector3f& scale,
+                                      f32 dropLength, f32 expXZ, f32 expY, f32 distYBase) {
+    ShadowMaskCastOvalCylinder* shadowMaskCastOvalCylinder = new ShadowMaskCastOvalCylinder(name);
+    shadowMaskCastOvalCylinder->createMtxConnector();
+    shadowMaskCastOvalCylinder->init(scale, dropLength, expXZ, expY, distYBase, offset, color);
+    shadowMaskCastOvalCylinder->setDrawCategory(drawCategory);
+    ShadowMaskCtrl* shadowMaskCtrl = actor->getShadowKeeper()->getShadowMaskCtrl();
+    shadowMaskCastOvalCylinder->setHost(actor);
+    shadowMaskCastOvalCylinder->declare(shadowMaskCastOvalCylinder->getDrawCategory());
+
+    MtxConnector* mtxConnector = shadowMaskCastOvalCylinder->getMtxConnector();
+    if (jointName && !isEqualString(jointName, "") && isExistJoint(actor, jointName))
+        attachMtxConnectorToJoint(mtxConnector, actor, jointName);
+    else
+        attachMtxConnectorToActor(mtxConnector, actor);
+
+    shadowMaskCtrl->appendShadowMask(shadowMaskCastOvalCylinder);
+}
+
+void initActorCollision(LiveActor* actor, const sead::SafeString& filePath,
+                        HitSensor* connectedSensor, const sead::Matrix34f* jointMtx) {
+    initActorCollisionWithResource(actor, getModelResource(actor), filePath, connectedSensor,
+                                   jointMtx, nullptr);
+}
+
+void initActorCollisionWithResource(LiveActor* actor, const Resource* resource,
+                                    const sead::SafeString& filePath, HitSensor* connectedSensor,
+                                    const sead::Matrix34f* jointMtx, const char* suffix) {
+    sead::FixedSafeString<256> attributePath;
+    attributePath = filePath;
+    attributePath.append("Attribute");
+
+    const void* kcl = resource->tryGetKcl(filePath);
+    if (!kcl)
+        return;
+
+    const u8* byml = resource->tryGetByml(attributePath);
+
+    const char* specialPurpose = nullptr;
+    const char* optionalPurpose = nullptr;
+    s32 priority = -1;
+
+    ByamlIter collision;
+    if (tryGetActorInitFileIter(&collision, resource, "InitCollision", suffix)) {
+        collision.tryGetStringByKey(&specialPurpose, "SpecialPurpose");
+        collision.tryGetStringByKey(&optionalPurpose, "OptionalPurpose");
+        collision.tryGetIntByKey(&priority, "Priority");
+    }
+
+    initActorCollisionWithFilePtr(actor, const_cast<void*>(kcl), byml, connectedSensor, jointMtx,
+                                  specialPurpose, optionalPurpose, priority);
+}
+
+void initActorCollisionWithArchiveName(LiveActor* actor, const sead::SafeString& resourceName,
+                                       const sead::SafeString& filePath, HitSensor* connectedSensor,
+                                       const sead::Matrix34f* jointMtx) {
+    initActorCollisionWithResource(actor, findOrCreateResource(resourceName, nullptr), filePath,
+                                   connectedSensor, jointMtx, nullptr);
+}
+
+void initActorCollisionWithFilePtr(LiveActor* actor, void* kcl, const void* byml,
+                                   HitSensor* connectedSensor, const sead::Matrix34f* jointMtx,
+                                   const char* specialPurpose, const char* optionalPurpose,
+                                   s32 priority) {
+    CollisionParts* parts = new CollisionParts(const_cast<void*>(kcl), byml);
+    parts->set_16e(true);
+    parts->setSpecialPurpose(specialPurpose);
+    parts->setOptionalPurpose(optionalPurpose);
+    parts->setPriority(priority);
+    sead::Matrix34f initMtx;
+    makeMtxSRT(&initMtx, actor);
+    parts->setConnectedSensor(connectedSensor);
+    parts->initParts(initMtx);
+    parts->setJointMtx(jointMtx);
+
+    actor->getCollisionDirector()->getActivePartsKeeper()->addCollisionParts(parts);
+    parts->invalidateBySystem();
+    actor->setCollisionParts(parts);
+}
+
+void initStageSwitch(LiveActor* actor, const ActorInitInfo& info) {
+    initStageSwitch(actor, info.stageSwitchDirector, *info.placementInfo);
+}
+
+void initActorItemKeeper(LiveActor* actor, const ActorInitInfo& info, const ByamlIter& iter) {
+    s32 addItemNum = 0;
+
+    ByamlIter initInfo;
+    if (iter.tryGetIterByKey(&initInfo, "InitInfo")) {
+        s32 addItemNum_ = 0;
+        if (initInfo.tryGetIntByKey(&addItemNum_, "AddItemNum"))
+            addItemNum = addItemNum_;
+    }
+
+    const ByamlIter* itemList;
+    ByamlIter itemList_;
+    if (iter.tryGetIterByKey(&itemList_, "ItemList"))
+        itemList = &itemList_;
+    else
+        itemList = &iter;
+    ByamlIter items = *itemList;
+
+    s32 itemsNum = items.getSize();
+    s32 totalItems = itemsNum + addItemNum;
+
+    if (totalItems <= 0)
+        return;
+
+    actor->initItemKeeper(totalItems);
+    for (s32 i = 0; i < totalItems; i++) {
+        ByamlIter itemIter;
+        if (!items.tryGetIterByIndex(&itemIter, i))
+            continue;
+
+        const char* item = nullptr;
+        if (!itemIter.tryGetStringByKey(&item, "Item"))
+            continue;
+
+        const char* timing = nullptr;
+        itemIter.tryGetStringByKey(&timing, "Timing");
+        const char* factor = nullptr;
+        itemIter.tryGetStringByKey(&factor, "Factor");
+        bool isNoDeclarePlacementActor =
+            tryGetByamlKeyBoolOrFalse(itemIter, "IsNoDeclarePlacementActor");
+        s32 numMax = -1;
+        itemIter.tryGetIntByKey(&numMax, "NumMax");
+        addItem(actor, info, item, timing, factor, numMax, isNoDeclarePlacementActor);
+    }
+}
+
+bool initActorPrePassLightKeeper(LiveActor* actor, const Resource* resource,
+                                 const ActorInitInfo& info, const char* suffix) {
+    if (!ActorPrePassLightKeeper::isExistFile(resource, suffix))
+        return false;
+
+    ActorPrePassLightKeeper* keeper = new ActorPrePassLightKeeper(actor);
+    keeper->init(resource, info, suffix);
+    actor->initActorPrePassLightKeeper(keeper);
+    return true;
+}
+
+void initActorOcclusionKeeper(LiveActor* actor, const Resource* resource, const ActorInitInfo& info,
+                              const char* fileSuffix) {
+    GraphicsSystemInfo* graphicsSystemInfo = info.actorSceneInfo.graphicsSystemInfo;
+    if (!ActorOcclusionKeeper::isExistFile(resource, fileSuffix))
+        return;
+
+    ActorOcclusionKeeper* keeper =
+        new ActorOcclusionKeeper(graphicsSystemInfo, resource, actor, fileSuffix);
+    actor->initActorOcclusionKeeper(keeper);
+}
+
+void initSubActorKeeper(LiveActor* actor, const ActorInitInfo& info, const char* suffix,
+                        s32 maxSubActors) {
+    SubActorKeeper* keeper = SubActorKeeper::tryCreate(actor, suffix, maxSubActors);
+    if (!keeper)
+        return;
+
+    actor->initSubActorKeeper(keeper);
+    keeper->init(info, suffix, maxSubActors);
+}
+
+void initSubActorKeeperNoFile(LiveActor* actor, const ActorInitInfo& info, s32 maxSubActors) {
+    SubActorKeeper* keeper = SubActorKeeper::create(actor);
+    actor->initSubActorKeeper(keeper);
+    keeper->init(info, nullptr, maxSubActors);
+}
+
+void registerSubActor(LiveActor* actor, LiveActor* subActor) {
+    actor->getSubActorKeeper()->registerSubActor(subActor, 0);
+}
+
+void registerSubActorSyncClipping(LiveActor* actor, LiveActor* subActor) {
+    actor->getSubActorKeeper()->registerSubActor(subActor, 2);
+}
+
+void registerSubActorSyncClippingAndHide(LiveActor* actor, LiveActor* subActor) {
+    actor->getSubActorKeeper()->registerSubActor(subActor, 6);
+}
+
+void registerSubActorSyncAll(LiveActor* actor, LiveActor* subActor) {
+    actor->getSubActorKeeper()->registerSubActor(subActor, 15);
+}
+
+void setSubActorOffSyncClipping(LiveActor* actor) {
+    SubActorKeeper* keeper = actor->getSubActorKeeper();
+    for (s32 i = 0; i < keeper->getCurActorCount(); i++)
+        keeper->getActorInfo(i)->syncType &= ~2;
+}
+
+void initScreenPointKeeper(LiveActor* actor, const Resource* resource, const ActorInitInfo& info,
+                           const char* fileName) {
+    if (!ScreenPointKeeper::isExistFile(resource, fileName))
+        return;
+
+    ScreenPointKeeper* keeper = new ScreenPointKeeper();
+    keeper->initByYaml(actor, resource, info, fileName);
+    actor->initScreenPointKeeper(keeper);
+}
+
+void initScreenPointKeeperNoYaml(LiveActor* actor, s32 size) {
+    if (actor->getScreenPointKeeper())
+        return;
+
+    ScreenPointKeeper* keeper = new ScreenPointKeeper();
+    keeper->initArray(size);
+    actor->initScreenPointKeeper(keeper);
+}
+
+// TODO: rename parameter
+void initActorMaterialCategory(LiveActor* actor, const ActorInitInfo& info, const char* a1) {
+    GraphicsSystemInfo* graphicsSystemInfo = info.actorSceneInfo.graphicsSystemInfo;
+    ModelMaterialCategory::tryCreate(actor->getModelKeeper()->getModelCtrl(), a1,
+                                     graphicsSystemInfo->getMaterialCategoryKeeper());
+}
+
+}  // namespace al

--- a/lib/al/Library/LiveActor/ActorInitFunction.h
+++ b/lib/al/Library/LiveActor/ActorInitFunction.h
@@ -23,8 +23,8 @@ class Resource;
 class ShadowMaskBase;
 
 void initActorSceneInfo(LiveActor* actor, const ActorInitInfo& info);
-void initExecutorUpdate(LiveActor* actor, const ActorInitInfo& info, const char*);
-void initExecutorDraw(LiveActor* actor, const ActorInitInfo& info, const char*);
+void initExecutorUpdate(LiveActor* actor, const ActorInitInfo& info, const char* listName);
+void initExecutorDraw(LiveActor* actor, const ActorInitInfo& info, const char* listName);
 void initExecutorPlayer(LiveActor* actor, const ActorInitInfo& info);
 void initExecutorPlayerPreMovement(LiveActor* actor, const ActorInitInfo& info);
 void initExecutorPlayerMovement(LiveActor* actor, const ActorInitInfo& info);

--- a/lib/al/Library/LiveActor/LiveActor.h
+++ b/lib/al/Library/LiveActor/LiveActor.h
@@ -162,6 +162,14 @@ public:
 
     void setName(const char* newName) { mName = newName; }
 
+    void setHitReactionKeeper(HitReactionKeeper* hitReactionKeeper) {
+        mHitReactionKeeper = hitReactionKeeper;
+    }
+
+    void setActorParamHolder(ActorParamHolder* paramHolder) { mParamHolder = paramHolder; }
+
+    void setCollisionParts(CollisionParts* collisionParts) { mCollisionParts = collisionParts; }
+
 protected:
     friend class alActorFunction;
 

--- a/lib/al/Library/Model/ModelCtrl.h
+++ b/lib/al/Library/Model/ModelCtrl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
 
 namespace nn::g3d {
 class ModelObj;
@@ -23,10 +24,14 @@ public:
     void show();
     void hide();
     void recreateDisplayList();
+    void setCameraInfo(const sead::Matrix34f*, const sead::Matrix34f*, const sead::Matrix44f*,
+                       const sead::Matrix44f*);
 
     nn::g3d::ModelObj* getModelObj() const { return mModelObj; }
 
     ActorDitherAnimator* getActorDitherAnimator() const { return mActorDitherAnimator; }
+
+    s32 getCalcViewCore() const { return mCalcViewCore; }
 
     void setCalcViewCore(s32 core) { mCalcViewCore = core; }
 

--- a/lib/al/Library/Model/ModelKeeper.h
+++ b/lib/al/Library/Model/ModelKeeper.h
@@ -27,7 +27,7 @@ public:
 
     virtual ~ModelKeeper();
 
-    void initResource();
+    void initResource(const ActorResource*);
     void createMatAnimForProgram(s32);
     void setDisplayRootJointMtxPtr(const sead::Matrix34f* mtx);
     void setModelLodCtrl(ModelLodCtrl* modelLodCtrl);

--- a/lib/al/Library/Model/ModelShapeUtil.h
+++ b/lib/al/Library/Model/ModelShapeUtil.h
@@ -3,10 +3,12 @@
 #include <math/seadMatrix.h>
 
 namespace al {
+class GraphicsSystemInfo;
 class ModelKeeper;
 
 bool isGreaterEqualMaxLodLevelNoClamp(const ModelKeeper* modelKeeper);
 bool isLessMaxLodLevelNoClamp(const ModelKeeper* modelKeeper);
 void setModelProjMtx0(const ModelKeeper*, const sead::Matrix44f&);
+void forceApplyCubeMap(ModelKeeper*, const GraphicsSystemInfo*, const char*);
 
 }  // namespace al

--- a/lib/al/Library/Play/Graphics/PrepassTriangleCulling.h
+++ b/lib/al/Library/Play/Graphics/PrepassTriangleCulling.h
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace al {
+
+bool isUsingPrepassTriangleCulling();
+
+}

--- a/lib/al/Library/Shader/ActorOcclusionKeeper.h
+++ b/lib/al/Library/Shader/ActorOcclusionKeeper.h
@@ -1,11 +1,24 @@
 #pragma once
 
 namespace al {
+class Resource;
+class GraphicsSystemInfo;
+class LiveActor;
+
 class ActorOcclusionKeeper {
 public:
+    static bool isExistFile(const Resource*, const char*);
+
+    ActorOcclusionKeeper(const GraphicsSystemInfo*, const Resource*, const LiveActor*, const char*);
     void appear(bool isModelHidden);
     void requestKill();
     void updateAndRequest();
     void hideModel();
+
+private:
+    void* _0[0x298 / 8];
 };
+
+static_assert(sizeof(ActorOcclusionKeeper) == 0x298);
+
 }  // namespace al

--- a/lib/al/Library/Shadow/ActorShadowUtil.h
+++ b/lib/al/Library/Shadow/ActorShadowUtil.h
@@ -3,6 +3,8 @@
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
 
+#include "Library/Shadow/ShadowMaskBase.h"
+
 namespace sead {
 class Color4f;
 }
@@ -12,8 +14,6 @@ class LiveActor;
 class ShadowMaskBase;
 class DepthShadowMapInfo;
 class OccSphere;
-
-enum class ShadowMaskDrawCategory : s32 {};
 
 bool isExistShadow(LiveActor* actor);
 bool isExistShadowMaskCtrl(LiveActor* actor);

--- a/lib/al/Library/Shadow/DepthShadowMapCtrl.h
+++ b/lib/al/Library/Shadow/DepthShadowMapCtrl.h
@@ -37,6 +37,8 @@ public:
     void update();
     void updateShapeVisible(const LiveActor* actor);
 
+    void setAppendSubActor(bool isAppendSubActor) { mIsAppendSubActor = isAppendSubActor; }
+
 private:
     LiveActor* mLiveActor;
     sead::Vector3f mLightDir;

--- a/lib/al/Library/Shadow/DepthShadowMapDirector.h
+++ b/lib/al/Library/Shadow/DepthShadowMapDirector.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+namespace al {
+class DepthShadowMapCtrl;
+class ModelKeeper;
+
+class DepthShadowMapDirector : public HioNode {
+public:
+    virtual ~DepthShadowMapDirector();
+
+    void createDepthShadowMap(const DepthShadowMapCtrl*, const ModelKeeper*, const char*, s32, s32,
+                              s32);
+
+    void declareUseDepthShadowMap(s32 num) { _68 += num; }
+
+private:
+    void* _8[0x60 / 8];
+    s32 _68;
+    s32 _6c;
+    void* _70[0x58 / 8];
+};
+
+static_assert(sizeof(DepthShadowMapDirector) == 0xc8);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowDirector.h
+++ b/lib/al/Library/Shadow/ShadowDirector.h
@@ -23,6 +23,8 @@ class Projection;
 class ShaderHolder;
 class DepthShadowParam;
 class DepthShadowClipParam;
+class DepthShadowMapDirector;
+class ShadowMaskDirector;
 
 class ShadowDirector {
 public:
@@ -53,6 +55,18 @@ public:
     void* getCurrentFar() const;          // unknown return type
     bool requestParam(s32, s32, const DepthShadowParam&);
     bool requestParam(s32, s32, const DepthShadowClipParam&);
+
+    ShadowMaskDirector* getShadowMaskDirector() const { return mShadowMaskDirector; }
+
+    DepthShadowMapDirector* getDepthShadowMapDirector() const { return mDepthShadowMapDirector; }
+
+private:
+    void* _0[1];
+    ShadowMaskDirector* mShadowMaskDirector;
+    DepthShadowMapDirector* mDepthShadowMapDirector;
+    void* _10[0x148 / 8];
 };
+
+static_assert(sizeof(ShadowDirector) == 0x160);
 
 }  // namespace al

--- a/lib/al/Library/Shadow/ShadowKeeper.h
+++ b/lib/al/Library/Shadow/ShadowKeeper.h
@@ -15,7 +15,13 @@ public:
     void hide();
     void show();
 
+    void setShadowMaskCtrl(ShadowMaskCtrl* ctrl) { mShadowMaskCtrl = ctrl; }
+
     ShadowMaskCtrl* getShadowMaskCtrl() const { return mShadowMaskCtrl; }
+
+    void setDepthShadowMapCtrl(DepthShadowMapCtrl* ctrl) { mDepthShadowMapCtrl = ctrl; }
+
+    DepthShadowMapCtrl* getDepthShadowMapCtrl() const { return mDepthShadowMapCtrl; }
 
 private:
     ShadowMaskCtrl* mShadowMaskCtrl = nullptr;

--- a/lib/al/Library/Shadow/ShadowMaskBase.h
+++ b/lib/al/Library/Shadow/ShadowMaskBase.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <gfx/seadColor.h>
+#include <math/seadMatrix.h>
+#include <prim/seadEnum.h>
+#include <prim/seadSafeString.h>
+
+namespace al {
+class LiveActor;
+class ByamlIter;
+class MtxConnector;
+enum class ShadowMaskType;
+
+SEAD_ENUM(ShadowMaskDrawCategory, シャドウ, AO, ライトスケール, ライトバッファ加算)
+
+class ShadowMaskBase {
+public:
+    ShadowMaskBase(const char*);
+
+    virtual ~ShadowMaskBase();
+    virtual void declare(ShadowMaskDrawCategory);
+    virtual void update();
+    virtual void initAfterPlacement();
+    virtual void calcShadowMatrix(sead::Matrix34f*);
+    virtual void createMtxConnector();
+    virtual void readParam(const ByamlIter&);
+    virtual void updateMulti();
+    virtual void addMulti();
+    virtual ShadowMaskType getShadowMaskType() const = 0;
+
+    void setHost(const LiveActor*);
+    void setDrawCategory(const char*);
+
+    MtxConnector* getMtxConnector() const { return mMtxConnector; }
+
+    ShadowMaskDrawCategory getDrawCategory() const { return mDrawCategory; }
+
+    void setDropLength(f32 dropLength) { mDropLength = dropLength; }
+
+    void setOffset(const sead::Vector3f& offset) { mOffset.set(offset); }
+
+    void setColor(const sead::Color4f& color) { mColor = color; }
+
+    void setDrawCategory(ShadowMaskDrawCategory drawCategory) { mDrawCategory = drawCategory; }
+
+private:
+    const LiveActor* mHost;
+    MtxConnector* mMtxConnector;
+    sead::Vector3f mOffset;
+    sead::Color4f mColor;
+    sead::Vector3f _34;
+    f32 mDropLength;
+    s32 pad2;
+    void* _48[1];
+    const char* mName;
+    bool mIsFixedIntensity;
+    bool mIsFollowHostScale;
+    bool mIsIgnoreHide;
+    bool pad4;
+    ShadowMaskDrawCategory mDrawCategory;
+    bool mIsShadowFixed;
+    bool pad3[7];
+    const char* mActorJointName;
+    void* _70[7];
+    sead::FixedSafeString<32> mSetHeightEvenTargetName;
+    s32 _dc[3];
+};
+
+static_assert(sizeof(ShadowMaskBase) == 0xf0);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowMaskCastOvalCylinder.h
+++ b/lib/al/Library/Shadow/ShadowMaskCastOvalCylinder.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include "Library/Shadow/ShadowMaskBase.h"
+
+namespace al {
+
+class ShadowMaskCastOvalCylinder : public ShadowMaskBase {
+public:
+    ShadowMaskCastOvalCylinder(const char*);
+
+    ~ShadowMaskCastOvalCylinder() override;
+    void declare(ShadowMaskDrawCategory) override;
+    void update() override;
+    void calcShadowMatrix(sead::Matrix34f*) override;
+    void updateMulti() override;
+    void addMulti() override;
+    ShadowMaskType getShadowMaskType() const override;
+
+    void calcOvalWrapMtxCylinder(sead::Matrix34f*, sead::Matrix34f, const sead::Vector3f&, f32);
+
+    void init(const sead::Vector3f& scale, f32 dropLength, f32 expXZ, f32 expY, f32 distYBase,
+              const sead::Vector3f& offset, const sead::Color4f& color) {
+        mScale = scale;
+        setDropLength(dropLength);
+        mExpXZ = expXZ;
+        mExpY = expY;
+        mDistYBase = distYBase;
+        setOffset(offset);
+        setColor(color);
+        setDrawCategory(ShadowMaskDrawCategory::ライトバッファ加算);
+    }
+
+private:
+    sead::Vector3f mScale;
+    void* _f8;
+    s32 _100;
+    f32 mExpXZ;
+    f32 mExpY;
+    f32 mDistYBase;
+    void* _110[6];
+};
+
+static_assert(sizeof(ShadowMaskCastOvalCylinder) == 0x140);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowMaskCtrl.h
+++ b/lib/al/Library/Shadow/ShadowMaskCtrl.h
@@ -33,6 +33,10 @@ public:
     void show();
     void validate();
 
+    s32 getShadowMaskNum() const { return mShadowMasks.size(); }
+
+    ShadowMaskBase* getShadowMask(s32 index) const { return mShadowMasks[index]; }
+
 private:
     sead::PtrArray<ShadowMaskBase> mShadowMasks;
     sead::Matrix34f mMtx;

--- a/lib/al/Library/Shadow/ShadowMaskCube.h
+++ b/lib/al/Library/Shadow/ShadowMaskCube.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <gfx/seadColor.h>
+
+#include "Library/Shadow/ShadowMaskBase.h"
+
+namespace al {
+
+class ShadowMaskCube : public ShadowMaskBase {
+public:
+    ShadowMaskCube(const char*);
+
+    ~ShadowMaskCube() override;
+    void declare(ShadowMaskDrawCategory) override;
+    void update() override;
+    void calcShadowMatrix(sead::Matrix34f*) override;
+    void updateMulti() override;
+    void addMulti() override;
+    ShadowMaskType getShadowMaskType() const override;
+
+    void tryInitTexture(const char*);
+
+    // TODO: assign proper parameter names
+    void init(f32 a1, f32 a2, f32 dropLength, const sead::Vector3f& a4, f32 a5,
+              const sead::Vector3f& offset, const sead::Color4f& color) {
+        _ec = a1;
+        _f4 = a2;
+        _f0 = 1.0f;
+        setDropLength(dropLength);
+        _f8.set(a4);
+        _104 = a5;
+        setOffset(offset);
+        setColor(color);
+        setDrawCategory(ShadowMaskDrawCategory::AO);
+    }
+
+private:
+    f32 _ec;
+    f32 _f0;
+    f32 _f4;
+    sead::Vector3f _f8;
+    f32 _104;
+    void* _108[46];
+};
+
+static_assert(sizeof(ShadowMaskCube) == 0x278);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowMaskCylinder.h
+++ b/lib/al/Library/Shadow/ShadowMaskCylinder.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Library/Shadow/ShadowMaskBase.h"
+
+namespace al {
+
+class ShadowMaskCylinder : public ShadowMaskBase {
+public:
+    ShadowMaskCylinder(const char*);
+
+    ~ShadowMaskCylinder() override;
+    void declare(ShadowMaskDrawCategory) override;
+    void update() override;
+    void calcShadowMatrix(sead::Matrix34f*) override;
+    void updateMulti() override;
+    void addMulti() override;
+    ShadowMaskType getShadowMaskType() const override;
+
+    // TODO: assign proper parameter names
+    void init(f32 a1, f32 dropLength, f32 a3, f32 a4, f32 a5, const sead::Vector3f& offset,
+              const sead::Color4f& color) {
+        _ec = a1;
+        _f4 = a1;
+        _f0 = 1.0f;
+        setDropLength(dropLength);
+        _104 = a3;
+        _108 = a4;
+        _10c = a5;
+        setOffset(offset);
+        setColor(color);
+        setDrawCategory(ShadowMaskDrawCategory::AO);
+    }
+
+private:
+    f32 _ec;
+    f32 _f0;
+    f32 _f4;
+    void* _f8;
+    s32 _100;
+    f32 _104;
+    f32 _108;
+    f32 _10c;
+    bool _110;
+};
+
+static_assert(sizeof(ShadowMaskCylinder) == 0x118);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowMaskDirector.h
+++ b/lib/al/Library/Shadow/ShadowMaskDirector.h
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace al {
+class ShadowMaskBase;
+
+class ShadowMaskDirector {
+public:
+    void registerShadowMask(ShadowMaskBase*);
+
+private:
+    void* _0[0x8D8 / 8];
+};
+
+static_assert(sizeof(ShadowMaskDirector) == 0x8D8);
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ShadowMaskSphere.h
+++ b/lib/al/Library/Shadow/ShadowMaskSphere.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Shadow/ShadowMaskBase.h"
+
+namespace al {
+
+class ShadowMaskSphere : public ShadowMaskBase {
+public:
+    ShadowMaskSphere(const char*);
+
+    ~ShadowMaskSphere() override;
+    void declare(ShadowMaskDrawCategory) override;
+    void update() override;
+    void calcShadowMatrix(sead::Matrix34f*) override;
+    void updateMulti() override;
+    void addMulti() override;
+    ShadowMaskType getShadowMaskType() const override;
+
+private:
+    void* _f0[2];
+};
+
+static_assert(sizeof(ShadowMaskSphere) == 0x100);
+
+}  // namespace al

--- a/src/Player/PlayerActorHakoniwa.h
+++ b/src/Player/PlayerActorHakoniwa.h
@@ -39,7 +39,7 @@ class PlayerCarryKeeper;
 class PlayerEquipmentUser;
 class PlayerHackKeeper;
 class PlayerFormSensorCollisionArranger;
-class PlayerJumpMessageRequest;
+struct PlayerJumpMessageRequest;
 class PlayerSandSinkAffect;
 class PlayerSpinCapAttack;
 class PlayerActionDiveInWater;

--- a/src/Player/PlayerFunction.h
+++ b/src/Player/PlayerFunction.h
@@ -12,7 +12,7 @@ class AudioKeeper;
 
 class PlayerConst;
 class PlayerCostumeInfo;
-class PlayerBodyCostumeInfo;
+struct PlayerBodyCostumeInfo;
 class PlayerJointControlPartsDynamics;
 
 class PlayerFunction {

--- a/src/Player/Yoshi.h
+++ b/src/Player/Yoshi.h
@@ -15,7 +15,7 @@ class PlayerAnimator;
 class PlayerColliderYoshi;
 class PlayerConst;
 class PlayerEffect;
-class PlayerJumpMessageRequest;
+struct PlayerJumpMessageRequest;
 class PlayerModelHolder;
 class PlayerModelChangerYoshi;
 class PlayerPushReceiver;


### PR DESCRIPTION
A pretty header-heavy utility function file, responsible for a lot of code around setting up various actors and their helper constructs.

Most functions were pretty straight-forward to match, except one:
- `initExecutorModelUpdate`: https://decomp.me/scratch/FIy2O
For some reason, the original stores a variable onto stack just to immediately read it again, which I seemingly cannot reproduce.

Also, we got the first occurrence of japanese text in standard code here, not just in the form of comments and strings: The `ShadowMaskDrawCategory` enum within `ShadowMaskBase.h` contains these values, which we know based on its `text_` function:
`シャドウ, AO, ライトスケール, ライトバッファ加算`
This means that four enum values exist and can be addressed with for example `ShadowMaskDrawCategory::ライトバッファ加算`. This is not used in this PR yet, as only `1` (`AO`) has been specified directly so far, but C++/clang seems to have no issue addressing enum values with non-ascii characters either.