### PR TITLE
Boss: Implement `BossRaidChainList`

### DIFF
--- a/src/Boss/BossRaid/BossRaidChain.h
+++ b/src/Boss/BossRaid/BossRaidChain.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BossRaidChain : public al::LiveActor {
+public:
+    BossRaidChain(const char* name, const char* archiveName, const char* modelName, f32 minDist,
+                  f32 maxDist);
+    void init(const al::ActorInitInfo& info) override;
+    void setPrevChain(BossRaidChain* chain);
+    void setNextChain(BossRaidChain* chain);
+    void setDemoFollowMtxPtr(const sead::Matrix34f* mtxPtr);
+    void setFix();
+    void addVelocityChain(const sead::Vector3f& velocity);
+    void updateVelocity(BossRaidChain* other);
+    void updateDirection(f32 yRate, f32 zRate);
+    void resetDirection();
+    void startBlowDown();
+    void active();
+    void deactive();
+    void setUpDemo();
+    void reset();
+    void exeDeactive();
+    void exeDemo();
+    void exeWait();
+    void exeBlowDown();
+
+private:
+    const char* mArchiveName = nullptr;
+    const char* mModelName = nullptr;
+    const sead::Matrix34f* mDemoFollowMtxPtr = nullptr;
+    BossRaidChain* mPrevChain = nullptr;
+    BossRaidChain* mNextChain = nullptr;
+    sead::Vector3f mBlowAxis = sead::Vector3f::ex;
+    f32 mMinDist = 0.0f;
+    f32 mMaxDist = 0.0f;
+    bool mIsFix = false;
+};
+
+static_assert(sizeof(BossRaidChain) == 0x148);

--- a/src/Boss/BossRaid/BossRaidChainList.cpp
+++ b/src/Boss/BossRaid/BossRaidChainList.cpp
@@ -1,0 +1,248 @@
+#include "Boss/BossRaid/BossRaidChainList.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/BossRaid/BossRaidChain.h"
+
+namespace {
+NERVE_IMPL(BossRaidChainList, BlowDown);
+NERVE_IMPL(BossRaidChainList, Demo);
+NERVE_IMPL(BossRaidChainList, Wait);
+NERVE_IMPL(BossRaidChainList, Deactive);
+NERVES_MAKE_NOSTRUCT(BossRaidChainList, BlowDown, Demo, Wait, Deactive);
+}  // namespace
+
+BossRaidChainList::BossRaidChainList(const char* name, const char* modelName, s32 count,
+                                     f32 minDist, f32 maxDist)
+    : al::LiveActor(name), mModelName(modelName), mChainCount(count), mMinDist(minDist),
+      mMaxDist(maxDist) {}
+
+void BossRaidChainList::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorEnemyMovement(this, info);
+    al::initActorPoseTQSV(this);
+    al::initActorClipping(this, info);
+    al::invalidateClipping(this);
+
+    mChains = new BossRaidChain*[mChainCount];
+
+    for (s32 i = 0; i < mChainCount; i++) {
+        BossRaidChain* chain = new BossRaidChain(
+            "鎖", mModelName, i == 0 || i == mChainCount - 1 ? "NoModel" : nullptr, mMinDist,
+            mMaxDist);
+        mChains[i] = chain;
+        al::initCreateActorWithPlacementInfo(mChains[i], info);
+    }
+
+    if (mChainCount > 1) {
+        for (s32 i = 0; i < mChainCount - 1; i++) {
+            mChains[i]->setNextChain(mChains[i + 1]);
+            mChains[i + 1]->setPrevChain(mChains[i]);
+        }
+    }
+
+    if (mChainCount >= 1) {
+        mChains[0]->setFix();
+        mChains[mChainCount - 1]->setFix();
+    }
+
+    al::initNerve(this, &Wait, 0);
+
+    const sead::Vector3f* rootPtr = mRootPosPtr;
+    if (!rootPtr)
+        rootPtr = &al::getTrans(this);
+
+    sead::Vector3f rootPos;
+    rootPos.set(*rootPtr);
+
+    const sead::Vector3f* tipPtr = mTipPosPtr;
+    if (!tipPtr)
+        tipPtr = &al::getTrans(this);
+
+    sead::Vector3f tipPos;
+    tipPos.set(*tipPtr);
+    resetChain(rootPos, tipPos);
+
+    makeActorAlive();
+}
+
+void BossRaidChainList::makeActorAlive() {
+    al::setNerve(this, &Wait);
+    al::LiveActor::makeActorAlive();
+    for (s32 i = 0; i < mChainCount; i++)
+        mChains[i]->makeActorAlive();
+}
+
+void BossRaidChainList::makeActorDead() {
+    al::LiveActor::makeActorDead();
+    for (s32 i = 0; i < mChainCount; i++)
+        mChains[i]->makeActorDead();
+}
+
+void BossRaidChainList::setRootPosPtr(const sead::Vector3f* pos) {
+    mRootPosPtr = pos;
+}
+
+void BossRaidChainList::setTipPosPtr(const sead::Vector3f* pos) {
+    mTipPosPtr = pos;
+}
+
+void BossRaidChainList::calcRootAndTipPos(sead::Vector3f* outRoot, sead::Vector3f* outTip) {
+    const sead::Vector3f* rootPos = mRootPosPtr;
+    if (!rootPos)
+        rootPos = &al::getTrans(this);
+    outRoot->set(*rootPos);
+
+    const sead::Vector3f* tipPos = mTipPosPtr;
+    if (!tipPos)
+        tipPos = &al::getTrans(this);
+    outTip->set(*tipPos);
+}
+
+BossRaidChain* BossRaidChainList::getChain(s32 index) {
+    return mChains[index];
+}
+
+void BossRaidChainList::registerHostSubActorSyncClipping(al::LiveActor* actor) {
+    al::registerSubActorSyncClipping(actor, this);
+    for (s32 i = 0; i < mChainCount; i++)
+        al::registerSubActorSyncClipping(actor, mChains[i]);
+}
+
+void BossRaidChainList::resetChain() {
+    const sead::Vector3f* rootPtr = mRootPosPtr;
+    if (!rootPtr)
+        rootPtr = &al::getTrans(this);
+
+    sead::Vector3f rootPos;
+    rootPos.set(*rootPtr);
+    const sead::Vector3f* tipPtr = mTipPosPtr;
+
+    if (!tipPtr)
+        tipPtr = &al::getTrans(this);
+
+    sead::Vector3f tipPos;
+    tipPos.set(*tipPtr);
+    resetChain(rootPos, tipPos);
+}
+
+void BossRaidChainList::resetChain(const sead::Vector3f& rootPos, const sead::Vector3f& tipPos) {
+    for (s32 i = 0; i < mChainCount; i++) {
+        sead::Vector3f* transPtr = al::getTransPtr(mChains[i]);
+        al::lerpVec(transPtr, rootPos, tipPos, (f32)i / (f32)(mChainCount - 1));
+        sead::Vector3f* transPtr2 = al::getTransPtr(mChains[i]);
+        const sead::Vector3f& trans = al::getTrans(mChains[i]);
+        al::addRandomVector(transPtr2, trans, 10.0f);
+    }
+    for (s32 i = 0; i < mChainCount; i++) {
+        mChains[i]->resetDirection();
+        mChains[i]->reset();
+    }
+}
+
+void BossRaidChainList::startBlowDown() {
+    al::setNerve(this, &BlowDown);
+}
+
+void BossRaidChainList::active() {
+    if (!al::isNerve(this, &Deactive))
+        return;
+    al::setNerve(this, &Wait);
+    for (s32 i = 0; i < mChainCount; i++)
+        mChains[i]->active();
+}
+
+void BossRaidChainList::deactive() {
+    if (!al::isNerve(this, &Wait))
+        return;
+    al::setNerve(this, &Deactive);
+    for (s32 i = 0; i < mChainCount; i++)
+        mChains[i]->deactive();
+}
+
+void BossRaidChainList::setUpDemo() {
+    al::setNerve(this, &Demo);
+    for (s32 i = 0; i < mChainCount; i++)
+        mChains[i]->setUpDemo();
+}
+
+void BossRaidChainList::reset() {
+    const sead::Vector3f* rootPtr = mRootPosPtr;
+    if (!rootPtr)
+        rootPtr = &al::getTrans(this);
+    sead::Vector3f rootPos;
+    rootPos.set(*rootPtr);
+    const sead::Vector3f* tipPtr = mTipPosPtr;
+    sead::Vector3f tipPos;
+    if (!tipPtr)
+        tipPtr = &al::getTrans(this);
+    tipPos.set(*tipPtr);
+    resetChain(rootPos, tipPos);
+    al::setNerve(this, &Wait);
+    makeActorAlive();
+}
+
+void BossRaidChainList::exeDemo() {}
+
+void BossRaidChainList::exeDeactive() {}
+
+void BossRaidChainList::exeWait() {
+    const sead::Vector3f* rootPtr = mRootPosPtr;
+    if (!rootPtr)
+        rootPtr = &al::getTrans(this);
+
+    sead::Vector3f rootPos;
+    rootPos.set(*rootPtr);
+
+    const sead::Vector3f* tipPtr = mTipPosPtr;
+    if (!tipPtr)
+        tipPtr = &al::getTrans(this);
+
+    sead::Vector3f tipPos;
+    tipPos.set(*tipPtr);
+
+    al::resetPosition(mChains[0], rootPos);
+    al::resetPosition(mChains[mChainCount - 1], tipPos);
+
+    for (s32 i = 1; i < mChainCount - 1; i++) {
+        sead::Vector3f lerpPos = sead::Vector3f::zero;
+        al::lerpVec(&lerpPos, rootPos, tipPos, (f32)i / (f32)(mChainCount - 1));
+
+        const sead::Vector3f& trans = al::getTrans(mChains[i]);
+        sead::Vector3f diff = {lerpPos - trans};
+        f32 dist = diff.length();
+        if (dist > 50.0f) {
+            f32 scale = (dist - 50.0f) / dist * 0.05f;
+            al::addVelocity(mChains[i], diff * scale);
+        }
+    }
+
+    for (s32 i = 0; i < mChainCount - 1; i++) {
+        mChains[i]->exeWait();
+        *al::getTransPtr(mChains[i]) += al::getVelocity(mChains[i]);
+    }
+}
+
+void BossRaidChainList::exeBlowDown() {
+    if (al::isFirstStep(this))
+        for (s32 i = 0; i < mChainCount; i++)
+            mChains[i]->startBlowDown();
+
+    if (mChainCount >= 1) {
+        for (s32 i = 0; i < mChainCount; i++)
+            if (al::isAlive(mChains[i]))
+                return;
+    }
+
+    kill();
+}

--- a/src/Boss/BossRaid/BossRaidChainList.h
+++ b/src/Boss/BossRaid/BossRaidChainList.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BossRaidChain;
+
+class BossRaidChainList : public al::LiveActor {
+public:
+    BossRaidChainList(const char* name, const char* modelName, s32 count, f32 minDist, f32 maxDist);
+    void init(const al::ActorInitInfo& info) override;
+    void makeActorAlive() override;
+    void makeActorDead() override;
+    void setRootPosPtr(const sead::Vector3f* pos);
+    void setTipPosPtr(const sead::Vector3f* pos);
+    void calcRootAndTipPos(sead::Vector3f* outRoot, sead::Vector3f* outTip);
+    BossRaidChain* getChain(s32 index);
+    void registerHostSubActorSyncClipping(al::LiveActor* actor);
+    void resetChain();
+    void resetChain(const sead::Vector3f& rootPos, const sead::Vector3f& tipPos);
+    void startBlowDown();
+    void active();
+    void deactive();
+    void setUpDemo();
+    void reset();
+    void exeDemo();
+    void exeDeactive();
+    void exeWait();
+    void exeBlowDown();
+
+private:
+    BossRaidChain** mChains = nullptr;
+    const char* mModelName = nullptr;
+    s32 mChainCount = 0;
+    const sead::Vector3f* mRootPosPtr = nullptr;
+    const sead::Vector3f* mTipPosPtr = nullptr;
+    f32 mMinDist = 0.0f;
+    f32 mMaxDist = 0.0f;
+};
+
+static_assert(sizeof(BossRaidChainList) == 0x138);


### PR DESCRIPTION
All 25 functions matching. Includes BossRaidChain.h as a header-only dependency.

Depends on #923.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/928)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (bf1e9d4 - 8720fc3)

📈 **Matched code**: 13.57% (+0.02%, +2972 bytes)

<details>
<summary>✅ 25 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::exeWait()` | +552 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::init(al::ActorInitInfo const&)` | +504 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::resetChain(sead::Vector3<float> const&, sead::Vector3<float> const&)` | +244 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::BossRaidChainList(char const*, char const*, int, float, float)` | +184 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::BossRaidChainList(char const*, char const*, int, float, float)` | +172 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `(anonymous namespace)::BossRaidChainListNrvBlowDown::execute(al::NerveKeeper*) const` | +152 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::reset()` | +148 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::exeBlowDown()` | +148 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::resetChain()` | +116 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::calcRootAndTipPos(sead::Vector3<float>*, sead::Vector3<float>*)` | +108 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::active()` | +108 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::deactive()` | +104 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::makeActorAlive()` | +100 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::registerHostSubActorSyncClipping(al::LiveActor*)` | +100 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::makeActorDead()` | +84 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::setUpDemo()` | +84 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::getChain(int)` | +12 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::startBlowDown()` | +12 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::setRootPosPtr(sead::Vector3<float> const*)` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::setTipPosPtr(sead::Vector3<float> const*)` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `(anonymous namespace)::BossRaidChainListNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::exeDemo()` | +4 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `BossRaidChainList::exeDeactive()` | +4 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `(anonymous namespace)::BossRaidChainListNrvDeactive::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `Boss/BossRaid/BossRaidChainList` | `(anonymous namespace)::BossRaidChainListNrvDemo::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->