### PR TITLE
Library/Area: Fix `calcNearestAreaObjEdgePos` return type

### DIFF
--- a/lib/al/Library/Area/AreaObjUtil.cpp
+++ b/lib/al/Library/Area/AreaObjUtil.cpp
@@ -165,9 +165,9 @@ void getAreaObjDirSide(sead::Vector3f* outSideDir, const AreaObj* areaObj) {
     getAreaObjBaseMtx(areaObj).getBase(*outSideDir, 0);
 }
 
-void calcNearestAreaObjEdgePos(sead::Vector3f* outNearestEdgePos, const AreaObj* areaObj,
+bool calcNearestAreaObjEdgePos(sead::Vector3f* outNearestEdgePos, const AreaObj* areaObj,
                                const sead::Vector3f& position) {
-    areaObj->getAreaShape()->calcNearestEdgePoint(outNearestEdgePos, position);
+    return areaObj->getAreaShape()->calcNearestEdgePoint(outNearestEdgePos, position);
 }
 
 void calcNearestAreaObjEdgePosTopY(sead::Vector3f* outNearestEdgePosTopY, const AreaObj* areaObj,

--- a/lib/al/Library/Area/AreaObjUtil.h
+++ b/lib/al/Library/Area/AreaObjUtil.h
@@ -46,7 +46,7 @@ const sead::Vector3f& getAreaObjScale(const AreaObj* areaObj);
 void getAreaObjDirFront(sead::Vector3f* outFrontDir, const AreaObj* areaObj);
 void getAreaObjDirUp(sead::Vector3f* outUpDir, const AreaObj* areaObj);
 void getAreaObjDirSide(sead::Vector3f* outSideDir, const AreaObj* areaObj);
-void calcNearestAreaObjEdgePos(sead::Vector3f* outNearestEdgePos, const AreaObj* areaObj,
+bool calcNearestAreaObjEdgePos(sead::Vector3f* outNearestEdgePos, const AreaObj* areaObj,
                                const sead::Vector3f& position);
 void calcNearestAreaObjEdgePosTopY(sead::Vector3f* outNearestEdgePosTopY, const AreaObj* areaObj,
                                    const sead::Vector3f& position);


### PR DESCRIPTION
This PR fix `calcNearestAreaObjEdgePos` return type.