### PR TITLE
Sequence: Implement `E3ResourceLoader`

### DIFF
--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -1,0 +1,210 @@
+#include "Sequence/E3ResourceLoader.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/File/FileUtil.h"
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Resource/ResourceHolder.h"
+#include "Library/Thread/AsyncFunctorThread.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/ByamlUtil.h"
+#include "System/GameDataFunction.h"
+#include "heap/seadFrameHeap.h"
+
+s32 cPriority = 22;
+s32 cCoreId = 16;
+
+E3ResourceLoader::E3ResourceLoader() {
+    using E3ResourceLoaderFunctor = al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>;
+
+    mLoadHomeStageResourceThread = new al::AsyncFunctorThread(
+        "LoadHomeStageResourceThread",
+        E3ResourceLoaderFunctor(this, &E3ResourceLoader::loadHomeStageResource), cPriority,
+        0x100000, 0);
+
+    mWorldResourceThread = new al::AsyncFunctorThread(
+        "WolrdResourceThread", E3ResourceLoaderFunctor(this, &E3ResourceLoader::loadWorldResource),
+        cPriority, 0x100000, 0);
+
+    al::createWorldResourceHeap(false);
+    mWorldResourceHeap = al::getWorldResourceHeap();
+}
+
+E3ResourceLoader::~E3ResourceLoader() {}
+
+void E3ResourceLoader::loadHomeStageResource() {
+    if (!_30) {
+        al::createCategoryResourceAll("プレイヤーモデル");
+        al::addResourceCategory("E3常駐", 0x400, mWorldResourceHeap);
+        al::createCategoryResourceAll("E3常駐");
+        _30 = true;
+    }
+    if (mWorldExResource) {
+        al::removeResourceCategory("ワールド常駐");
+        mWorldExResource->destroy();
+        mWorldExResource = nullptr;
+    }
+    if (!mSandWorldHomeStageResource) {
+        sead::FrameHeap* heap =
+            sead::FrameHeap::create(0x11800000, "SandWorldHomeStageResource", mWorldResourceHeap, 8,
+                                    sead::Heap::cHeapDirection_Forward, false);
+        mSandWorldHomeStageResource = heap;
+        al::addResourceCategory("砂ワールドホーム", 0x400, heap);
+        s32 worldIndexSand = GameDataFunction::getWorldIndexSand();
+        loadHomeStageResourceByWorld("砂ワールドホーム", mWorldResourceHeap, worldIndexSand, 8);
+    }
+    if (!mCityWorldHomeStageResource) {
+        sead::FrameHeap* heap =
+            sead::FrameHeap::create(0x12200000, "CityWorldHomeStageResource", mWorldResourceHeap, 8,
+                                    sead::Heap::cHeapDirection_Reverse, false);
+        mCityWorldHomeStageResource = heap;
+        al::addResourceCategory("都市ワールドホーム", 0x400, heap);
+        s32 worldIndexCity = GameDataFunction::getWorldIndexCity();
+        loadHomeStageResourceByWorld("都市ワールドホーム", heap, worldIndexCity, 12);
+    }
+}
+
+void E3ResourceLoader::loadWorldResource() {
+    al::setCurrentCategoryNameDefault();
+
+    u8* byml = (al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
+
+    al::ByamlIter byamlIter = al::ByamlIter(byml);
+    al::ByamlIter worldIter;
+    al::getByamlIterByIndex(&worldIter, byamlIter, _3c);
+    al::ByamlIter worldResourceIter;
+    al::getByamlIterByKey(&worldResourceIter, worldIter, "WorldResource");
+
+    s32 size = worldResourceIter.getSize();
+
+    for (s32 i = 0; i < size; i++) {
+        al::ByamlIter v8;
+        worldResourceIter.tryGetIterByIndex(&v8, i);
+        const char* name = nullptr;
+        const char* ext = nullptr;
+        v8.tryGetStringByKey(&name, "Name");
+        v8.tryGetStringByKey(&ext, "Ext");
+
+        if (!al::findResource(name))
+            al::findOrCreateResource(name, ext);
+        if (mHasLoadedWorldResource)
+            return;
+    }
+    _39 = true;
+}
+
+void E3ResourceLoader::cancelLoadWorldResource() {
+    mHasLoadedWorldResource = true;
+}
+
+bool E3ResourceLoader::requestLoadWorldHomeStageResource() {
+    if (mSandWorldHomeStageResource && mCityWorldHomeStageResource &&
+        isEndLoadWorldHomeStageResource())
+        return false;
+    if (isEndLoadWorldHomeStageResource()) {
+        mHasLoadedWorldResource = false;
+        _39 = false;
+        _3c = -1;
+        al::clearFileLoaderEntry();
+        mLoadHomeStageResourceThread->start();
+        return true;
+    }
+    return false;
+}
+
+bool E3ResourceLoader::isEndLoadWorldHomeStageResource() const {
+    return mLoadHomeStageResourceThread->isDone();
+}
+
+bool E3ResourceLoader::requestLoadWorldResource(s32 id) {
+    if (_3c == id && _39)
+        return false;
+    if (isEndLoadAny()) {
+        mHasLoadedWorldResource = false;
+        al::clearFileLoaderEntry();
+        _39 = false;
+        _3c = id;
+        mWorldResourceThread->start();
+        return true;
+    }
+    return false;
+}
+
+bool E3ResourceLoader::isEndLoadAny() const {
+    return mWorldResourceThread->isDone() && isEndLoadWorldHomeStageResource();
+}
+
+void E3ResourceLoader::tryCreateExHeap(s32 worldId) {
+    if (mWorldExResource)
+        return;
+
+    if (GameDataFunction::getWorldIndexSand() == worldId) {
+        if (mCityWorldHomeStageResource) {
+            if (mSandWorldHomeStageResource == mCityWorldHomeStageResource) {
+                al::removeResourceCategory("砂ワールドホーム");
+                mSandWorldHomeStageResource->destroy();
+                mSandWorldHomeStageResource = nullptr;
+            }
+            al::removeResourceCategory("都市ワールドホーム");
+            mCityWorldHomeStageResource->destroy();
+            mCityWorldHomeStageResource = nullptr;
+        }
+    } else {
+        if (GameDataFunction::getWorldIndexCity() == worldId) {
+            if (mSandWorldHomeStageResource) {
+                al::removeResourceCategory("砂ワールドホーム");
+                mSandWorldHomeStageResource->destroy();
+                mSandWorldHomeStageResource = nullptr;
+            }
+        }
+    }
+
+    sead::FrameHeap* newHeap = sead::FrameHeap::create(0, "WorldExResource", mWorldResourceHeap, 8,
+                                                       sead::Heap::cHeapDirection_Forward, false);
+    mWorldExResource = newHeap;
+    al::addResourceCategory("ワールド常駐", 0x400, newHeap);
+}
+
+void E3ResourceLoader::tryDestroyWorldResource(sead::Heap* heap) {
+    if (!heap)
+        return;
+
+    if (mSandWorldHomeStageResource == heap) {
+        al::removeResourceCategory("砂ワールドホーム");
+        mSandWorldHomeStageResource->destroy();
+        mSandWorldHomeStageResource = nullptr;
+    }
+
+    if (mCityWorldHomeStageResource == heap) {
+        al::removeResourceCategory("都市ワールドホーム");
+        mCityWorldHomeStageResource->destroy();
+        mCityWorldHomeStageResource = nullptr;
+    }
+}
+
+void E3ResourceLoader::printHeapInfo() const {}
+
+void E3ResourceLoader::loadHomeStageResourceByWorld(const char* worldName, sead::Heap*, s32 id,
+                                                    s32 scenarioid) {
+    al::ByamlIter byamlIter = (al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
+    al::ByamlIter worldIter;
+    al::getByamlIterByIndex(&worldIter, byamlIter, id);
+    al::ByamlIter worldResourceIter;
+    al::StringTmp<32> scenarioId{"Scenario%d", scenarioid};
+
+    if (!al::tryGetByamlIterByKey(&worldResourceIter, worldIter, scenarioId.cstr()))
+        return;
+
+    al::setCurrentCategoryName(worldName);
+    s32 size = worldResourceIter.getSize();
+    for (s32 i = 0; i < size; i++) {
+        al::ByamlIter v8;
+        worldResourceIter.tryGetIterByIndex(&v8, i);
+        const char* name = nullptr;
+        const char* ext = nullptr;
+        v8.tryGetStringByKey(&name, "Name");
+        v8.tryGetStringByKey(&ext, "Ext");
+
+        al::findOrCreateResource(name, ext);
+        if (mHasLoadedWorldResource)
+            return;
+    }
+}

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -7,12 +7,12 @@
 #include "Library/Thread/AsyncFunctorThread.h"
 #include "Library/Yaml/ByamlIter.h"
 #include "Library/Yaml/ByamlUtil.h"
-#include "Sequence/E3Sequence.h"
 #include "System/GameDataFunction.h"
 #include "heap/seadFrameHeap.h"
+#include "thread/seadThread.h"
 
-s32 cE3Priority = E3Sequence::cLoaderPriority;
-s32 cDefaultPriority = E3Sequence::cDefaultPriority;
+s32 cE3Priority = sead::Thread::cDefaultPriority + 6;
+static s32 cDefaultPriority = sead::Thread::cDefaultPriority;
 
 // NON_MATCHING: Compiler creates the first functor in the wrong place
 E3ResourceLoader::E3ResourceLoader() {

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -3,7 +3,7 @@
 #include "Library/Base/StringUtil.h"
 #include "Library/File/FileUtil.h"
 #include "Library/Memory/HeapUtil.h"
-#include "Library/Resource/ResourceHolder.h"
+#include "Library/Resource/ResourceFunction.h"
 #include "Library/Thread/AsyncFunctorThread.h"
 #include "Library/Yaml/ByamlIter.h"
 #include "Library/Yaml/ByamlUtil.h"
@@ -107,7 +107,7 @@ void E3ResourceLoader::loadHomeStageResource() {
 void E3ResourceLoader::loadWorldResource() {
     al::setCurrentCategoryNameDefault();
 
-    u8* byml = (al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
+    const u8* byml = (al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
 
     al::ByamlIter byamlIter = al::ByamlIter(byml);
     al::ByamlIter worldIter;

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -13,7 +13,7 @@
 
 #include "System/GameDataFunction.h"
 
-s32 cPriority = sead::Thread::cDefaultPriority + 6;
+static s32 cPriority = sead::Thread::cDefaultPriority + 6;
 static s32 _cDefaultPriority = sead::Thread::cDefaultPriority;
 
 // NON_MATCHING: Compiler creates the first functor in the wrong place
@@ -93,7 +93,7 @@ void E3ResourceLoader::loadHomeStageResource() {
             280 * 1024 * 1024, "SandWorldHomeStageResource", mWorldResourceHeap, 8,
             sead::Heap::cHeapDirection_Forward, false);
         mSandWorldHomeStageResource = heap;
-        al::addResourceCategory("砂ワールドホーム", 512, heap);
+        al::addResourceCategory("砂ワールドホーム", 1024, heap);
         s32 worldIndexSand = GameDataFunction::getWorldIndexSand();
         loadHomeStageResourceByWorld("砂ワールドホーム", mWorldResourceHeap, worldIndexSand, 8);
     }
@@ -103,7 +103,7 @@ void E3ResourceLoader::loadHomeStageResource() {
             290 * 1024 * 1024, "CityWorldHomeStageResource", mWorldResourceHeap, 8,
             sead::Heap::cHeapDirection_Reverse, false);
         mCityWorldHomeStageResource = heap;
-        al::addResourceCategory("都市ワールドホーム", 512, heap);
+        al::addResourceCategory("都市ワールドホーム", 1024, heap);
         s32 worldIndexCity = GameDataFunction::getWorldIndexCity();
         loadHomeStageResourceByWorld("都市ワールドホーム", heap, worldIndexCity, 12);
     }
@@ -219,7 +219,7 @@ void E3ResourceLoader::tryCreateExHeap(s32 loadWorldId) {
                                                        sead::Heap::cHeapDirection_Forward, false);
     mWorldExResource = newHeap;
 
-    al::addResourceCategory("ワールド常駐", 512, newHeap);
+    al::addResourceCategory("ワールド常駐", 1024, newHeap);
 }
 
 void E3ResourceLoader::tryDestroyWorldResource(sead::Heap* heap) {

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -16,8 +16,6 @@
 static s32 cPriority = sead::Thread::cDefaultPriority + 6;
 static s32 _cDefaultPriority = sead::Thread::cDefaultPriority;
 
-// NON_MATCHING: Compiler creates the first functor in the wrong place
-// https://decomp.me/scratch/fyi2M
 E3ResourceLoader::E3ResourceLoader() {
     using E3ResourceLoaderFunctor = al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>;
 
@@ -112,7 +110,7 @@ void E3ResourceLoader::loadHomeStageResource() {
 void E3ResourceLoader::loadWorldResource() {
     al::setCurrentCategoryNameDefault();
 
-    const u8* byml = (al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
+    const u8* byml = al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource");
     al::ByamlIter byamlIter = al::ByamlIter(byml);
 
     al::ByamlIter worldIter;
@@ -123,12 +121,12 @@ void E3ResourceLoader::loadWorldResource() {
     s32 size = worldResourceIter.getSize();
 
     for (s32 i = 0; i < size; i++) {
-        al::ByamlIter v8;
-        worldResourceIter.tryGetIterByIndex(&v8, i);
+        al::ByamlIter resourceIter;
+        worldResourceIter.tryGetIterByIndex(&resourceIter, i);
         const char* name = nullptr;
         const char* ext = nullptr;
-        v8.tryGetStringByKey(&name, "Name");
-        v8.tryGetStringByKey(&ext, "Ext");
+        resourceIter.tryGetStringByKey(&name, "Name");
+        resourceIter.tryGetStringByKey(&ext, "Ext");
 
         if (!al::findResource(name))
             al::findOrCreateResource(name, ext);
@@ -183,43 +181,16 @@ void E3ResourceLoader::tryCreateExHeap(s32 loadWorldId) {
     if (mWorldExResource)
         return;
 
-    if (GameDataFunction::getWorldIndexSand() == loadWorldId) {
-        sead::FrameHeap* cityResource = mCityWorldHomeStageResource;
+    if (GameDataFunction::getWorldIndexSand() == loadWorldId)
+        tryDestroyWorldResource(mCityWorldHomeStageResource);
 
-        if (cityResource) {
-            if (mSandWorldHomeStageResource == cityResource) {
-                al::removeResourceCategory("砂ワールドホーム");
-                mSandWorldHomeStageResource->destroy();
-                mSandWorldHomeStageResource = nullptr;
-            }
-            if (mCityWorldHomeStageResource == cityResource) {
-                al::removeResourceCategory("都市ワールドホーム");
-                mCityWorldHomeStageResource->destroy();
-                mCityWorldHomeStageResource = nullptr;
-            }
-        }
+    else if (GameDataFunction::getWorldIndexCity() == loadWorldId)
+        tryDestroyWorldResource(mSandWorldHomeStageResource);
 
-    } else if (GameDataFunction::getWorldIndexCity() == loadWorldId) {
-        sead::FrameHeap* sandResource = mSandWorldHomeStageResource;
+    mWorldExResource = sead::FrameHeap::create(0, "WorldExResource", mWorldResourceHeap, 8,
+                                               sead::Heap::cHeapDirection_Forward, false);
 
-        if (sandResource) {
-            al::removeResourceCategory("砂ワールドホーム");
-            mSandWorldHomeStageResource->destroy();
-            mSandWorldHomeStageResource = nullptr;
-
-            if (mCityWorldHomeStageResource == sandResource) {
-                al::removeResourceCategory("都市ワールドホーム");
-                mCityWorldHomeStageResource->destroy();
-                mCityWorldHomeStageResource = nullptr;
-            }
-        }
-    }
-
-    sead::FrameHeap* newHeap = sead::FrameHeap::create(0, "WorldExResource", mWorldResourceHeap, 8,
-                                                       sead::Heap::cHeapDirection_Forward, false);
-    mWorldExResource = newHeap;
-
-    al::addResourceCategory("ワールド常駐", 1024, newHeap);
+    al::addResourceCategory("ワールド常駐", 1024, mWorldExResource);
 }
 
 void E3ResourceLoader::tryDestroyWorldResource(sead::Heap* heap) {

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -16,6 +16,12 @@
 static s32 _cDefaultPriority = sead::Thread::cDefaultPriority;
 static s32 cPriority = _cDefaultPriority + 6;
 
+static void destroyResource(sead::FrameHeap*& resource, const char* category) {
+    al::removeResourceCategory(category);
+    resource->destroy();
+    resource = nullptr;
+}
+
 E3ResourceLoader::E3ResourceLoader() {
     using E3ResourceLoaderFunctor = al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>;
 
@@ -47,23 +53,14 @@ E3ResourceLoader::~E3ResourceLoader() {
 
     al::removeResourceCategory("E3常駐");
 
-    if (mSandWorldHomeStageResource) {
-        al::removeResourceCategory("砂ワールドホーム");
-        mSandWorldHomeStageResource->destroy();
-        mSandWorldHomeStageResource = nullptr;
-    }
+    if (mSandWorldHomeStageResource)
+        destroyResource(mSandWorldHomeStageResource, "砂ワールドホーム");
 
-    if (mCityWorldHomeStageResource) {
-        al::removeResourceCategory("都市ワールドホーム");
-        mCityWorldHomeStageResource->destroy();
-        mCityWorldHomeStageResource = nullptr;
-    }
+    if (mCityWorldHomeStageResource)
+        destroyResource(mCityWorldHomeStageResource, "都市ワールドホーム");
 
-    if (mWorldExResource) {
-        al::removeResourceCategory("ワールド常駐");
-        mWorldExResource->destroy();
-        mWorldExResource = nullptr;
-    }
+    if (mWorldExResource)
+        destroyResource(mWorldExResource, "ワールド常駐");
 
     if (mWorldResourceHeap) {
         al::destroyWorldResourceHeap(false);
@@ -80,16 +77,12 @@ void E3ResourceLoader::loadHomeStageResource() {
         al::createCategoryResourceAll("E3常駐");
         mHasCreatedResourceCategory = true;
     }
-    if (mWorldExResource) {
-        al::removeResourceCategory("ワールド常駐");
-        mWorldExResource->destroy();
-        mWorldExResource = nullptr;
-    }
+    if (mWorldExResource)
+        destroyResource(mWorldExResource, "ワールド常駐");
     if (!mSandWorldHomeStageResource) {
         // 280 MB
         sead::FrameHeap* heap = sead::FrameHeap::create(
-            280 * 1024 * 1024, "SandWorldHomeStageResource", mWorldResourceHeap, 8,
-            sead::Heap::cHeapDirection_Forward, false);
+            280 * 1024 * 1024, "SandWorldHomeStageResource", mWorldResourceHeap);
         mSandWorldHomeStageResource = heap;
         al::addResourceCategory("砂ワールドホーム", 1024, heap);
         s32 worldIndexSand = GameDataFunction::getWorldIndexSand();
@@ -97,9 +90,9 @@ void E3ResourceLoader::loadHomeStageResource() {
     }
     if (!mCityWorldHomeStageResource) {
         // 290 MB
-        sead::FrameHeap* heap = sead::FrameHeap::create(
-            290 * 1024 * 1024, "CityWorldHomeStageResource", mWorldResourceHeap, 8,
-            sead::Heap::cHeapDirection_Reverse, false);
+        sead::FrameHeap* heap =
+            sead::FrameHeap::create(290 * 1024 * 1024, "CityWorldHomeStageResource",
+                                    mWorldResourceHeap, 8, sead::Heap::cHeapDirection_Reverse);
         mCityWorldHomeStageResource = heap;
         al::addResourceCategory("都市ワールドホーム", 1024, heap);
         s32 worldIndexCity = GameDataFunction::getWorldIndexCity();
@@ -130,29 +123,30 @@ void E3ResourceLoader::loadWorldResource() {
 
         if (!al::findResource(name))
             al::findOrCreateResource(name, ext);
-        if (mHasLoadedWorldResource)
+        if (mIsCancelLoadWorldResource)
             return;
     }
     mIsLoaded = true;
 }
 
 void E3ResourceLoader::cancelLoadWorldResource() {
-    mHasLoadedWorldResource = true;
+    mIsCancelLoadWorldResource = true;
 }
 
 bool E3ResourceLoader::requestLoadWorldHomeStageResource() {
     if (mSandWorldHomeStageResource && mCityWorldHomeStageResource &&
         isEndLoadWorldHomeStageResource())
         return false;
-    if (isEndLoadWorldHomeStageResource()) {
-        mHasLoadedWorldResource = false;
-        mIsLoaded = false;
-        mLoadWorldId = -1;
-        al::clearFileLoaderEntry();
-        mLoadHomeStageResourceThread->start();
-        return true;
-    }
-    return false;
+
+    if (!isEndLoadWorldHomeStageResource())
+        return false;
+
+    mIsCancelLoadWorldResource = false;
+    mIsLoaded = false;
+    mLoadWorldId = -1;
+    al::clearFileLoaderEntry();
+    mLoadHomeStageResourceThread->start();
+    return true;
 }
 
 bool E3ResourceLoader::isEndLoadWorldHomeStageResource() const {
@@ -162,15 +156,15 @@ bool E3ResourceLoader::isEndLoadWorldHomeStageResource() const {
 bool E3ResourceLoader::requestLoadWorldResource(s32 loadWorldId) {
     if (mLoadWorldId == loadWorldId && mIsLoaded)
         return false;
-    if (isEndLoadAny()) {
-        mHasLoadedWorldResource = false;
-        al::clearFileLoaderEntry();
-        mIsLoaded = false;
-        mLoadWorldId = loadWorldId;
-        mWorldResourceThread->start();
-        return true;
-    }
-    return false;
+    if (!isEndLoadAny())
+        return false;
+
+    mIsCancelLoadWorldResource = false;
+    al::clearFileLoaderEntry();
+    mIsLoaded = false;
+    mLoadWorldId = loadWorldId;
+    mWorldResourceThread->start();
+    return true;
 }
 
 bool E3ResourceLoader::isEndLoadAny() const {
@@ -187,8 +181,7 @@ void E3ResourceLoader::tryCreateExHeap(s32 loadWorldId) {
     else if (GameDataFunction::getWorldIndexCity() == loadWorldId)
         tryDestroyWorldResource(mSandWorldHomeStageResource);
 
-    mWorldExResource = sead::FrameHeap::create(0, "WorldExResource", mWorldResourceHeap, 8,
-                                               sead::Heap::cHeapDirection_Forward, false);
+    mWorldExResource = sead::FrameHeap::create(0, "WorldExResource", mWorldResourceHeap, 8);
 
     al::addResourceCategory("ワールド常駐", 1024, mWorldExResource);
 }
@@ -197,35 +190,29 @@ void E3ResourceLoader::tryDestroyWorldResource(sead::Heap* heap) {
     if (!heap)
         return;
 
-    if (mSandWorldHomeStageResource == heap) {
-        al::removeResourceCategory("砂ワールドホーム");
-        mSandWorldHomeStageResource->destroy();
-        mSandWorldHomeStageResource = nullptr;
-    }
+    if (mSandWorldHomeStageResource == heap)
+        destroyResource(mSandWorldHomeStageResource, "砂ワールドホーム");
 
-    if (mCityWorldHomeStageResource == heap) {
-        al::removeResourceCategory("都市ワールドホーム");
-        mCityWorldHomeStageResource->destroy();
-        mCityWorldHomeStageResource = nullptr;
-    }
+    if (mCityWorldHomeStageResource == heap)
+        destroyResource(mCityWorldHomeStageResource, "都市ワールドホーム");
 }
 
 void E3ResourceLoader::printHeapInfo() const {}
 
-void E3ResourceLoader::loadHomeStageResourceByWorld(const char* worldName, sead::Heap* _heap,
-                                                    s32 loadWorldId, s32 scenarioId) {
+void E3ResourceLoader::loadHomeStageResourceByWorld(const char* categoryName, sead::Heap* _heap,
+                                                    s32 worldId, s32 scenarioId) {
     const u8* byml = al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource");
     al::ByamlIter byamlIter = al::ByamlIter(byml);
 
     al::ByamlIter worldIter;
-    al::getByamlIterByIndex(&worldIter, byamlIter, loadWorldId);
+    al::getByamlIterByIndex(&worldIter, byamlIter, worldId);
     al::ByamlIter worldResourceIter;
 
     if (!al::tryGetByamlIterByKey(&worldResourceIter, worldIter,
                                   al::StringTmp<32>{"Scenario%d", scenarioId}.cstr()))
         return;
 
-    al::setCurrentCategoryName(worldName);
+    al::setCurrentCategoryName(categoryName);
 
     s32 size = worldResourceIter.getSize();
     for (s32 i = 0; i < size; i++) {
@@ -237,7 +224,7 @@ void E3ResourceLoader::loadHomeStageResourceByWorld(const char* worldName, sead:
         iter.tryGetStringByKey(&ext, "Ext");
 
         al::findOrCreateResource(name, ext);
-        if (mHasLoadedWorldResource)
+        if (mIsCancelLoadWorldResource)
             return;
     }
 }

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -13,8 +13,8 @@
 
 #include "System/GameDataFunction.h"
 
-static s32 cPriority = sead::Thread::cDefaultPriority + 6;
 static s32 _cDefaultPriority = sead::Thread::cDefaultPriority;
+static s32 cPriority = _cDefaultPriority + 6;
 
 E3ResourceLoader::E3ResourceLoader() {
     using E3ResourceLoaderFunctor = al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>;

--- a/src/Sequence/E3ResourceLoader.cpp
+++ b/src/Sequence/E3ResourceLoader.cpp
@@ -16,10 +16,10 @@
 static s32 _cDefaultPriority = sead::Thread::cDefaultPriority;
 static s32 cPriority = _cDefaultPriority + 6;
 
-static void destroyResource(sead::FrameHeap*& resource, const char* category) {
+static void destroyResource(sead::FrameHeap** resource, const char* category) {
     al::removeResourceCategory(category);
-    resource->destroy();
-    resource = nullptr;
+    (*resource)->destroy();
+    (*resource) = nullptr;
 }
 
 E3ResourceLoader::E3ResourceLoader() {
@@ -54,13 +54,13 @@ E3ResourceLoader::~E3ResourceLoader() {
     al::removeResourceCategory("E3常駐");
 
     if (mSandWorldHomeStageResource)
-        destroyResource(mSandWorldHomeStageResource, "砂ワールドホーム");
+        destroyResource(&mSandWorldHomeStageResource, "砂ワールドホーム");
 
     if (mCityWorldHomeStageResource)
-        destroyResource(mCityWorldHomeStageResource, "都市ワールドホーム");
+        destroyResource(&mCityWorldHomeStageResource, "都市ワールドホーム");
 
     if (mWorldExResource)
-        destroyResource(mWorldExResource, "ワールド常駐");
+        destroyResource(&mWorldExResource, "ワールド常駐");
 
     if (mWorldResourceHeap) {
         al::destroyWorldResourceHeap(false);
@@ -78,7 +78,7 @@ void E3ResourceLoader::loadHomeStageResource() {
         mHasCreatedResourceCategory = true;
     }
     if (mWorldExResource)
-        destroyResource(mWorldExResource, "ワールド常駐");
+        destroyResource(&mWorldExResource, "ワールド常駐");
     if (!mSandWorldHomeStageResource) {
         // 280 MB
         sead::FrameHeap* heap = sead::FrameHeap::create(
@@ -191,10 +191,10 @@ void E3ResourceLoader::tryDestroyWorldResource(sead::Heap* heap) {
         return;
 
     if (mSandWorldHomeStageResource == heap)
-        destroyResource(mSandWorldHomeStageResource, "砂ワールドホーム");
+        destroyResource(&mSandWorldHomeStageResource, "砂ワールドホーム");
 
     if (mCityWorldHomeStageResource == heap)
-        destroyResource(mCityWorldHomeStageResource, "都市ワールドホーム");
+        destroyResource(&mCityWorldHomeStageResource, "都市ワールドホーム");
 }
 
 void E3ResourceLoader::printHeapInfo() const {}

--- a/src/Sequence/E3ResourceLoader.h
+++ b/src/Sequence/E3ResourceLoader.h
@@ -16,12 +16,13 @@ public:
     void cancelLoadWorldResource();
     bool requestLoadWorldHomeStageResource();
     bool isEndLoadWorldHomeStageResource() const;
-    bool requestLoadWorldResource(s32);
+    bool requestLoadWorldResource(s32 loadWorldId);
     bool isEndLoadAny() const;
-    void tryCreateExHeap(s32);
-    void tryDestroyWorldResource(sead::Heap*);
+    void tryCreateExHeap(s32 loadWorldId);
+    void tryDestroyWorldResource(sead::Heap* heap);
     void printHeapInfo() const;
-    void loadHomeStageResourceByWorld(const char*, sead::Heap*, s32, s32);
+    void loadHomeStageResourceByWorld(const char* worldName, sead::Heap* _heap, s32 loadWorldId,
+                                      s32 scenarioId);
 
 private:
     al::AsyncFunctorThread* mLoadHomeStageResourceThread = nullptr;
@@ -31,7 +32,7 @@ private:
     sead::FrameHeap* mCityWorldHomeStageResource = nullptr;
     sead::FrameHeap* mWorldExResource = nullptr;
     bool mHasLoadedWorldResource = false;
-    bool _39 = false;
-    bool _30 = false;
-    s32 _3c = -1;
+    bool mIsLoaded = false;
+    bool mHasCreatedResourceCategory = false;
+    s32 mLoadWorldId = -1;
 };

--- a/src/Sequence/E3ResourceLoader.h
+++ b/src/Sequence/E3ResourceLoader.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <heap/seadFrameHeap.h>
+
+namespace al {
+class AsyncFunctorThread;
+}
+
+class E3ResourceLoader {
+public:
+    E3ResourceLoader();
+    virtual ~E3ResourceLoader();
+
+    void loadHomeStageResource();
+    void loadWorldResource();
+    void cancelLoadWorldResource();
+    bool requestLoadWorldHomeStageResource();
+    bool isEndLoadWorldHomeStageResource() const;
+    bool requestLoadWorldResource(s32);
+    bool isEndLoadAny() const;
+    void tryCreateExHeap(s32);
+    void tryDestroyWorldResource(sead::Heap*);
+    void printHeapInfo() const;
+    void loadHomeStageResourceByWorld(const char*, sead::Heap*, s32, s32);
+
+private:
+    al::AsyncFunctorThread* mLoadHomeStageResourceThread = nullptr;
+    al::AsyncFunctorThread* mWorldResourceThread = nullptr;
+    sead::Heap* mWorldResourceHeap = nullptr;
+    sead::FrameHeap* mSandWorldHomeStageResource = nullptr;
+    sead::FrameHeap* mCityWorldHomeStageResource = nullptr;
+    sead::FrameHeap* mWorldExResource = nullptr;
+    bool mHasLoadedWorldResource = false;
+    bool _39 = false;
+    bool _30 = false;
+    s32 _3c = -1;
+};

--- a/src/Sequence/E3ResourceLoader.h
+++ b/src/Sequence/E3ResourceLoader.h
@@ -21,7 +21,7 @@ public:
     void tryCreateExHeap(s32 loadWorldId);
     void tryDestroyWorldResource(sead::Heap* heap);
     void printHeapInfo() const;
-    void loadHomeStageResourceByWorld(const char* worldName, sead::Heap* _heap, s32 loadWorldId,
+    void loadHomeStageResourceByWorld(const char* categoryName, sead::Heap* _heap, s32 worldId,
                                       s32 scenarioId);
 
 private:
@@ -31,7 +31,7 @@ private:
     sead::FrameHeap* mSandWorldHomeStageResource = nullptr;
     sead::FrameHeap* mCityWorldHomeStageResource = nullptr;
     sead::FrameHeap* mWorldExResource = nullptr;
-    bool mHasLoadedWorldResource = false;
+    bool mIsCancelLoadWorldResource = false;
     bool mIsLoaded = false;
     bool mHasCreatedResourceCategory = false;
     s32 mLoadWorldId = -1;

--- a/src/Sequence/E3ResourceLoader.h
+++ b/src/Sequence/E3ResourceLoader.h
@@ -36,3 +36,5 @@ private:
     bool mHasCreatedResourceCategory = false;
     s32 mLoadWorldId = -1;
 };
+
+static_assert(sizeof(E3ResourceLoader) == 0x40);

--- a/src/Sequence/E3Sequence.cpp
+++ b/src/Sequence/E3Sequence.cpp
@@ -1,0 +1,4 @@
+#include "Sequence/E3Sequence.h"
+
+const s32 E3Sequence::cLoaderPriority = 22;
+const s32 E3Sequence::cDefaultPriority = 16;

--- a/src/Sequence/E3Sequence.cpp
+++ b/src/Sequence/E3Sequence.cpp
@@ -1,4 +1,0 @@
-#include "Sequence/E3Sequence.h"
-
-const s32 E3Sequence::cLoaderPriority = 22;
-const s32 E3Sequence::cDefaultPriority = 16;

--- a/src/Sequence/E3Sequence.h
+++ b/src/Sequence/E3Sequence.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class E3Sequence {
+public:
+    static const s32 cLoaderPriority;
+    static const s32 cDefaultPriority;
+};

--- a/src/Sequence/E3Sequence.h
+++ b/src/Sequence/E3Sequence.h
@@ -1,9 +1,0 @@
-#pragma once
-
-#include <basis/seadTypes.h>
-
-class E3Sequence {
-public:
-    static const s32 cLoaderPriority;
-    static const s32 cDefaultPriority;
-};


### PR DESCRIPTION
In backlog from last year.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/879)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 5e51944)

📈 **Matched code**: 15.52% (+0.02%, +2820 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::loadHomeStageResource()` | +452 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::tryCreateExHeap(int)` | +396 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::loadHomeStageResourceByWorld(char const*, sead::Heap*, int, int)` | +360 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::loadWorldResource()` | +348 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::~E3ResourceLoader()` | +332 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::E3ResourceLoader()` | +276 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::tryDestroyWorldResource(sead::Heap*)` | +180 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::requestLoadWorldResource(int)` | +112 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::requestLoadWorldHomeStageResource()` | +104 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::isEndLoadAny() const` | +60 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::~E3ResourceLoader()` | +36 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `_GLOBAL__sub_I_E3ResourceLoader.cpp` | +32 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::cancelLoadWorldResource()` | +12 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::isEndLoadWorldHomeStageResource() const` | +8 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `E3ResourceLoader::printHeapInfo() const` | +4 | 0.00% | 100.00% |
| `Sequence/E3ResourceLoader` | `al::FunctorV0M<E3ResourceLoader*, void (E3ResourceLoader::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->