### PR TITLE
Boss: Implement `BossRaidElectric`

### DIFF
--- a/src/Boss/BossRaid/BossRaidElectric.cpp
+++ b/src/Boss/BossRaid/BossRaidElectric.cpp
@@ -1,0 +1,218 @@
+#include "Boss/BossRaid/BossRaidElectric.h"
+
+#include <math/seadMathCalcCommon.h>
+#include <math/seadVector.h>
+
+#include "Library/Area/AreaObjUtil.h"
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(BossRaidElectric, Wait);
+NERVE_IMPL(BossRaidElectric, Disappear);
+NERVE_IMPL(BossRaidElectric, Hide);
+NERVES_MAKE_NOSTRUCT(BossRaidElectric, Wait, Disappear, Hide);
+}  // namespace
+
+BossRaidElectric::BossRaidElectric(const char* name) : al::LiveActor(name) {}
+
+void BossRaidElectric::makeActorDead() {
+    al::LiveActor::makeActorDead();
+    if (mNextBullet != nullptr) {
+        mNextBullet->mPrevBullet = nullptr;
+        mNextBullet = nullptr;
+    }
+    if (mPrevBullet != nullptr) {
+        mPrevBullet->mNextBullet = nullptr;
+        mPrevBullet = nullptr;
+    }
+    if (mActorGroup != nullptr) {
+        mActorGroup->removeActor(this);
+        mActorGroup = nullptr;
+    }
+}
+
+void BossRaidElectric::setPrevBullet(BossRaidElectric* bullet) {
+    mPrevBullet = bullet;
+}
+
+void BossRaidElectric::setNextBullet(BossRaidElectric* bullet) {
+    mNextBullet = bullet;
+}
+
+void BossRaidElectric::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "BossRaidElectric", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::invalidateClipping(this);
+    al::offCollide(this);
+    al::initJointControllerKeeper(this, 1);
+    al::initJointLocalTransControllerX(this, &_144, "Electric2");
+    al::setHitSensorPosPtr(this, "Attack", &_12c);
+    al::setSensorRadius(this, "Attack", 50.0f);
+    makeActorDead();
+}
+
+void BossRaidElectric::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (!al::isNerve(this, &Wait))
+        return;
+    if (al::isHitCylinderSensor(other, _12c, mFrontDir, 50.0f))
+        al::sendMsgEnemyAttack(other, self);
+}
+
+void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& dir,
+                            BossRaidElectric* prevBullet,
+                            al::DeriveActorGroup<BossRaidElectric>* actorGroup) {
+    al::setModelAlphaMask(this, 1.0f);
+    al::showModelIfHide(this);
+    al::resetPosition(this, pos);
+    mMoveDir.set(dir);
+    mNextBullet = prevBullet;
+    if (prevBullet != nullptr) {
+        al::showModelIfHide(this);
+        prevBullet->mPrevBullet = this;
+    } else {
+        al::hideModelIfShow(this);
+    }
+    mActorGroup = actorGroup;
+    actorGroup->registerActor(this);
+    _148 = true;
+    al::setNerve(this, &Wait);
+    makeActorAlive();
+}
+
+void BossRaidElectric::updatePosition() {
+    sead::Vector3f* trans = al::getTransPtr(this);
+    *trans += mMoveDir;
+}
+
+void BossRaidElectric::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, mNextBullet != nullptr ? "Wait" : "Hide");
+
+    updateAnimAndJoint();
+    if (_148) {
+        if (al::isInAreaObj(this, "BossRaidElectricArea", al::getTrans(this))) {
+            if (_148)
+                return;
+        } else {
+            _148 = false;
+        }
+    }
+    if (isAirAll())
+        al::setNerve(this, &Disappear);
+}
+
+void BossRaidElectric::updateAnimAndJoint() {
+    _144 = -500.0f;
+    if (mNextBullet == nullptr) {
+        _12c = al::getTrans(this);
+        al::setSensorRadius(this, "Attack", 50.0f);
+
+        sead::Vector3f scale(1.0f, 1.0f, 1.0f);
+        al::setEffectEmitterVolumeScale(this, "Spark", scale);
+        al::setEffectParticleScale(this, "Body", scale);
+
+        mFrontDir.set(sead::Vector3f::ez);
+        return;
+    }
+
+    sead::Vector3f diff = al::getTrans(this) - al::getTrans(mNextBullet);
+    f32 length = diff.length();
+    if (!al::tryNormalizeOrZero(&mFrontDir, diff))
+        mFrontDir.set(sead::Vector3f::ez);
+
+    _144 = length - 500.0f;
+
+    if (sead::Mathf::abs(mFrontDir.y) > 0.98f)
+        al::makeQuatFrontUp(al::getQuatPtr(this), mFrontDir, sead::Vector3f::ex);
+    else
+        al::makeQuatFrontUp(al::getQuatPtr(this), mFrontDir, sead::Vector3f::ey);
+
+    al::lerpVec(&_12c, al::getTrans(this), al::getTrans(mNextBullet), 0.5f);
+    al::setSensorRadius(this, "Attack", length * 0.5f + 50.0f);
+    updateEffectScale(length);
+}
+
+bool BossRaidElectric::isAirAll() const {
+    if (_148)
+        return false;
+    if (mNextBullet && mNextBullet->_148)
+        return false;
+    return true;
+}
+
+void BossRaidElectric::exeDisappear() {
+    updateAnimAndJoint();
+    f32 alpha = al::calcNerveEaseInOutValue(this, 39, 1.0f, 0.0f);
+    al::setModelAlphaMask(this, alpha);
+
+    if (al::isGreaterEqualStep(this, 40)) {
+        al::hideModelIfShow(this);
+        al::setNerve(this, &Hide);
+    }
+}
+
+void BossRaidElectric::exeHide() {
+    if (!al::isNerve(this, &Hide))
+        return;
+
+    BossRaidElectric* next = mNextBullet;
+    if (next == nullptr || al::isNerve(next, &Hide)) {
+        BossRaidElectric* prev = mPrevBullet;
+        if (prev == nullptr) {
+            makeActorDead();
+            return;
+        }
+        if (al::isNerve(prev, &Hide))
+            makeActorDead();
+    }
+}
+
+bool BossRaidElectric::isHideAll() const {
+    if (!isHide())
+        return false;
+
+    BossRaidElectric* next = mNextBullet;
+    if (next != nullptr && !next->isHide())
+        return false;
+
+    BossRaidElectric* prev = mPrevBullet;
+    if (prev != nullptr && !prev->isHide())
+        return false;
+    return true;
+}
+
+bool BossRaidElectric::isHide() const {
+    return al::isNerve(this, &Hide);
+}
+
+void BossRaidElectric::updateEffectScale(f32 scale) {
+    sead::Vector3f v(1.0f, scale / 100.0f, 1.0f);
+    al::setEffectEmitterVolumeScale(this, "Spark", v);
+    al::setEffectParticleScale(this, "Body", v);
+}
+
+void BossRaidElectric::calcNearPos(sead::Vector3f* outPos, const sead::Vector3f& targetPos) const {
+    BossRaidElectric* next = mNextBullet;
+    const sead::Vector3f& thisTrans = al::getTrans(this);
+
+    if (next != nullptr) {
+        const sead::Vector3f& nextTrans = al::getTrans(mNextBullet);
+        al::calcClosestSegmentPoint(outPos, thisTrans, nextTrans, targetPos);
+    } else {
+        outPos->set(thisTrans);
+    }
+}

--- a/src/Boss/BossRaid/BossRaidElectric.cpp
+++ b/src/Boss/BossRaid/BossRaidElectric.cpp
@@ -66,23 +66,21 @@ void BossRaidElectric::init(const al::ActorInitInfo& info) {
 }
 
 void BossRaidElectric::attackSensor(al::HitSensor* self, al::HitSensor* other) {
-    if (!al::isNerve(this, &Wait))
-        return;
-    if (al::isHitCylinderSensor(other, _12c, mFrontDir, 50.0f))
+    if (al::isNerve(this, &Wait) && al::isHitCylinderSensor(other, _12c, mFrontDir, 50.0f))
         al::sendMsgEnemyAttack(other, self);
 }
 
-void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& dir,
-                            BossRaidElectric* prevBullet,
+void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& vel,
+                            BossRaidElectric* nextBullet,
                             al::DeriveActorGroup<BossRaidElectric>* actorGroup) {
     al::setModelAlphaMask(this, 1.0f);
     al::showModelIfHide(this);
     al::resetPosition(this, pos);
-    mMoveDir.set(dir);
-    mNextBullet = prevBullet;
-    if (prevBullet != nullptr) {
+    mVelocity.set(vel);
+    mNextBullet = nextBullet;
+    if (nextBullet != nullptr) {
         al::showModelIfHide(this);
-        prevBullet->mPrevBullet = this;
+        nextBullet->mPrevBullet = this;
     } else {
         al::hideModelIfShow(this);
     }
@@ -94,22 +92,17 @@ void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& dir
 }
 
 void BossRaidElectric::updatePosition() {
-    sead::Vector3f* trans = al::getTransPtr(this);
-    *trans += mMoveDir;
+    *al::getTransPtr(this) += mVelocity;
 }
 
 void BossRaidElectric::exeWait() {
     if (al::isFirstStep(this))
-        al::startAction(this, mNextBullet != nullptr ? "Wait" : "Hide");
+        al::startAction(this, mNextBullet ? "Wait" : "Hide");
 
     updateAnimAndJoint();
     if (_148) {
-        if (al::isInAreaObj(this, "BossRaidElectricArea", al::getTrans(this))) {
-            if (_148)
-                return;
-        } else {
+        if (!al::isInAreaObj(this, "BossRaidElectricArea", al::getTrans(this)))
             _148 = false;
-        }
     }
     if (isAirAll())
         al::setNerve(this, &Disappear);
@@ -117,13 +110,11 @@ void BossRaidElectric::exeWait() {
 
 void BossRaidElectric::updateAnimAndJoint() {
     _144 = -500.0f;
-    if (mNextBullet == nullptr) {
+    if (!mNextBullet) {
         _12c = al::getTrans(this);
         al::setSensorRadius(this, "Attack", 50.0f);
 
-        sead::Vector3f scale(1.0f, 1.0f, 1.0f);
-        al::setEffectEmitterVolumeScale(this, "Spark", scale);
-        al::setEffectParticleScale(this, "Body", scale);
+        updateEffectScale(100.0f);
 
         mFrontDir.set(sead::Vector3f::ez);
         return;
@@ -166,31 +157,18 @@ void BossRaidElectric::exeDisappear() {
 }
 
 void BossRaidElectric::exeHide() {
-    if (!al::isNerve(this, &Hide))
-        return;
-
-    BossRaidElectric* next = mNextBullet;
-    if (next == nullptr || al::isNerve(next, &Hide)) {
-        BossRaidElectric* prev = mPrevBullet;
-        if (prev == nullptr) {
-            makeActorDead();
-            return;
-        }
-        if (al::isNerve(prev, &Hide))
-            makeActorDead();
-    }
+    if (isHideAll())
+        makeActorDead();
 }
 
 bool BossRaidElectric::isHideAll() const {
     if (!isHide())
         return false;
 
-    BossRaidElectric* next = mNextBullet;
-    if (next != nullptr && !next->isHide())
+    if (mNextBullet && !mNextBullet->isHide())
         return false;
 
-    BossRaidElectric* prev = mPrevBullet;
-    if (prev != nullptr && !prev->isHide())
+    if (mPrevBullet && !mPrevBullet->isHide())
         return false;
     return true;
 }
@@ -206,13 +184,10 @@ void BossRaidElectric::updateEffectScale(f32 scale) {
 }
 
 void BossRaidElectric::calcNearPos(sead::Vector3f* outPos, const sead::Vector3f& targetPos) const {
-    BossRaidElectric* next = mNextBullet;
-    const sead::Vector3f& thisTrans = al::getTrans(this);
-
-    if (next != nullptr) {
-        const sead::Vector3f& nextTrans = al::getTrans(mNextBullet);
-        al::calcClosestSegmentPoint(outPos, thisTrans, nextTrans, targetPos);
+    if (mNextBullet) {
+        al::calcClosestSegmentPoint(outPos, al::getTrans(this), al::getTrans(mNextBullet),
+                                    targetPos);
     } else {
-        outPos->set(thisTrans);
+        outPos->set(al::getTrans(this));
     }
 }

--- a/src/Boss/BossRaid/BossRaidElectric.cpp
+++ b/src/Boss/BossRaid/BossRaidElectric.cpp
@@ -59,14 +59,15 @@ void BossRaidElectric::init(const al::ActorInitInfo& info) {
     al::invalidateClipping(this);
     al::offCollide(this);
     al::initJointControllerKeeper(this, 1);
-    al::initJointLocalTransControllerX(this, &_144, "Electric2");
-    al::setHitSensorPosPtr(this, "Attack", &_12c);
+    al::initJointLocalTransControllerX(this, &mJointControl, "Electric2");
+    al::setHitSensorPosPtr(this, "Attack", &mAttackSensorPos);
     al::setSensorRadius(this, "Attack", 50.0f);
     makeActorDead();
 }
 
 void BossRaidElectric::attackSensor(al::HitSensor* self, al::HitSensor* other) {
-    if (al::isNerve(this, &Wait) && al::isHitCylinderSensor(other, _12c, mFrontDir, 50.0f))
+    if (al::isNerve(this, &Wait) &&
+        al::isHitCylinderSensor(other, mAttackSensorPos, mFrontDir, 50.0f))
         al::sendMsgEnemyAttack(other, self);
 }
 
@@ -86,7 +87,7 @@ void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& vel
     }
     mActorGroup = actorGroup;
     actorGroup->registerActor(this);
-    _148 = true;
+    isInElectricArea = true;
     al::setNerve(this, &Wait);
     makeActorAlive();
 }
@@ -100,18 +101,18 @@ void BossRaidElectric::exeWait() {
         al::startAction(this, mNextBullet ? "Wait" : "Hide");
 
     updateAnimAndJoint();
-    if (_148) {
+    if (isInElectricArea) {
         if (!al::isInAreaObj(this, "BossRaidElectricArea", al::getTrans(this)))
-            _148 = false;
+            isInElectricArea = false;
     }
     if (isAirAll())
         al::setNerve(this, &Disappear);
 }
 
 void BossRaidElectric::updateAnimAndJoint() {
-    _144 = -500.0f;
+    mJointControl = -500.0f;
     if (!mNextBullet) {
-        _12c = al::getTrans(this);
+        mAttackSensorPos = al::getTrans(this);
         al::setSensorRadius(this, "Attack", 50.0f);
 
         updateEffectScale(100.0f);
@@ -125,22 +126,22 @@ void BossRaidElectric::updateAnimAndJoint() {
     if (!al::tryNormalizeOrZero(&mFrontDir, diff))
         mFrontDir.set(sead::Vector3f::ez);
 
-    _144 = length - 500.0f;
+    mJointControl = length - 500.0f;
 
     if (sead::Mathf::abs(mFrontDir.y) > 0.98f)
         al::makeQuatFrontUp(al::getQuatPtr(this), mFrontDir, sead::Vector3f::ex);
     else
         al::makeQuatFrontUp(al::getQuatPtr(this), mFrontDir, sead::Vector3f::ey);
 
-    al::lerpVec(&_12c, al::getTrans(this), al::getTrans(mNextBullet), 0.5f);
+    al::lerpVec(&mAttackSensorPos, al::getTrans(this), al::getTrans(mNextBullet), 0.5f);
     al::setSensorRadius(this, "Attack", length * 0.5f + 50.0f);
     updateEffectScale(length);
 }
 
 bool BossRaidElectric::isAirAll() const {
-    if (_148)
+    if (isInElectricArea)
         return false;
-    if (mNextBullet && mNextBullet->_148)
+    if (mNextBullet && mNextBullet->isInElectricArea)
         return false;
     return true;
 }

--- a/src/Boss/BossRaid/BossRaidElectric.cpp
+++ b/src/Boss/BossRaid/BossRaidElectric.cpp
@@ -87,7 +87,7 @@ void BossRaidElectric::shot(const sead::Vector3f& pos, const sead::Vector3f& vel
     }
     mActorGroup = actorGroup;
     actorGroup->registerActor(this);
-    isInElectricArea = true;
+    mIsInElectricArea = true;
     al::setNerve(this, &Wait);
     makeActorAlive();
 }
@@ -101,9 +101,9 @@ void BossRaidElectric::exeWait() {
         al::startAction(this, mNextBullet ? "Wait" : "Hide");
 
     updateAnimAndJoint();
-    if (isInElectricArea) {
+    if (mIsInElectricArea) {
         if (!al::isInAreaObj(this, "BossRaidElectricArea", al::getTrans(this)))
-            isInElectricArea = false;
+            mIsInElectricArea = false;
     }
     if (isAirAll())
         al::setNerve(this, &Disappear);
@@ -139,9 +139,9 @@ void BossRaidElectric::updateAnimAndJoint() {
 }
 
 bool BossRaidElectric::isAirAll() const {
-    if (isInElectricArea)
+    if (mIsInElectricArea)
         return false;
-    if (mNextBullet && mNextBullet->isInElectricArea)
+    if (mNextBullet && mNextBullet->mIsInElectricArea)
         return false;
     return true;
 }

--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+template <class T>
+class DeriveActorGroup;
+}
+
+class BossRaidElectric : public al::LiveActor {
+public:
+    BossRaidElectric(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void makeActorDead() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+
+    void setPrevBullet(BossRaidElectric* bullet);
+    void setNextBullet(BossRaidElectric* bullet);
+
+    void shot(const sead::Vector3f& pos, const sead::Vector3f& dir, BossRaidElectric* prevBullet,
+              al::DeriveActorGroup<BossRaidElectric>* actorGroup);
+    void updatePosition();
+    void exeWait();
+    void updateAnimAndJoint();
+    bool isAirAll() const;
+    void exeDisappear();
+    void exeHide();
+    bool isHideAll() const;
+    bool isHide() const;
+    void updateEffectScale(f32 scale);
+    void calcNearPos(sead::Vector3f* outPos, const sead::Vector3f& targetPos) const;
+
+private:
+    al::DeriveActorGroup<BossRaidElectric>* mActorGroup = nullptr;
+    BossRaidElectric* mNextBullet = nullptr;
+    BossRaidElectric* mPrevBullet = nullptr;
+    sead::Vector3f mFrontDir = sead::Vector3f::ez;
+    sead::Vector3f _12c = sead::Vector3f::zero;
+    sead::Vector3f mMoveDir = sead::Vector3f::zero;
+    f32 _144 = 0.0f;
+    bool _148 = true;
+};
+
+static_assert(sizeof(BossRaidElectric) == 0x150);

--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -19,7 +19,7 @@ public:
     void setPrevBullet(BossRaidElectric* bullet);
     void setNextBullet(BossRaidElectric* bullet);
 
-    void shot(const sead::Vector3f& pos, const sead::Vector3f& dir, BossRaidElectric* prevBullet,
+    void shot(const sead::Vector3f& pos, const sead::Vector3f& vel, BossRaidElectric* nextBullet,
               al::DeriveActorGroup<BossRaidElectric>* actorGroup);
     void updatePosition();
     void exeWait();
@@ -38,7 +38,7 @@ private:
     BossRaidElectric* mPrevBullet = nullptr;
     sead::Vector3f mFrontDir = sead::Vector3f::ez;
     sead::Vector3f _12c = sead::Vector3f::zero;
-    sead::Vector3f mMoveDir = sead::Vector3f::zero;
+    sead::Vector3f mVelocity = sead::Vector3f::zero;
     f32 _144 = 0.0f;
     bool _148 = true;
 };

--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -40,7 +40,7 @@ private:
     sead::Vector3f mAttackSensorPos = sead::Vector3f::zero;
     sead::Vector3f mVelocity = sead::Vector3f::zero;
     f32 mJointControl = 0.0f;
-    bool isInElectricArea = true;
+    bool mIsInElectricArea = true;
 };
 
 static_assert(sizeof(BossRaidElectric) == 0x150);

--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -37,10 +37,10 @@ private:
     BossRaidElectric* mNextBullet = nullptr;
     BossRaidElectric* mPrevBullet = nullptr;
     sead::Vector3f mFrontDir = sead::Vector3f::ez;
-    sead::Vector3f _12c = sead::Vector3f::zero;
+    sead::Vector3f mAttackSensorPos = sead::Vector3f::zero;
     sead::Vector3f mVelocity = sead::Vector3f::zero;
-    f32 _144 = 0.0f;
-    bool _148 = true;
+    f32 mJointControl = 0.0f;
+    bool isInElectricArea = true;
 };
 
 static_assert(sizeof(BossRaidElectric) == 0x150);


### PR DESCRIPTION
Hi everyone, I'm an AI assistant (Claude) helping GRAnimated with decompilation work. All 21 functions are matching.

Some fields couldn't be fully named yet and are noted here for reference:

_12c (offset 0x12c): center position of the segment between this bullet and the next, used for hit sensor placement and calcNearPos
_144 (offset 0x144): joint controller extension value, set to (segment length - 500) to stretch the electric joint
_148 (offset 0x148): flag that is true while the bullet is still inside the BossRaidElectricArea trigger zone; disappear logic is suppressed until this clears

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/924)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - d3263c2)

📈 **Matched code**: 15.52% (+0.02%, +2740 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::updateAnimAndJoint()` | +588 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::BossRaidElectric(char const*)` | +220 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::BossRaidElectric(char const*)` | +208 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::init(al::ActorInitInfo const&)` | +204 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::shot(sead::Vector3<float> const&, sead::Vector3<float> const&, BossRaidElectric*, al::DeriveActorGroup<BossRaidElectric>*)` | +192 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::exeWait()` | +180 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::calcNearPos(sead::Vector3<float>*, sead::Vector3<float> const&) const` | +128 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `(anonymous namespace)::BossRaidElectricNrvHide::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::exeHide()` | +116 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::attackSensor(al::HitSensor*, al::HitSensor*)` | +112 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `(anonymous namespace)::BossRaidElectricNrvDisappear::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::exeDisappear()` | +108 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::isHideAll() const` | +104 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::updateEffectScale(float)` | +104 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::makeActorDead()` | +84 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::updatePosition()` | +76 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::isAirAll() const` | +48 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::isHide() const` | +12 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::setPrevBullet(BossRaidElectric*)` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `BossRaidElectric::setNextBullet(BossRaidElectric*)` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectric` | `(anonymous namespace)::BossRaidElectricNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->