### PR TITLE
sead: Configure to `SEAD_VERSION_SMO`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ target_compile_options(odyssey PRIVATE -Wno-invalid-offsetof)
 set(NN_WARE 3.5.1)
 set(NN_SDK 3.5.1)
 set(NN_SDK_TYPE "Release")
+add_compile_definitions(SEAD_VERSION=SEAD_VERSION_SMO)
 
 include_directories(lib)
 include_directories(lib/aarch64)


### PR DESCRIPTION
Based on @fruityloops1's PR on `sead` (https://github.com/open-ead/sead/pull/201), games can now configure their own version of SMO with custom changes based on which features are included/not included, or which things might be deprecated/added in later versions.

However, we never configured it properly - which so far does not have much effect, but removes 5 lines from `tools/listsym` related to `sead::Delegate::isNoDummy()` (versioning difference introduced in https://github.com/open-ead/sead/pull/208).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/774)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c9d013c - be8ed75)

No changes

<!-- decomp.dev report end -->