### PR TITLE
System: Implement `GameDataHolder`

### DIFF
--- a/lib/al/Library/Scene/GameDataHolderBase.h
+++ b/lib/al/Library/Scene/GameDataHolderBase.h
@@ -1,10 +1,7 @@
 #pragma once
 
-#include "Library/HostIO/HioNode.h"
-#include "Library/Message/IUseMessageSystem.h"
-#include "Library/Scene/ISceneObj.h"
-
 namespace al {
 
-class GameDataHolderBase : public ISceneObj, public HioNode, public IUseMessageSystem {};
+class GameDataHolderBase {};
+
 }  // namespace al

--- a/lib/al/Library/Scene/GameDataHolderBase.h
+++ b/lib/al/Library/Scene/GameDataHolderBase.h
@@ -5,5 +5,6 @@
 #include "Library/Scene/ISceneObj.h"
 
 namespace al {
-class GameDataHolderBase {};
+
+class GameDataHolderBase : public ISceneObj, public HioNode, public IUseMessageSystem {};
 }  // namespace al

--- a/src/Scene/QuestInfoHolder.h
+++ b/src/Scene/QuestInfoHolder.h
@@ -10,9 +10,11 @@
 #include "Scene/SceneObjFactory.h"
 
 namespace al {
+struct ActorInitInfo;
 class IUseSceneObjHolder;
 class LiveActor;
 class PlacementInfo;
+class SceneObjHolder;
 }  // namespace al
 class QuestInfo;
 

--- a/src/Sequence/WorldResourceLoader.cpp
+++ b/src/Sequence/WorldResourceLoader.cpp
@@ -181,9 +181,8 @@ void WorldResourceLoader::loadWorldResource(s32 loadWorldId, s32 scenario, bool 
     nn::os::GetSystemTick();
     nn::os::GetSystemTick();
 
-    const u8* bymlData = al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource");
-
-    al::ByamlIter worldResourceIter(bymlData);
+    al::ByamlIter worldResourceIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldResource"));
     al::ByamlIter loadWorldIter;
     al::getByamlIterByIndex(&loadWorldIter, worldResourceIter, loadWorldId);
     al::ByamlIter resourceListIter;

--- a/src/System/CapMessageBossData.h
+++ b/src/System/CapMessageBossData.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class CapMessageBossData {
+public:
+    CapMessageBossData();
+
+    void init();
+    bool invalidateMessage(s32);
+    bool isValidateMessage(s32) const;
+    void incrementBossBattleCount(s32);
+    s32 getBattleCount(s32) const;
+
+private:
+    char filler[0x10];
+};
+
+static_assert(sizeof(CapMessageBossData) == 0x10);

--- a/src/System/GameDataFile.h
+++ b/src/System/GameDataFile.h
@@ -707,6 +707,10 @@ public:
 
     sead::FixedSafeString<64>* getGiftList() { return mItemGift.begin(); }
 
+    GameProgressData* getGameProgressData() { return mGameProgressData; }
+
+    void setWarpHoleWorldId(s32 worldId) { mWarpHoleWorldId = worldId; }
+
 private:
     struct WorldHintList {
         sead::PtrArray<HintInfo> list;
@@ -917,7 +921,7 @@ private:
     FixedHeapArray<s32, sNumWorlds> mWorldWarpIndex;
     s32 mWorldWarpNum = 0;
     s32 mUnlockedWorldNum = 1;
-    s32 _b60 = 0;
+    s32 mWarpHoleWorldId = 0;
     bool mIsKoopaLv3 = false;
     bool mIsEnableCapMessageLifeOneKidsMode = true;
 };

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -1,0 +1,1241 @@
+#include "System/GameDataHolder.h"
+
+#include <heap/seadFrameHeap.h>
+#include <heap/seadHeap.h>
+#include <stream/seadRamStream.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/File/FileUtil.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Message/LanguageUtil.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/SaveData/SaveDataFunction.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/ByamlUtil.h"
+#include "Library/Yaml/Writer/ByamlWriter.h"
+
+#include "Item/Coin.h"
+#include "Layout/ShopLayoutInfo.h"
+#include "Npc/AchievementHolder.h"
+#include "Npc/AchievementInfoReader.h"
+#include "Scene/QuestInfoHolder.h"
+#include "Sequence/GameSequenceInfo.h"
+#include "System/CapMessageBossData.h"
+#include "System/GameConfigData.h"
+#include "System/GameDataFile.h"
+#include "System/GameDataFunction.h"
+#include "System/GameProgressData.h"
+#include "System/MapDataHolder.h"
+#include "System/SaveDataAccessFunction.h"
+#include "System/SaveDataAccessSequence.h"
+#include "System/TempSaveData.h"
+#include "System/UniqObjInfo.h"
+#include "System/WorldList.h"
+#include "Util/ScenePrepoFunction.h"
+#include "Util/SpecialBuildUtil.h"
+
+void initializeShopItemList(sead::PtrArray<ShopItem::ShopItemInfo>* shopItemList,
+                            const char* name) {
+    if (!al::isExistArchive("SystemData/ItemList"))
+        return;
+
+    al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
+    const u8* yaml = al::findResourceYaml(resource, name, nullptr);
+    al::ByamlIter iter(yaml);
+
+    s32 size = iter.getSize();
+    if (size <= 0)
+        return;
+
+    shopItemList->allocBuffer(size, nullptr);
+
+    for (s32 i = 0; i < size; i++) {
+        ShopItem::ShopItemInfo* itemInfo = new ShopItem::ShopItemInfo();
+        al::ByamlIter itemIter;
+        iter.tryGetIterByIndex(&itemIter, i);
+        itemInfo->info.index = i;
+
+        al::copyString(itemInfo->info.name, al::tryGetByamlKeyStringOrNULL(itemIter, "ItemName"),
+                       0x80);
+
+        const char* itemType = al::tryGetByamlKeyStringOrNULL(itemIter, "ItemType");
+        if (al::isEqualString(itemType, "Clothes"))
+            itemInfo->info.type = ShopItem::ItemType::Cloth;
+        else if (al::isEqualString(itemType, "Cap"))
+            itemInfo->info.type = ShopItem::ItemType::Cap;
+        else if (al::isEqualString(itemType, "Gift"))
+            itemInfo->info.type = ShopItem::ItemType::Gift;
+        else if (al::isEqualString(itemType, "Sticker"))
+            itemInfo->info.type = ShopItem::ItemType::Sticker;
+        else if (al::isEqualString(itemType, "UseItem"))
+            itemInfo->info.type = ShopItem::ItemType::UseItem;
+        else if (al::isEqualString(itemType, "Shine"))
+            itemInfo->info.type = ShopItem::ItemType::Moon;
+
+        al::tryGetByamlS32(&itemInfo->price, itemIter, "Price");
+
+        const char* coinType = al::tryGetByamlKeyStringOrNULL(itemIter, "CoinType");
+        if (coinType) {
+            if (al::isEqualString(coinType, "Coin"))
+                itemInfo->coinType = ShopItem::CoinType::Coin;
+            else if (al::isEqualString(coinType, "Collect"))
+                itemInfo->coinType = ShopItem::CoinType::Collect;
+        }
+
+        const char* storeName = al::tryGetByamlKeyStringOrNULL(itemIter, "StoreName");
+        if (storeName && storeName[0] != '\0')
+            al::copyString(itemInfo->storeName, storeName, 0x80);
+
+        const char* clearWorld = al::tryGetByamlKeyStringOrNULL(itemIter, "ClearWorld");
+        if (clearWorld && clearWorld[0] != '\0')
+            al::copyString(itemInfo->clearWorld, clearWorld, 0x80);
+
+        al::tryGetByamlS32(&itemInfo->moonNum, itemIter, "MoonNum");
+
+        shopItemList->pushBack(itemInfo);
+    }
+}
+
+void initializeItemList(sead::PtrArray<ShopItem::ItemInfo>* shopItemList, const char* name) {
+    if (!al::isExistArchive("SystemData/ItemList"))
+        return;
+
+    al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
+    const u8* yaml = al::findResourceYaml(resource, name, nullptr);
+    al::ByamlIter iter(yaml);
+
+    s32 size = iter.getSize();
+    if (size <= 0)
+        return;
+
+    shopItemList->allocBuffer(size, nullptr);
+
+    for (s32 i = 0; i < size; i++) {
+        ShopItem::ItemInfo* itemInfo = new ShopItem::ItemInfo();
+
+        al::ByamlIter itemIter;
+        iter.tryGetIterByIndex(&itemIter, i);
+        itemInfo->index = i;
+
+        const char* itemName = al::tryGetByamlKeyStringOrNULL(itemIter, "ItemName");
+        if (!itemName)
+            continue;
+
+        al::copyString(itemInfo->name, itemName, 0x80);
+
+        if (al::isEqualString(name, "ItemCap"))
+            itemInfo->type = ShopItem::ItemType::Cap;
+        else if (al::isEqualString(name, "ItemCloth"))
+            itemInfo->type = ShopItem::ItemType::Cloth;
+        else if (al::isEqualString(name, "ItemGift"))
+            itemInfo->type = ShopItem::ItemType::Gift;
+        else if (al::isEqualString(name, "ItemSticker"))
+            itemInfo->type = ShopItem::ItemType::Sticker;
+
+        al::ByamlIter amiiboIter;
+        if (itemIter.tryGetIterByKey(&amiiboIter, "Amiibo")) {
+            s32 amiiboSize = amiiboIter.getSize();
+            if (amiiboSize > 0) {
+                itemInfo->amiiboInfoList.tryAllocBuffer(amiiboSize, nullptr);
+
+                for (s32 j = 0; j < amiiboSize; j++) {
+                    al::ByamlIter amiiboJiter;
+                    amiiboIter.tryGetIterByIndex(&amiiboJiter, j);
+
+                    s32 characterId = -1;
+                    if (al::tryGetByamlS32(&characterId, amiiboJiter, "CharacterId"))
+                        itemInfo->amiiboInfoList[j].characterId = characterId;
+
+                    s32 numberingId = -1;
+                    if (al::tryGetByamlS32(&numberingId, amiiboJiter, "NumberingId"))
+                        itemInfo->amiiboInfoList[j].numberingId = numberingId;
+                }
+            }
+        }
+
+        bool isAOC;
+        if (itemIter.tryGetBoolByKey(&isAOC, "IsAOC"))
+            itemInfo->isAOC = isAOC;
+
+        shopItemList->pushBack(itemInfo);
+    }
+}
+
+// NON-MATCHING: Major issues https://decomp.me/scratch/CyzkJ
+GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
+    : mMessageSystem(messageSystem) {
+    setLanguage(al::getLanguageString());
+    mSaveDataWriteHeap =
+        sead::FrameHeap::create(0x200000, "セーブデータByamlIter書き込み用", nullptr, 8,
+                                sead::FrameHeap::cHeapDirection_Forward, false);
+    mSaveDataWorkBuffer = new u8[0x200000];
+    mGameConfigData = new GameConfigData();
+    mGameConfigData->init();
+
+    mWorldList = new WorldList();
+
+    al::ByamlIter changeStageListIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "ChangeStageList"));
+    s32 changeStageListSize = changeStageListIter.getSize();
+    mChangeStageList.allocBuffer(changeStageListSize, nullptr);
+
+    for (s32 i = 0; i < changeStageListSize; i++) {
+        al::ByamlIter iter;
+        changeStageListIter.tryGetIterByIndex(&iter, i);
+        const char* srcStageName = nullptr;
+        iter.tryGetStringByKey(&srcStageName, "SrcStageName");
+        const char* srcLabel = nullptr;
+        iter.tryGetStringByKey(&srcLabel, "SrcLabel");
+        const char* destStageName = nullptr;
+        iter.tryGetStringByKey(&destStageName, "DestStageName");
+        const char* destLabel = nullptr;
+        iter.tryGetStringByKey(&destLabel, "DestLabel");
+
+        ChangeStageItem* stageItem = new ChangeStageItem();
+        stageItem->srcStageName.format("%s", srcStageName);
+        stageItem->srcLabel.format("%s", srcLabel);
+        stageItem->destStageName.format("%s", destStageName);
+        stageItem->destLabel.format("%s", destLabel);
+
+        mChangeStageList.pushBack(stageItem);
+    }
+
+    al::ByamlIter exStageListIter(al::tryGetBymlFromArcName("SystemData/WorldList", "ExStageList"));
+    s32 exStageListSize = exStageListIter.getSize();
+    mExStageList.allocBuffer(exStageListSize, nullptr);
+
+    for (s32 i = 0; i < exStageListSize; i++) {
+        const char* name = nullptr;
+        exStageListIter.tryGetStringByIndex(&name, i);
+
+        ExStageItem* stageItem = new ExStageItem;
+        stageItem->name.format("%s", name);
+
+        mExStageList.pushBack(stageItem);
+    }
+
+    al::ByamlIter invalidOpenMapListIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "InvalidOpenMapList"));
+    s32 invalidOpenMapListSize = invalidOpenMapListIter.getSize();
+    mInvalidOpenMapList.allocBuffer(invalidOpenMapListSize, nullptr);
+
+    for (s32 i = 0; i < invalidOpenMapListSize; i++) {
+        al::ByamlIter iter;
+        invalidOpenMapListIter.tryGetIterByIndex(&iter, i);
+
+        InvalidOpenMapInfo* mapInfo = new InvalidOpenMapInfo();
+
+        iter.tryGetStringByKey(&mapInfo->name, "Name");
+        iter.tryGetIntByKey(&mapInfo->scenario, "Scenario");
+
+        mInvalidOpenMapList.pushBack(mapInfo);
+    }
+
+    al::ByamlIter stageLockListIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "StageLockList"));
+    stageLockListIter.tryGetIterByKey(&stageLockListIter, "StageLockList");
+    s32 stageLockListSize = stageLockListIter.getSize();
+
+    mIsPlayAlreadyScenarioStartCamera = new bool[0x10];
+    mAchievementInfoReader = new AchievementInfoReader();
+    mAchievementInfoReader->init();
+
+    mAchievementHolder = new AchievementHolder();
+    mAchievementHolder->init();
+
+    mStageLockList.allocBuffer(stageLockListSize, nullptr);
+
+    for (s32 i = 0; i < stageLockListSize; i++) {
+        al::ByamlIter iter;
+        stageLockListIter.tryGetIterByIndex(&iter, i);
+        StageLockInfo* lockInfo = new StageLockInfo();
+
+        al::tryGetByamlBool(&lockInfo->isCountTotal, iter, "IsCountTotal");
+        al::tryGetByamlBool(&lockInfo->isCrash, iter, "IsCrash");
+
+        al::ByamlIter shineInfoIter;
+        iter.tryGetIterByKey(&shineInfoIter, "ShineNumInfo");
+        lockInfo->shineNumInfoNum = shineInfoIter.getSize();
+        lockInfo->shineNumInfo = new s32[lockInfo->shineNumInfoNum];
+
+        for (s32 j = 0; j < lockInfo->shineNumInfoNum; j++)
+            shineInfoIter.tryGetIntByIndex(&lockInfo->shineNumInfo[j], j);
+
+        mStageLockList.pushBack(lockInfo);
+    }
+
+    initializeShopItemList(&mShopItemList, "ItemList");
+    if (rs::isModeE3Rom() || rs::isModeE3LiveRom())
+        initializeShopItemList(&mShopItemListE3, "ItemListE3");
+
+    initializeItemList(&mItemCloth, "ItemCloth");
+    initializeItemList(&mItemCap, "ItemCap");
+    initializeItemList(&mItemGift, "ItemGift");
+    initializeItemList(&mItemSticker, "ItemSticker");
+
+    s32 sizer = mShopItemList.size();
+    s32 shopItemSize = 0;
+    s32 shopTalkDataSize = 0;
+    const char* nameList[10];
+    for (s32 i = 0; i < sizer; i++) {
+        if (!al::isEqualString(mShopItemList[i]->clearWorld, "")) {
+            bool found = false;
+            for (s32 j = 0; j < shopTalkDataSize; j++) {
+                if (al::isEqualString(nameList[j], mShopItemList[i]->clearWorld)) {
+                    found = true;
+                    break;
+                }
+            }
+
+            if (!found)
+                nameList[shopTalkDataSize++] = mShopItemList[i]->clearWorld;
+        }
+
+        if (mShopItemList[i]->moonNum != -1)
+            shopItemSize++;
+    }
+
+    mWorldsForNewReleaseShop.allocBuffer(shopTalkDataSize, nullptr);
+    for (s32 i = 0; i < shopTalkDataSize; i++) {
+        sead::FixedSafeString<64>* newWorld = new sead::FixedSafeString<64>(nameList[i]);
+        mWorldsForNewReleaseShop.pushBack(newWorld);
+    }
+
+    mShopTalkDataInfos = new s32[shopItemSize];
+
+    for (s32 i = 0; i < sizer; i++)
+        if (mShopItemList[i]->moonNum != -1)
+            mShopTalkDataInfos[mShopTalkDataSize++] = mShopItemList[i]->moonNum;
+
+    al::ByamlIter hackObjListIter(al::findResourceYaml(
+        al::findOrCreateResource("SystemData/HackObjList", nullptr), "HackObjList", nullptr));
+    s32 hackObjListSize = hackObjListIter.getSize();
+    mHackObjList.allocBuffer(hackObjListSize, nullptr);
+
+    for (s32 i = 0; i < hackObjListSize; i++) {
+        al::ByamlIter iter;
+        hackObjListIter.tryGetIterByIndex(&iter, i);
+        HackObjInfo* objInfo = new HackObjInfo;
+
+        objInfo->hackName = al::tryGetByamlKeyStringOrNULL(iter, "HackName");
+        objInfo->isScare = al::tryGetByamlKeyBoolOrFalse(iter, "IsScare");
+        objInfo->isNoCollisionMsg = al::tryGetByamlKeyBoolOrFalse(iter, "IsNoCollisionMsg");
+        objInfo->isNoSeparateCameraInput =
+            al::tryGetByamlKeyBoolOrFalse(iter, "IsNoSeparateCameraInput");
+        objInfo->isUsePlayerCollision = al::tryGetByamlKeyBoolOrFalse(iter, "IsUsePlayerCollision");
+        objInfo->isUseCollisionPartsFilterActor =
+            al::tryGetByamlKeyBoolOrFalse(iter, "IsUseCollisionPartsFilterActor");
+        objInfo->tutorialName = al::tryGetByamlKeyStringOrNULL(iter, "TutorialName");
+        al::tryGetByamlF32(&objInfo->guideHeight, iter, "GuideHeight");
+        al::tryGetByamlBool(&objInfo->isGuideEnable, iter, "IsGuideEnable");
+        al::tryGetByamlF32(&objInfo->stayGravityMargine, iter, "StayGravityMargine");
+
+        mHackObjList.pushBack(objInfo);
+    }
+
+    s32 tutoralLabelNum = al::getSystemMessageLabelNum(this, "Tutorial");
+    mShowHackTutorialList.allocBuffer(tutoralLabelNum, nullptr);
+
+    for (s32 i = 0; i < mShowHackTutorialList.capacity(); i++)
+        mShowHackTutorialList.pushBack(new sead::FixedSafeString<128>(""));
+
+    mFiles = new GameDataFile*[5];
+    for (s32 i = 0; i < 5; i++)
+        mFiles[i] = new GameDataFile(this);
+    mSequenceInfo = new GameSequenceInfo();
+    mTempSaveData = new TempSaveData();
+    mTempSaveDataBackup = new TempSaveData();
+    mCapMessageBossData = new CapMessageBossData();
+    mIsShowBindTutorial = new bool[3];
+    mLocationName = new UniqObjInfo();
+    mCoinTransForDeadPlayer = new sead::Vector3f[10];
+    mQuestInfoHolder = new QuestInfoHolder(0x40);
+    mMapDataHolder = new MapDataHolder(this);
+
+    al::ByamlIter worldItemTypeListIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldItemTypeList"));
+    s32 worldItemTypeListSize = worldItemTypeListIter.getSize();
+
+    mWorldItemTypeInfo.allocBuffer(worldItemTypeListSize, nullptr);
+    if (worldItemTypeListSize > 0) {
+        for (s32 i = 0; i < worldItemTypeListSize; i++) {
+            WorldItemTypeInfo* info = new WorldItemTypeInfo;
+            mWorldItemTypeInfo.pushBack(info);
+        }
+
+        for (s32 i = 0; i < worldItemTypeListSize; i++) {
+            al::ByamlIter iter;
+            s32 shine = 0;
+            const char* coinCollect = "";
+            worldItemTypeListIter.tryGetIterByIndex(&iter, i);
+
+            iter.tryGetStringByKey(&coinCollect, "CoinCollect");
+            iter.tryGetIntByKey(&shine, "Shine");
+            const char* worldName = al::getByamlKeyString(iter, "WorldName");
+            s32 worldIndex = mWorldList->tryFindWorldIndexByDevelopName(worldName);
+            WorldItemTypeInfo* info = mWorldItemTypeInfo[worldIndex];
+            info->coinCollect.format("CoinCollect%s", coinCollect);
+            info->coinCollectEmpty.format("CoinCollectEmpty%s", coinCollect);
+            info->coinCollect2D.format("CoinCollect2D_%s", coinCollect);
+            info->coinCollectEmpty2D.format("CoinCollectEmpty2D_%s", coinCollect);
+            info->shineAnimFrame = shine;
+        }
+    }
+
+    mCoinCollectNumMax = new s32[mWorldList->getWorldNum()];
+
+    al::ByamlIter collectCoinNumIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "CollectCoinNum"));
+
+    for (s32 i = 0; i < collectCoinNumIter.getSize(); i++) {
+        al::ByamlIter iter;
+        collectCoinNumIter.tryGetIterByIndex(&iter, i);
+
+        s32 collectCoinNum = al::getByamlKeyInt(iter, "CollectCoinNum");
+        s32 worldIndex =
+            mWorldList->tryFindWorldIndexByDevelopName(al::getByamlKeyString(iter, "WorldName"));
+        mCoinCollectNumMax[worldIndex] = collectCoinNum;
+    }
+
+    mWorldWarpHoleDestIds = new s32[mWorldList->getWorldNum()];
+
+    al::ByamlIter worldWarpHoleInfoIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldWarpHoleInfo"));
+    al::ByamlIter worldLinkInfoIter;
+    al::getByamlIterByKey(&worldLinkInfoIter, worldWarpHoleInfoIter, "WorldLinkInfo");
+
+    for (s32 i = 0; i < mWorldList->getWorldNum(); i++) {
+        s32 destId = -1;
+
+        worldLinkInfoIter.tryGetIntByKey(&destId, al::StringTmp<32>("%d", i).cstr());
+        mWorldWarpHoleDestIds[i] = destId;
+    }
+
+    al::ByamlIter worldWarpHoleInfoIter2;
+    al::getByamlIterByKey(&worldWarpHoleInfoIter2, worldWarpHoleInfoIter, "WorldWarpHoleInfo");
+    mWorldWarpHoleInfoNum = worldWarpHoleInfoIter2.getSize();
+    mWorldWarpHoleInfos = new WorldWarpHoleInfo[mWorldWarpHoleInfoNum];
+
+    for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
+        al::ByamlIter infoIter;
+        al::getByamlIterByIndex(&infoIter, worldWarpHoleInfoIter2, i);
+
+        mWorldWarpHoleInfos[i].stageName.format("%s", al::getByamlKeyString(infoIter, "StageName"));
+        mWorldWarpHoleInfos[i].name.format("%s", al::getByamlKeyString(infoIter, "Name"));
+        mWorldWarpHoleInfos[i].worldId = al::getByamlKeyInt(infoIter, "WorldId");
+        mWorldWarpHoleInfos[i].scenarioNo = al::tryGetByamlKeyIntOrZero(infoIter, "ScenarioNo");
+    }
+
+    setPlayingFileId(0);
+    initializeData();
+}
+
+// NON-MATCHING: Initializer is broken https://decomp.me/scratch/vbHSh
+GameDataHolder::GameDataHolder() {
+    setLanguage(al::getLanguageString());
+}
+
+GameDataHolder::~GameDataHolder() = default;
+
+const char* GameDataHolder::getSceneObjName() const {
+    return "ゲームデータ保持";
+}
+
+const al::MessageSystem* GameDataHolder::getMessageSystem() const {
+    return mMessageSystem;
+}
+
+void GameDataHolder::setPlayingFileId(s32 fileId) {
+    mPlayingFile = getGameDataFile(fileId);
+    resetTempSaveData(false);
+    if (fileId != -1)
+        mPlayingFileId = fileId;
+}
+
+void GameDataHolder::initializeData() {
+    for (s32 i = 0; i < 5; i++)
+        initializeDataId(i);
+
+    initializeDataCommon();
+    setPlayingFileId(0);
+}
+
+void GameDataHolder::initializeDataCommon() {
+    _244 = false;
+    mPlayTimeAcrossFile = 0;
+    mIsExistKoopaShip = false;
+    resetTempSaveData(false);
+    mIsValidCheckpointWarp = true;
+    mStageMapPlayerPos = sead::Vector3f::zero;
+    mIsPlayDemoLavaErupt = false;
+    mIsDisableExplainAmiibo = false;
+    mSearchHintByAmiiboCount = 0;
+    mCapMessageBossData->init();
+
+    for (s32 i = 0; i < mShowHackTutorialList.size(); i++)
+        mShowHackTutorialList[i]->clear();
+
+    for (s32 i = 0; i < 3; i++)
+        mIsShowBindTutorial[i] = false;
+
+    for (s32 i = 0; i < 10; i++)
+        mCoinTransForDeadPlayer[i].set(sead::Vector3f::zero);
+
+    mDeadPlayerCoinIdx = 0;
+    resetLocationName();
+    mQuestInfoHolder->clearAll();
+    mSequenceInfo->init();
+}
+
+void GameDataHolder::resetTempSaveData(bool isSwapTempSaveData) {
+    if (isSwapTempSaveData) {
+        s32 worldIndex = mWorldList->tryFindWorldIndexByMainStageName(getNextStageName());
+        TempSaveData* tempSaveData = mTempSaveData;
+        s32 worldIndexBackup = mTempSaveDataBackup->getWorldIndex();
+
+        mTempSaveData = mTempSaveDataBackup;
+        mTempSaveDataBackup = tempSaveData;
+        if (worldIndex != worldIndexBackup)
+            mTempSaveData->init();
+    } else {
+        mTempSaveData->init();
+        mTempSaveDataBackup->init();
+    }
+
+    for (s32 i = 0; i < 5; i++)
+        getGameDataFile(i)->resetTempData();
+
+    mCapMessageBossData->init();
+    resetLocationName();
+    resetScenarioStartCamera();
+
+    mQuestInfoHolder->clearAll();
+    mIsExistKoopaShip = false;
+}
+
+void GameDataHolder::initializeDataId(s32 fileId) {
+    getGameDataFile(fileId)->initializeData();
+}
+
+void GameDataHolder::readByamlData(s32 fileId, const char* fileName) {
+    resetTempSaveData(false);
+    initializeDataId(fileId);
+
+    const u8* bymlData = al::getBymlFromArcName("DebugData/DebugSaveData", fileName);
+    getGameDataFile(fileId)->tryReadByamlData(bymlData);
+
+    SaveDataAccessFunction::startSaveDataWriteSync(this);
+}
+
+s32 GameDataHolder::tryFindEmptyFileId() const {
+    for (s32 i = 0; i < 5; i++)
+        if (getGameDataFile(i)->isEmpty())
+            return i;
+    return -1;
+}
+
+void GameDataHolder::createSaveDataAccessSequence(const al::LayoutInitInfo& layoutInitInfo) {
+    mSaveDataAccessSequence = new SaveDataAccessSequence(this, layoutInitInfo);
+}
+
+void GameDataHolder::createSaveDataAccessSequenceDevelop(const al::LayoutInitInfo& layoutInitInfo) {
+    createSaveDataAccessSequence(layoutInitInfo);
+    mSaveDataAccessSequence->setDevelop();
+}
+
+bool GameDataHolder::isRequireSave() const {
+    return mIsRequireSave && mRequireSaveFrame == 0;
+}
+
+void GameDataHolder::setRequireSave() {
+    mIsRequireSave = true;
+    mRequireSaveFrame = 0;
+}
+
+void GameDataHolder::setRequireSaveFalse() {
+    mIsRequireSave = false;
+    mRequireSaveFrame = 0;
+}
+
+void GameDataHolder::setRequireSaveFrame() {
+    if (!mIsRequireSave || mRequireSaveFrame > 0) {
+        mRequireSaveFrame = 60;
+        mIsRequireSave = true;
+    }
+}
+
+void GameDataHolder::updateRequireSaveFrame() {
+    mRequireSaveFrame = sead::Mathi::clampMin(mRequireSaveFrame - 1, 0);
+}
+
+bool GameDataHolder::isInvalidSaveForMoonGet() const {
+    return mIsInvalidSaveForMoonGet;
+}
+
+void GameDataHolder::invalidateSaveForMoonGet() {
+    mIsInvalidSaveForMoonGet = true;
+}
+
+void GameDataHolder::validateSaveForMoonGet() {
+    mIsInvalidSaveForMoonGet = false;
+}
+
+void GameDataHolder::setLanguage(const char* language) {
+    mLanguage.format("%s", language);
+}
+
+const char* GameDataHolder::getLanguage() const {
+    return mLanguage.cstr();
+}
+
+void GameDataHolder::changeNextStage(const ChangeStageInfo* changeStageInfo, s32 raceType) {
+    if (mIsStageChanging)
+        return;
+
+    mPlayingFile->changeNextStage(changeStageInfo, raceType);
+    mIsStageChanging = true;
+    resetLocationName();
+}
+
+void GameDataHolder::resetLocationName() {
+    mLocationName->clear();
+}
+
+void GameDataHolder::changeNextStageWithDemoWorldWarp(const char* stageName) {
+    if (mIsStageChanging)
+        return;
+
+    resetTempSaveData(false);
+    mPlayingFile->changeNextStageWithDemoWorldWarp(stageName);
+    mIsStageChanging = false;
+}
+
+bool GameDataHolder::tryChangeNextStageWithWorldWarpHole(const char* stageName) {
+    if (mIsStageChanging)
+        return false;
+
+    mPlayingFile->changeNextStageWithWorldWarpHole(stageName);
+    mIsStageChanging = true;
+    resetTempSaveData(true);
+    return true;
+}
+
+void GameDataHolder::returnPrevStage() {
+    if (mIsStageChanging)
+        return;
+
+    mPlayingFile->returnPrevStage();
+    mIsStageChanging = true;
+    resetLocationName();
+}
+
+const char* GameDataHolder::getNextStageName() const {
+    return mPlayingFile->getStageNameNext();
+}
+
+const char* GameDataHolder::getNextStageName(s32 fileId) const {
+    return getGameDataFile(fileId)->getStageNameNext();
+}
+
+GameDataFile* GameDataHolder::getGameDataFile(s32 fileId) const {
+    return mFiles[fileId];
+}
+
+const char* GameDataHolder::getNextPlayerStartId() const {
+    return mPlayingFile->getPlayerStartId();
+}
+
+const char* GameDataHolder::getCurrentStageName() const {
+    return mPlayingFile->getStageNameCurrent();
+}
+
+const char* GameDataHolder::tryGetCurrentStageName() const {
+    return mPlayingFile->tryGetStageNameCurrent();
+}
+
+const char* GameDataHolder::getCurrentStageName(s32 fileId) const {
+    return getGameDataFile(fileId)->getStageNameCurrent();
+}
+
+void GameDataHolder::setCheckpointId(const al::PlacementId* placementId) {
+    mPlayingFile->setCheckpointId(placementId);
+    setRequireSaveFrame();
+}
+
+const char* GameDataHolder::tryGetRestartPointIdString() const {
+    return mPlayingFile->tryGetRestartPointIdString();
+}
+
+void GameDataHolder::endStage() {
+    if (mIsStageEnding)
+        return;
+    mPlayingFile->endStage();
+}
+
+void GameDataHolder::startStage(const char* stageName, s32 scenarioNo) {
+    mPlayingFile->startStage(stageName, scenarioNo);
+    mTempSaveData->setInfo(mPlayingFile->getCurrentWorldId(), scenarioNo);
+}
+
+void GameDataHolder::onObjNoWriteSaveData(const al::PlacementId* placementId) {
+    mTempSaveData->writeInWorld(placementId, getCurrentStageName());
+}
+
+void GameDataHolder::offObjNoWriteSaveData(const al::PlacementId* placementId) {
+    mTempSaveData->deleteInWorld(placementId, getCurrentStageName());
+}
+
+bool GameDataHolder::isOnObjNoWriteSaveData(const al::PlacementId* placementId) const {
+    return mTempSaveData->isOnInWorld(placementId, getCurrentStageName());
+}
+
+void GameDataHolder::onObjNoWriteSaveDataResetMiniGame(const al::PlacementId* placementId) {
+    mTempSaveData->writeInWorldResetMiniGame(placementId, getCurrentStageName());
+}
+
+void GameDataHolder::offObjNoWriteSaveDataResetMiniGame(const al::PlacementId* placementId) {
+    mTempSaveData->deleteInWorldResetMiniGame(placementId, getCurrentStageName());
+}
+
+bool GameDataHolder::isOnObjNoWriteSaveDataResetMiniGame(const al::PlacementId* placementId) const {
+    return mTempSaveData->isOnInWorldResetMiniGame(placementId, getCurrentStageName());
+}
+
+void GameDataHolder::onObjNoWriteSaveDataInSameScenario(const al::PlacementId* placementId) {
+    mTempSaveData->writeInScenario(placementId, getCurrentStageName());
+}
+
+bool GameDataHolder::isOnObjNoWriteSaveDataInSameScenario(
+    const al::PlacementId* placementId) const {
+    return mTempSaveData->isOnInScenario(placementId, getCurrentStageName());
+}
+
+void GameDataHolder::writeTempSaveDataToHash(const char* hashName, bool value) {
+    mTempSaveData->writeHashInWorld(hashName, value);
+}
+
+bool GameDataHolder::findValueFromTempSaveDataHash(const char* hashName) {
+    return mTempSaveData->findHashValueInWorld(hashName);
+}
+
+void GameDataHolder::resetMiniGameData() {
+    mTempSaveData->resetMiniGame();
+}
+
+s32 GameDataHolder::getPlayingFileId() const {
+    for (s32 i = 0; i < 5; i++)
+        if (mPlayingFile == getGameDataFile(i))
+            return i;
+
+    return -1;
+}
+
+s32 GameDataHolder::getPlayingOrNextFileId() const {
+    GameDataFile* gameDataFile = mPlayingFile;
+
+    if (mNextFile)
+        gameDataFile = mNextFile;
+
+    for (s32 i = 0; i < 5; i++)
+        if (gameDataFile == getGameDataFile(i))
+            return i;
+
+    return -1;
+}
+
+void GameDataHolder::requestSetPlayingFileId(s32 fileId) {
+    mNextFile = getGameDataFile(fileId);
+}
+
+void GameDataHolder::receiveSetPlayingFileIdMsg() {
+    mPlayingFile = mNextFile;
+    mNextFile = nullptr;
+
+    s32 fileId = getPlayingFileId();
+    if (fileId != -1)
+        mPlayingFileId = fileId;
+
+    resetTempSaveData(false);
+}
+
+GameDataFile* GameDataHolder::findGameDataFile(const char* fileName) const {
+    for (s32 i = 0; i < 5; i++)
+        if (al::isEqualString(fileName, al::StringTmp<32>("%s%d.bin", "File", i + 1)))
+            return getGameDataFile(i);
+
+    return nullptr;
+}
+
+GameDataFile* GameDataHolder::findFileByName(const char* fileName) const {
+    return findGameDataFile(fileName);
+}
+
+void GameDataHolder::resetScenarioStartCamera() {
+    for (s32 i = 0; i < 16; i++)
+        mIsPlayAlreadyScenarioStartCamera[i] = false;
+}
+
+void GameDataHolder::resetTempSaveDataInSameScenario() {
+    mTempSaveData->initForScenario();
+    mIsExistKoopaShip = false;
+}
+
+struct SaveDataBuffer {
+    s32 _0;
+    s32 _4;
+    s32 playingFileId;
+    char language[0x20];
+    u64 playTime;
+};
+
+static_assert(sizeof(SaveDataBuffer) == 0x38);
+
+void GameDataHolder::readFromSaveDataBuffer(const char* fileName) {
+    u8* saveDataBuffer = al::getSaveDataWorkBuffer();
+    memset(mSaveDataWorkBuffer, 0, 0x200000);
+
+    if (al::isEqualString("Common.bin", fileName)) {
+        sead::RamReadStream readStream(saveDataBuffer, 0x400, sead::Stream::Modes::Binary);
+        initializeDataCommon();
+
+        SaveDataBuffer buffer;
+        memset(&buffer, 0, sizeof(SaveDataBuffer));
+        readStream.readMemBlock((void*)&buffer, sizeof(SaveDataBuffer));
+
+        if (buffer._0 != 0) {
+            initializeDataCommon();
+            return;
+        }
+
+        mLanguage.format("%s", buffer.language);
+        mPlayTimeAcrossFile = buffer.playTime;
+        s32 id = sead::Mathi::clampMin(buffer.playingFileId, 0);
+        setPlayingFileId(id);
+
+        s32 saveDataSize = 0;
+        readStream.readS32(saveDataSize);
+        if (saveDataSize > 0x200000)
+            return;
+
+        readStream.readMemBlock((void*)mSaveDataWorkBuffer, saveDataSize);
+        tryReadByamlDataCommon(mSaveDataWorkBuffer);
+    } else {
+        GameDataFile* dataFile = findGameDataFile(fileName);
+        sead::RamReadStream readStream(saveDataBuffer, 0x200000, sead::Stream::Modes::Binary);
+        dataFile->initializeData();
+        if (!dataFile->readFromStream(&readStream, mSaveDataWorkBuffer))
+            dataFile->initializeData();
+    }
+}
+
+bool GameDataHolder::tryReadByamlDataCommon(const u8* byamlData) {
+    if (alByamlLocalUtil::verifiByaml(byamlData)) {
+        al::ByamlIter save{byamlData};
+        mGameConfigData->read(save);
+        return true;
+    }
+    return false;
+}
+
+void GameDataHolder::readFromSaveDataBufferCommonFileOnlyLanguage() {
+    sead::RamReadStream readStream(al::getSaveDataWorkBuffer(), 0x400, sead::Stream::Modes::Binary);
+
+    SaveDataBuffer buffer;
+    memset(&buffer, 0, sizeof(SaveDataBuffer));
+    readStream.readMemBlock((void*)&buffer, sizeof(SaveDataBuffer));
+
+    if (buffer._0 == 0)
+        mLanguage.format("%s", buffer.language);
+}
+
+void GameDataHolder::writeToSaveDataBuffer(const char* fileName) {
+    u8* saveDataBuffer = al::getSaveDataWorkBuffer();
+    mSaveDataWriteHeap->freeAll();
+
+    if (al::isEqualString(fileName, "Common.bin")) {
+        sead::RamWriteStream writeStream(saveDataBuffer, 0x400, sead::Stream::Modes::Binary);
+
+        SaveDataBuffer buffer;
+        memset(&buffer, 0, sizeof(SaveDataBuffer));
+
+        buffer.playingFileId = sead::Mathi::clampMin(getPlayingOrNextFileId(), 0);
+        buffer._4 = 0;
+        al::copyString(buffer.language, getLanguage(), 0x20);
+        buffer.playTime = mPlayTimeAcrossFile;
+        writeStream.writeMemBlock(&buffer, sizeof(SaveDataBuffer));
+
+        al::ByamlWriter byamlWriter{mSaveDataWriteHeap, false};
+        byamlWriter.pushHash();
+        mGameConfigData->write(&byamlWriter);
+        byamlWriter.pop();
+        writeStream.writeS32(byamlWriter.calcPackSize());
+        byamlWriter.write(&writeStream);
+    } else {
+        GameDataFile* dataFile = findGameDataFile(fileName);
+        sead::RamWriteStream writeStream(saveDataBuffer, 0x200000, sead::Stream::Modes::Binary);
+
+        dataFile->updateSaveTime();
+        dataFile->writeToStream(&writeStream, mSaveDataWriteHeap);
+    }
+
+    setRequireSaveFalse();
+}
+
+void GameDataHolder::updateSaveInfoForDisp(const char* fileName) {
+    if (al::isEqualString(fileName, "Common.bin"))
+        return;
+
+    findGameDataFile(fileName)->updateSaveInfoForDisp();
+}
+
+void GameDataHolder::updateSaveTimeForDisp(const char* fileName) {
+    if (al::isEqualString(fileName, "Common.bin"))
+        return;
+
+    findGameDataFile(fileName)->updateSaveTimeForDisp();
+}
+
+// NON-MATCHING: Add operation references "j" variable https://decomp.me/scratch/l1ctd
+s32 GameDataHolder::findUnlockShineNum(bool* isCountTotal, s32 worldId) const {
+    s32 worldNumMax = 0;
+    for (s32 i = 0; i < mStageLockList.size(); i++) {
+        if (mStageLockList[i]->shineNumInfoNum <= 0)
+            continue;
+
+        for (s32 j = 0; j < mStageLockList[i]->shineNumInfoNum; j++) {
+            if (j + worldNumMax == worldId) {
+                if (mStageLockList[i]->isCountTotal && isCountTotal)
+                    *isCountTotal = true;
+
+                return mStageLockList[i]->shineNumInfo[j];
+            }
+        }
+
+        worldNumMax += mStageLockList[i]->shineNumInfoNum;
+    }
+
+    return -1;
+}
+
+s32 GameDataHolder::calcBeforePhaseWorldNumMax(s32 worldId) const {
+    s32 worldNumMax = -1;
+    for (s32 i = 0; i < mStageLockList.size(); i++) {
+        if (mStageLockList[i]->shineNumInfoNum + worldNumMax >= worldId)
+            return worldNumMax;
+
+        worldNumMax += mStageLockList[i]->shineNumInfoNum;
+    }
+
+    return -1;
+}
+
+bool GameDataHolder::isFindKoopaNext(s32 worldId) const {
+    if ((mPlayingFile->getGameProgressData()->getUnlockWorldNum() ==
+             GameDataFunction::getWorldIndexCloud() ||
+         mPlayingFile->getGameProgressData()->getUnlockWorldNum() ==
+             GameDataFunction::getWorldIndexCloud() + 1) &&
+        GameDataFunction::getWorldIndexCity() == worldId) {
+        return true;
+    }
+    return false;
+}
+
+bool GameDataHolder::isBossAttackedHomeNext(s32 worldId) const {
+    if ((mPlayingFile->getGameProgressData()->getUnlockWorldNum() ==
+             GameDataFunction::getWorldIndexBoss() ||
+         mPlayingFile->getGameProgressData()->getUnlockWorldNum() ==
+             GameDataFunction::getWorldIndexBoss() + 1) &&
+        GameDataFunction::getWorldIndexSky() == worldId) {
+        return true;
+    }
+    return false;
+}
+
+void GameDataHolder::playScenarioStartCamera(s32 questNo) {
+    mIsPlayAlreadyScenarioStartCamera[questNo] = true;
+}
+
+bool GameDataHolder::isPlayAlreadyScenarioStartCamera(s32 questNo) const {
+    return mIsPlayAlreadyScenarioStartCamera[questNo];
+}
+
+const sead::PtrArray<ShopItem::ShopItemInfo>& GameDataHolder::getShopItemInfoList() const {
+    if (rs::isModeE3Rom() || rs::isModeE3LiveRom())
+        return mShopItemListE3;
+    return mShopItemList;
+}
+
+bool GameDataHolder::checkNeedTreasureMessageStage(const char* stageName) const {
+    return mWorldList->checkNeedTreasureMessageStage(stageName);
+}
+
+bool GameDataHolder::tryFindLinkDestStageInfo(const char** destStageName, const char** destLabel,
+                                              const char* srcStageName,
+                                              const char* srcLabel) const {
+    for (s32 i = 0; i < mChangeStageList.size(); i++) {
+        if (!al::isEqualString(srcStageName, mChangeStageList[i]->srcStageName.cstr()))
+            continue;
+        if (!al::isEqualString(srcLabel, mChangeStageList[i]->srcLabel.cstr()))
+            continue;
+
+        *destLabel = mChangeStageList[i]->destLabel.cstr();
+        *destStageName = mChangeStageList[i]->destStageName.cstr();
+        return true;
+    }
+    return false;
+}
+
+bool GameDataHolder::isShowHackTutorial(const char* hackName, const char* suffix) const {
+    for (s32 i = 0; i < mShowHackTutorialList.size(); i++) {
+        if (mShowHackTutorialList[i]->isEmpty())
+            continue;
+
+        if (mShowHackTutorialList[i]->isEqual(al::StringTmp<128>{"%s%s", hackName, suffix}))
+            return true;
+    }
+    return false;
+}
+
+void GameDataHolder::setShowHackTutorial(const char* hackName, const char* suffix) {
+    if (isShowHackTutorial(hackName, suffix))
+        return;
+
+    for (s32 i = 0; i < mShowHackTutorialList.size(); i++) {
+        if (mShowHackTutorialList[i]->isEmpty()) {
+            mShowHackTutorialList[i]->format("%s%s", hackName, suffix);
+            return;
+        }
+    }
+}
+
+bool GameDataHolder::isShowBindTutorial(const char* bindName) const {
+    s32 index;
+
+    if (al::isEqualString("SphinxRide", bindName))
+        index = 0;
+    else if (al::isEqualString("Motorcycle", bindName))
+        index = 1;
+    else if (al::isEqualString("WorldWarpHole", bindName))
+        index = 2;
+    else
+        return false;
+
+    return mIsShowBindTutorial[index];
+}
+
+const char* GameDataHolder::getCoinCollectArchiveName(s32 worldId) const {
+    if (worldId > -1)
+        return mWorldItemTypeInfo[worldId]->coinCollect.cstr();
+    return "CoinCollect";
+}
+
+const char* GameDataHolder::getCoinCollectEmptyArchiveName(s32 worldId) const {
+    if (worldId > -1)
+        return mWorldItemTypeInfo[worldId]->coinCollectEmpty.cstr();
+    return "CoinCollectEmptyA";
+}
+
+const char* GameDataHolder::getCoinCollect2DArchiveName(s32 worldId) const {
+    if (worldId > -1)
+        return mWorldItemTypeInfo[worldId]->coinCollect2D.cstr();
+    return "CoinCollect2D";
+}
+
+const char* GameDataHolder::getCoinCollect2DEmptyArchiveName(s32 worldId) const {
+    if (worldId > -1)
+        return mWorldItemTypeInfo[worldId]->coinCollectEmpty2D.cstr();
+    return "CoinCollectEmpty2D_A";
+}
+
+s32 GameDataHolder::getShineAnimFrame(s32 worldId) const {
+    if (worldId < 0)
+        return 0;
+
+    return mWorldItemTypeInfo[worldId]->shineAnimFrame;
+}
+
+s32 GameDataHolder::getCoinCollectNumMax(s32 worldId) const {
+    return mCoinCollectNumMax[worldId];
+}
+
+bool GameDataHolder::isInvalidOpenMapStage(const char* stageName, s32 scenarioNo) const {
+    s32 size = mInvalidOpenMapList.size();
+    for (s32 i = 0; i < size; i++) {
+        auto* list = mInvalidOpenMapList[i];
+        if (al::isEqualString(stageName, list->name)) {
+            if (list->scenario < 0 || list->scenario == scenarioNo)
+                return true;
+        }
+    }
+    return false;
+}
+
+void GameDataHolder::setShowBindTutorial(const char* bindName) {
+    s32 index;
+
+    if (al::isEqualString("SphinxRide", bindName))
+        index = 0;
+    else if (al::isEqualString("Motorcycle", bindName))
+        index = 1;
+    else if (al::isEqualString("WorldWarpHole", bindName))
+        index = 2;
+    else
+        return;
+
+    mIsShowBindTutorial[index] = true;
+}
+
+s32 GameDataHolder::tryCalcWorldWarpHoleSrcId(s32 destId) const {
+    s32 holeSrcId = -1;
+    for (s32 i = 0; i < mWorldList->getWorldNum(); i++) {
+        if (calcWorldWarpHoleDestId(i) != destId)
+            continue;
+        if (holeSrcId != -1)
+            return -1;
+        holeSrcId = i;
+    }
+
+    return holeSrcId;
+}
+
+s32 GameDataHolder::calcWorldWarpHoleDestId(s32 srcId) const {
+    return mWorldWarpHoleDestIds[srcId];
+}
+
+s32 GameDataHolder::calcWorldWarpHoleIdFromWorldId(s32 worldId) const {
+    if (GameDataFunction::getWorldIndexPeach() == worldId ||
+        GameDataFunction::getWorldIndexLava() == worldId ||
+        GameDataFunction::getWorldIndexCity() == worldId) {
+        return worldId;
+    }
+
+    for (s32 i = 0; i < mWorldList->getWorldNum(); i++)
+        if (calcWorldIdFromWorldWarpHoleId(i) == worldId)
+            return i;
+
+    return -1;
+}
+
+s32 GameDataHolder::calcWorldIdFromWorldWarpHoleId(s32 worldWarpHoleId) const {
+    return mPlayingFile->getGameProgressData()->getWorldIdForWorldWarpHole(worldWarpHoleId);
+}
+
+void GameDataHolder::calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeString* label,
+                                                        sead::BufferedSafeString* stageName,
+                                                        const char* srcLabel, s32 worldId) const {
+    label->clear();
+    s32 warpHoleId = calcWorldWarpHoleIdFromWorldId(worldId);
+    if (warpHoleId == -1)
+        return;
+
+    // BUG: "Go" and "Come" are inverted in warpHoleInfo
+    const WorldWarpHoleInfo* warpHoleInfo;
+    if (al::isEqualSubString(srcLabel, "Come")) {
+        s32 srcId = tryCalcWorldWarpHoleSrcId(warpHoleId);
+        if (srcId == -1) {
+            for (s32 i = 0; i < mWorldList->getWorldNum(); i++) {
+                sead::FixedSafeString<128> nmp;
+                nmp.format("%s%s%d", "Come", "From", i);
+
+                if (al::isEqualString(nmp.cstr(), srcLabel)) {
+                    srcId = i;
+                    break;
+                }
+            }
+            if (srcId == -1)
+                return;
+        }
+
+        s32 warpHoleWorldId = calcWorldIdFromWorldWarpHoleId(srcId);
+        if (warpHoleWorldId == -1)
+            return;
+
+        // BUG: Correct call findWorldWarpHoleInfo(warpHoleWorldId, warpHoleId, "Go")
+        warpHoleInfo = findWorldWarpHoleInfo(warpHoleWorldId, worldId, "Go");
+    } else {
+        s32 warpHoleWorldId = calcWorldIdFromWorldWarpHoleId(calcWorldWarpHoleDestId(warpHoleId));
+        if (warpHoleWorldId == -1)
+            return;
+
+        warpHoleInfo =
+            findWorldWarpHoleInfo(warpHoleWorldId, calcWorldWarpHoleIdFromWorldId(worldId), "Come");
+    }
+
+    label->format("%s", warpHoleInfo->name.cstr());
+    stageName->format("%s", warpHoleInfo->stageName.cstr());
+    mPlayingFile->setWarpHoleWorldId(warpHoleInfo->worldId);
+}
+
+const GameDataHolder::WorldWarpHoleInfo*
+GameDataHolder::findWorldWarpHoleInfo(s32 worldId, s32 scenarioNo, const char* name) const {
+    for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
+        if (mWorldWarpHoleInfos[i].worldId != worldId)
+            continue;
+        sead::FixedSafeString<128> nmp;
+        nmp.format("%s%s%d", name, "From", scenarioNo);
+
+        if (al::isEqualString(name, mWorldWarpHoleInfos[i].name) ||
+            al::isEqualString(nmp, mWorldWarpHoleInfos[i].name)) {
+            return &mWorldWarpHoleInfos[i];
+        }
+    }
+
+    return nullptr;
+}
+
+bool GameDataHolder::checkIsOpenWorldWarpHoleInScenario(s32 worldId, s32 scenarioNo) const {
+    for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
+        if (mWorldWarpHoleInfos[i].worldId != worldId)
+            continue;
+
+        if (al::isEqualString(mWorldWarpHoleInfos[i].name, "Go"))
+            return mWorldWarpHoleInfos[i].scenarioNo <= scenarioNo;
+    }
+
+    return false;
+}
+
+void GameDataHolder::setLocationName(const al::PlacementInfo* placementInfo) {
+    mLocationName->set(GameDataFunction::getCurrentStageName(const_cast<GameDataHolder*>(this)),
+                       placementInfo);
+}
+
+bool GameDataHolder::isPrevLocation(const al::PlacementInfo* placementInfo) const {
+    UniqObjInfo objInfo;
+
+    objInfo.set(GameDataFunction::getCurrentStageName(const_cast<GameDataHolder*>(this)),
+                placementInfo);
+
+    return mLocationName->isEqual(objInfo);
+}
+
+void GameDataHolder::setCoinTransForDeadPlayer(const sead::PtrArray<Coin>& coins, s32 coinNum) {
+    mDeadPlayerCoinIdx = 0;
+    for (s32 i = 0; i < coinNum; i++) {
+        if (coins[i] == nullptr || al::isDead(coins[i]))
+            continue;
+
+        mCoinTransForDeadPlayer[mDeadPlayerCoinIdx].set(al::getTrans(coins[i]));
+        mDeadPlayerCoinIdx++;
+    }
+}
+
+const sead::Vector3f& GameDataHolder::getCoinTransForDeadPlayer(s32 coinIdx) {
+    return mCoinTransForDeadPlayer[coinIdx];
+}
+
+void GameDataHolder::setSeparatePlay(bool isSeparatePlay) {
+    mIsSeparatePlay = isSeparatePlay;
+    rs::trySavePrepoSeparatePlayMode(isSeparatePlay, mPlayingFile->getPlayTimeTotal(),
+                                     mPlayingFile->getSaveDataIdForPrepo(), mPlayTimeAcrossFile);
+}
+
+CapMessageBossData* GameDataHolder::getCapMessageBossData() const {
+    return mCapMessageBossData;
+}
+
+s32 GameDataHolder::findUseScenarioNo(const char* stageName) const {
+    return mWorldList->findUseScenarioNo(stageName);
+}

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -42,8 +42,7 @@ void initializeShopItemList(sead::PtrArray<ShopItem::ShopItemInfo>* shopItemList
         return;
 
     al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
-    const u8* yaml = al::findResourceYaml(resource, name, nullptr);
-    al::ByamlIter iter(yaml);
+    al::ByamlIter iter(al::findResourceYaml(resource, name, nullptr));
 
     s32 size = iter.getSize();
     if (size <= 0)
@@ -103,8 +102,7 @@ void initializeItemList(sead::PtrArray<ShopItem::ItemInfo>* shopItemList, const 
         return;
 
     al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
-    const u8* yaml = al::findResourceYaml(resource, name, nullptr);
-    al::ByamlIter iter(yaml);
+    al::ByamlIter iter(al::findResourceYaml(resource, name, nullptr));
 
     s32 size = iter.getSize();
     if (size <= 0)
@@ -141,15 +139,15 @@ void initializeItemList(sead::PtrArray<ShopItem::ItemInfo>* shopItemList, const 
                 itemInfo->amiiboInfoList.tryAllocBuffer(amiiboSize, nullptr);
 
                 for (s32 j = 0; j < amiiboSize; j++) {
-                    al::ByamlIter amiiboJiter;
-                    amiiboIter.tryGetIterByIndex(&amiiboJiter, j);
+                    al::ByamlIter amiiboInfoIter;
+                    amiiboIter.tryGetIterByIndex(&amiiboInfoIter, j);
 
                     s32 characterId = -1;
-                    if (al::tryGetByamlS32(&characterId, amiiboJiter, "CharacterId"))
+                    if (al::tryGetByamlS32(&characterId, amiiboInfoIter, "CharacterId"))
                         itemInfo->amiiboInfoList[j].characterId = characterId;
 
                     s32 numberingId = -1;
-                    if (al::tryGetByamlS32(&numberingId, amiiboJiter, "NumberingId"))
+                    if (al::tryGetByamlS32(&numberingId, amiiboInfoIter, "NumberingId"))
                         itemInfo->amiiboInfoList[j].numberingId = numberingId;
                 }
             }
@@ -432,7 +430,6 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     initializeData();
 }
 
-// NON-MATCHING: Initializer is broken https://decomp.me/scratch/vbHSh
 GameDataHolder::GameDataHolder() {
     setLanguage(al::getLanguageString());
 }

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -161,23 +161,12 @@ void initializeItemList(sead::PtrArray<ShopItem::ItemInfo>* shopItemList, const 
     }
 }
 
-// NON-MATCHING: Major issues https://decomp.me/scratch/CyzkJ
-GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
-    : mMessageSystem(messageSystem) {
-    setLanguage(al::getLanguageString());
-    mSaveDataWriteHeap =
-        sead::FrameHeap::create(0x200000, "セーブデータByamlIter書き込み用", nullptr, 8,
-                                sead::FrameHeap::cHeapDirection_Forward, false);
-    mSaveDataWorkBuffer = new u8[0x200000];
-    mGameConfigData = new GameConfigData();
-    mGameConfigData->init();
-
-    mWorldList = new WorldList();
-
+static void
+initializeChangeStageList(sead::PtrArray<GameDataHolder::ChangeStageItem>* mChangeStageList) {
     al::ByamlIter changeStageListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "ChangeStageList"));
     s32 changeStageListSize = changeStageListIter.getSize();
-    mChangeStageList.allocBuffer(changeStageListSize, nullptr);
+    mChangeStageList->allocBuffer(changeStageListSize, nullptr);
 
     for (s32 i = 0; i < changeStageListSize; i++) {
         al::ByamlIter iter;
@@ -191,45 +180,127 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
         const char* destLabel = nullptr;
         iter.tryGetStringByKey(&destLabel, "DestLabel");
 
-        ChangeStageItem* stageItem = new ChangeStageItem();
+        GameDataHolder::ChangeStageItem* stageItem = new GameDataHolder::ChangeStageItem();
         stageItem->srcStageName.format("%s", srcStageName);
         stageItem->srcLabel.format("%s", srcLabel);
         stageItem->destStageName.format("%s", destStageName);
         stageItem->destLabel.format("%s", destLabel);
 
-        mChangeStageList.pushBack(stageItem);
+        mChangeStageList->pushBack(stageItem);
     }
+}
 
+static void initializeExStageList(sead::PtrArray<GameDataHolder::ExStageItem>* mExStageList) {
     al::ByamlIter exStageListIter(al::tryGetBymlFromArcName("SystemData/WorldList", "ExStageList"));
     s32 exStageListSize = exStageListIter.getSize();
-    mExStageList.allocBuffer(exStageListSize, nullptr);
+    mExStageList->allocBuffer(exStageListSize, nullptr);
 
     for (s32 i = 0; i < exStageListSize; i++) {
         const char* name = nullptr;
         exStageListIter.tryGetStringByIndex(&name, i);
 
-        ExStageItem* stageItem = new ExStageItem;
+        GameDataHolder::ExStageItem* stageItem = new GameDataHolder::ExStageItem;
         stageItem->name.format("%s", name);
 
-        mExStageList.pushBack(stageItem);
+        mExStageList->pushBack(stageItem);
     }
+}
 
+static void initializeInvalidOpenMapList(
+    sead::PtrArray<GameDataHolder::InvalidOpenMapInfo>* mInvalidOpenMapList) {
     al::ByamlIter invalidOpenMapListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "InvalidOpenMapList"));
     s32 invalidOpenMapListSize = invalidOpenMapListIter.getSize();
-    mInvalidOpenMapList.allocBuffer(invalidOpenMapListSize, nullptr);
+    mInvalidOpenMapList->allocBuffer(invalidOpenMapListSize, nullptr);
 
     for (s32 i = 0; i < invalidOpenMapListSize; i++) {
         al::ByamlIter iter;
         invalidOpenMapListIter.tryGetIterByIndex(&iter, i);
 
-        InvalidOpenMapInfo* mapInfo = new InvalidOpenMapInfo();
+        GameDataHolder::InvalidOpenMapInfo* mapInfo = new GameDataHolder::InvalidOpenMapInfo();
 
         iter.tryGetStringByKey(&mapInfo->name, "Name");
         iter.tryGetIntByKey(&mapInfo->scenario, "Scenario");
 
-        mInvalidOpenMapList.pushBack(mapInfo);
+        mInvalidOpenMapList->pushBack(mapInfo);
     }
+}
+
+static void initializeHackObjectList(sead::PtrArray<HackObjInfo>* mHackObjList) {
+    al::ByamlIter hackObjListIter(al::findResourceYaml(
+        al::findOrCreateResource("SystemData/HackObjList", nullptr), "HackObjList", nullptr));
+    s32 hackObjListSize = hackObjListIter.getSize();
+    mHackObjList->allocBuffer(hackObjListSize, nullptr);
+
+    for (s32 i = 0; i < hackObjListSize; i++) {
+        al::ByamlIter iter;
+        hackObjListIter.tryGetIterByIndex(&iter, i);
+        HackObjInfo* objInfo = new HackObjInfo;
+
+        objInfo->hackName = al::tryGetByamlKeyStringOrNULL(iter, "HackName");
+        objInfo->isScare = al::tryGetByamlKeyBoolOrFalse(iter, "IsScare");
+        objInfo->isNoCollisionMsg = al::tryGetByamlKeyBoolOrFalse(iter, "IsNoCollisionMsg");
+        objInfo->isNoSeparateCameraInput =
+            al::tryGetByamlKeyBoolOrFalse(iter, "IsNoSeparateCameraInput");
+        objInfo->isUsePlayerCollision = al::tryGetByamlKeyBoolOrFalse(iter, "IsUsePlayerCollision");
+        objInfo->isUseCollisionPartsFilterActor =
+            al::tryGetByamlKeyBoolOrFalse(iter, "IsUseCollisionPartsFilterActor");
+        objInfo->tutorialName = al::tryGetByamlKeyStringOrNULL(iter, "TutorialName");
+        al::tryGetByamlF32(&objInfo->guideHeight, iter, "GuideHeight");
+        al::tryGetByamlBool(&objInfo->isGuideEnable, iter, "IsGuideEnable");
+        al::tryGetByamlF32(&objInfo->stayGravityMargine, iter, "StayGravityMargine");
+
+        mHackObjList->pushBack(objInfo);
+    }
+}
+
+static void
+initializeWorldItemTypeList(sead::PtrArray<GameDataHolder::WorldItemTypeInfo>* mWorldItemTypeInfo,
+                            WorldList* mWorldList) {
+    al::ByamlIter worldItemTypeListIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldItemTypeList"));
+    s32 worldItemTypeListSize = worldItemTypeListIter.getSize();
+
+    mWorldItemTypeInfo->allocBuffer(worldItemTypeListSize, nullptr);
+    for (s32 i = 0; i < worldItemTypeListSize; i++) {
+        GameDataHolder::WorldItemTypeInfo* info = new GameDataHolder::WorldItemTypeInfo();
+        mWorldItemTypeInfo->pushBack(info);
+    }
+
+    for (s32 i = 0; i < worldItemTypeListSize; i++) {
+        al::ByamlIter iter;
+        s32 shine = 0;
+        const char* coinCollect = "";
+        worldItemTypeListIter.tryGetIterByIndex(&iter, i);
+
+        iter.tryGetStringByKey(&coinCollect, "CoinCollect");
+        iter.tryGetIntByKey(&shine, "Shine");
+        const char* worldName = al::getByamlKeyString(iter, "WorldName");
+        s32 worldIndex = mWorldList->tryFindWorldIndexByDevelopName(worldName);
+        GameDataHolder::WorldItemTypeInfo* info = mWorldItemTypeInfo->at(worldIndex);
+        info->coinCollect.format("CoinCollect%s", coinCollect);
+        info->coinCollectEmpty.format("CoinCollectEmpty%s", coinCollect);
+        info->coinCollect2D.format("CoinCollect2D_%s", coinCollect);
+        info->coinCollectEmpty2D.format("CoinCollectEmpty2D_%s", coinCollect);
+        info->shineAnimFrame = shine;
+    }
+}
+
+// NON-MATCHING: Stack issues https://decomp.me/scratch/tN9Ww
+GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
+    : mMessageSystem(messageSystem) {
+    setLanguage(al::getLanguageString());
+    mSaveDataWriteHeap =
+        sead::FrameHeap::create(0x200000, "セーブデータByamlIter書き込み用", nullptr, 8,
+                                sead::FrameHeap::cHeapDirection_Forward, false);
+    mSaveDataWorkBuffer = new u8[0x200000];
+    mGameConfigData = new GameConfigData();
+    mGameConfigData->init();
+
+    mWorldList = new WorldList();
+    initializeChangeStageList(&mChangeStageList);
+    initializeExStageList(&mExStageList);
+    initializeInvalidOpenMapList(&mInvalidOpenMapList);
 
     al::ByamlIter stageLockListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "StageLockList"));
@@ -273,11 +344,11 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     initializeItemList(&mItemGift, "ItemGift");
     initializeItemList(&mItemSticker, "ItemSticker");
 
-    s32 sizer = mShopItemList.size();
+    s32 shopItemListSize = mShopItemList.size();
     s32 shopItemSize = 0;
     s32 shopTalkDataSize = 0;
-    const char* nameList[10];
-    for (s32 i = 0; i < sizer; i++) {
+    const char* nameList[20];
+    for (s32 i = 0; i < shopItemListSize; i++) {
         if (!al::isEqualString(mShopItemList[i]->clearWorld, "")) {
             bool found = false;
             for (s32 j = 0; j < shopTalkDataSize; j++) {
@@ -303,35 +374,11 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
 
     mShopTalkDataInfos = new s32[shopItemSize];
 
-    for (s32 i = 0; i < sizer; i++)
+    for (s32 i = 0; i < shopItemListSize; i++)
         if (mShopItemList[i]->moonNum != -1)
             mShopTalkDataInfos[mShopTalkDataSize++] = mShopItemList[i]->moonNum;
 
-    al::ByamlIter hackObjListIter(al::findResourceYaml(
-        al::findOrCreateResource("SystemData/HackObjList", nullptr), "HackObjList", nullptr));
-    s32 hackObjListSize = hackObjListIter.getSize();
-    mHackObjList.allocBuffer(hackObjListSize, nullptr);
-
-    for (s32 i = 0; i < hackObjListSize; i++) {
-        al::ByamlIter iter;
-        hackObjListIter.tryGetIterByIndex(&iter, i);
-        HackObjInfo* objInfo = new HackObjInfo;
-
-        objInfo->hackName = al::tryGetByamlKeyStringOrNULL(iter, "HackName");
-        objInfo->isScare = al::tryGetByamlKeyBoolOrFalse(iter, "IsScare");
-        objInfo->isNoCollisionMsg = al::tryGetByamlKeyBoolOrFalse(iter, "IsNoCollisionMsg");
-        objInfo->isNoSeparateCameraInput =
-            al::tryGetByamlKeyBoolOrFalse(iter, "IsNoSeparateCameraInput");
-        objInfo->isUsePlayerCollision = al::tryGetByamlKeyBoolOrFalse(iter, "IsUsePlayerCollision");
-        objInfo->isUseCollisionPartsFilterActor =
-            al::tryGetByamlKeyBoolOrFalse(iter, "IsUseCollisionPartsFilterActor");
-        objInfo->tutorialName = al::tryGetByamlKeyStringOrNULL(iter, "TutorialName");
-        al::tryGetByamlF32(&objInfo->guideHeight, iter, "GuideHeight");
-        al::tryGetByamlBool(&objInfo->isGuideEnable, iter, "IsGuideEnable");
-        al::tryGetByamlF32(&objInfo->stayGravityMargine, iter, "StayGravityMargine");
-
-        mHackObjList.pushBack(objInfo);
-    }
+    initializeHackObjectList(&mHackObjList);
 
     s32 tutoralLabelNum = al::getSystemMessageLabelNum(this, "Tutorial");
     mShowHackTutorialList.allocBuffer(tutoralLabelNum, nullptr);
@@ -352,35 +399,7 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     mQuestInfoHolder = new QuestInfoHolder(0x40);
     mMapDataHolder = new MapDataHolder(this);
 
-    al::ByamlIter worldItemTypeListIter(
-        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldItemTypeList"));
-    s32 worldItemTypeListSize = worldItemTypeListIter.getSize();
-
-    mWorldItemTypeInfo.allocBuffer(worldItemTypeListSize, nullptr);
-    if (worldItemTypeListSize > 0) {
-        for (s32 i = 0; i < worldItemTypeListSize; i++) {
-            WorldItemTypeInfo* info = new WorldItemTypeInfo;
-            mWorldItemTypeInfo.pushBack(info);
-        }
-
-        for (s32 i = 0; i < worldItemTypeListSize; i++) {
-            al::ByamlIter iter;
-            s32 shine = 0;
-            const char* coinCollect = "";
-            worldItemTypeListIter.tryGetIterByIndex(&iter, i);
-
-            iter.tryGetStringByKey(&coinCollect, "CoinCollect");
-            iter.tryGetIntByKey(&shine, "Shine");
-            const char* worldName = al::getByamlKeyString(iter, "WorldName");
-            s32 worldIndex = mWorldList->tryFindWorldIndexByDevelopName(worldName);
-            WorldItemTypeInfo* info = mWorldItemTypeInfo[worldIndex];
-            info->coinCollect.format("CoinCollect%s", coinCollect);
-            info->coinCollectEmpty.format("CoinCollectEmpty%s", coinCollect);
-            info->coinCollect2D.format("CoinCollect2D_%s", coinCollect);
-            info->coinCollectEmpty2D.format("CoinCollectEmpty2D_%s", coinCollect);
-            info->shineAnimFrame = shine;
-        }
-    }
+    initializeWorldItemTypeList(&mWorldItemTypeInfo, mWorldList);
 
     mCoinCollectNumMax = new s32[mWorldList->getWorldNum()];
 
@@ -414,7 +433,7 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     al::ByamlIter worldWarpHoleInfoIter2;
     al::getByamlIterByKey(&worldWarpHoleInfoIter2, worldWarpHoleInfoIter, "WorldWarpHoleInfo");
     mWorldWarpHoleInfoNum = worldWarpHoleInfoIter2.getSize();
-    mWorldWarpHoleInfos = new WorldWarpHoleInfo[mWorldWarpHoleInfoNum];
+    mWorldWarpHoleInfos = new GameDataHolder::WorldWarpHoleInfo[mWorldWarpHoleInfoNum];
 
     for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
         al::ByamlIter infoIter;
@@ -1133,10 +1152,10 @@ void GameDataHolder::calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeString
         s32 srcId = tryCalcWorldWarpHoleSrcId(warpHoleId);
         if (srcId == -1) {
             for (s32 i = 0; i < mWorldList->getWorldNum(); i++) {
-                sead::FixedSafeString<128> nmp;
-                nmp.format("%s%s%d", "Come", "From", i);
+                al::StringTmp<128> name;
+                name.format("%s%s%d", "Come", "From", i);
 
-                if (al::isEqualString(nmp.cstr(), srcLabel)) {
+                if (al::isEqualString(name.cstr(), srcLabel)) {
                     srcId = i;
                     break;
                 }
@@ -1170,11 +1189,11 @@ GameDataHolder::findWorldWarpHoleInfo(s32 worldId, s32 scenarioNo, const char* n
     for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
         if (mWorldWarpHoleInfos[i].worldId != worldId)
             continue;
-        sead::FixedSafeString<128> nmp;
-        nmp.format("%s%s%d", name, "From", scenarioNo);
+        al::StringTmp<128> fromName;
+        fromName.format("%s%s%d", name, "From", scenarioNo);
 
         if (al::isEqualString(name, mWorldWarpHoleInfos[i].name) ||
-            al::isEqualString(nmp, mWorldWarpHoleInfos[i].name)) {
+            al::isEqualString(fromName, mWorldWarpHoleInfos[i].name)) {
             return &mWorldWarpHoleInfos[i];
         }
     }

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -452,16 +452,6 @@ GameDataHolder::GameDataHolder() {
     setLanguage(al::getLanguageString());
 }
 
-GameDataHolder::~GameDataHolder() = default;
-
-const char* GameDataHolder::getSceneObjName() const {
-    return "ゲームデータ保持";
-}
-
-const al::MessageSystem* GameDataHolder::getMessageSystem() const {
-    return mMessageSystem;
-}
-
 void GameDataHolder::setPlayingFileId(s32 fileId) {
     mPlayingFile = getGameDataFile(fileId);
     resetTempSaveData(false);

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -227,8 +227,8 @@ static void initializeInvalidOpenMapList(
 }
 
 static void initializeHackObjectList(sead::PtrArray<HackObjInfo>* mHackObjList) {
-    al::ByamlIter hackObjListIter(al::findResourceYaml(
-        al::findOrCreateResource("SystemData/HackObjList", nullptr), "HackObjList", nullptr));
+    al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
+    al::ByamlIter hackObjListIter(al::findResourceYaml(resource, "HackObjList", nullptr));
     s32 hackObjListSize = hackObjListIter.getSize();
     mHackObjList->allocBuffer(hackObjListSize, nullptr);
 
@@ -286,7 +286,6 @@ initializeWorldItemTypeList(sead::PtrArray<GameDataHolder::WorldItemTypeInfo>* m
     }
 }
 
-// NON-MATCHING: Stack issues https://decomp.me/scratch/tN9Ww
 GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     : mMessageSystem(messageSystem) {
     setLanguage(al::getLanguageString());
@@ -344,8 +343,8 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     initializeItemList(&mItemGift, "ItemGift");
     initializeItemList(&mItemSticker, "ItemSticker");
 
-    s32 shopItemListSize = mShopItemList.size();
     s32 shopItemSize = 0;
+    s32 shopItemListSize = mShopItemList.size();
     s32 shopTalkDataSize = 0;
     const char* nameList[20];
     for (s32 i = 0; i < shopItemListSize; i++) {
@@ -408,7 +407,7 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
 
     for (s32 i = 0; i < collectCoinNumIter.getSize(); i++) {
         al::ByamlIter iter;
-        collectCoinNumIter.tryGetIterByIndex(&iter, i);
+        al::getByamlIterByIndex(&iter, collectCoinNumIter, i);
 
         s32 collectCoinNum = al::getByamlKeyInt(iter, "CollectCoinNum");
         s32 worldIndex =

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -789,7 +789,7 @@ void GameDataHolder::resetTempSaveDataInSameScenario() {
     mIsExistKoopaShip = false;
 }
 
-struct SaveDataBuffer {
+struct SaveDataCommon {
     s32 _0;
     s32 _4;
     s32 playingFileId;
@@ -797,7 +797,7 @@ struct SaveDataBuffer {
     u64 playTime;
 };
 
-static_assert(sizeof(SaveDataBuffer) == 0x38);
+static_assert(sizeof(SaveDataCommon) == 0x38);
 
 void GameDataHolder::readFromSaveDataBuffer(const char* fileName) {
     u8* saveDataBuffer = al::getSaveDataWorkBuffer();
@@ -807,19 +807,17 @@ void GameDataHolder::readFromSaveDataBuffer(const char* fileName) {
         sead::RamReadStream readStream(saveDataBuffer, 0x400, sead::Stream::Modes::Binary);
         initializeDataCommon();
 
-        SaveDataBuffer buffer;
-        memset(&buffer, 0, sizeof(SaveDataBuffer));
-        readStream.readMemBlock((void*)&buffer, sizeof(SaveDataBuffer));
+        SaveDataCommon saveData = {};
+        readStream.readMemBlock((void*)&saveData, sizeof(SaveDataCommon));
 
-        if (buffer._0 != 0) {
+        if (saveData._0 != 0) {
             initializeDataCommon();
             return;
         }
 
-        mLanguage.format("%s", buffer.language);
-        mPlayTimeAcrossFile = buffer.playTime;
-        s32 id = sead::Mathi::clampMin(buffer.playingFileId, 0);
-        setPlayingFileId(id);
+        mLanguage.format("%s", saveData.language);
+        mPlayTimeAcrossFile = saveData.playTime;
+        setPlayingFileId(sead::Mathi::clampMin(saveData.playingFileId, 0));
 
         s32 saveDataSize = 0;
         readStream.readS32(saveDataSize);
@@ -838,23 +836,25 @@ void GameDataHolder::readFromSaveDataBuffer(const char* fileName) {
 }
 
 bool GameDataHolder::tryReadByamlDataCommon(const u8* byamlData) {
-    if (alByamlLocalUtil::verifiByaml(byamlData)) {
-        al::ByamlIter save{byamlData};
-        mGameConfigData->read(save);
-        return true;
-    }
-    return false;
+    if (!alByamlLocalUtil::verifiByaml(byamlData))
+        return false;
+
+    al::ByamlIter save{byamlData};
+    mGameConfigData->read(save);
+    return true;
 }
 
 void GameDataHolder::readFromSaveDataBufferCommonFileOnlyLanguage() {
     sead::RamReadStream readStream(al::getSaveDataWorkBuffer(), 0x400, sead::Stream::Modes::Binary);
 
-    SaveDataBuffer buffer;
-    memset(&buffer, 0, sizeof(SaveDataBuffer));
-    readStream.readMemBlock((void*)&buffer, sizeof(SaveDataBuffer));
+    SaveDataCommon saveData;
+    memset(&saveData, 0, sizeof(SaveDataCommon));
+    readStream.readMemBlock((void*)&saveData, sizeof(SaveDataCommon));
 
-    if (buffer._0 == 0)
-        mLanguage.format("%s", buffer.language);
+    if (saveData._0 != 0)
+        return;
+
+    mLanguage.format("%s", saveData.language);
 }
 
 void GameDataHolder::writeToSaveDataBuffer(const char* fileName) {
@@ -864,14 +864,13 @@ void GameDataHolder::writeToSaveDataBuffer(const char* fileName) {
     if (al::isEqualString(fileName, "Common.bin")) {
         sead::RamWriteStream writeStream(saveDataBuffer, 0x400, sead::Stream::Modes::Binary);
 
-        SaveDataBuffer buffer;
-        memset(&buffer, 0, sizeof(SaveDataBuffer));
+        SaveDataCommon saveData = {};
 
-        buffer.playingFileId = sead::Mathi::clampMin(getPlayingOrNextFileId(), 0);
-        buffer._4 = 0;
-        al::copyString(buffer.language, getLanguage(), 0x20);
-        buffer.playTime = mPlayTimeAcrossFile;
-        writeStream.writeMemBlock(&buffer, sizeof(SaveDataBuffer));
+        saveData.playingFileId = sead::Mathi::clampMin(getPlayingOrNextFileId(), 0);
+        saveData._4 = 0;
+        al::copyString(saveData.language, getLanguage(), 0x20);
+        saveData.playTime = mPlayTimeAcrossFile;
+        writeStream.writeMemBlock(&saveData, sizeof(SaveDataCommon));
 
         al::ByamlWriter byamlWriter{mSaveDataWriteHeap, false};
         byamlWriter.pushHash();

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -288,8 +288,7 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     : mMessageSystem(messageSystem) {
     setLanguage(al::getLanguageString());
     mSaveDataWriteHeap =
-        sead::FrameHeap::create(0x200000, "セーブデータByamlIter書き込み用", nullptr, 8,
-                                sead::FrameHeap::cHeapDirection_Forward, false);
+        sead::FrameHeap::create(0x200000, "セーブデータByamlIter書き込み用", nullptr);
     mSaveDataWorkBuffer = new u8[0x200000];
     mGameConfigData = new GameConfigData();
     mGameConfigData->init();
@@ -1132,7 +1131,6 @@ void GameDataHolder::calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeString
     if (warpHoleId == -1)
         return;
 
-    // BUG: "Go" and "Come" are inverted in warpHoleInfo
     const WorldWarpHoleInfo* warpHoleInfo;
     if (al::isEqualSubString(srcLabel, "Come")) {
         s32 srcId = tryCalcWorldWarpHoleSrcId(warpHoleId);
@@ -1171,12 +1169,12 @@ void GameDataHolder::calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeString
 }
 
 const GameDataHolder::WorldWarpHoleInfo*
-GameDataHolder::findWorldWarpHoleInfo(s32 worldId, s32 scenarioNo, const char* name) const {
+GameDataHolder::findWorldWarpHoleInfo(s32 worldId, s32 warpHoleId, const char* name) const {
     for (s32 i = 0; i < mWorldWarpHoleInfoNum; i++) {
         if (mWorldWarpHoleInfos[i].worldId != worldId)
             continue;
         al::StringTmp<128> fromName;
-        fromName.format("%s%s%d", name, "From", scenarioNo);
+        fromName.format("%s%s%d", name, "From", warpHoleId);
 
         if (al::isEqualString(name, mWorldWarpHoleInfos[i].name) ||
             al::isEqualString(fromName, mWorldWarpHoleInfos[i].name)) {

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -162,11 +162,11 @@ void initializeItemList(sead::PtrArray<ShopItem::ItemInfo>* shopItemList, const 
 }
 
 static void
-initializeChangeStageList(sead::PtrArray<GameDataHolder::ChangeStageItem>* mChangeStageList) {
+initializeChangeStageList(sead::PtrArray<GameDataHolder::ChangeStageItem>* changeStageList) {
     al::ByamlIter changeStageListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "ChangeStageList"));
     s32 changeStageListSize = changeStageListIter.getSize();
-    mChangeStageList->allocBuffer(changeStageListSize, nullptr);
+    changeStageList->allocBuffer(changeStageListSize, nullptr);
 
     for (s32 i = 0; i < changeStageListSize; i++) {
         al::ByamlIter iter;
@@ -186,32 +186,32 @@ initializeChangeStageList(sead::PtrArray<GameDataHolder::ChangeStageItem>* mChan
         stageItem->destStageName.format("%s", destStageName);
         stageItem->destLabel.format("%s", destLabel);
 
-        mChangeStageList->pushBack(stageItem);
+        changeStageList->pushBack(stageItem);
     }
 }
 
-static void initializeExStageList(sead::PtrArray<GameDataHolder::ExStageItem>* mExStageList) {
+static void initializeExStageList(sead::PtrArray<GameDataHolder::ExStageItem>* exStageList) {
     al::ByamlIter exStageListIter(al::tryGetBymlFromArcName("SystemData/WorldList", "ExStageList"));
     s32 exStageListSize = exStageListIter.getSize();
-    mExStageList->allocBuffer(exStageListSize, nullptr);
+    exStageList->allocBuffer(exStageListSize, nullptr);
 
     for (s32 i = 0; i < exStageListSize; i++) {
         const char* name = nullptr;
         exStageListIter.tryGetStringByIndex(&name, i);
 
-        GameDataHolder::ExStageItem* stageItem = new GameDataHolder::ExStageItem;
+        GameDataHolder::ExStageItem* stageItem = new GameDataHolder::ExStageItem();
         stageItem->name.format("%s", name);
 
-        mExStageList->pushBack(stageItem);
+        exStageList->pushBack(stageItem);
     }
 }
 
 static void initializeInvalidOpenMapList(
-    sead::PtrArray<GameDataHolder::InvalidOpenMapInfo>* mInvalidOpenMapList) {
+    sead::PtrArray<GameDataHolder::InvalidOpenMapInfo>* invalidOpenMapList) {
     al::ByamlIter invalidOpenMapListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "InvalidOpenMapList"));
     s32 invalidOpenMapListSize = invalidOpenMapListIter.getSize();
-    mInvalidOpenMapList->allocBuffer(invalidOpenMapListSize, nullptr);
+    invalidOpenMapList->allocBuffer(invalidOpenMapListSize, nullptr);
 
     for (s32 i = 0; i < invalidOpenMapListSize; i++) {
         al::ByamlIter iter;
@@ -222,20 +222,20 @@ static void initializeInvalidOpenMapList(
         iter.tryGetStringByKey(&mapInfo->name, "Name");
         iter.tryGetIntByKey(&mapInfo->scenario, "Scenario");
 
-        mInvalidOpenMapList->pushBack(mapInfo);
+        invalidOpenMapList->pushBack(mapInfo);
     }
 }
 
-static void initializeHackObjectList(sead::PtrArray<HackObjInfo>* mHackObjList) {
+static void initializeHackObjectList(sead::PtrArray<HackObjInfo>* hackObjList) {
     al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
     al::ByamlIter hackObjListIter(al::findResourceYaml(resource, "HackObjList", nullptr));
     s32 hackObjListSize = hackObjListIter.getSize();
-    mHackObjList->allocBuffer(hackObjListSize, nullptr);
+    hackObjList->allocBuffer(hackObjListSize, nullptr);
 
     for (s32 i = 0; i < hackObjListSize; i++) {
         al::ByamlIter iter;
         hackObjListIter.tryGetIterByIndex(&iter, i);
-        HackObjInfo* objInfo = new HackObjInfo;
+        HackObjInfo* objInfo = new HackObjInfo();
 
         objInfo->hackName = al::tryGetByamlKeyStringOrNULL(iter, "HackName");
         objInfo->isScare = al::tryGetByamlKeyBoolOrFalse(iter, "IsScare");
@@ -250,22 +250,20 @@ static void initializeHackObjectList(sead::PtrArray<HackObjInfo>* mHackObjList) 
         al::tryGetByamlBool(&objInfo->isGuideEnable, iter, "IsGuideEnable");
         al::tryGetByamlF32(&objInfo->stayGravityMargine, iter, "StayGravityMargine");
 
-        mHackObjList->pushBack(objInfo);
+        hackObjList->pushBack(objInfo);
     }
 }
 
 static void
-initializeWorldItemTypeList(sead::PtrArray<GameDataHolder::WorldItemTypeInfo>* mWorldItemTypeInfo,
-                            WorldList* mWorldList) {
+initializeWorldItemTypeList(sead::PtrArray<GameDataHolder::WorldItemTypeInfo>* worldItemTypeInfo,
+                            WorldList* worldList) {
     al::ByamlIter worldItemTypeListIter(
         al::tryGetBymlFromArcName("SystemData/WorldList", "WorldItemTypeList"));
     s32 worldItemTypeListSize = worldItemTypeListIter.getSize();
 
-    mWorldItemTypeInfo->allocBuffer(worldItemTypeListSize, nullptr);
-    for (s32 i = 0; i < worldItemTypeListSize; i++) {
-        GameDataHolder::WorldItemTypeInfo* info = new GameDataHolder::WorldItemTypeInfo();
-        mWorldItemTypeInfo->pushBack(info);
-    }
+    worldItemTypeInfo->allocBuffer(worldItemTypeListSize, nullptr);
+    for (s32 i = 0; i < worldItemTypeListSize; i++)
+        worldItemTypeInfo->pushBack(new GameDataHolder::WorldItemTypeInfo());
 
     for (s32 i = 0; i < worldItemTypeListSize; i++) {
         al::ByamlIter iter;
@@ -276,8 +274,8 @@ initializeWorldItemTypeList(sead::PtrArray<GameDataHolder::WorldItemTypeInfo>* m
         iter.tryGetStringByKey(&coinCollect, "CoinCollect");
         iter.tryGetIntByKey(&shine, "Shine");
         const char* worldName = al::getByamlKeyString(iter, "WorldName");
-        s32 worldIndex = mWorldList->tryFindWorldIndexByDevelopName(worldName);
-        GameDataHolder::WorldItemTypeInfo* info = mWorldItemTypeInfo->at(worldIndex);
+        s32 worldIndex = worldList->tryFindWorldIndexByDevelopName(worldName);
+        GameDataHolder::WorldItemTypeInfo* info = worldItemTypeInfo->at(worldIndex);
         info->coinCollect.format("CoinCollect%s", coinCollect);
         info->coinCollectEmpty.format("CoinCollectEmpty%s", coinCollect);
         info->coinCollect2D.format("CoinCollect2D_%s", coinCollect);
@@ -343,14 +341,17 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
     initializeItemList(&mItemGift, "ItemGift");
     initializeItemList(&mItemSticker, "ItemSticker");
 
-    s32 shopItemSize = 0;
+    s32 numShopsWithMoons = 0;
     s32 shopItemListSize = mShopItemList.size();
-    s32 shopTalkDataSize = 0;
+    s32 nameListSize = 0;
+
+    // NOTE: out-of-bounds read/write possible here
+    // does not happen in practice, because only 17 kingdoms exist
     const char* nameList[20];
     for (s32 i = 0; i < shopItemListSize; i++) {
         if (!al::isEqualString(mShopItemList[i]->clearWorld, "")) {
             bool found = false;
-            for (s32 j = 0; j < shopTalkDataSize; j++) {
+            for (s32 j = 0; j < nameListSize; j++) {
                 if (al::isEqualString(nameList[j], mShopItemList[i]->clearWorld)) {
                     found = true;
                     break;
@@ -358,24 +359,24 @@ GameDataHolder::GameDataHolder(const al::MessageSystem* messageSystem)
             }
 
             if (!found)
-                nameList[shopTalkDataSize++] = mShopItemList[i]->clearWorld;
+                nameList[nameListSize++] = mShopItemList[i]->clearWorld;
         }
 
         if (mShopItemList[i]->moonNum != -1)
-            shopItemSize++;
+            numShopsWithMoons++;
     }
 
-    mWorldsForNewReleaseShop.allocBuffer(shopTalkDataSize, nullptr);
-    for (s32 i = 0; i < shopTalkDataSize; i++) {
+    mWorldsForNewReleaseShop.allocBuffer(nameListSize, nullptr);
+    for (s32 i = 0; i < nameListSize; i++) {
         sead::FixedSafeString<64>* newWorld = new sead::FixedSafeString<64>(nameList[i]);
         mWorldsForNewReleaseShop.pushBack(newWorld);
     }
 
-    mShopTalkDataInfos = new s32[shopItemSize];
+    mShopsMoonNum = new s32[numShopsWithMoons];
 
     for (s32 i = 0; i < shopItemListSize; i++)
         if (mShopItemList[i]->moonNum != -1)
-            mShopTalkDataInfos[mShopTalkDataSize++] = mShopItemList[i]->moonNum;
+            mShopsMoonNum[mShopTalkDataSize++] = mShopItemList[i]->moonNum;
 
     initializeHackObjectList(&mHackObjList);
 
@@ -453,6 +454,7 @@ GameDataHolder::GameDataHolder() {
 }
 
 void GameDataHolder::setPlayingFileId(s32 fileId) {
+    // NOTE: if `fileId` is not in [0, 4], this is pointing out-of-bounds
     mPlayingFile = getGameDataFile(fileId);
     resetTempSaveData(false);
     if (fileId != -1)

--- a/src/System/GameDataHolder.cpp
+++ b/src/System/GameDataHolder.cpp
@@ -847,8 +847,7 @@ bool GameDataHolder::tryReadByamlDataCommon(const u8* byamlData) {
 void GameDataHolder::readFromSaveDataBufferCommonFileOnlyLanguage() {
     sead::RamReadStream readStream(al::getSaveDataWorkBuffer(), 0x400, sead::Stream::Modes::Binary);
 
-    SaveDataCommon saveData;
-    memset(&saveData, 0, sizeof(SaveDataCommon));
+    SaveDataCommon saveData = {};
     readStream.readMemBlock((void*)&saveData, sizeof(SaveDataCommon));
 
     if (saveData._0 != 0)
@@ -903,35 +902,28 @@ void GameDataHolder::updateSaveTimeForDisp(const char* fileName) {
     findGameDataFile(fileName)->updateSaveTimeForDisp();
 }
 
-// NON-MATCHING: Add operation references "j" variable https://decomp.me/scratch/l1ctd
 s32 GameDataHolder::findUnlockShineNum(bool* isCountTotal, s32 worldId) const {
-    s32 worldNumMax = 0;
+    s32 curWorldId = 0;
     for (s32 i = 0; i < mStageLockList.size(); i++) {
-        if (mStageLockList[i]->shineNumInfoNum <= 0)
-            continue;
-
-        for (s32 j = 0; j < mStageLockList[i]->shineNumInfoNum; j++) {
-            if (j + worldNumMax == worldId) {
+        for (s32 e = 0; e < mStageLockList[i]->shineNumInfoNum; e++) {
+            if (curWorldId == worldId) {
                 if (mStageLockList[i]->isCountTotal && isCountTotal)
                     *isCountTotal = true;
-
-                return mStageLockList[i]->shineNumInfo[j];
+                return mStageLockList[i]->shineNumInfo[e];
             }
+            curWorldId += 1;
         }
-
-        worldNumMax += mStageLockList[i]->shineNumInfoNum;
     }
-
     return -1;
 }
 
 s32 GameDataHolder::calcBeforePhaseWorldNumMax(s32 worldId) const {
-    s32 worldNumMax = -1;
+    s32 curWorldId = -1;
     for (s32 i = 0; i < mStageLockList.size(); i++) {
-        if (mStageLockList[i]->shineNumInfoNum + worldNumMax >= worldId)
-            return worldNumMax;
+        if (mStageLockList[i]->shineNumInfoNum + curWorldId >= worldId)
+            return curWorldId;
 
-        worldNumMax += mStageLockList[i]->shineNumInfoNum;
+        curWorldId += mStageLockList[i]->shineNumInfoNum;
     }
 
     return -1;
@@ -1032,27 +1024,31 @@ bool GameDataHolder::isShowBindTutorial(const char* bindName) const {
 }
 
 const char* GameDataHolder::getCoinCollectArchiveName(s32 worldId) const {
-    if (worldId > -1)
-        return mWorldItemTypeInfo[worldId]->coinCollect.cstr();
-    return "CoinCollect";
+    if (worldId < 0)
+        return "CoinCollect";
+
+    return mWorldItemTypeInfo[worldId]->coinCollect.cstr();
 }
 
 const char* GameDataHolder::getCoinCollectEmptyArchiveName(s32 worldId) const {
-    if (worldId > -1)
-        return mWorldItemTypeInfo[worldId]->coinCollectEmpty.cstr();
-    return "CoinCollectEmptyA";
+    if (worldId < 0)
+        return "CoinCollectEmptyA";
+
+    return mWorldItemTypeInfo[worldId]->coinCollectEmpty.cstr();
 }
 
 const char* GameDataHolder::getCoinCollect2DArchiveName(s32 worldId) const {
-    if (worldId > -1)
-        return mWorldItemTypeInfo[worldId]->coinCollect2D.cstr();
-    return "CoinCollect2D";
+    if (worldId < 0)
+        return "CoinCollect2D";
+
+    return mWorldItemTypeInfo[worldId]->coinCollect2D.cstr();
 }
 
 const char* GameDataHolder::getCoinCollect2DEmptyArchiveName(s32 worldId) const {
-    if (worldId > -1)
-        return mWorldItemTypeInfo[worldId]->coinCollectEmpty2D.cstr();
-    return "CoinCollectEmpty2D_A";
+    if (worldId < 0)
+        return "CoinCollectEmpty2D_A";
+
+    return mWorldItemTypeInfo[worldId]->coinCollectEmpty2D.cstr();
 }
 
 s32 GameDataHolder::getShineAnimFrame(s32 worldId) const {
@@ -1069,9 +1065,9 @@ s32 GameDataHolder::getCoinCollectNumMax(s32 worldId) const {
 bool GameDataHolder::isInvalidOpenMapStage(const char* stageName, s32 scenarioNo) const {
     s32 size = mInvalidOpenMapList.size();
     for (s32 i = 0; i < size; i++) {
-        auto* list = mInvalidOpenMapList[i];
-        if (al::isEqualString(stageName, list->name)) {
-            if (list->scenario < 0 || list->scenario == scenarioNo)
+        InvalidOpenMapInfo* entry = mInvalidOpenMapList[i];
+        if (al::isEqualString(stageName, entry->name)) {
+            if (entry->scenario < 0 || entry->scenario == scenarioNo)
                 return true;
         }
     }
@@ -1197,15 +1193,14 @@ bool GameDataHolder::checkIsOpenWorldWarpHoleInScenario(s32 worldId, s32 scenari
             continue;
 
         if (al::isEqualString(mWorldWarpHoleInfos[i].name, "Go"))
-            return mWorldWarpHoleInfos[i].scenarioNo <= scenarioNo;
+            return scenarioNo >= mWorldWarpHoleInfos[i].scenarioNo;
     }
 
     return false;
 }
 
 void GameDataHolder::setLocationName(const al::PlacementInfo* placementInfo) {
-    mLocationName->set(GameDataFunction::getCurrentStageName(const_cast<GameDataHolder*>(this)),
-                       placementInfo);
+    mLocationName->set(GameDataFunction::getCurrentStageName(this), placementInfo);
 }
 
 bool GameDataHolder::isPrevLocation(const al::PlacementInfo* placementInfo) const {

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -4,7 +4,10 @@
 #include <math/seadVector.h>
 #include <prim/seadSafeString.h>
 
+#include "Library/HostIO/HioNode.h"
+#include "Library/Message/IUseMessageSystem.h"
 #include "Library/Scene/GameDataHolderBase.h"
+#include "Library/Scene/ISceneObj.h"
 
 #include "Scene/SceneObjFactory.h"
 
@@ -51,7 +54,10 @@ struct HackObjInfo {
 
 static_assert(sizeof(HackObjInfo) == 0x20);
 
-class GameDataHolder : public al::GameDataHolderBase {
+class GameDataHolder : public al::GameDataHolderBase,
+                       public al::ISceneObj,
+                       public al::HioNode,
+                       public al::IUseMessageSystem {
 public:
     static constexpr s32 sSceneObjId = SceneObjID_GameDataHolder;
 
@@ -309,8 +315,7 @@ private:
     TempSaveData* mTempSaveData = nullptr;
     TempSaveData* mTempSaveDataBackup = nullptr;
     CapMessageBossData* mCapMessageBossData = nullptr;
-    void* _c0 = nullptr;
-    s32 _c8 = 0;
+    sead::Vector3f _c0 = sead::Vector3f::zero;
 
     TemporaryScenarioCameraHolder* mTemporaryScenarioCameraHolder = nullptr;
     bool* mIsPlayAlreadyScenarioStartCamera = nullptr;

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -37,24 +37,21 @@ class UniqObjInfo;
 class WorldList;
 
 struct HackObjInfo {
-    const char* hackName;
-    f32 guideHeight;
-    f32 stayGravityMargine;
-    bool isScare;
-    bool isNoCollisionMsg;
-    bool isNoSeparateCameraInput;
-    bool isUsePlayerCollision;
-    bool isUseCollisionPartsFilterActor;
-    bool isGuideEnable;
-    const char* tutorialName;
+    const char* hackName = nullptr;
+    f32 guideHeight = 200.0f;
+    f32 stayGravityMargine = 0.0f;
+    bool isScare = false;
+    bool isNoCollisionMsg = false;
+    bool isNoSeparateCameraInput = false;
+    bool isUsePlayerCollision = false;
+    bool isUseCollisionPartsFilterActor = false;
+    bool isGuideEnable = true;
+    const char* tutorialName = nullptr;
 };
 
 static_assert(sizeof(HackObjInfo) == 0x20);
 
-class GameDataHolder : public al::GameDataHolderBase,
-                       public al::ISceneObj,
-                       public al::HioNode,
-                       public al::IUseMessageSystem {
+class GameDataHolder : public al::GameDataHolderBase {
 public:
     static constexpr s32 sSceneObjId = SceneObjID_GameDataHolder;
 
@@ -66,6 +63,18 @@ public:
     };
 
     static_assert(sizeof(ChangeStageItem) == 0x260);
+
+    struct ExStageItem {
+        sead::FixedSafeString<128> name;
+    };
+
+    static_assert(sizeof(ExStageItem) == 0x98);
+
+    struct ShowHackTutorialInfo {
+        sead::FixedSafeString<128> label;
+    };
+
+    static_assert(sizeof(ShowHackTutorialInfo) == 0x98);
 
     struct WorldWarpHoleInfo {
         sead::FixedSafeString<128> stageName;
@@ -87,17 +96,17 @@ public:
     static_assert(sizeof(WorldItemTypeInfo) == 0x268);
 
     struct StageLockInfo {
-        s32* shineNumInfo;
-        s32 shineNumInfoNum;
-        bool isCountTotal;
-        bool isCrash;
+        s32* shineNumInfo = nullptr;
+        s32 shineNumInfoNum = 0;
+        bool isCountTotal = false;
+        bool isCrash = false;
     };
 
     static_assert(sizeof(StageLockInfo) == 0x10);
 
     struct InvalidOpenMapInfo {
-        const char* name;
-        s32 scenario;
+        const char* name = nullptr;
+        s32 scenario = 0;
     };
 
     static_assert(sizeof(InvalidOpenMapInfo) == 0x10);
@@ -108,12 +117,12 @@ public:
     ~GameDataHolder() override;
 
     const char* getSceneObjName() const override;
-    al::MessageSystem* getMessageSystem() const override;
+    const al::MessageSystem* getMessageSystem() const override;
 
     void setPlayingFileId(s32 fileId);
     void initializeData();
     void initializeDataCommon();
-    void resetTempSaveData(bool isSwap);
+    void resetTempSaveData(bool isSwapTempSaveData);
     void initializeDataId(s32 fileId);
     void readByamlData(s32 fileId, const char* fileName);
     s32 tryFindEmptyFileId() const;
@@ -167,7 +176,7 @@ public:
     void readFromSaveDataBuffer(const char* fileName);
     bool tryReadByamlDataCommon(const u8* byamlData);
     void readFromSaveDataBufferCommonFileOnlyLanguage();
-    void writeToSaveBuffer(const char* fileName);
+    void writeToSaveDataBuffer(const char* fileName);
     void updateSaveInfoForDisp(const char* fileName);
     void updateSaveTimeForDisp(const char* fileName);
     s32 findUnlockShineNum(bool* isCountTotal, s32 worldId) const;
@@ -237,10 +246,6 @@ public:
         return mWorldsForNewReleaseShop;
     }
 
-    const s32* get_170() const { return _170; }
-
-    s32 get_178() const { return _178; }
-
     AchievementInfoReader* getAchievementInfoReader() const { return mAchievementInfoReader; }
 
     WorldList* getWorldList() const { return mWorldList; }
@@ -284,29 +289,31 @@ public:
     SaveDataAccessSequence* getSaveDataAccessSequence() const { return mSaveDataAccessSequence; }
 
 private:
-    al::MessageSystem* mMessageSystem;
-    GameDataFile** mFiles;
-    GameDataFile* mPlayingFile;
-    GameDataFile* mNextFile;
-    s32 mPlayingFileId;
-    SaveDataAccessSequence* mSaveDataAccessSequence;
-    bool mIsRequireSave;
-    u32 mRequireSaveFrame;
-    bool mIsInvalidSaveForMoonGet;
-    bool mIsStageChanging;
-    bool mIsStageEnding;
+    const al::MessageSystem* mMessageSystem = nullptr;
+    GameDataFile** mFiles = nullptr;
+    GameDataFile* mPlayingFile = nullptr;
+    GameDataFile* mNextFile = nullptr;
+    s32 mPlayingFileId = 0;
+    SaveDataAccessSequence* mSaveDataAccessSequence = nullptr;
+    bool mIsRequireSave = false;
+    u32 mRequireSaveFrame = 0;
+    bool mIsInvalidSaveForMoonGet = false;
+    bool mIsStageChanging = false;  // Similar to mutex lock
+    bool mIsStageEnding = false;    // Similar to mutex lock
     sead::FixedSafeString<32> mLanguage;
-    u64 mPlayTimeAcrossFile;
-    sead::Heap* mSaveDataWriteThread;
-    const u8* mSaveDataWorkBuffer;
-    GameConfigData* mGameConfigData;
-    TempSaveData* mTempSaveData;
-    TempSaveData* mTempSaveDataBackup;
-    CapMessageBossData* mCapMessageBossData;
-    void* _c0;
-    void* _c8;
-    TemporaryScenarioCameraHolder* mTemporaryScenarioCameraHolder;
-    bool* mIsPlayAlreadyScenarioStartCamera;
+
+    u64 mPlayTimeAcrossFile = 0;
+    sead::Heap* mSaveDataWriteHeap = nullptr;
+    u8* mSaveDataWorkBuffer = nullptr;
+    GameConfigData* mGameConfigData = nullptr;
+    TempSaveData* mTempSaveData = nullptr;
+    TempSaveData* mTempSaveDataBackup = nullptr;
+    CapMessageBossData* mCapMessageBossData = nullptr;
+    void* _c0 = nullptr;
+    s32 _c8 = 0;
+
+    TemporaryScenarioCameraHolder* mTemporaryScenarioCameraHolder = nullptr;
+    bool* mIsPlayAlreadyScenarioStartCamera = nullptr;
     sead::PtrArray<StageLockInfo> mStageLockList;
     sead::PtrArray<ShopItem::ShopItemInfo> mShopItemList;
     sead::PtrArray<ShopItem::ShopItemInfo> mShopItemListE3;
@@ -316,36 +323,36 @@ private:
     sead::PtrArray<ShopItem::ItemInfo> mItemSticker;
     sead::PtrArray<HackObjInfo> mHackObjList;
     sead::PtrArray<sead::FixedSafeString<64>> mWorldsForNewReleaseShop;
-    s32* _170;
-    s32 _178;
-    AchievementInfoReader* mAchievementInfoReader;
-    AchievementHolder* mAchievementHolder;
-    WorldList* mWorldList;
+    s32* mShopTalkDataInfos = nullptr;
+    s32 mShopTalkDataSize = 0;
+    AchievementInfoReader* mAchievementInfoReader = nullptr;
+    AchievementHolder* mAchievementHolder = nullptr;
+    WorldList* mWorldList = nullptr;
     sead::PtrArray<ChangeStageItem> mChangeStageList;
-    sead::PtrArray<sead::FixedSafeString<128>> mExStageList;
+    sead::PtrArray<ExStageItem> mExStageList;
     sead::PtrArray<InvalidOpenMapInfo> mInvalidOpenMapList;
     sead::PtrArray<sead::FixedSafeString<128>> mShowHackTutorialList;
-    bool* mIsShowBindTutorial;
-    MapDataHolder* mMapDataHolder;
+    bool* mIsShowBindTutorial = nullptr;
+    MapDataHolder* mMapDataHolder = nullptr;
     sead::PtrArray<WorldItemTypeInfo> mWorldItemTypeInfo;
-    s32* mCoinCollectNumMax;
-    s32* mWorldWarpHoleDestIds;
-    WorldWarpHoleInfo* mWorldWarpHoleInfos;
-    s32 mWorldWarpHoleInfoNum;
-    UniqObjInfo* mLocationName;
-    bool mIsDisableExplainAmiibo;
-    s32 mSearchHintByAmiiboCount;
-    bool mIsValidCheckpointWarp;
-    sead::Vector3f mStageMapPlayerPos;
-    sead::Vector3f* mCoinTransForDeadPlayer;
-    s32 mDeadPlayerCoinIdx;
-    bool _244;
-    bool mIsSeparatePlay;
-    bool mIsPlayDemoLavaErupt;
-    QuestInfoHolder* mQuestInfoHolder;
-    bool mIsExistKoopaShip;
-    GameSequenceInfo* mSequenceInfo;
-    TimeBalloonSequenceInfo* mTimeBalloonSequenceInfo;
+    s32* mCoinCollectNumMax = nullptr;
+    s32* mWorldWarpHoleDestIds = nullptr;
+    WorldWarpHoleInfo* mWorldWarpHoleInfos = nullptr;
+    s32 mWorldWarpHoleInfoNum = 0;
+    UniqObjInfo* mLocationName = nullptr;
+    bool mIsDisableExplainAmiibo = false;
+    s32 mSearchHintByAmiiboCount = 0;
+    bool mIsValidCheckpointWarp = true;
+    sead::Vector3f mStageMapPlayerPos = sead::Vector3f::zero;
+    sead::Vector3f* mCoinTransForDeadPlayer = nullptr;
+    s32 mDeadPlayerCoinIdx = 0;
+    bool _244 = false;  // Part of E3Sequence
+    bool mIsSeparatePlay = false;
+    bool mIsPlayDemoLavaErupt = false;
+    QuestInfoHolder* mQuestInfoHolder = nullptr;
+    bool mIsExistKoopaShip = false;
+    GameSequenceInfo* mSequenceInfo = nullptr;
+    TimeBalloonSequenceInfo* mTimeBalloonSequenceInfo = nullptr;
 };
 
 static_assert(sizeof(GameDataHolder) == 0x268);

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -76,12 +76,6 @@ public:
 
     static_assert(sizeof(ExStageItem) == 0x98);
 
-    struct ShowHackTutorialInfo {
-        sead::FixedSafeString<128> label;
-    };
-
-    static_assert(sizeof(ShowHackTutorialInfo) == 0x98);
-
     struct WorldWarpHoleInfo {
         sead::FixedSafeString<128> stageName;
         s32 worldId;
@@ -119,11 +113,6 @@ public:
 
     GameDataHolder(const al::MessageSystem* messageSystem);
     GameDataHolder();
-
-    ~GameDataHolder() override;
-
-    const char* getSceneObjName() const override;
-    const al::MessageSystem* getMessageSystem() const override;
 
     void setPlayingFileId(s32 fileId);
     void initializeData();
@@ -223,6 +212,10 @@ public:
     void setSeparatePlay(bool isSeparatePlay);
     CapMessageBossData* getCapMessageBossData() const;
     s32 findUseScenarioNo(const char* stageName) const;
+
+    const char* getSceneObjName() const override { return "ゲームデータ保持"; }
+
+    const al::MessageSystem* getMessageSystem() const override { return mMessageSystem; }
 
     GameDataFile* getGameDataFile() const { return mPlayingFile; }
 

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -206,8 +206,8 @@ public:
     void calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeString* label,
                                             sead::BufferedSafeString* stageName,
                                             const char* srcLabel, s32 worldId) const;
-    // TODO: parameter name
-    const WorldWarpHoleInfo* findWorldWarpHoleInfo(s32 worldId, s32, const char* label) const;
+    const WorldWarpHoleInfo* findWorldWarpHoleInfo(s32 worldId, s32 warpHoleId,
+                                                   const char* name) const;
     bool checkIsOpenWorldWarpHoleInScenario(s32 worldId, s32 scenarioNo) const;
     void setLocationName(const al::PlacementInfo* placementInfo);
     bool isPrevLocation(const al::PlacementInfo* placementInfo) const;

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -40,6 +40,8 @@ class UniqObjInfo;
 class WorldList;
 
 struct HackObjInfo {
+    HackObjInfo() {}
+
     const char* hackName = nullptr;
     f32 guideHeight = 200.0f;
     f32 stayGravityMargine = 0.0f;
@@ -71,6 +73,8 @@ public:
     static_assert(sizeof(ChangeStageItem) == 0x260);
 
     struct ExStageItem {
+        ExStageItem() {}
+
         sead::FixedSafeString<128> name;
     };
 
@@ -321,7 +325,7 @@ private:
     sead::PtrArray<ShopItem::ItemInfo> mItemSticker;
     sead::PtrArray<HackObjInfo> mHackObjList;
     sead::PtrArray<sead::FixedSafeString<64>> mWorldsForNewReleaseShop;
-    s32* mShopTalkDataInfos = nullptr;
+    s32* mShopsMoonNum = nullptr;
     s32 mShopTalkDataSize = 0;
     AchievementInfoReader* mAchievementInfoReader = nullptr;
     AchievementHolder* mAchievementHolder = nullptr;

--- a/src/System/SaveDataAccessSequence.h
+++ b/src/System/SaveDataAccessSequence.h
@@ -6,7 +6,6 @@
 #include "Library/Nerve/NerveExecutor.h"
 
 class GameDataHolder;
-class SaveDataAccessor;
 
 namespace al {
 class LayoutInitInfo;
@@ -49,8 +48,13 @@ public:
     void setWindowDelete();
     bool isExistRequest() const;
 
+    void setDevelop() { mIsDevelop = true; }
+
 private:
-    char filler_8[0x50];
+    char filler[0x10];
+    bool _20;
+    bool mIsDevelop;
+    char filler_22[0x3e];
 };
 
 static_assert(sizeof(SaveDataAccessSequence) == 0x60);

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class PlacementId;
+}  // namespace al
+
+class TempSaveData {
+public:
+    TempSaveData();
+
+    void init();
+    void initForScenario();
+    void resetMiniGame();
+    void setInfo(s32, s32);
+    void writeInWorld(const al::PlacementId*, const char*);
+    void deleteInWorld(const al::PlacementId*, const char*);
+    bool isOnInWorld(const al::PlacementId*, const char*) const;
+    void writeInWorldResetMiniGame(const al::PlacementId*, const char*);
+    void deleteInWorldResetMiniGame(const al::PlacementId*, const char*);
+    bool isOnInWorldResetMiniGame(const al::PlacementId*, const char*) const;
+    void writeInScenario(const al::PlacementId*, const char*);
+    bool isOnInScenario(const al::PlacementId*, const char*) const;
+    void writeHashInWorld(const char*, bool);
+    bool findHashValueInWorld(const char*) const;
+
+    s32 getWorldIndex() { return mWorldIndex; }
+
+private:
+    char filler[0x18];
+    s32 mWorldIndex;
+    char filler_1c[0x24];
+};
+
+static_assert(sizeof(TempSaveData) == 0x40);

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -25,7 +25,7 @@ public:
     void writeHashInWorld(const char*, bool);
     bool findHashValueInWorld(const char*) const;
 
-    s32 getWorldIndex() { return mWorldIndex; }
+    s32 getWorldIndex() const { return mWorldIndex; }
 
 private:
     char filler[0x18];


### PR DESCRIPTION
Most dependencies are already merged so this code is relatively small now. 

The constructor of this thing is huge at ~6kB but that isn't the main issue. The main problem is that the initialization order doesn't match creating big mismatches in all 4 ctors. Making really hard to spot real issues to fix the mismatches. If the small one is fixed I can spend more time addressing the remaining issues on the big ctor.

~~I suspect that `GameDataHolderBase` plays a role here since is currently doing nothing.
`GameDataHolder(const al::MessageSystem* messageSystem)` https://decomp.me/scratch/CyzkJ~~ Fixed
~~`GameDataHolder()` https://decomp.me/scratch/vbHSh~~ Fixed

The remaining issue is something interesting. It does `worldNumMax += j;` instead of `mStageLockList[i]->shineNumInfoNum` both values contain the same value at this point but the register is different. However if I use `j` the compiler does something completely different.
`findUnlockShineNum(bool* isCountTotal, s32 worldId) ` https://decomp.me/scratch/l1ctd

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/904)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6583c24 - 67d24a4)

📈 **Matched code**: 14.91% (+0.14%, +17800 bytes)

<details>
<summary>✅ 103 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/GameDataHolder` | `GameDataHolder::GameDataHolder(al::MessageSystem const*)` | +6108 | 0.00% | 100.00% |
| `System/GameDataHolder` | `initializeItemList(sead::PtrArray<ShopItem::ItemInfo>*, char const*)` | +800 | 0.00% | 100.00% |
| `System/GameDataHolder` | `initializeShopItemList(sead::PtrArray<ShopItem::ShopItemInfo>*, char const*)` | +784 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::calcWorldWarpHoleLabelAndStageName(sead::BufferedSafeStringBase<char>*, sead::BufferedSafeStringBase<char>*, char const*, int) const` | +652 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::writeToSaveDataBuffer(char const*)` | +596 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::readFromSaveDataBuffer(char const*)` | +528 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::setShowHackTutorial(char const*, char const*)` | +440 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::initializeDataCommon()` | +416 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::tryFindLinkDestStageInfo(char const**, char const**, char const*, char const*) const` | +364 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::isShowHackTutorial(char const*, char const*) const` | +356 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::GameDataHolder()` | +332 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::findWorldWarpHoleInfo(int, int, char const*) const` | +328 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::resetTempSaveData(bool)` | +316 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::isPrevLocation(al::PlacementInfo const*) const` | +216 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::checkIsOpenWorldWarpHoleInScenario(int, int) const` | +196 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::calcWorldWarpHoleIdFromWorldId(int) const` | +188 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::setCoinTransForDeadPlayer(sead::PtrArray<Coin> const&, int)` | +188 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::updateSaveInfoForDisp(char const*)` | +184 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::updateSaveTimeForDisp(char const*)` | +184 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::findUnlockShineNum(bool*, int) const` | +164 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::findGameDataFile(char const*) const` | +160 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::findFileByName(char const*) const` | +160 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::isInvalidOpenMapStage(char const*, int) const` | +160 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::tryFindEmptyFileId() const` | +148 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::readByamlData(int, char const*)` | +140 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::tryCalcWorldWarpHoleSrcId(int) const` | +140 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::resetScenarioStartCamera()` | +132 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::readFromSaveDataBufferCommonFileOnlyLanguage()` | +132 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::isShowBindTutorial(char const*) const` | +128 | 0.00% | 100.00% |
| `System/GameDataHolder` | `GameDataHolder::initializeData()` | +124 | 0.00% | 100.00% |

...and 73 more new matches
</details>


<!-- decomp.dev report end -->