### PR TITLE
Library/Play/Layout: Implement `WindowConfirm`

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,6 @@
 [submodule "lib/eui"]
 	path = lib/eui
 	url = https://github.com/open-ead/eui
+[submodule "lib/NintendoSDK-NEX"]
+	path = lib/NintendoSDK-NEX
+	url = https://github.com/open-ead/NintendoSDK-NEX

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,6 +16,3 @@
 [submodule "lib/eui"]
 	path = lib/eui
 	url = https://github.com/open-ead/eui
-[submodule "lib/NintendoSDK-NEX"]
-	path = lib/NintendoSDK-NEX
-	url = https://github.com/open-ead/NintendoSDK-NEX

--- a/lib/al/Library/Play/Layout/WindowConfirm.cpp
+++ b/lib/al/Library/Play/Layout/WindowConfirm.cpp
@@ -25,7 +25,7 @@ namespace al {
 
 WindowConfirm::WindowConfirm(const LayoutInitInfo& info, const char* name, const char* actorName)
     : LayoutActor(actorName) {
-    initLayoutActor(this, info, name, nullptr);
+    initLayoutActor(this, info, name);
 
     s32 paneChildNum = getPaneChildNum(this, "All");
     s32 i = 0;
@@ -46,41 +46,40 @@ WindowConfirm::WindowConfirm(const LayoutInitInfo& info, const char* name, const
 
     if (isExistPane(this, "ParHardKey")) {
         mButtonActor = new LayoutActor("Ａボタン");
-        initLayoutPartsActor(mButtonActor, this, info, "ParHardKey", nullptr);
+        initLayoutPartsActor(mButtonActor, this, info, "ParHardKey");
     }
 
     mCursorActor = new LayoutActor("カーソル");
-    initLayoutPartsActor(mCursorActor, this, info, "ParCursor", nullptr);
-
-    initNerve(&Hide, 0);
+    initLayoutPartsActor(mCursorActor, this, info, "ParCursor");
+    initNerve(&Hide);
 }
 
 void WindowConfirm::setTxtMessage(const char16* message) {
-    setPaneString(this, "TxtMessage", message, 0);
+    setPaneString(this, "TxtMessage", message);
 }
 
 void WindowConfirm::setTxtList(s32 index, const char16* message) {
-    setPaneString(mParListArray.at(index), "TxtContent", message, 0);
+    setPaneString(mParListArray.at(index), "TxtContent", message);
 }
 
 void WindowConfirm::setListNum(s32 num) {
     SelectionType selectionType = (SelectionType)num;
     mSelection.selectionType = selectionType;
     if (selectionType == SelectionType::List01)
-        setCancelIdx(1);
+        setCancelIdx((s32)SelectionType::List00);
     if (selectionType == SelectionType::List02)
-        setCancelIdx(0);
+        setCancelIdx((s32)SelectionType::HardKey);
 }
 
 void WindowConfirm::setCancelIdx(s32 index) {
-    mCancelIdx = index;
+    mSelection.cancelType = (SelectionType)index;
 }
 
 void WindowConfirm::appear() {
     if (isAlive())
         return;
 
-    mSelection.index = 0;
+    mSelection.prevSelectionType = SelectionType::HardKey;
     mDirection = Direction::None;
 
     startAction(this, "Appear", nullptr);
@@ -101,8 +100,8 @@ void WindowConfirm::appear() {
     case SelectionType::List01:
         startAction(this, "Select2", "Select");
         startAction(mCursorActor, "Appear", nullptr);
-        startAction(mParListArray[0], "Select", nullptr);
-        startAction(mParListArray[1], "Wait", nullptr);
+        startAction(mParListArray[(s32)SelectionType::HardKey], "Select", nullptr);
+        startAction(mParListArray[(s32)SelectionType::List00], "Wait", nullptr);
 
         showPane(this, "ParCursor");
         hidePane(this, "ParHardKey");
@@ -110,9 +109,9 @@ void WindowConfirm::appear() {
     case SelectionType::List02:
         startAction(this, "Select3", "Select");
         startAction(mCursorActor, "Appear", nullptr);
-        startAction(mParListArray[0], "Select", nullptr);
-        startAction(mParListArray[1], "Wait", nullptr);
-        startAction(mParListArray[2], "Wait", nullptr);
+        startAction(mParListArray[(s32)SelectionType::HardKey], "Select", nullptr);
+        startAction(mParListArray[(s32)SelectionType::List00], "Wait", nullptr);
+        startAction(mParListArray[(s32)SelectionType::List01], "Wait", nullptr);
 
         showPane(this, "ParCursor");
         hidePane(this, "ParHardKey");
@@ -131,14 +130,14 @@ void WindowConfirm::appearWithChoicingCancel() {
     appear();
 
     if (mSelection.selectionType == SelectionType::List01) {
-        startAction(mParListArray[mSelection.index], "Wait", nullptr);
-        startAction(mParListArray[mCancelIdx], "Select", nullptr);
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        startAction(mParListArray[getCancelIdx()], "Select", nullptr);
     } else if (mSelection.selectionType == SelectionType::List02) {
-        startAction(mParListArray[mSelection.index], "Wait", nullptr);
-        startAction(mParListArray[mCancelIdx], "Select", nullptr);
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        startAction(mParListArray[getCancelIdx()], "Select", nullptr);
     }
 
-    mSelection.index = mCancelIdx;
+    mSelection.prevSelectionType = mSelection.cancelType;
 }
 
 bool WindowConfirm::isNerveEnd() {
@@ -190,7 +189,7 @@ bool WindowConfirm::tryDecide() {
 
 bool WindowConfirm::tryDecideWithoutEnd() {
     if (isEnableInput()) {
-        mIsDecided = false;
+        mIsDecided = true;
         setNerve(this, &NrvWindowConfirm.Decide);
         return true;
     }
@@ -200,14 +199,16 @@ bool WindowConfirm::tryDecideWithoutEnd() {
 bool WindowConfirm::tryCancel() {
     if (!isEnableInput())
         return false;
+
     if ((mSelection.selectionType == SelectionType::List01 ||
          mSelection.selectionType == SelectionType::List02) &&
-        mSelection.index != mCancelIdx) {
-        startAction(mParListArray[(s32)mSelection.index], "Wait", nullptr);
-        startAction(mParListArray[(s32)mCancelIdx], "Select", nullptr);
-        mSelection.index = mCancelIdx;
+        mSelection.prevSelectionType != mSelection.cancelType) {
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        startAction(mParListArray[getCancelIdx()], "Select", nullptr);
+        mSelection.prevSelectionType = mSelection.cancelType;
         setCursorToPane();
     }
+
     startHitReaction(this, "キャンセル", nullptr);
     mIsDecided = false;
     setNerve(this, &NrvWindowConfirm.Decide);
@@ -215,28 +216,28 @@ bool WindowConfirm::tryCancel() {
 }
 
 void WindowConfirm::setCursorToPane() {
-    if (mSelection.selectionType < SelectionType::List01)
-        return;
-    sead::Vector3f trans = {1.0f, 1.0f, 1.0f};
-    calcPaneTrans(&trans, mParListArray[mSelection.index], "Cursor");
-    setPaneLocalTrans(this, "ParCursor", trans);
+    if (mSelection.selectionType >= SelectionType::List01) {
+        sead::Vector3f trans = {1.0f, 1.0f, 1.0f};
+        calcPaneTrans(&trans, mParListArray[getPrevSelectionIdx()], "Cursor");
+        setPaneLocalTrans(this, "ParCursor", trans);
+    }
 }
 
 bool WindowConfirm::tryCancelWithoutEnd() {
-    if (isEnableInput()) {
-        if ((mSelection.selectionType == SelectionType::List01 ||
-             mSelection.selectionType == SelectionType::List02) &&
-            mSelection.index != mCancelIdx) {
-            startAction(mParListArray[(s32)mSelection.index], "Wait", nullptr);
-            startAction(mParListArray[mCancelIdx], "Select", nullptr);
-            mSelection.index = mCancelIdx;
-            setCursorToPane();
-        }
-        mIsDecided = true;
-        setNerve(this, &NrvWindowConfirm.Decide);
-        return true;
+    if (!isEnableInput())
+        return false;
+
+    if ((mSelection.selectionType == SelectionType::List01 ||
+         mSelection.selectionType == SelectionType::List02) &&
+        mSelection.prevSelectionType != mSelection.cancelType) {
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        startAction(mParListArray[getCancelIdx()], "Select", nullptr);
+        mSelection.prevSelectionType = mSelection.cancelType;
+        setCursorToPane();
     }
-    return false;
+    mIsDecided = true;
+    setNerve(this, &NrvWindowConfirm.Decide);
+    return true;
 }
 
 void WindowConfirm::exeHide() {}
@@ -254,6 +255,7 @@ void WindowConfirm::exeWait() {
         startAction(this, "Wait", nullptr);
         mCooldown = -1;
     }
+
     if (mSelection.selectionType == SelectionType::List01 ||
         mSelection.selectionType == SelectionType::List02) {
         if (isActionPlaying(mCursorActor, "Appear", nullptr) && isActionEnd(mCursorActor, nullptr))
@@ -266,20 +268,19 @@ void WindowConfirm::exeWait() {
     }
 
     if (mDirection == Direction::Up) {
-        startAction(mParListArray[mSelection.index], "Wait", nullptr);
-        if (mSelection.index-- <= 0)
-            mSelection.index = (s32)mSelection.selectionType - 1;
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        if (updateSelectionIdx(Direction::Up) < SelectionType::HardKey)
+            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.selectionType - 1);
 
-        startAction(mParListArray[mSelection.index], "Select", nullptr);
+        startAction(mParListArray[getPrevSelectionIdx()], "Select", nullptr);
         setCursorToPane();
     }
     if (mDirection == Direction::Down) {
-        startAction(mParListArray[mSelection.index], "Wait", nullptr);
-        mSelection.index++;
-        if (mSelection.index >= (s32)mSelection.selectionType)
-            mSelection.index = 0;
+        startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
+        if (updateSelectionIdx(Direction::Down) >= mSelection.selectionType)
+            mSelection.prevSelectionType = SelectionType::HardKey;
 
-        startAction(mParListArray[mSelection.index], "Select", nullptr);
+        startAction(mParListArray[getPrevSelectionIdx()], "Select", nullptr);
         setCursorToPane();
     }
 
@@ -291,20 +292,36 @@ void WindowConfirm::exeWait() {
 
 void WindowConfirm::exeDecide() {
     if (isFirstStep(this)) {
-        if (((s32)mSelection.selectionType & 0xFFFFFFFE) == 2) {
-            startAction(mParListArray[mSelection.index], "Decide", nullptr);
-            startAction(mCursorActor, "End", nullptr);
-        } else if (((s32)mSelection.selectionType & 0xFFFFFFFE) == 1) {
-            startAction(mButtonActor, "PageEnd", nullptr);
-        } else if (((s32)mSelection.selectionType & 0xFFFFFFFE) == 0) {
+        switch (mSelection.selectionType) {
+        case SelectionType::HardKey:
             setNerve(this, &DecideAfter);
+            return;
+        case SelectionType::List00:
+            startAction(mButtonActor, "PageEnd", nullptr);
+            break;
+        case SelectionType::List01:
+        case SelectionType::List02:
+            startAction(mParListArray[getPrevSelectionIdx()], "Decide", nullptr);
+            startAction(mCursorActor, "End", nullptr);
+            break;
+        default:
+            break;
         }
     }
-    if (((s32)mSelection.selectionType & 0xFFFFFFFE) == 2) {
-        if (isActionEnd(mParListArray[mSelection.index], nullptr))
+
+    switch (mSelection.selectionType) {
+    case SelectionType::List00:
+        if (isActionEnd(mButtonActor, nullptr))
             setNerve(this, &DecideAfter);
-    } else if (isActionEnd(mButtonActor, nullptr))
-        setNerve(this, &DecideAfter);
+        return;
+    case SelectionType::List01:
+    case SelectionType::List02:
+        if (isActionEnd(mParListArray[getPrevSelectionIdx()], nullptr))
+            setNerve(this, &DecideAfter);
+        return;
+    default:
+        break;
+    }
 }
 
 void WindowConfirm::exeDecideAfter() {

--- a/lib/al/Library/Play/Layout/WindowConfirm.cpp
+++ b/lib/al/Library/Play/Layout/WindowConfirm.cpp
@@ -1,0 +1,317 @@
+#include "Library/Play/Layout/WindowConfirm.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+using namespace al;
+NERVE_IMPL(WindowConfirm, Hide);
+NERVE_IMPL(WindowConfirm, Appear);
+NERVE_IMPL(WindowConfirm, End);
+NERVE_IMPL(WindowConfirm, Decide);
+NERVE_IMPL(WindowConfirm, Wait);
+NERVE_IMPL(WindowConfirm, DecideAfter);
+
+NERVES_MAKE_NOSTRUCT(WindowConfirm, Hide, Appear, DecideAfter);
+NERVES_MAKE_STRUCT(WindowConfirm, End, Decide, Wait);
+
+}  // namespace
+
+namespace al {
+
+WindowConfirm::WindowConfirm(const LayoutInitInfo& info, const char* name, const char* actorName)
+    : LayoutActor(actorName) {
+    initLayoutActor(this, info, name, nullptr);
+
+    s32 paneChildNum = getPaneChildNum(this, "All");
+    s32 i = 0;
+
+    s32 numberOfPanes = 0;
+    for (i = 0; i < paneChildNum; i++)
+        numberOfPanes += isExistPane(this, StringTmp<64>("ParList%02d", i).cstr());
+
+    mParListArray.allocBuffer(numberOfPanes, nullptr, 8);
+
+    for (i = 0; i < numberOfPanes; i++) {
+        LayoutActor* choiceActor = new LayoutActor(StringTmp<64>("選択肢%02d", i).cstr());
+        initLayoutPartsActor(choiceActor, this, info, StringTmp<64>("ParList%02d", i).cstr(),
+                             nullptr);
+
+        mParListArray.pushBack(choiceActor);
+    }
+
+    if (isExistPane(this, "ParHardKey")) {
+        mButtonActor = new LayoutActor("Ａボタン");
+        initLayoutPartsActor(mButtonActor, this, info, "ParHardKey", nullptr);
+    }
+
+    mCursorActor = new LayoutActor("カーソル");
+    initLayoutPartsActor(mCursorActor, this, info, "ParCursor", nullptr);
+
+    initNerve(&Hide, 0);
+}
+
+void WindowConfirm::setTxtMessage(const char16* message) {
+    setPaneString(this, "TxtMessage", message, 0);
+}
+
+void WindowConfirm::setTxtList(s32 index, const char16* message) {
+    setPaneString(mParListArray.at(index), "TxtContent", message, 0);
+}
+
+void WindowConfirm::setListNum(s32 num) {
+    mSelectionType = (SelectionType)num;
+    if (num == SelectionType_List01)
+        mCancelIdx = 1;
+    if (num == SelectionType_List02)
+        mCancelIdx = 0;
+}
+
+void WindowConfirm::setCancelIdx(s32 index) {
+    mCancelIdx = index;
+}
+
+void WindowConfirm::appear() {
+    if (isAlive())
+        return;
+    mSelectionIndex = 0;
+    mDirection = Direction_None;
+
+    startAction(this, "Appear", nullptr);
+    switch (mSelectionType) {
+    case SelectionType_HardKey:
+        startAction(this, "SelectHardKey", "Select");
+
+        hidePane(this, "ParCursor");
+        hidePane(this, "ParHardKey");
+        break;
+    case SelectionType_List00:
+        startAction(this, "SelectHardKey", "Select");
+        startAction(mButtonActor, "Appear", nullptr);
+
+        hidePane(this, "ParCursor");
+        showPane(this, "ParHardKey");
+        break;
+    case SelectionType_List01:
+        startAction(this, "Select2", "Select");
+        startAction(mCursorActor, "Appear", nullptr);
+        startAction(mParListArray[0], "Select", nullptr);
+        startAction(mParListArray[1], "Wait", nullptr);
+
+        showPane(this, "ParCursor");
+        hidePane(this, "ParHardKey");
+        break;
+    case SelectionType_List02:
+        startAction(this, "Select3", "Select");
+        startAction(mCursorActor, "Appear", nullptr);
+        startAction(mParListArray[0], "Select", nullptr);
+        startAction(mParListArray[1], "Wait", nullptr);
+        startAction(mParListArray[2], "Wait", nullptr);
+
+        showPane(this, "ParCursor");
+        hidePane(this, "ParHardKey");
+        break;
+    default:
+        break;
+    }
+    LayoutActor::appear();
+    setNerve(this, &Appear);
+}
+
+void WindowConfirm::appearWithChoicingCancel() {
+    if (isAlive())
+        return;
+    appear();
+
+    if (mSelectionType == SelectionType_List01) {
+        startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+        startAction(mParListArray[mCancelIdx], "Select", nullptr);
+    } else if (mSelectionType == SelectionType_List02) {
+        startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+        startAction(mParListArray[mCancelIdx], "Select", nullptr);
+    }
+
+    mSelectionIndex = mCancelIdx;
+}
+
+bool WindowConfirm::isNerveEnd() {
+    return isNerve(this, &NrvWindowConfirm.End);
+}
+
+bool WindowConfirm::tryEnd() {
+    if (isEnableInput()) {
+        mIsDecided = false;
+        setNerve(this, &NrvWindowConfirm.End);
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::isEnableInput() {
+    if (mCooldown <= 0 && isNerve(this, &NrvWindowConfirm.Wait) && isGreaterEqualStep(this, 10)) {
+        mCooldown = 10;
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::tryUp() {
+    if (isEnableInput()) {
+        mDirection = Direction_Up;
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::tryDown() {
+    if (isEnableInput()) {
+        mDirection = Direction_Down;
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::tryDecide() {
+    if (isEnableInput()) {
+        mIsDecided = false;
+        startHitReaction(this, "決定", nullptr);
+        setNerve(this, &NrvWindowConfirm.Decide);
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::tryDecideWithoutEnd() {
+    if (isEnableInput()) {
+        mIsDecided = false;
+        setNerve(this, &NrvWindowConfirm.Decide);
+        return true;
+    }
+    return false;
+}
+
+bool WindowConfirm::tryCancel() {
+    if (!isEnableInput())
+        return false;
+    if ((mSelectionType == SelectionType_List01 || mSelectionType == SelectionType_List02) &&
+        mSelectionIndex != mCancelIdx) {
+        startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+        startAction(mParListArray[mCancelIdx], "Select", nullptr);
+        mSelectionIndex = mCancelIdx;
+        setCursorToPane();
+    }
+    startHitReaction(this, "キャンセル", nullptr);
+    mIsDecided = false;
+    setNerve(this, &NrvWindowConfirm.Decide);
+    return true;
+}
+
+void WindowConfirm::setCursorToPane() {
+    if (mSelectionType < SelectionType_List01)
+        return;
+    sead::Vector3f trans = {1.0f, 1.0f, 1.0f};
+    calcPaneTrans(&trans, mParListArray[mSelectionIndex], "Cursor");
+    setPaneLocalTrans(this, "ParCursor", trans);
+}
+
+bool WindowConfirm::tryCancelWithoutEnd() {
+    if (isEnableInput()) {
+        if ((mSelectionType == SelectionType_List01 || mSelectionType == SelectionType_List02) &&
+            mSelectionIndex != mCancelIdx) {
+            startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+            startAction(mParListArray[mCancelIdx], "Select", nullptr);
+            mSelectionIndex = mCancelIdx;
+            setCursorToPane();
+        }
+        mIsDecided = true;
+        setNerve(this, &NrvWindowConfirm.Decide);
+        return true;
+    }
+    return false;
+}
+
+void WindowConfirm::exeHide() {}
+
+void WindowConfirm::exeAppear() {
+    if (mSelectionType == SelectionType_List01 || mSelectionType == SelectionType_List02)
+        setCursorToPane();
+    if (isActionEnd(this, nullptr))
+        setNerve(this, &NrvWindowConfirm.Wait);
+}
+
+void WindowConfirm::exeWait() {
+    if (isFirstStep(this)) {
+        startAction(this, "Wait", nullptr);
+        mCooldown = -1;
+    }
+    if (mSelectionType == SelectionType_List01 || mSelectionType == SelectionType_List02) {
+        if (isActionPlaying(mCursorActor, "Appear", nullptr) && isActionEnd(mCursorActor, nullptr))
+            startAction(mCursorActor, "Wait", nullptr);
+    } else {
+        if (mSelectionType == SelectionType_List00)
+            if (isActionPlaying(mButtonActor, "Appear", nullptr) &&
+                isActionEnd(mButtonActor, nullptr))
+                startAction(mButtonActor, "Wait", nullptr);
+    }
+
+    if (mDirection == Direction_Up) {
+        startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+        if (mSelectionIndex-- <= 0)
+            mSelectionIndex = mSelectionType - 1;
+
+        startAction(mParListArray[mSelectionIndex], "Select", nullptr);
+        setCursorToPane();
+    }
+    if (mDirection == Direction_Down) {
+        startAction(mParListArray[mSelectionIndex], "Wait", nullptr);
+        mSelectionIndex++;
+        if (mSelectionIndex >= mSelectionType)
+            mSelectionIndex = 0;
+
+        startAction(mParListArray[mSelectionIndex], "Select", nullptr);
+        setCursorToPane();
+    }
+
+    mDirection = Direction_None;
+
+    if (mCooldown >= 0)
+        mCooldown--;
+}
+
+void WindowConfirm::exeDecide() {
+    if (isFirstStep(this)) {
+        if ((mSelectionType & 0xFFFFFFFE) == 2) {
+            startAction(mParListArray[mSelectionIndex], "Decide", nullptr);
+            startAction(mCursorActor, "End", nullptr);
+        } else if ((mSelectionType & 0xFFFFFFFE) == 1) {
+            startAction(mButtonActor, "PageEnd", nullptr);
+        } else if ((mSelectionType & 0xFFFFFFFE) == 0) {
+            setNerve(this, &DecideAfter);
+        }
+    }
+    if ((mSelectionType & 0xFFFFFFFE) == 2) {
+        if (isActionEnd(mParListArray[mSelectionIndex], nullptr))
+            setNerve(this, &DecideAfter);
+    } else if (isActionEnd(mButtonActor, nullptr))
+        setNerve(this, &DecideAfter);
+}
+
+void WindowConfirm::exeDecideAfter() {
+    setNerveAtGreaterEqualStep(this, &NrvWindowConfirm.End, 0);
+}
+
+void WindowConfirm::exeEnd() {
+    if (!mIsDecided) {
+        if (isFirstStep(this))
+            startAction(this, "End", nullptr);
+
+        if (isActionEnd(this, nullptr))
+            kill();
+    }
+}
+
+}  // namespace al

--- a/lib/al/Library/Play/Layout/WindowConfirm.cpp
+++ b/lib/al/Library/Play/Layout/WindowConfirm.cpp
@@ -64,11 +64,12 @@ void WindowConfirm::setTxtList(s32 index, const char16* message) {
 }
 
 void WindowConfirm::setListNum(s32 num) {
-    mSelection.selectionType = (SelectionType)num;
-    if (num == (s32)SelectionType::List01)
-        mCancelIdx = 1;
-    if (num == (s32)SelectionType::List02)
-        mCancelIdx = 0;
+    SelectionType selectionType = (SelectionType)num;
+    mSelection.selectionType = selectionType;
+    if (selectionType == SelectionType::List01)
+        setCancelIdx(1);
+    if (selectionType == SelectionType::List02)
+        setCancelIdx(0);
 }
 
 void WindowConfirm::setCancelIdx(s32 index) {
@@ -78,6 +79,7 @@ void WindowConfirm::setCancelIdx(s32 index) {
 void WindowConfirm::appear() {
     if (isAlive())
         return;
+
     mSelection.index = 0;
     mDirection = Direction::None;
 
@@ -125,13 +127,14 @@ void WindowConfirm::appear() {
 void WindowConfirm::appearWithChoicingCancel() {
     if (isAlive())
         return;
+
     appear();
 
     if (mSelection.selectionType == SelectionType::List01) {
-        startAction(mParListArray[(s32)mSelection.index], "Wait", nullptr);
+        startAction(mParListArray[mSelection.index], "Wait", nullptr);
         startAction(mParListArray[mCancelIdx], "Select", nullptr);
     } else if (mSelection.selectionType == SelectionType::List02) {
-        startAction(mParListArray[(s32)mSelection.index], "Wait", nullptr);
+        startAction(mParListArray[mSelection.index], "Wait", nullptr);
         startAction(mParListArray[mCancelIdx], "Select", nullptr);
     }
 

--- a/lib/al/Library/Play/Layout/WindowConfirm.cpp
+++ b/lib/al/Library/Play/Layout/WindowConfirm.cpp
@@ -63,11 +63,10 @@ void WindowConfirm::setTxtList(s32 index, const char16* message) {
 }
 
 void WindowConfirm::setListNum(s32 num) {
-    SelectionType selectionType = (SelectionType)num;
-    mSelection.selectionType = selectionType;
-    if (selectionType == SelectionType::List01)
+    mSelection.selectionType = (SelectionType)num;
+    if (mSelection.selectionType == SelectionType::List01)
         setCancelIdx((s32)SelectionType::List00);
-    if (selectionType == SelectionType::List02)
+    if (mSelection.selectionType == SelectionType::List02)
         setCancelIdx((s32)SelectionType::HardKey);
 }
 

--- a/lib/al/Library/Play/Layout/WindowConfirm.cpp
+++ b/lib/al/Library/Play/Layout/WindowConfirm.cpp
@@ -64,10 +64,10 @@ void WindowConfirm::setTxtList(s32 index, const char16* message) {
 
 void WindowConfirm::setListNum(s32 num) {
     mSelection.selectionType = (SelectionType)num;
-    if (mSelection.selectionType == SelectionType::List01)
-        setCancelIdx((s32)SelectionType::List00);
-    if (mSelection.selectionType == SelectionType::List02)
-        setCancelIdx((s32)SelectionType::HardKey);
+    if (mSelection.selectionType == SelectionType_List01)
+        setCancelIdx(SelectionType_List00);
+    if (mSelection.selectionType == SelectionType_List02)
+        setCancelIdx(SelectionType_HardKey);
 }
 
 void WindowConfirm::setCancelIdx(s32 index) {
@@ -78,39 +78,39 @@ void WindowConfirm::appear() {
     if (isAlive())
         return;
 
-    mSelection.prevSelectionType = SelectionType::HardKey;
+    mSelection.prevSelectionType = SelectionType_HardKey;
     mDirection = Direction::None;
 
     startAction(this, "Appear", nullptr);
     switch (mSelection.selectionType) {
-    case SelectionType::HardKey:
+    case SelectionType_HardKey:
         startAction(this, "SelectHardKey", "Select");
 
         hidePane(this, "ParCursor");
         hidePane(this, "ParHardKey");
         break;
-    case SelectionType::List00:
+    case SelectionType_List00:
         startAction(this, "SelectHardKey", "Select");
         startAction(mButtonActor, "Appear", nullptr);
 
         hidePane(this, "ParCursor");
         showPane(this, "ParHardKey");
         break;
-    case SelectionType::List01:
+    case SelectionType_List01:
         startAction(this, "Select2", "Select");
         startAction(mCursorActor, "Appear", nullptr);
-        startAction(mParListArray[(s32)SelectionType::HardKey], "Select", nullptr);
-        startAction(mParListArray[(s32)SelectionType::List00], "Wait", nullptr);
+        startAction(mParListArray[SelectionType_HardKey], "Select", nullptr);
+        startAction(mParListArray[SelectionType_List00], "Wait", nullptr);
 
         showPane(this, "ParCursor");
         hidePane(this, "ParHardKey");
         break;
-    case SelectionType::List02:
+    case SelectionType_List02:
         startAction(this, "Select3", "Select");
         startAction(mCursorActor, "Appear", nullptr);
-        startAction(mParListArray[(s32)SelectionType::HardKey], "Select", nullptr);
-        startAction(mParListArray[(s32)SelectionType::List00], "Wait", nullptr);
-        startAction(mParListArray[(s32)SelectionType::List01], "Wait", nullptr);
+        startAction(mParListArray[SelectionType_HardKey], "Select", nullptr);
+        startAction(mParListArray[SelectionType_List00], "Wait", nullptr);
+        startAction(mParListArray[SelectionType_List01], "Wait", nullptr);
 
         showPane(this, "ParCursor");
         hidePane(this, "ParHardKey");
@@ -128,10 +128,10 @@ void WindowConfirm::appearWithChoicingCancel() {
 
     appear();
 
-    if (mSelection.selectionType == SelectionType::List01) {
+    if (mSelection.selectionType == SelectionType_List01) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
         startAction(mParListArray[getCancelIdx()], "Select", nullptr);
-    } else if (mSelection.selectionType == SelectionType::List02) {
+    } else if (mSelection.selectionType == SelectionType_List02) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
         startAction(mParListArray[getCancelIdx()], "Select", nullptr);
     }
@@ -199,8 +199,8 @@ bool WindowConfirm::tryCancel() {
     if (!isEnableInput())
         return false;
 
-    if ((mSelection.selectionType == SelectionType::List01 ||
-         mSelection.selectionType == SelectionType::List02) &&
+    if ((mSelection.selectionType == SelectionType_List01 ||
+         mSelection.selectionType == SelectionType_List02) &&
         mSelection.prevSelectionType != mSelection.cancelType) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
         startAction(mParListArray[getCancelIdx()], "Select", nullptr);
@@ -215,7 +215,7 @@ bool WindowConfirm::tryCancel() {
 }
 
 void WindowConfirm::setCursorToPane() {
-    if (mSelection.selectionType >= SelectionType::List01) {
+    if (mSelection.selectionType >= SelectionType_List01) {
         sead::Vector3f trans = {1.0f, 1.0f, 1.0f};
         calcPaneTrans(&trans, mParListArray[getPrevSelectionIdx()], "Cursor");
         setPaneLocalTrans(this, "ParCursor", trans);
@@ -226,8 +226,8 @@ bool WindowConfirm::tryCancelWithoutEnd() {
     if (!isEnableInput())
         return false;
 
-    if ((mSelection.selectionType == SelectionType::List01 ||
-         mSelection.selectionType == SelectionType::List02) &&
+    if ((mSelection.selectionType == SelectionType_List01 ||
+         mSelection.selectionType == SelectionType_List02) &&
         mSelection.prevSelectionType != mSelection.cancelType) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
         startAction(mParListArray[getCancelIdx()], "Select", nullptr);
@@ -242,8 +242,8 @@ bool WindowConfirm::tryCancelWithoutEnd() {
 void WindowConfirm::exeHide() {}
 
 void WindowConfirm::exeAppear() {
-    if (mSelection.selectionType == SelectionType::List01 ||
-        mSelection.selectionType == SelectionType::List02)
+    if (mSelection.selectionType == SelectionType_List01 ||
+        mSelection.selectionType == SelectionType_List02)
         setCursorToPane();
     if (isActionEnd(this, nullptr))
         setNerve(this, &NrvWindowConfirm.Wait);
@@ -255,12 +255,12 @@ void WindowConfirm::exeWait() {
         mCooldown = -1;
     }
 
-    if (mSelection.selectionType == SelectionType::List01 ||
-        mSelection.selectionType == SelectionType::List02) {
+    if (mSelection.selectionType == SelectionType_List01 ||
+        mSelection.selectionType == SelectionType_List02) {
         if (isActionPlaying(mCursorActor, "Appear", nullptr) && isActionEnd(mCursorActor, nullptr))
             startAction(mCursorActor, "Wait", nullptr);
     } else {
-        if (mSelection.selectionType == SelectionType::List00)
+        if (mSelection.selectionType == SelectionType_List00)
             if (isActionPlaying(mButtonActor, "Appear", nullptr) &&
                 isActionEnd(mButtonActor, nullptr))
                 startAction(mButtonActor, "Wait", nullptr);
@@ -268,8 +268,8 @@ void WindowConfirm::exeWait() {
 
     if (mDirection == Direction::Up) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
-        if (updateSelectionIdx(Direction::Up) < SelectionType::HardKey)
-            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.selectionType - 1);
+        if (updateSelectionIdx(Direction::Up) < SelectionType_HardKey)
+            mSelection.prevSelectionType = (SelectionType)(mSelection.selectionType - 1);
 
         startAction(mParListArray[getPrevSelectionIdx()], "Select", nullptr);
         setCursorToPane();
@@ -277,7 +277,7 @@ void WindowConfirm::exeWait() {
     if (mDirection == Direction::Down) {
         startAction(mParListArray[getPrevSelectionIdx()], "Wait", nullptr);
         if (updateSelectionIdx(Direction::Down) >= mSelection.selectionType)
-            mSelection.prevSelectionType = SelectionType::HardKey;
+            mSelection.prevSelectionType = SelectionType_HardKey;
 
         startAction(mParListArray[getPrevSelectionIdx()], "Select", nullptr);
         setCursorToPane();
@@ -292,14 +292,14 @@ void WindowConfirm::exeWait() {
 void WindowConfirm::exeDecide() {
     if (isFirstStep(this)) {
         switch (mSelection.selectionType) {
-        case SelectionType::HardKey:
+        case SelectionType_HardKey:
             setNerve(this, &DecideAfter);
             return;
-        case SelectionType::List00:
+        case SelectionType_List00:
             startAction(mButtonActor, "PageEnd", nullptr);
             break;
-        case SelectionType::List01:
-        case SelectionType::List02:
+        case SelectionType_List01:
+        case SelectionType_List02:
             startAction(mParListArray[getPrevSelectionIdx()], "Decide", nullptr);
             startAction(mCursorActor, "End", nullptr);
             break;
@@ -309,12 +309,12 @@ void WindowConfirm::exeDecide() {
     }
 
     switch (mSelection.selectionType) {
-    case SelectionType::List00:
+    case SelectionType_List00:
         if (isActionEnd(mButtonActor, nullptr))
             setNerve(this, &DecideAfter);
         return;
-    case SelectionType::List01:
-    case SelectionType::List02:
+    case SelectionType_List01:
+    case SelectionType_List02:
         if (isActionEnd(mParListArray[getPrevSelectionIdx()], nullptr))
             setNerve(this, &DecideAfter);
         return;

--- a/lib/al/Library/Play/Layout/WindowConfirm.h
+++ b/lib/al/Library/Play/Layout/WindowConfirm.h
@@ -25,15 +25,16 @@ public:
 
     struct Selection {
         SelectionType selectionType = SelectionType::None;
-        s32 index = -1;
+        SelectionType prevSelectionType = SelectionType::None;
+        SelectionType cancelType = SelectionType::None;
     };
 
-    WindowConfirm(const LayoutInitInfo&, const char*, const char*);
+    WindowConfirm(const LayoutInitInfo& info, const char* name, const char* actorName);
 
-    void setTxtMessage(const char16*);
-    void setTxtList(s32, const char16*);
-    void setListNum(s32);
-    void setCancelIdx(s32);
+    void setTxtMessage(const char16* message);
+    void setTxtList(s32 index, const char16* message);
+    void setListNum(s32 num);
+    void setCancelIdx(s32 index);
     void appear() override;
     void appearWithChoicingCancel();
     bool isNerveEnd();
@@ -46,6 +47,7 @@ public:
     bool tryCancel();
     void setCursorToPane();
     bool tryCancelWithoutEnd();
+
     void exeHide();
     void exeAppear();
     void exeWait();
@@ -53,12 +55,29 @@ public:
     void exeDecideAfter();
     void exeEnd();
 
-    SelectionType getPrevSelectionType() { return (SelectionType)mSelection.index; }
+    int getSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+
+    int getPrevSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+
+    int getCancelIdx() { return (s32)mSelection.cancelType; }
+
+    SelectionType getSelectionType() { return mSelection.selectionType; }
+
+    SelectionType getPrevSelectionType() { return mSelection.prevSelectionType; }
+
+    SelectionType getCancelType() { return mSelection.cancelType; }
+
+    SelectionType updateSelectionIdx(Direction dir) {
+        if (dir == Direction::Up)
+            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.prevSelectionType - 1);
+        else if (dir == Direction::Down)
+            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.prevSelectionType + 1);
+        return mSelection.prevSelectionType;
+    }
 
 private:
     Direction mDirection = Direction::None;
     Selection mSelection;
-    s32 mCancelIdx = -1;
     bool mIsDecided = false;
     s32 mCooldown = -1;
     sead::PtrArray<LayoutActor> mParListArray;

--- a/lib/al/Library/Play/Layout/WindowConfirm.h
+++ b/lib/al/Library/Play/Layout/WindowConfirm.h
@@ -25,7 +25,7 @@ public:
 
     struct Selection {
         SelectionType selectionType = SelectionType::None;
-        SelectionType prevSelectionType = SelectionType::None;
+        s32 index = -1;
     };
 
     WindowConfirm(const LayoutInitInfo&, const char*, const char*);
@@ -53,10 +53,10 @@ public:
     void exeDecideAfter();
     void exeEnd();
 
-    SelectionType getPrevSelectionType() { return mSelection.prevSelectionType; }
+    SelectionType getPrevSelectionType() { return (SelectionType)mSelection.index; }
 
 private:
-    Direction mDirection;
+    Direction mDirection = Direction::None;
     Selection mSelection;
     s32 mCancelIdx = -1;
     bool mIsDecided = false;

--- a/lib/al/Library/Play/Layout/WindowConfirm.h
+++ b/lib/al/Library/Play/Layout/WindowConfirm.h
@@ -55,11 +55,11 @@ public:
     void exeDecideAfter();
     void exeEnd();
 
-    int getSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+    s32 getSelectionIdx() { return (s32)mSelection.prevSelectionType; }
 
-    int getPrevSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+    s32 getPrevSelectionIdx() { return (s32)mSelection.prevSelectionType; }
 
-    int getCancelIdx() { return (s32)mSelection.cancelType; }
+    s32 getCancelIdx() { return (s32)mSelection.cancelType; }
 
     SelectionType getSelectionType() { return mSelection.selectionType; }
 

--- a/lib/al/Library/Play/Layout/WindowConfirm.h
+++ b/lib/al/Library/Play/Layout/WindowConfirm.h
@@ -24,8 +24,8 @@ public:
     };
 
     struct Selection {
-        SelectionType selectionType;
-        SelectionType prevSelectionType;
+        SelectionType selectionType = SelectionType::None;
+        SelectionType prevSelectionType = SelectionType::None;
     };
 
     WindowConfirm(const LayoutInitInfo&, const char*, const char*);
@@ -58,9 +58,9 @@ public:
 private:
     Direction mDirection;
     Selection mSelection;
-    s32 mCancelIdx;
-    bool mIsDecided;
-    s32 mCooldown;
+    s32 mCancelIdx = -1;
+    bool mIsDecided = false;
+    s32 mCooldown = -1;
     sead::PtrArray<LayoutActor> mParListArray;
     LayoutActor* mCursorActor;
     LayoutActor* mButtonActor;

--- a/lib/al/Library/Play/Layout/WindowConfirm.h
+++ b/lib/al/Library/Play/Layout/WindowConfirm.h
@@ -9,12 +9,12 @@ class LayoutInitInfo;
 
 class WindowConfirm : public LayoutActor {
 public:
-    enum class SelectionType {
-        None = -1,
-        HardKey = 0,
-        List00 = 1,
-        List01 = 2,
-        List02 = 3,
+    enum SelectionType {
+        SelectionType_None = -1,
+        SelectionType_HardKey = 0,
+        SelectionType_List00 = 1,
+        SelectionType_List01 = 2,
+        SelectionType_List02 = 3,
     };
 
     enum class Direction {
@@ -24,9 +24,9 @@ public:
     };
 
     struct Selection {
-        SelectionType selectionType = SelectionType::None;
-        SelectionType prevSelectionType = SelectionType::None;
-        SelectionType cancelType = SelectionType::None;
+        SelectionType selectionType = SelectionType_None;
+        SelectionType prevSelectionType = SelectionType_None;
+        SelectionType cancelType = SelectionType_None;
     };
 
     WindowConfirm(const LayoutInitInfo& info, const char* name, const char* actorName);
@@ -55,11 +55,11 @@ public:
     void exeDecideAfter();
     void exeEnd();
 
-    s32 getSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+    s32 getSelectionIdx() { return mSelection.prevSelectionType; }
 
-    s32 getPrevSelectionIdx() { return (s32)mSelection.prevSelectionType; }
+    s32 getPrevSelectionIdx() { return mSelection.prevSelectionType; }
 
-    s32 getCancelIdx() { return (s32)mSelection.cancelType; }
+    s32 getCancelIdx() { return mSelection.cancelType; }
 
     SelectionType getSelectionType() { return mSelection.selectionType; }
 
@@ -69,9 +69,9 @@ public:
 
     SelectionType updateSelectionIdx(Direction dir) {
         if (dir == Direction::Up)
-            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.prevSelectionType - 1);
+            mSelection.prevSelectionType = (SelectionType)(mSelection.prevSelectionType - 1);
         else if (dir == Direction::Down)
-            mSelection.prevSelectionType = (SelectionType)((s32)mSelection.prevSelectionType + 1);
+            mSelection.prevSelectionType = (SelectionType)(mSelection.prevSelectionType + 1);
         return mSelection.prevSelectionType;
     }
 

--- a/src/Scene/StageSceneStatePauseMenu.cpp
+++ b/src/Scene/StageSceneStatePauseMenu.cpp
@@ -640,16 +640,16 @@ void StageSceneStatePauseMenu::exeConfirmNewGame() {
     al::WindowConfirm::SelectionType selectionType = mWindowConfirm->getPrevSelectionType();
 
     if (rs::isTriggerUiDecide(getHost())) {
-        if (selectionType == al::WindowConfirm::SelectionType::HardKey)
+        if (selectionType == al::WindowConfirm::SelectionType_HardKey)
             mWindowConfirm->tryDecideWithoutEnd();
-        if (selectionType == al::WindowConfirm::SelectionType::List00)
+        if (selectionType == al::WindowConfirm::SelectionType_List00)
             mWindowConfirm->tryCancel();
     }
 
     if (rs::isTriggerUiCancel(getHost()))
         mWindowConfirm->tryCancel();
 
-    if (selectionType == al::WindowConfirm::SelectionType::HardKey &&
+    if (selectionType == al::WindowConfirm::SelectionType_HardKey &&
         mWindowConfirm->isNerveEnd()) {
         mWindowConfirm->tryDecide();
         s32 emptyFileId = mGameDataHolderAccessor->tryFindEmptyFileId();
@@ -658,7 +658,7 @@ void StageSceneStatePauseMenu::exeConfirmNewGame() {
         mIsNewGame = true;
     }
 
-    if (selectionType == al::WindowConfirm::SelectionType::List00) {
+    if (selectionType == al::WindowConfirm::SelectionType_List00) {
         if (al::isDead(mWindowConfirm)) {
             mSelectParts->appearWait();
             al::setNerve(this, &NrvStageSceneStatePauseMenu.Wait);

--- a/src/Scene/StageSceneStatePauseMenu.cpp
+++ b/src/Scene/StageSceneStatePauseMenu.cpp
@@ -649,8 +649,7 @@ void StageSceneStatePauseMenu::exeConfirmNewGame() {
     if (rs::isTriggerUiCancel(getHost()))
         mWindowConfirm->tryCancel();
 
-    if (selectionType == al::WindowConfirm::SelectionType_HardKey &&
-        mWindowConfirm->isNerveEnd()) {
+    if (selectionType == al::WindowConfirm::SelectionType_HardKey && mWindowConfirm->isNerveEnd()) {
         mWindowConfirm->tryDecide();
         s32 emptyFileId = mGameDataHolderAccessor->tryFindEmptyFileId();
         mGameDataHolderAccessor->requestSetPlayingFileId(emptyFileId);


### PR DESCRIPTION
Backlog from last year. I was stuck on styling and I've settled on header functions to reduce the amount of casts.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/880)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 3d14303)

📈 **Matched code**: 15.54% (+0.05%, +5788 bytes)

<details>
<summary>✅ 30 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeWait()` | +816 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::WindowConfirm(al::LayoutInitInfo const&, char const*, char const*)` | +748 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::WindowConfirm(al::LayoutInitInfo const&, char const*, char const*)` | +740 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::appear()` | +652 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryCancel()` | +428 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryCancelWithoutEnd()` | +412 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeDecide()` | +304 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::appearWithChoicingCancel()` | +200 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeAppear()` | +200 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::setCursorToPane()` | +148 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryDecide()` | +144 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryDecideWithoutEnd()` | +128 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryEnd()` | +120 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeEnd()` | +112 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvEnd::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryDown()` | +108 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::tryUp()` | +104 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::isEnableInput()` | +100 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::setTxtList(int, char16_t const*)` | +56 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::setListNum(int)` | +40 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::setTxtMessage(char16_t const*)` | +28 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvDecideAfter::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeDecideAfter()` | +16 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::isNerveEnd()` | +12 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::setCancelIdx(int)` | +8 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvAppear::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvDecide::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `al::WindowConfirm::exeHide()` | +4 | 0.00% | 100.00% |
| `Library/Play/Layout/WindowConfirm` | `(anonymous namespace)::WindowConfirmNrvHide::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->