### PR TITLE
Boss: Implement `BossUtil`

### DIFF
--- a/src/Boss/BossUtil/BossUtil.cpp
+++ b/src/Boss/BossUtil/BossUtil.cpp
@@ -1,0 +1,112 @@
+#include "Boss/BossUtil/BossUtil.h"
+
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Boss/BarrierField.h"
+#include "Sequence/GameSequenceInfo.h"
+#include "System/BossSaveData.h"
+#include "System/CapMessageBossData.h"
+#include "System/GameDataFile.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolder.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+
+namespace rs {
+
+BarrierField* tryCreateBarrierField(const al::ActorInitInfo& info) {
+    if (al::calcLinkChildNum(info, "BarrierField") < 1)
+        return nullptr;
+    auto* barrierField = new BarrierField("ボス結界");
+    al::initLinksActor(barrierField, info, "BarrierField", 0);
+    barrierField->makeActorDead();
+    return barrierField;
+}
+
+void updateEyeMove(al::LiveActor* actor, const sead::Vector3f& target, f32 maxAngle,
+                   const char* animName) {
+    f32 angle = al::calcAngleToTargetH(actor, target);
+    if (angle > maxAngle)
+        angle = 180.0f - angle;
+    else if (angle < -maxAngle)
+        angle = -180.0f - angle;
+    f32 frameMax = al::getMtsAnimFrameMax(actor, animName);
+    f32 frame = al::lerpValue(angle, -maxAngle, maxAngle, 0.0f, frameMax);
+    al::startMtsAnimAndSetFrameAndStop(actor, animName, frame);
+}
+
+void resetEyeMove(al::LiveActor* actor, const char* animName) {
+    f32 frameMax = al::getMtsAnimFrameMax(actor, animName);
+    al::startMtsAnimAndSetFrameAndStop(actor, animName, frameMax * 0.5f);
+}
+
+void startBossBattle(const al::LiveActor* actor, s32 worldId) {
+    CapMessageBossData* data = getCapMessageBossData(actor);
+    data->incrementBossBattleCount(worldId);
+    setSceneStatusBossBattle(actor);
+}
+
+void endBossBattle(const al::LiveActor* actor, s32 worldId) {
+    setSceneStatusBossBattleEndForPlayerAnim(actor);
+
+    if (GameDataFunction::isWorldSky(actor) && (worldId == 0 || worldId == 2))
+        setSceneStatusBossBattleEnd(actor);
+
+    if (GameDataFunction::isWorldMoon(actor) && worldId == 12)
+        setSceneStatusBossBattleEnd(actor);
+
+    if (GameDataFunction::isWorldSpecial1(actor) && worldId != 10)
+        setSceneStatusBossBattleEnd(actor);
+}
+
+s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 worldId) {
+    CapMessageBossData* data = getCapMessageBossData(actor);
+    return data->getBattleCount(worldId);
+}
+
+bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level) {
+    GameDataHolderAccessor accessor(actor);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyShowDemoBossBattleStart(worldId,
+                                                                                            level);
+}
+
+void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level) {
+    GameDataHolderAccessor accessor(actor);
+    accessor->getGameDataFile()->getBossSaveData()->showDemoBossBattleStart(worldId, level);
+}
+
+bool isAlreadyShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyShowDemoBattleEndKoopaLv2();
+}
+
+void saveShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    accessor->getGameDataFile()->getBossSaveData()->saveDemoBattleEndKoopaLv2();
+}
+
+bool isAlreadyShowDemoMoonBasementCollapse(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyShowDemoMoonBasementCollapse();
+}
+
+void saveShowDemoMoonBasementCollapse(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    accessor->getGameDataFile()->getBossSaveData()->saveShowDemoMoonBasementCollapse();
+}
+
+bool isAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level) {
+    GameDataHolderAccessor accessor(actor);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyDeadGK(worldId, level);
+}
+
+void onAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level) {
+    GameDataHolderAccessor accessor(actor);
+    accessor->getGameDataFile()->getBossSaveData()->onAlreadyDeadGK(worldId, level);
+}
+
+}  // namespace rs

--- a/src/Boss/BossUtil/BossUtil.cpp
+++ b/src/Boss/BossUtil/BossUtil.cpp
@@ -35,6 +35,9 @@ void updateEyeMove(al::LiveActor* actor, const sead::Vector3f& target, f32 maxAn
     else if (angle < -maxAngle)
         angle = -180.0f - angle;
     f32 frameMax = al::getMtsAnimFrameMax(actor, animName);
+    // BUG: arguments ordered incorrectly
+    // should have been (-maxAngle, maxAngle, angle, 0.0f, frameMax)
+    // NOTE: angle might be outside range [-maxAngle, maxAngle], but is clamped by lerpValue
     f32 frame = al::lerpValue(angle, -maxAngle, maxAngle, 0.0f, frameMax);
     al::startMtsAnimAndSetFrameAndStop(actor, animName, frame);
 }
@@ -44,39 +47,40 @@ void resetEyeMove(al::LiveActor* actor, const char* animName) {
     al::startMtsAnimAndSetFrameAndStop(actor, animName, frameMax * 0.5f);
 }
 
-void startBossBattle(const al::LiveActor* actor, s32 worldId) {
+void startBossBattle(const al::LiveActor* actor, s32 bossType) {
     CapMessageBossData* data = getCapMessageBossData(actor);
-    data->incrementBossBattleCount(worldId);
+    data->incrementBossBattleCount(bossType);
     setSceneStatusBossBattle(actor);
 }
 
-void endBossBattle(const al::LiveActor* actor, s32 worldId) {
+void endBossBattle(const al::LiveActor* actor, s32 bossType) {
     setSceneStatusBossBattleEndForPlayerAnim(actor);
 
-    if (GameDataFunction::isWorldSky(actor) && (worldId == 0 || worldId == 2))
+    if (GameDataFunction::isWorldSky(actor) &&
+        (bossType == BossType::cStacker || bossType == BossType::cBombTail))
         setSceneStatusBossBattleEnd(actor);
 
-    if (GameDataFunction::isWorldMoon(actor) && worldId == 12)
+    if (GameDataFunction::isWorldMoon(actor) && bossType == BossType::cBreeda)
         setSceneStatusBossBattleEnd(actor);
 
-    if (GameDataFunction::isWorldSpecial1(actor) && worldId != 10)
+    if (GameDataFunction::isWorldSpecial1(actor) && bossType != BossType::cGolemClimb)
         setSceneStatusBossBattleEnd(actor);
 }
 
-s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 worldId) {
+s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 bossType) {
     CapMessageBossData* data = getCapMessageBossData(actor);
-    return data->getBattleCount(worldId);
+    return data->getBattleCount(bossType);
 }
 
-bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level) {
+bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 bossType, s32 level) {
     GameDataHolderAccessor accessor(actor);
-    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyShowDemoBossBattleStart(worldId,
-                                                                                            level);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyShowDemoBossBattleStart(
+        bossType, level);
 }
 
-void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level) {
+void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 bossType, s32 level) {
     GameDataHolderAccessor accessor(actor);
-    accessor->getGameDataFile()->getBossSaveData()->showDemoBossBattleStart(worldId, level);
+    accessor->getGameDataFile()->getBossSaveData()->showDemoBossBattleStart(bossType, level);
 }
 
 bool isAlreadyShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor) {
@@ -99,14 +103,14 @@ void saveShowDemoMoonBasementCollapse(const al::LiveActor* actor) {
     accessor->getGameDataFile()->getBossSaveData()->saveShowDemoMoonBasementCollapse();
 }
 
-bool isAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level) {
+bool isAlreadyDeadGK(const al::LiveActor* actor, s32 bossType, s32 level) {
     GameDataHolderAccessor accessor(actor);
-    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyDeadGK(worldId, level);
+    return accessor->getGameDataFile()->getBossSaveData()->isAlreadyDeadGK(bossType, level);
 }
 
-void onAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level) {
+void onAlreadyDeadGK(const al::LiveActor* actor, s32 bossType, s32 level) {
     GameDataHolderAccessor accessor(actor);
-    accessor->getGameDataFile()->getBossSaveData()->onAlreadyDeadGK(worldId, level);
+    accessor->getGameDataFile()->getBossSaveData()->onAlreadyDeadGK(bossType, level);
 }
 
 }  // namespace rs

--- a/src/Boss/BossUtil/BossUtil.h
+++ b/src/Boss/BossUtil/BossUtil.h
@@ -11,18 +11,21 @@ class LiveActor;
 class BarrierField;
 
 namespace rs {
-BarrierField* tryCreateBarrierField(const al::ActorInitInfo&);
-void updateEyeMove(al::LiveActor*, const sead::Vector3f&, f32, const char*);
-void resetEyeMove(al::LiveActor*, const char*);
-void startBossBattle(const al::LiveActor*, s32);
-void endBossBattle(const al::LiveActor*, s32);
-s32 getBossBattleDeadCount(const al::LiveActor*, s32);
-bool isAlreadyShowDemoBossBattleStart(const al::LiveActor*, s32, s32);
-void saveShowDemoBossBattleStart(const al::LiveActor*, s32, s32);
-bool isAlreadyShowDemoBossBattleEndKoopaLv2(const al::LiveActor*);
-void saveShowDemoBossBattleEndKoopaLv2(const al::LiveActor*);
-bool isAlreadyShowDemoMoonBasementCollapse(const al::LiveActor*);
-void saveShowDemoMoonBasementCollapse(const al::LiveActor*);
-bool isAlreadyDeadGK(const al::LiveActor*, s32, s32);
-void onAlreadyDeadGK(const al::LiveActor*, s32, s32);
+
+BarrierField* tryCreateBarrierField(const al::ActorInitInfo& info);
+void updateEyeMove(al::LiveActor* actor, const sead::Vector3f& target, f32 maxAngle,
+                   const char* animName);
+void resetEyeMove(al::LiveActor* actor, const char* animName);
+void startBossBattle(const al::LiveActor* actor, s32 worldId);
+void endBossBattle(const al::LiveActor* actor, s32 worldId);
+s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 worldId);
+bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level);
+void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level);
+bool isAlreadyShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor);
+void saveShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor);
+bool isAlreadyShowDemoMoonBasementCollapse(const al::LiveActor* actor);
+void saveShowDemoMoonBasementCollapse(const al::LiveActor* actor);
+bool isAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level);
+void onAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level);
+
 }  // namespace rs

--- a/src/Boss/BossUtil/BossUtil.h
+++ b/src/Boss/BossUtil/BossUtil.h
@@ -2,6 +2,7 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+#include <prim/seadEnum.h>
 
 namespace al {
 struct ActorInitInfo;
@@ -12,20 +13,25 @@ class BarrierField;
 
 namespace rs {
 
+SEAD_ENUM(BossType, cStacker, cCapThrower, cBombTail, cFireBlower, 
+                    cBossKnuckle, cBossForest, cKoopa, cMofumofu, 
+                    cGiantWanderBoss, cBossRaid, cGolemClimb, 
+                    cBossMagma, cBreeda);
+
 BarrierField* tryCreateBarrierField(const al::ActorInitInfo& info);
 void updateEyeMove(al::LiveActor* actor, const sead::Vector3f& target, f32 maxAngle,
                    const char* animName);
 void resetEyeMove(al::LiveActor* actor, const char* animName);
-void startBossBattle(const al::LiveActor* actor, s32 worldId);
-void endBossBattle(const al::LiveActor* actor, s32 worldId);
-s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 worldId);
-bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level);
-void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 worldId, s32 level);
+void startBossBattle(const al::LiveActor* actor, s32 bossType);
+void endBossBattle(const al::LiveActor* actor, s32 bossType);
+s32 getBossBattleDeadCount(const al::LiveActor* actor, s32 bossType);
+bool isAlreadyShowDemoBossBattleStart(const al::LiveActor* actor, s32 bossType, s32 level);
+void saveShowDemoBossBattleStart(const al::LiveActor* actor, s32 bossType, s32 level);
 bool isAlreadyShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor);
 void saveShowDemoBossBattleEndKoopaLv2(const al::LiveActor* actor);
 bool isAlreadyShowDemoMoonBasementCollapse(const al::LiveActor* actor);
 void saveShowDemoMoonBasementCollapse(const al::LiveActor* actor);
-bool isAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level);
-void onAlreadyDeadGK(const al::LiveActor* actor, s32 worldId, s32 level);
+bool isAlreadyDeadGK(const al::LiveActor* actor, s32 bossType, s32 level);
+void onAlreadyDeadGK(const al::LiveActor* actor, s32 bossType, s32 level);
 
 }  // namespace rs

--- a/src/Boss/BossUtil/BossUtil.h
+++ b/src/Boss/BossUtil/BossUtil.h
@@ -13,9 +13,9 @@ class BarrierField;
 
 namespace rs {
 
-SEAD_ENUM(BossType, cStacker, cCapThrower, cBombTail, cFireBlower, 
-                    cBossKnuckle, cBossForest, cKoopa, cMofumofu, 
-                    cGiantWanderBoss, cBossRaid, cGolemClimb, 
+SEAD_ENUM(BossType, cStacker, cCapThrower, cBombTail, cFireBlower,
+                    cBossKnuckle, cBossForest, cKoopa, cMofumofu,
+                    cGiantWanderBoss, cBossRaid, cGolemClimb,
                     cBossMagma, cBreeda);
 
 BarrierField* tryCreateBarrierField(const al::ActorInitInfo& info);

--- a/src/System/BossSaveData.h
+++ b/src/System/BossSaveData.h
@@ -15,11 +15,9 @@ public:
     bool isAlreadyShowDemoBattleEndKoopaLv2() const;
     void saveDemoBattleEndKoopaLv2();
 
-    bool isAlreadyShowDemoMoonBasementCollapse() const {
-        return mIsAlreadyShowDemoMoonBasementCollapse;
-    }
+    bool isAlreadyShowDemoMoonBasementCollapse() const { return mIsShowDemoMoonBasementCollapse; }
 
-    void saveShowDemoMoonBasementCollapse() { mIsAlreadyShowDemoMoonBasementCollapse = true; }
+    void saveShowDemoMoonBasementCollapse() { mIsShowDemoMoonBasementCollapse = true; }
 
     void resetLv3Data();
     void write(al::ByamlWriter* writer) override;

--- a/src/System/BossSaveData.h
+++ b/src/System/BossSaveData.h
@@ -14,6 +14,13 @@ public:
     void onAlreadyDeadGK(s32 world, s32 lv);
     bool isAlreadyShowDemoBattleEndKoopaLv2() const;
     void saveDemoBattleEndKoopaLv2();
+
+    bool isAlreadyShowDemoMoonBasementCollapse() const {
+        return mIsAlreadyShowDemoMoonBasementCollapse;
+    }
+
+    void saveShowDemoMoonBasementCollapse() { mIsAlreadyShowDemoMoonBasementCollapse = true; }
+
     void resetLv3Data();
     void write(al::ByamlWriter* writer) override;
     void read(const al::ByamlIter& save) override;

--- a/src/System/BossSaveData.h
+++ b/src/System/BossSaveData.h
@@ -15,13 +15,13 @@ public:
     bool isAlreadyShowDemoBattleEndKoopaLv2() const;
     void saveDemoBattleEndKoopaLv2();
 
-    bool isAlreadyShowDemoMoonBasementCollapse() const { return mIsShowDemoMoonBasementCollapse; }
-
-    void saveShowDemoMoonBasementCollapse() { mIsShowDemoMoonBasementCollapse = true; }
-
     void resetLv3Data();
     void write(al::ByamlWriter* writer) override;
     void read(const al::ByamlIter& save) override;
+
+    bool isAlreadyShowDemoMoonBasementCollapse() const { return mIsShowDemoMoonBasementCollapse; }
+
+    void saveShowDemoMoonBasementCollapse() { mIsShowDemoMoonBasementCollapse = true; }
 
 private:
     static constexpr u32 sBossBattleStartWorldNum = 13;

--- a/src/System/CapMessageBossData.h
+++ b/src/System/CapMessageBossData.h
@@ -6,14 +6,14 @@ class CapMessageBossData {
 public:
     CapMessageBossData();
     void init();
-    void invalidateMessage(s32 worldId);
-    bool isValidateMessage(s32 worldId) const;
-    void incrementBossBattleCount(s32 worldId);
-    s32 getBattleCount(s32 worldId) const;
+    void invalidateMessage(s32 flag);
+    bool isValidateMessage(s32 flag) const;
+    void incrementBossBattleCount(s32 bossType);
+    s32 getBattleCount(s32 bossType) const;
 
 private:
-    bool* mMessageFlags;
-    s32* mBattleCounts;
+    bool* mMessageFlag;
+    s32* mBattleCount;
 };
 
 static_assert(sizeof(CapMessageBossData) == 0x10);

--- a/src/System/CapMessageBossData.h
+++ b/src/System/CapMessageBossData.h
@@ -5,15 +5,15 @@
 class CapMessageBossData {
 public:
     CapMessageBossData();
-
     void init();
-    bool invalidateMessage(s32);
-    bool isValidateMessage(s32) const;
-    void incrementBossBattleCount(s32);
-    s32 getBattleCount(s32) const;
+    void invalidateMessage(s32 worldId);
+    bool isValidateMessage(s32 worldId) const;
+    void incrementBossBattleCount(s32 worldId);
+    s32 getBattleCount(s32 worldId) const;
 
 private:
-    char filler[0x10];
+    bool* mMessageFlags;
+    s32* mBattleCounts;
 };
 
 static_assert(sizeof(CapMessageBossData) == 0x10);

--- a/src/System/GameDataFile.h
+++ b/src/System/GameDataFile.h
@@ -530,6 +530,8 @@ public:
 
     MoonRockData* getMoonRockData() const { return mMoonRockData; }
 
+    BossSaveData* getBossSaveData() const { return mBossSaveData; }
+
     NetworkUploadFlag* getNetworkUploadFlag() const { return mNetworkUploadFlag; }
 
     HintPhotoData* getHintPhotoData() const { return mHintPhotoData; }


### PR DESCRIPTION
Free functions in the `rs` namespace for boss battle state tracking and eye movement. Includes `CapMessageBossData.h`, `BossSaveData.h`, and an update to `GameDataFile.h` as required dependencies.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/929)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 1f8d28c)

📈 **Matched code**: 15.50% (+0.01%, +1196 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossUtil/BossUtil` | `rs::endBossBattle(al::LiveActor const*, int)` | +188 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::updateEyeMove(al::LiveActor*, sead::Vector3<float> const&, float, char const*)` | +156 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::tryCreateBarrierField(al::ActorInitInfo const&)` | +124 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::isAlreadyShowDemoBossBattleStart(al::LiveActor const*, int, int)` | +88 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::isAlreadyDeadGK(al::LiveActor const*, int, int)` | +88 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::saveShowDemoBossBattleStart(al::LiveActor const*, int, int)` | +84 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::onAlreadyDeadGK(al::LiveActor const*, int, int)` | +84 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::isAlreadyShowDemoBossBattleEndKoopaLv2(al::LiveActor const*)` | +64 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::saveShowDemoMoonBasementCollapse(al::LiveActor const*)` | +64 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::saveShowDemoBossBattleEndKoopaLv2(al::LiveActor const*)` | +60 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::isAlreadyShowDemoMoonBasementCollapse(al::LiveActor const*)` | +60 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::resetEyeMove(al::LiveActor*, char const*)` | +52 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::startBossBattle(al::LiveActor const*, int)` | +48 | 0.00% | 100.00% |
| `Boss/BossUtil/BossUtil` | `rs::getBossBattleDeadCount(al::LiveActor const*, int)` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->