### PR TITLE
Boss: Implement `BossRaidElectricLine`

### DIFF
--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+template <class T>
+class DeriveActorGroup;
+}
+
+class BossRaidElectric : public al::LiveActor {
+public:
+    BossRaidElectric(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void makeActorDead() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+
+    void setPrevBullet(BossRaidElectric* bullet);
+    void setNextBullet(BossRaidElectric* bullet);
+
+    void shot(const sead::Vector3f& pos, const sead::Vector3f& dir, BossRaidElectric* prevBullet,
+              al::DeriveActorGroup<BossRaidElectric>* actorGroup);
+    void updatePosition();
+    void exeWait();
+    void updateAnimAndJoint();
+    bool isAirAll() const;
+    void exeDisappear();
+    void exeHide();
+    bool isHideAll() const;
+    bool isHide() const;
+    void updateEffectScale(f32 scale);
+    void calcNearPos(sead::Vector3f* outPos, const sead::Vector3f& targetPos) const;
+
+private:
+    al::DeriveActorGroup<BossRaidElectric>* mActorGroup = nullptr;
+    BossRaidElectric* mNextBullet = nullptr;
+    BossRaidElectric* mPrevBullet = nullptr;
+    sead::Vector3f mFrontDir = sead::Vector3f::ez;
+    sead::Vector3f _12c = sead::Vector3f::zero;
+    sead::Vector3f mMoveDir = sead::Vector3f::zero;
+    f32 _144 = 0.0f;
+    bool _148 = true;
+};
+
+static_assert(sizeof(BossRaidElectric) == 0x150);

--- a/src/Boss/BossRaid/BossRaidElectric.h
+++ b/src/Boss/BossRaid/BossRaidElectric.h
@@ -19,7 +19,7 @@ public:
     void setPrevBullet(BossRaidElectric* bullet);
     void setNextBullet(BossRaidElectric* bullet);
 
-    void shot(const sead::Vector3f& pos, const sead::Vector3f& dir, BossRaidElectric* prevBullet,
+    void shot(const sead::Vector3f& pos, const sead::Vector3f& vel, BossRaidElectric* nextBullet,
               al::DeriveActorGroup<BossRaidElectric>* actorGroup);
     void updatePosition();
     void exeWait();
@@ -37,10 +37,10 @@ private:
     BossRaidElectric* mNextBullet = nullptr;
     BossRaidElectric* mPrevBullet = nullptr;
     sead::Vector3f mFrontDir = sead::Vector3f::ez;
-    sead::Vector3f _12c = sead::Vector3f::zero;
-    sead::Vector3f mMoveDir = sead::Vector3f::zero;
-    f32 _144 = 0.0f;
-    bool _148 = true;
+    sead::Vector3f mAttackSensorPos = sead::Vector3f::zero;
+    sead::Vector3f mVelocity = sead::Vector3f::zero;
+    f32 mJointControl = 0.0f;
+    bool isInElectricArea = true;
 };
 
 static_assert(sizeof(BossRaidElectric) == 0x150);

--- a/src/Boss/BossRaid/BossRaidElectricLine.cpp
+++ b/src/Boss/BossRaid/BossRaidElectricLine.cpp
@@ -1,0 +1,81 @@
+#include "Boss/BossRaid/BossRaidElectricLine.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+
+#include "Boss/BossRaid/BossRaidElectric.h"
+
+namespace {
+NERVE_ACTION_IMPL(BossRaidElectricLine, Move);
+NERVE_ACTIONS_MAKE_STRUCT(BossRaidElectricLine, Move);
+}  // namespace
+
+BossRaidElectricLine::BossRaidElectricLine(const char* name) : al::LiveActor(name) {
+    mActors = new al::DeriveActorGroup<BossRaidElectric>("電撃アクティブリスト", 64);
+}
+
+void BossRaidElectricLine::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Move", &NrvBossRaidElectricLine.collector, 0);
+    al::initActorWithArchiveName(this, info, "BossRaidElectricLine", nullptr);
+    makeActorDead();
+}
+
+void BossRaidElectricLine::setBulletList(al::DeriveActorGroup<BossRaidElectric>* bulletList) {
+    mBulletList = bulletList;
+}
+
+void BossRaidElectricLine::shot(const sead::Vector3f& pos, const sead::Vector3f& dir) {
+    if (mBulletList == nullptr)
+        return;
+
+    BossRaidElectric* bullet = mBulletList->tryFindDeadDeriveActor();
+    if (bullet == nullptr)
+        return;
+
+    bullet->shot(pos, dir, mPrevBullet, mActors);
+    mPrevBullet = bullet;
+    if (al::isDead(this)) {
+        al::startNerveAction(this, "Move");
+        makeActorAlive();
+    }
+}
+
+void BossRaidElectricLine::exeMove() {
+    s32 actorCount = mActors->getActorCount();
+    if (actorCount == 0) {
+        mPrevBullet = nullptr;
+        makeActorDead();
+        return;
+    }
+
+    sead::Vector3f nearPos = al::getTrans(this);
+    f32 minDist = sead::Mathf::maxNumber();
+
+    for (s32 i = 0; i < actorCount; i++) {
+        BossRaidElectric* electric = mActors->getDeriveActor(i);
+
+        sead::Vector3f calcPos;
+        electric->calcNearPos(&calcPos, al::getPlayerPos(this, 0));
+        const sead::Vector3f& playerPos = al::getPlayerPos(this, 0);
+
+        f32 dist = sqrtf((playerPos - calcPos).squaredLength());
+        if (dist < minDist) {
+            nearPos.set(calcPos);
+            minDist = dist;
+        }
+    }
+
+    al::setTrans(this, nearPos);
+}
+
+void BossRaidElectricLine::killForce() {
+    mActors->removeActorAll();
+    mPrevBullet = nullptr;
+    makeActorDead();
+}

--- a/src/Boss/BossRaid/BossRaidElectricLine.h
+++ b/src/Boss/BossRaid/BossRaidElectricLine.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+template <class T>
+class DeriveActorGroup;
+}
+
+class BossRaidElectric;
+
+class BossRaidElectricLine : public al::LiveActor {
+public:
+    BossRaidElectricLine(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void setBulletList(al::DeriveActorGroup<BossRaidElectric>* bulletList);
+    void shot(const sead::Vector3f& pos, const sead::Vector3f& dir);
+    void exeMove();
+    void killForce();
+
+    void resetPrevBullet() { mPrevBullet = nullptr; }
+
+private:
+    BossRaidElectric* mPrevBullet = nullptr;
+    al::DeriveActorGroup<BossRaidElectric>* mActors = nullptr;
+    al::DeriveActorGroup<BossRaidElectric>* mBulletList = nullptr;
+};
+
+static_assert(sizeof(BossRaidElectricLine) == 0x120);


### PR DESCRIPTION
All 10 functions matching. Includes BossRaidElectric.h as a header-only dependency.

Depends on #924.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/927)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (befc651 - d229cd4)

📈 **Matched code**: 15.42% (+0.01%, +1104 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::exeMove()` | +320 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::BossRaidElectricLine(char const*)` | +188 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::BossRaidElectricLine(char const*)` | +176 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::shot(sead::Vector3<float> const&, sead::Vector3<float> const&)` | +144 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::init(al::ActorInitInfo const&)` | +132 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `_GLOBAL__sub_I_BossRaidElectricLine.cpp` | +64 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::killForce()` | +52 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `(anonymous namespace)::BossRaidElectricLineNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `BossRaidElectricLine::setBulletList(al::DeriveActorGroup<BossRaidElectric>*)` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidElectricLine` | `(anonymous namespace)::BossRaidElectricLineNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->