### PR TITLE
(claude) Boss: Implement BossStateChasePlayer

### DIFF
--- a/src/Boss/BossUtil/BossStateChasePlayer.cpp
+++ b/src/Boss/BossUtil/BossStateChasePlayer.cpp
@@ -1,0 +1,156 @@
+#include "Boss/BossUtil/BossStateChasePlayer.h"
+
+#include <cmath>
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(BossStateChasePlayer, Chase)
+NERVE_IMPL(BossStateChasePlayer, Stop)
+NERVE_IMPL(BossStateChasePlayer, Lost)
+
+NERVES_MAKE_NOSTRUCT(BossStateChasePlayer, Chase, Stop, Lost)
+
+const BossStateChasePlayerParam sDefaultParam = {1.0f, 0.3f, 0.9f,  500.0f, 0.2f,
+                                                 2.0f, 0.1f, 10.0f, 90.0f};
+}  // namespace
+
+BossStateChasePlayer::BossStateChasePlayer(const char* name, al::LiveActor* actor,
+                                           const BossStateChasePlayerParam* param)
+    : al::ActorStateBase(name, actor), mParam(param) {
+    initNerve(&Chase, 0);
+    if (!param)
+        mParam = &sDefaultParam;
+}
+
+void BossStateChasePlayer::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Chase);
+}
+
+void BossStateChasePlayer::startStop() {
+    al::setNerve(this, &Stop);
+}
+
+// NON_MATCHING: https://decomp.me/scratch/pvWjE/ - Stack frame and register allocation differ
+// (target uses d8-d11/x20-x21 as callee-saved regs, extra loads of mRotationAngle/mTargetPlayer
+// early); dirToPlayer built on-stack with different field ordering; subtraction operand order
+// flipped in several fsub instructions
+void BossStateChasePlayer::exeChase() {
+    mTargetPlayer = al::tryFindAlivePlayerActorFirst(mActor);
+    if (!mTargetPlayer) {
+        al::setNerve(this, &Lost);
+        return;
+    }
+
+    // Compute direction from actor to player (horizontal only, for rotation)
+    sead::Vector3f dirToPlayer;
+    dirToPlayer = al::getTrans(mTargetPlayer);
+    const sead::Vector3f& actorTrans = al::getTrans(mActor);
+    dirToPlayer.x -= actorTrans.x;
+    dirToPlayer.y = 0.0f;
+    dirToPlayer.z -= actorTrans.z;
+
+    // Update rotation toward player
+    if (al::tryNormalizeOrZero(&dirToPlayer)) {
+        sead::Vector3f frontDir = sead::Vector3f::ez;
+        al::calcFrontDir(&frontDir, mActor);
+
+        f32 angle = al::calcAngleOnPlaneDegree(frontDir, dirToPlayer, sead::Vector3f::ey);
+        f32 sign = al::sign(angle);
+
+        // Choose turn speed based on whether we're already roughly facing the player
+        f32 turnSpeed;
+        if (angle <= -mParam->frontAngleThreshold || angle >= mParam->frontAngleThreshold)
+            turnSpeed = mParam->turnSpeedFast;
+        else
+            turnSpeed = mParam->turnSpeedSlow;
+
+        // Clamp rotation to turn speed, preserving sign
+        f32 absAngle = angle > 0.0f ? angle : -angle;
+        f32 absTurnSpeed = turnSpeed > 0.0f ? turnSpeed : -turnSpeed;
+        f32 targetRotation = sign * (absAngle < absTurnSpeed ? absAngle : absTurnSpeed);
+
+        mRotationAngle = al::converge(mRotationAngle, targetRotation, mParam->turnConvergeSpeed);
+        al::rotateQuatYDirDegree(mActor, mRotationAngle);
+    } else {
+        mRotationAngle = al::converge(mRotationAngle, 0.0f, mParam->turnConvergeSpeed);
+    }
+
+    // Compute current XZ speed
+    const sead::Vector3f& vel = al::getVelocity(mActor);
+    f32 speedXZ = sqrtf(vel.x * vel.x + vel.z * vel.z);
+
+    // Get fresh front direction after rotation
+    sead::Vector3f frontDir = sead::Vector3f::ez;
+    al::calcFrontDir(&frontDir, mActor);
+
+    // Recompute direction to player for speed logic
+    dirToPlayer = al::getTrans(mTargetPlayer);
+    const sead::Vector3f& actorTrans2 = al::getTrans(mActor);
+    dirToPlayer.x -= actorTrans2.x;
+    dirToPlayer.y = 0.0f;
+    dirToPlayer.z -= actorTrans2.z;
+
+    bool decelerate = false;
+    if (al::tryNormalizeOrZero(&dirToPlayer)) {
+        if (al::calcAngleDegree(frontDir, dirToPlayer) > mParam->chaseAngleMax)
+            decelerate = true;
+    }
+
+    f32 newSpeed;
+    if (!decelerate) {
+        // Check if close enough to stop accelerating
+        const sead::Vector3f& at = al::getTrans(mActor);
+        const sead::Vector3f& pt = al::getTrans(mTargetPlayer);
+        f32 dx = at.x - pt.x;
+        f32 dz = at.z - pt.z;
+        f32 dist = sqrtf(dx * dx + dz * dz);
+        if (dist <= mParam->proximityStopDist)
+            decelerate = true;
+    }
+
+    if (decelerate)
+        newSpeed = al::converge(speedXZ, 0.0f, mParam->deceleration);
+    else
+        newSpeed = speedXZ + mParam->acceleration;
+
+    al::setVelocityToDirection(mActor, frontDir, newSpeed);
+    al::scaleVelocityDirection(mActor, frontDir, mParam->scaleVelocity);
+}
+
+void BossStateChasePlayer::exeLost() {
+    const sead::Vector3f& vel = al::getVelocity(mActor);
+    f32 speed = sqrtf(vel.x * vel.x + vel.y * vel.y + vel.z * vel.z);
+    f32 newSpeed = al::converge(speed, 0.0f, mParam->deceleration);
+
+    sead::Vector3f newVelocity = al::getVelocity(mActor);
+    f32 len = sqrtf(newVelocity.x * newVelocity.x + newVelocity.y * newVelocity.y +
+                    newVelocity.z * newVelocity.z);
+    if (len > 0.0f) {
+        f32 scale = newSpeed / len;
+        newVelocity.x *= scale;
+        newVelocity.y *= scale;
+        newVelocity.z *= scale;
+    }
+    al::setVelocity(mActor, newVelocity);
+
+    mTargetPlayer = al::tryFindAlivePlayerActorFirst(mActor);
+    if (mTargetPlayer)
+        al::setNerve(this, &Chase);
+}
+
+void BossStateChasePlayer::exeStop() {
+    const sead::Vector3f& vel = al::getVelocity(mActor);
+    f32 speedXZ = sqrtf(vel.x * vel.x + vel.z * vel.z);
+    f32 newSpeed = al::converge(speedXZ, 0.0f, mParam->deceleration);
+
+    al::setVelocityToDirection(mActor, al::getVelocity(mActor), newSpeed);
+    if (al::isNearZero(newSpeed, 0.001f))
+        kill();
+}

--- a/src/Boss/BossUtil/BossStateChasePlayer.h
+++ b/src/Boss/BossUtil/BossStateChasePlayer.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+struct BossStateChasePlayerParam {
+    f32 acceleration;
+    f32 deceleration;
+    f32 scaleVelocity;
+    f32 proximityStopDist;
+    f32 turnSpeedSlow;
+    f32 turnSpeedFast;
+    f32 turnConvergeSpeed;
+    f32 frontAngleThreshold;
+    f32 chaseAngleMax;
+};
+
+class BossStateChasePlayer : public al::ActorStateBase {
+public:
+    BossStateChasePlayer(const char* name, al::LiveActor* actor,
+                         const BossStateChasePlayerParam* param);
+
+    void appear() override;
+
+    void startStop();
+
+    void exeChase();
+    void exeLost();
+    void exeStop();
+
+private:
+    const BossStateChasePlayerParam* mParam = nullptr;
+    const al::LiveActor* mTargetPlayer = nullptr;
+    f32 mRotationAngle = 0.0f;
+};


### PR DESCRIPTION
Claude Sonnet 4.6 created this entire PR from scratch. Runtime was ~1h with it using about 50% of the Pro subscription's rolling 5 hour session.

Given [ida-pro-mcp](https://github.com/mrexodia/ida-pro-mcp) and a list of available decomp tools (`tools/build.py`, `tools/check`, and `tools/decompme`, it spent around 15 minutes gathering info about the codebase before one-shotting the header and source file. The constructor was initially mismatching but it fixed it on its own.

Then, it got stuck for 15 minutes because I forgot to tell it about `--no-pager` on `tools/check` and I had to manually bail it out. Claude then got stuck in another 15 minute loop analyzing `exeChase` without making any changes, wasting 90k tokens and a lot of the session. I bailed it out of that and had it to move on from that function. It fixed every `tools/check-format.py` issue on its own, and it got stuck on the interactive prompt for `tools/decompme` but found its own solution to continue. 

I think a better initial prompt would help smooth the entire process over.

NOTE: AI attributions are tricky. Ideally, I wouldn't have my name on this PR at all. A lot of agents have their own GitHub account/bot now, maybe that would be useful to setup? There's still a lot to discuss about AI contributions before going forward though.

-------

Implements BossStateChasePlayer, a nerve state that handles a boss chasing and rotating toward the player. All functions match except exeChase, which has a  
  major mismatch due to differing stack frame layout and register allocation by the compiler (scratch: https://decomp.me/scratch/pvWjE/).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/916)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6cbaded - 3553f39)

📈 **Matched code**: 13.33% (+0.01%, +812 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::exeLost()` | +276 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::exeStop()` | +180 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `(anonymous namespace)::BossStateChasePlayerNrvStop::execute(al::NerveKeeper*) const` | +180 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::BossStateChasePlayer(char const*, al::LiveActor*, BossStateChasePlayerParam const*)` | +96 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::~BossStateChasePlayer()` | +36 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::appear()` | +16 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::startStop()` | +12 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `(anonymous namespace)::BossStateChasePlayerNrvChase::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossUtil/BossStateChasePlayer` | `(anonymous namespace)::BossStateChasePlayerNrvLost::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossUtil/BossStateChasePlayer` | `BossStateChasePlayer::exeChase()` | +184 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->