### PR TITLE
Enemy: Add some headers

### DIFF
--- a/lib/al/Library/Action/RootSercher.h
+++ b/lib/al/Library/Action/RootSercher.h
@@ -15,7 +15,7 @@ public:
     u32 calcTotalCost() const;
 };
 
-class RootSercher : public al::HioNode {
+class RootSercher : public HioNode {
 public:
     RootSercher();
 

--- a/lib/al/Library/Action/RootSercher.h
+++ b/lib/al/Library/Action/RootSercher.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+namespace al {
+class RootSercherNode {
+public:
+    RootSercherNode();
+
+    void clear();
+    void open();
+    void close();
+    u32 calcTotalCost() const;
+};
+
+class RootSercher : public al::HioNode {
+public:
+    RootSercher();
+
+    void init(s32, s32);
+    void clear();
+    RootSercherNode* tryGetNode(s32, s32) const;
+    RootSercherNode* getNode(s32, s32) const;
+    RootSercherNode* findMinCostOpenNode() const;
+    void closeNode(RootSercherNode*, s32, s32);
+    void removeOpenList(RootSercherNode*);
+    void openNode(s32, s32, s32, s32, RootSercherNode*);
+    bool isEnableNode(s32, s32) const;
+    void addOpenList(RootSercherNode*);
+    bool start(s32, s32, s32, s32, s32, s32);
+    u32 calcNextIndex(s32*, s32*, s32, s32) const;
+
+    virtual u32 calcHeuristicCost(s32, s32, s32, s32) const;
+    virtual u32 getConnectCount() const;
+    virtual u32 getConnectIndex(s32*, s32*, s32, s32, s32) const;
+    virtual bool checkReach(s32, s32) const;
+    virtual u32 calcCost(s32, s32, const RootSercherNode*) const;
+
+private:
+    char filler_0[0x48];
+};
+
+static_assert(sizeof(RootSercher) == 0x48);
+
+}  // namespace al

--- a/lib/al/Library/Action/RootSercher.h
+++ b/lib/al/Library/Action/RootSercher.h
@@ -39,7 +39,7 @@ public:
     virtual u32 calcCost(s32, s32, const RootSercherNode*) const;
 
 private:
-    char filler_0[0x48];
+    char filler_8[0x40];
 };
 
 static_assert(sizeof(RootSercher) == 0x48);

--- a/src/Enemy/BirdCarryMeat.h
+++ b/src/Enemy/BirdCarryMeat.h
@@ -6,8 +6,9 @@ class BirdCarryMeat : public al::LiveActor {
 public:
     BirdCarryMeat(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void control() override;
 
     const sead::Matrix34f* getBindMtx() const;

--- a/src/Enemy/BirdCarryMeat.h
+++ b/src/Enemy/BirdCarryMeat.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BirdCarryMeat : public al::LiveActor {
+public:
+    BirdCarryMeat(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void control() override;
+
+    const sead::Matrix34f* getBindMtx() const;
+    void skipDemo();
+    void exeWaitOnRail();
+    void exeDemoCarryMeat();
+    void exeMoveMeat();
+    void exeReactionCarry();
+    void exeDrop();
+    void exeFlyAway();
+    bool isDropNerve() const;
+
+    al::RailRider* getRailRider() const override;
+
+private:
+    char filler_108[0x78];
+};
+
+static_assert(sizeof(BirdCarryMeat) == 0x180);

--- a/src/Enemy/BirdCarryMeat.h
+++ b/src/Enemy/BirdCarryMeat.h
@@ -24,7 +24,7 @@ public:
     al::RailRider* getRailRider() const override;
 
 private:
-    char filler_108[0x78];
+    char filler_108[0x180 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(BirdCarryMeat) == 0x180);

--- a/src/Enemy/Bubble.cpp
+++ b/src/Enemy/Bubble.cpp
@@ -193,7 +193,7 @@ void Bubble::init(const al::ActorInitInfo& info) {
 
     mShadowMaskOffset.set(al::getShadowMaskOffset(this, "body"));
     mShadowMaskDropLength = al::getShadowMaskDropLength(this, "body");
-    mDisregardReceiver = new DisregardReceiver(this, nullptr);
+    mDisregardReceiver = new DisregardReceiver(this);
     mPlayerHackStartShaderCtrl = new PlayerHackStartShaderCtrl(this, &gPlayerHackStartShaderParam);
 
     al::startAction(this, "Wait");

--- a/src/Enemy/Bubble2D.h
+++ b/src/Enemy/Bubble2D.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+class Bubble2D : public al::LiveActor, public IUseDimension {
+public:
+    Bubble2D(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void exeInitDelay();
+
+    void exeWait();
+    void exeMove();
+    void exeReturn();
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+
+private:
+    char filler_110[0x38];
+};
+
+static_assert(sizeof(Bubble2D) == 0x148);

--- a/src/Enemy/Bubble2D.h
+++ b/src/Enemy/Bubble2D.h
@@ -8,8 +8,8 @@ class Bubble2D : public al::LiveActor, public IUseDimension {
 public:
     Bubble2D(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     void exeInitDelay();
 
     void exeWait();
@@ -19,7 +19,7 @@ public:
     ActorDimensionKeeper* getActorDimensionKeeper() const override;
 
 private:
-    char filler_110[0x38];
+    char filler_110[0x148 - sizeof(al::LiveActor) - sizeof(IUseDimension)];
 };
 
 static_assert(sizeof(Bubble2D) == 0x148);

--- a/src/Enemy/Bull.h
+++ b/src/Enemy/Bull.h
@@ -7,7 +7,7 @@ public:
     Bull(const char* name) : al::LiveActor(name) { /* TODO: Implement inlined ctor */ }
 
     const char* getSensorNameSendAttack();
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void switchOn();
     void control() override;
     void deathAndReset();
@@ -35,8 +35,9 @@ public:
     void exeReviveAppear();
     void exeHack();
 
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void startHack(const al::SensorMsg*, al::HitSensor*, al::HitSensor*);
     bool tryReceiveMsgTrample(const al::SensorMsg*, const al::HitSensor*, const al::HitSensor*);
 

--- a/src/Enemy/Bull.h
+++ b/src/Enemy/Bull.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Bull : public al::LiveActor {
+public:
+    Bull(const char* name) : al::LiveActor(name) { /* TODO: Implement inlined ctor */ }
+
+    const char* getSensorNameSendAttack();
+    void init(const al::ActorInitInfo&) override;
+    void switchOn();
+    void control() override;
+    void deathAndReset();
+    void updateCollider() override;
+
+    void exeNoStart();
+    void exeWait();
+    void exeTurn();
+    void exeFind();
+    void exeChase();
+    void endChase();
+    void exeBrake();
+    void exeClash();
+    void exeAttack();
+    void exeFall();
+    void exeDamageCap();
+    void exeTrampled();
+    void exeTrampledEnd();
+    void exeAngry();
+    void exePressDown();
+    void exeBlowDown();
+    void exeSwoon();
+    void exeReset();
+    void exeRevive();
+    void exeReviveAppear();
+    void exeHack();
+
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void startHack(const al::SensorMsg*, al::HitSensor*, al::HitSensor*);
+    bool tryReceiveMsgTrample(const al::SensorMsg*, const al::HitSensor*, const al::HitSensor*);
+
+private:
+    char filler_108[0x40];
+};
+
+static_assert(sizeof(Bull) == 0x148);

--- a/src/Enemy/Bull.h
+++ b/src/Enemy/Bull.h
@@ -42,7 +42,7 @@ public:
     bool tryReceiveMsgTrample(const al::SensorMsg*, const al::HitSensor*, const al::HitSensor*);
 
 private:
-    char filler_108[0x40];
+    char filler_108[0x148 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Bull) == 0x148);

--- a/src/Enemy/Byugo.h
+++ b/src/Enemy/Byugo.h
@@ -6,12 +6,13 @@ class Byugo : public al::LiveActor {
 public:
     Byugo(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     void calcBlowPowerRate() const;
     void calcWindForce(sead::Vector3f*, const sead::Vector3f&, f32) const;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void exeDelay();
     void exeRevive();

--- a/src/Enemy/Byugo.h
+++ b/src/Enemy/Byugo.h
@@ -36,7 +36,7 @@ public:
     f32 getFrontStart() const;
 
 private:
-    char filler_108[0x70];
+    char filler_108[0x178 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Byugo) == 0x178);

--- a/src/Enemy/Byugo.h
+++ b/src/Enemy/Byugo.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Byugo : public al::LiveActor {
+public:
+    Byugo(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void calcBlowPowerRate() const;
+    void calcWindForce(sead::Vector3f*, const sead::Vector3f&, f32) const;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+    void exeDelay();
+    void exeRevive();
+    void exeAppear();
+    void exeWait();
+    bool isMoveAtWait() const;
+    bool updateKeyMove();
+    void exeBlowSign();
+    void exeBlowStart();
+    void exeBlow();
+    bool isMoveAtBlow() const;
+    void sendBlowMsgToCollision();
+    void exeBlowEnd();
+    void exeReactionBlow();
+    void exeDamageCap();
+    void exeHack();
+    void exeSwoon();
+    f32 getSideStart() const;
+    f32 getFrontEnd() const;
+    f32 getSideEnd() const;
+    f32 getFrontStart() const;
+
+private:
+    char filler_108[0x70];
+};
+
+static_assert(sizeof(Byugo) == 0x178);

--- a/src/Enemy/CatchBomb.cpp
+++ b/src/Enemy/CatchBomb.cpp
@@ -67,7 +67,7 @@ void CatchBomb::init(const al::ActorInitInfo& info) {
     mJointSpringControllerHolder->init(this, "InitJointSpringCtrl");
     makeActorAlive();
     al::invalidateShadowMask(this, "ダミー帽子影");
-    mDisregardReceiver = new DisregardReceiver(this, nullptr);
+    mDisregardReceiver = new DisregardReceiver(this);
     mCatchBombGeneratePoint = new al::LiveActor("キャッチボム出現ポイント");
     al::initActorWithArchiveName(mCatchBombGeneratePoint, info, "CatchBombGeneratePoint", nullptr);
     mCatchBombGeneratePoint->makeActorAlive();

--- a/src/Enemy/Chorobon.h
+++ b/src/Enemy/Chorobon.h
@@ -8,18 +8,18 @@ class Chorobon : public al::LiveActor, public IUseDimension {
 public:
     Chorobon(const char* name, const f32*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
 
     void exeMove();
     void exeReaction();
 
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
     ActorDimensionKeeper* getActorDimensionKeeper() const override;
 
 private:
-    char filler_110[0x50];
+    char filler_110[0x160 - sizeof(al::LiveActor) - sizeof(IUseDimension)];
 };
 
 static_assert(sizeof(Chorobon) == 0x160);

--- a/src/Enemy/Chorobon.h
+++ b/src/Enemy/Chorobon.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+class Chorobon : public al::LiveActor, public IUseDimension {
+public:
+    Chorobon(const char* name, const f32*);
+
+    void init(const al::ActorInitInfo&) override;
+    void control() override;
+
+    void exeMove();
+    void exeReaction();
+
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+
+private:
+    char filler_110[0x50];
+};
+
+static_assert(sizeof(Chorobon) == 0x160);

--- a/src/Enemy/ChorobonHolder.h
+++ b/src/Enemy/ChorobonHolder.h
@@ -6,7 +6,7 @@ class ChorobonHolder : public al::LiveActor {
 public:
     ChorobonHolder(const char*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     void appear() override;
 

--- a/src/Enemy/ChorobonHolder.h
+++ b/src/Enemy/ChorobonHolder.h
@@ -4,14 +4,14 @@
 
 class ChorobonHolder : public al::LiveActor {
 public:
-    ChorobonHolder(const char*);
+    ChorobonHolder(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
     void control() override;
     void appear() override;
 
 private:
-    char filler_108[0x30];
+    char filler_108[0x138 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(ChorobonHolder) == 0x138);

--- a/src/Enemy/ChorobonHolder.h
+++ b/src/Enemy/ChorobonHolder.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class ChorobonHolder : public al::LiveActor {
+public:
+    ChorobonHolder(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+    void control() override;
+    void appear() override;
+
+private:
+    char filler_108[0x30];
+};
+
+static_assert(sizeof(ChorobonHolder) == 0x138);

--- a/src/Enemy/CornBoy.h
+++ b/src/Enemy/CornBoy.h
@@ -7,10 +7,11 @@ class CornBoy : public al::LiveActor {
 public:
     CornBoy(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void endCapture();
     void exeWait();

--- a/src/Enemy/CornBoy.h
+++ b/src/Enemy/CornBoy.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+// Unused class
+class CornBoy : public al::LiveActor {
+public:
+    CornBoy(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void control() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+    void endCapture();
+    void exeWait();
+    void exeSwoon();
+    void exeCaptureStart();
+    void exeCaptureStartEnd();
+    void exeCaptureEnd();
+    void isEnableCharge() const;
+    bool tryCharge();
+    bool tryStartLaunch();
+    void exeCaptureWait();
+    void exeCaptureRun();
+    void exeCaptureAim();
+    void exeCaptureLaunchStart();
+    void exeCaptureLaunch();
+    void exeCaptureLaunchEnd();
+    void exeCaptureFall();
+    void exeCaptureLand();
+    void exeCaptureCoolDown();
+    void exeDie();
+
+private:
+    char filler_108[0x80];
+};
+
+static_assert(sizeof(CornBoy) == 0x188);

--- a/src/Enemy/CornBoy.h
+++ b/src/Enemy/CornBoy.h
@@ -34,7 +34,7 @@ public:
     void exeDie();
 
 private:
-    char filler_108[0x80];
+    char filler_108[0x188 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(CornBoy) == 0x188);

--- a/src/Enemy/DisregardReceiver.h
+++ b/src/Enemy/DisregardReceiver.h
@@ -11,9 +11,9 @@ class SensorMsg;
 
 class DisregardReceiver {
 public:
-    DisregardReceiver(al::LiveActor*, const char*);
+    DisregardReceiver(al::LiveActor* actor, const char* fileSuffix = nullptr);
 
-    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other);
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
     bool checkActionDisregardAll() const;
     bool checkActionDisregardHomingAttack() const;
     bool checkActionDisregardTargetMarker() const;

--- a/src/Enemy/Donsuke.h
+++ b/src/Enemy/Donsuke.h
@@ -6,10 +6,11 @@ class Donsuke : public al::LiveActor {
 public:
     Donsuke(const char*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void endClipped() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void control() override;
 
     void exeWait();

--- a/src/Enemy/Donsuke.h
+++ b/src/Enemy/Donsuke.h
@@ -4,7 +4,7 @@
 
 class Donsuke : public al::LiveActor {
 public:
-    Donsuke(const char*);
+    Donsuke(const char* name);
 
     void init(const al::ActorInitInfo& info) override;
     void endClipped() override;
@@ -52,7 +52,7 @@ public:
     bool isPlayerPosBack();
 
 private:
-    char filler_108[0x78];
+    char filler_108[0x180 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Donsuke) == 0x180);

--- a/src/Enemy/Donsuke.h
+++ b/src/Enemy/Donsuke.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Donsuke : public al::LiveActor {
+public:
+    Donsuke(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+    void endClipped() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void control() override;
+
+    void exeWait();
+    void exeFind();
+    void mainMove();
+    void exeSideStep();
+    void exeRunFront();
+    void startActionRunFront();
+    void exeRunBack();
+    void exeSideStepUnwilling();
+    void exeRunFrontUnwilling();
+    void exeTurn();
+    void exeAttackSign();
+    void exeAttack();
+    void exeAttackImpact();
+    void exeAttackWait();
+    void exeAttackEndSign();
+    void exeAttackEnd();
+    void exeDamage();
+    void exeDown();
+    void exeReviveWait();
+    void exeAppearSign();
+
+    bool tryCalcPlayerPos();
+    bool isAbleAttack();
+    bool isAbleMove(s32);
+    bool isPlayerPosCenter();
+    bool isPlayerPosHead();
+    bool isAbleTurn(s32);
+    bool isPlayerPosFront();
+    bool isPlayerPosAttack();
+    bool isPlayerPosAttackCenterLine();
+    bool isPlayerPosAttackNotMoveable();
+    bool isShouldSideStep(s32);
+    bool isPlayerPosRight();
+    bool isPlayerPosLeft();
+    bool isPlayerPosSide();
+    bool isPlayerPosCenterLine();
+    bool isPlayerPosBack();
+
+private:
+    char filler_108[0x78];
+};
+
+static_assert(sizeof(Donsuke) == 0x180);

--- a/src/Enemy/ElectricBall.h
+++ b/src/Enemy/ElectricBall.h
@@ -7,7 +7,7 @@ class ElectricBall : public al::LiveActor {
 public:
     ElectricBall(const char* name, al::LiveActor*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
 
     void setChargeLevel(s32);

--- a/src/Enemy/ElectricBall.h
+++ b/src/Enemy/ElectricBall.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+// Unused class
+class ElectricBall : public al::LiveActor {
+public:
+    ElectricBall(const char* name, al::LiveActor*);
+
+    void init(const al::ActorInitInfo&) override;
+    void control() override;
+
+    void setChargeLevel(s32);
+    void exeWait();
+
+private:
+    al::LiveActor* _108;
+    s32 _110;
+};
+
+static_assert(sizeof(ElectricBall) == 0x118);

--- a/src/Enemy/ElectricExplosion.h
+++ b/src/Enemy/ElectricExplosion.h
@@ -7,9 +7,9 @@ class ElectricExplosion : public al::LiveActor {
 public:
     ElectricExplosion(const char* name, al::LiveActor*);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void attack(s32);
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
 
     void exeWait();
     void exeAttack();

--- a/src/Enemy/ElectricExplosion.h
+++ b/src/Enemy/ElectricExplosion.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+// Unused class
+class ElectricExplosion : public al::LiveActor {
+public:
+    ElectricExplosion(const char* name, al::LiveActor*);
+
+    void init(const al::ActorInitInfo&) override;
+    void attack(s32);
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+
+    void exeWait();
+    void exeAttack();
+
+private:
+    al::LiveActor* _108;
+    s32 _110;
+};
+
+static_assert(sizeof(ElectricExplosion) == 0x118);

--- a/src/Enemy/GabuZou.h
+++ b/src/Enemy/GabuZou.h
@@ -7,14 +7,15 @@ class GabuZouGroup;
 class GabuZou : public al::LiveActor {
 public:
     GabuZou(const char* name);
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
 
     f32 calcSerchSizeX() const;
     f32 calcSerchSizeZ() const;
     void initAfterPlacement() override;
     bool checkCollision(const sead::Vector3i&) const;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void setGabuzouGroup(const GabuZouGroup*);
     bool checkReach(s32, s32) const;

--- a/src/Enemy/GabuZou.h
+++ b/src/Enemy/GabuZou.h
@@ -34,7 +34,7 @@ public:
     void exeSink();
 
 private:
-    char filler_108[0xc8];
+    char filler_108[0x1d0 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(GabuZou) == 0x1d0);

--- a/src/Enemy/GabuZou.h
+++ b/src/Enemy/GabuZou.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GabuZouGroup;
+
+class GabuZou : public al::LiveActor {
+public:
+    GabuZou(const char* name);
+    void init(const al::ActorInitInfo&) override;
+
+    f32 calcSerchSizeX() const;
+    f32 calcSerchSizeZ() const;
+    void initAfterPlacement() override;
+    bool checkCollision(const sead::Vector3i&) const;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+    void setGabuzouGroup(const GabuZouGroup*);
+    bool checkReach(s32, s32) const;
+    bool checkReach(const sead::Vector3f&) const;
+    bool isInSerchRange(const sead::Vector3i&) const;
+    f32 calcPlayerExpectPos() const;
+    bool isLeftPlayer() const;
+    void nextNerve();
+    void exeWait();
+    void exeMove();
+    void exeTurn();
+    void exeRiseSign();
+    void exeRise();
+    void exeAttackSign();
+    void exeAttack();
+    void exeSink();
+
+private:
+    char filler_108[0xc8];
+};
+
+static_assert(sizeof(GabuZou) == 0x1d0);

--- a/src/Enemy/GabuZouGroup.h
+++ b/src/Enemy/GabuZouGroup.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/Action/RootSercher.h"
+#include "Library/LiveActor/LiveActor.h"
+
+class GabuZou;
+
+class GabuZouRootSercher : al::RootSercher {
+public:
+    bool checkReach(s32, s32) const override;
+};
+
+static_assert(sizeof(GabuZouRootSercher) == 0x48);
+
+class GabuZouGroup : public al::LiveActor {
+public:
+    GabuZouGroup(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    bool checkReach(const GabuZou*, const sead::Vector3f&) const;
+
+private:
+    al::LiveActorGroup* _108;
+};
+
+static_assert(sizeof(GabuZouGroup) == 0x110);

--- a/src/Enemy/GabuZouGroup.h
+++ b/src/Enemy/GabuZouGroup.h
@@ -5,7 +5,7 @@
 
 class GabuZou;
 
-class GabuZouRootSercher : al::RootSercher {
+class GabuZouRootSercher : public al::RootSercher {
 public:
     bool checkReach(s32, s32) const override;
 };
@@ -16,7 +16,7 @@ class GabuZouGroup : public al::LiveActor {
 public:
     GabuZouGroup(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     bool checkReach(const GabuZou*, const sead::Vector3f&) const;
 
 private:

--- a/src/Enemy/GabuZouGroup.h
+++ b/src/Enemy/GabuZouGroup.h
@@ -3,6 +3,10 @@
 #include "Library/Action/RootSercher.h"
 #include "Library/LiveActor/LiveActor.h"
 
+namespace al {
+class LiveActorGroup;
+}
+
 class GabuZou;
 
 class GabuZouRootSercher : public al::RootSercher {

--- a/src/Enemy/Gotogoton.h
+++ b/src/Enemy/Gotogoton.h
@@ -6,10 +6,11 @@ class Gotogoton : public al::LiveActor {
 public:
     Gotogoton(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void makeFaceList(const sead::Vector3i&, f32);
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void endHack(bool);
     void control() override;
 

--- a/src/Enemy/Gotogoton.h
+++ b/src/Enemy/Gotogoton.h
@@ -27,7 +27,7 @@ public:
     void exeEnd();
 
 private:
-    char filler_108[0xb0];
+    char filler_108[0x1B8 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Gotogoton) == 0x1b8);

--- a/src/Enemy/Gotogoton.h
+++ b/src/Enemy/Gotogoton.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Gotogoton : public al::LiveActor {
+public:
+    Gotogoton(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void makeFaceList(const sead::Vector3i&, f32);
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void endHack(bool);
+    void control() override;
+
+    void exeWait();
+    void exeHackStart();
+    void setNerveHackWait();
+    void exeHackWait();
+    void exeDontMoveReflect();
+    void exeDontMove();
+    void exeRotate();
+    void exeRotateCancel();
+    void exeHackEnd();
+    void exeSuccess();
+    void exeEnd();
+
+private:
+    char filler_108[0xb0];
+};
+
+static_assert(sizeof(Gotogoton) == 0x1b8);

--- a/src/Enemy/GotogotonEdge.h
+++ b/src/Enemy/GotogotonEdge.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+class GotogotonFace;
+
+class GotogotonEdge {
+public:
+    GotogotonEdge();
+
+    void setTrans(const sead::Vector3f&);
+    void setAxis(const sead::Vector3f&);
+    void setNextFace(const GotogotonFace*);
+    void calcAxisAndPos(sead::Vector3f*, sead::Vector3f*, const sead::Quatf&,
+                        const sead::Vector3f&) const;
+
+private:
+    sead::Vector3f mTrans;
+    sead::Vector3f mAxis;
+    const GotogotonFace* mNextFace;
+};
+
+static_assert(sizeof(GotogotonEdge) == 0x20);

--- a/src/Enemy/GotogotonFace.h
+++ b/src/Enemy/GotogotonFace.h
@@ -17,21 +17,20 @@ public:
     void setOppositeFace(const GotogotonFace*);
     void setCenter(const sead::Vector3f&);
     void setNormal(const sead::Vector3f&);
-    s32 calcNearEdgeIndexToPos(const sead::Vector3f&, const sead::Quat<float>&,
+    s32 calcNearEdgeIndexToPos(const sead::Vector3f&, const sead::Quatf&,
                                const sead::Vector3f&) const;
-    s32 calcNearEdgeIndexToDir(const sead::Vector3f&, const sead::Quat<float>&,
+    s32 calcNearEdgeIndexToDir(const sead::Vector3f&, const sead::Quatf&,
                                const sead::Vector3f&) const;
-    void rotate(sead::Quat<float>*, sead::Vector3f*, s32, const sead::Quat<float>&,
-                const sead::Vector3f&, f32) const;
+    void rotate(sead::Quatf*, sead::Vector3f*, s32, const sead::Quatf&, const sead::Vector3f&,
+                f32) const;
     s32 calcOppositeEdgeIndex(s32) const;
-    void calcRotateCenterPos(sead::Vector3f*, s32, const sead::Quat<float>&, const sead::Vector3f&,
+    void calcRotateCenterPos(sead::Vector3f*, s32, const sead::Quatf&, const sead::Vector3f&,
                              f32) const;
-    void calcLandEffectMtx(sead::Matrix34<float>*, const sead::Quat<float>&, const sead::Vector3f&,
-                           s32) const;
-    void calcLandEffectMtxNextFace(sead::Matrix34<float>*, const sead::Quat<float>&,
-                                   const sead::Vector3f&, s32) const;
-    void calcCenterPos(sead::Vector3f*, const sead::Quat<float>&, const sead::Vector3f&) const;
-    void calcCenterDir(sead::Vector3f*, const sead::Quat<float>&) const;
+    void calcLandEffectMtx(sead::Matrix34f*, const sead::Quatf&, const sead::Vector3f&, s32) const;
+    void calcLandEffectMtxNextFace(sead::Matrix34f*, const sead::Quatf&, const sead::Vector3f&,
+                                   s32) const;
+    void calcCenterPos(sead::Vector3f*, const sead::Quatf&, const sead::Vector3f&) const;
+    void calcCenterDir(sead::Vector3f*, const sead::Quatf&) const;
 
 private:
     char filler_0[0x28];

--- a/src/Enemy/GotogotonFace.h
+++ b/src/Enemy/GotogotonFace.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+class GotogotonMark;
+class GotogotonEdge;
+
+class GotogotonFace {
+public:
+    GotogotonFace();
+
+    GotogotonEdge* getEdge(s32);
+    const GotogotonEdge* getEdge(s32) const;
+    const GotogotonFace* getNextFace(s32) const;
+    void setOppositeFace(const GotogotonFace*);
+    void setCenter(const sead::Vector3f&);
+    void setNormal(const sead::Vector3f&);
+    s32 calcNearEdgeIndexToPos(const sead::Vector3f&, const sead::Quat<float>&,
+                               const sead::Vector3f&) const;
+    s32 calcNearEdgeIndexToDir(const sead::Vector3f&, const sead::Quat<float>&,
+                               const sead::Vector3f&) const;
+    void rotate(sead::Quat<float>*, sead::Vector3f*, s32, const sead::Quat<float>&,
+                const sead::Vector3f&, f32) const;
+    s32 calcOppositeEdgeIndex(s32) const;
+    void calcRotateCenterPos(sead::Vector3f*, s32, const sead::Quat<float>&, const sead::Vector3f&,
+                             f32) const;
+    void calcLandEffectMtx(sead::Matrix34<float>*, const sead::Quat<float>&, const sead::Vector3f&,
+                           s32) const;
+    void calcLandEffectMtxNextFace(sead::Matrix34<float>*, const sead::Quat<float>&,
+                                   const sead::Vector3f&, s32) const;
+    void calcCenterPos(sead::Vector3f*, const sead::Quat<float>&, const sead::Vector3f&) const;
+    void calcCenterDir(sead::Vector3f*, const sead::Quat<float>&) const;
+
+private:
+    char filler_0[0x28];
+};
+
+static_assert(sizeof(GotogotonFace) == 0x28);

--- a/src/Enemy/GrowerBug.h
+++ b/src/Enemy/GrowerBug.h
@@ -28,7 +28,7 @@ public:
                     al::HitSensor* self) override;
 
 private:
-    char filler_108[0x38];
+    char filler_108[0x140 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(GrowerBug) == 0x140);

--- a/src/Enemy/GrowerBug.h
+++ b/src/Enemy/GrowerBug.h
@@ -8,7 +8,7 @@ public:
               bool createdFromFactory =
                   true);  // Defaults to true so that the default createActorFunction template works
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void onKill();
     void appear() override;
     void updateCollider() override;
@@ -23,8 +23,9 @@ public:
     void exePressDown();
     void exeDead();
 
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
 private:
     char filler_108[0x38];

--- a/src/Enemy/GrowerBug.h
+++ b/src/Enemy/GrowerBug.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GrowerBug : public al::LiveActor {
+public:
+    GrowerBug(const char* name,
+              bool createdFromFactory =
+                  true);  // Defaults to true so that the default createActorFunction template works
+
+    void init(const al::ActorInitInfo&) override;
+    void onKill();
+    void appear() override;
+    void updateCollider() override;
+
+    void exeAppear();
+    void exeWander();
+    void exeFind();
+    void exeAttackSign();
+    void exeAttack();
+    void exeBurst();
+    void exeBlowDown();
+    void exePressDown();
+    void exeDead();
+
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+private:
+    char filler_108[0x38];
+};
+
+static_assert(sizeof(GrowerBug) == 0x140);

--- a/src/Enemy/GrowerWorm.h
+++ b/src/Enemy/GrowerWorm.h
@@ -6,7 +6,7 @@ class GrowerWorm : public al::LiveActor {
 public:
     GrowerWorm(const char* nane);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void onKill();
     void appear() override;
     bool isEnableReAppear() const;
@@ -22,8 +22,9 @@ public:
     void exePressDown();
     void exeBlowDown();
 
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
 private:
     char filler_108[0x28];

--- a/src/Enemy/GrowerWorm.h
+++ b/src/Enemy/GrowerWorm.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GrowerWorm : public al::LiveActor {
+public:
+    GrowerWorm(const char* nane);
+
+    void init(const al::ActorInitInfo&) override;
+    void onKill();
+    void appear() override;
+    bool isEnableReAppear() const;
+
+    void exeWait();
+    void exeAppear();
+    void exeMove();
+    void exeTurn();
+    void exeBornSign();
+    void exeBorn();
+    void exeBornDead();
+    void exeDead();
+    void exePressDown();
+    void exeBlowDown();
+
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+private:
+    char filler_108[0x28];
+};
+
+static_assert(sizeof(GrowerWorm) == 0x130);

--- a/src/Enemy/GrowerWorm.h
+++ b/src/Enemy/GrowerWorm.h
@@ -27,7 +27,7 @@ public:
                     al::HitSensor* self) override;
 
 private:
-    char filler_108[0x28];
+    char filler_108[0x130 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(GrowerWorm) == 0x130);

--- a/src/Enemy/Gunetter.h
+++ b/src/Enemy/Gunetter.h
@@ -6,11 +6,12 @@ class Gunetter : public al::LiveActor {
 public:
     Gunetter(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
     void control() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void exeWait();
     void exeChase();

--- a/src/Enemy/Gunetter.h
+++ b/src/Enemy/Gunetter.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Gunetter : public al::LiveActor {
+public:
+    Gunetter(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void initAfterPlacement() override;
+    void control() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+    void exeWait();
+    void exeChase();
+    void exeKeyMove();
+    void exeKeyMoveSide();
+
+private:
+    char filler_108[0x40];
+};
+
+static_assert(sizeof(Gunetter) == 0x148);

--- a/src/Enemy/Imomu.h
+++ b/src/Enemy/Imomu.h
@@ -6,13 +6,14 @@ class Imomu : public al::LiveActor {
 public:
     Imomu(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void control() override;
     bool tryResetHack(bool);
     void updateCameraTarget();
     void updateCollider() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
 
     void endHack(bool);
     void exeEnemy();

--- a/src/Enemy/Imomu.h
+++ b/src/Enemy/Imomu.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Imomu : public al::LiveActor {
+public:
+    Imomu(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void control() override;
+    bool tryResetHack(bool);
+    void updateCameraTarget();
+    void updateCollider() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+
+    void endHack(bool);
+    void exeEnemy();
+    void exeHackMove();
+    void exeHackExpandSign();
+    bool tryEndHackExpand(bool);
+    void exeHackExpand();
+    void updateExpandCore(bool*, bool*, bool*, f32);
+    void exeHackExpandWait();
+    void exeHackExpandHold();
+    void exeHackEndExpandNoShrink();
+    void exeHackShrinkToBody();
+    void exeShrinkToHead();
+    void exeHackShrinkReaction();
+    u32 getVisibleBodyNum() const;
+
+private:
+    char filler_108[0xb8];
+};
+
+static_assert(sizeof(Imomu) == 0x1c0);

--- a/src/Enemy/Imomu.h
+++ b/src/Enemy/Imomu.h
@@ -31,7 +31,7 @@ public:
     u32 getVisibleBodyNum() const;
 
 private:
-    char filler_108[0xb8];
+    char filler_108[0x1c0 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Imomu) == 0x1c0);

--- a/src/Enemy/Jango/Jango.h
+++ b/src/Enemy/Jango/Jango.h
@@ -6,10 +6,11 @@ class Jango : public al::LiveActor {
 public:
     Jango(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void initAfterPlacement() override;
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     void control() override;
 
     bool isEnableCap() const;

--- a/src/Enemy/Jango/Jango.h
+++ b/src/Enemy/Jango/Jango.h
@@ -22,7 +22,7 @@ public:
     void exeBlowDown();
 
 private:
-    char filler_108[0x80];
+    char filler_108[0x188 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Jango) == 0x188);

--- a/src/Enemy/Jango/Jango.h
+++ b/src/Enemy/Jango/Jango.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Jango : public al::LiveActor {
+public:
+    Jango(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    void control() override;
+
+    bool isEnableCap() const;
+    bool tryOffCapCatchedSwitch();
+    void exeWaitCapGetDemo();
+    void exeCapGetDemo();
+    void exeEscape();
+    void exeSurprise();
+    void exeBlowDown();
+
+private:
+    char filler_108[0x80];
+};
+
+static_assert(sizeof(Jango) == 0x188);
+
+namespace JangoFunction {
+void setCapTransOnJoint(al::LiveActor*, al::LiveActor*);
+void resetCapTransOnJoint(al::LiveActor*, al::LiveActor*);
+void resetTransJointRoot(al::LiveActor*);
+}  // namespace JangoFunction

--- a/src/Enemy/Tsukkun.h
+++ b/src/Enemy/Tsukkun.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class HitInfo;
+class ArrowHitInfo;
+}  // namespace al
+
+namespace TsukkunUtil {
+bool isStickReflectCode(const al::HitInfo*);
+}  // namespace TsukkunUtil
+
+class Tsukkun : public al::LiveActor {
+public:
+    Tsukkun(const char* name);
+
+    void init(const al::ActorInitInfo&) override;
+    void validateSensors();
+    void setAnimHackOff();
+    void start();
+    void setAnimHackOn();
+    void setBend(const sead::Vector3f&, const sead::Vector3f&, f32);
+    void clearBend();
+    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    bool isEnableAttack() const;
+    bool isEnablePush() const;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    bool isEnableDamage() const;
+    bool isStateEnemy() const;
+    void deathAndReset();
+    bool isEnableCapLockOn() const;
+    void startHack(al::HitSensor*, al::HitSensor*);
+    bool isEnableCap() const;
+    bool isEnableCapAttack() const;
+    void blowDownCap(al::HitSensor*);
+    void control() override;
+    void calcCenterPos(sead::Vector3f*) const;
+    void calcBeakPos(sead::Vector3f*) const;
+    void calcStickPos(sead::Vector3f*, sead::Vector3f*) const;
+    void appearBall(const sead::Vector3f&, const sead::Vector3f&);
+    void appearCap();
+    void exeStandBy();
+    void exeRevive();
+    void exeAppear();
+    void exeAppearBall();
+    void updateVelocity(f32, f32);
+    void exeAppearBallEnd();
+    void updateGround();
+    void exeWait();
+    void exeFind();
+    void exeMove();
+    void addMoveAccel(const sead::Vector3f&);
+    void setMoveActionRate(f32);
+    void exeThrustSign();
+    void exeThrust();
+    bool checkHitBeak(const al::ArrowHitInfo**, sead::Vector3f*) const;
+    void exeThrustLoop();
+    void exeThrustEnd();
+    void exeThrustCancel();
+    void exeDamageCap();
+    void exeSwoon();
+    void exeHack();
+    void exeTrampleDown();
+    void exeBlowDown();
+    void exeReset();
+    void updateVelocity();
+
+private:
+    char filler_108[0x78];
+};
+
+static_assert(sizeof(Tsukkun) == 0x180);

--- a/src/Enemy/Tsukkun.h
+++ b/src/Enemy/Tsukkun.h
@@ -15,17 +15,18 @@ class Tsukkun : public al::LiveActor {
 public:
     Tsukkun(const char* name);
 
-    void init(const al::ActorInitInfo&) override;
+    void init(const al::ActorInitInfo& info) override;
     void validateSensors();
     void setAnimHackOff();
     void start();
     void setAnimHackOn();
     void setBend(const sead::Vector3f&, const sead::Vector3f&, f32);
     void clearBend();
-    void attackSensor(al::HitSensor*, al::HitSensor*) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool isEnableAttack() const;
     bool isEnablePush() const;
-    bool receiveMsg(const al::SensorMsg*, al::HitSensor*, al::HitSensor*) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
     bool isEnableDamage() const;
     bool isStateEnemy() const;
     void deathAndReset();

--- a/src/Enemy/Tsukkun.h
+++ b/src/Enemy/Tsukkun.h
@@ -68,7 +68,7 @@ public:
     void updateVelocity();
 
 private:
-    char filler_108[0x78];
+    char filler_108[0x180 - sizeof(al::LiveActor)];
 };
 
 static_assert(sizeof(Tsukkun) == 0x180);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -39,10 +39,24 @@
 #include "Boss/Mofumofu/MofumofuScrap.h"
 #include "Camera/ScenarioStartCamera.h"
 #include "Demo/DemoPeachWedding.h"
+#include "Enemy/BirdCarryMeat.h"
 #include "Enemy/Bubble.h"
+#include "Enemy/Bubble2D.h"
+#include "Enemy/Bull.h"
+#include "Enemy/Byugo.h"
 #include "Enemy/CatchBomb.h"
+#include "Enemy/ChorobonHolder.h"
 #include "Enemy/DonkeyKong2D.h"
+#include "Enemy/Donsuke.h"
+#include "Enemy/GabuZou.h"
+#include "Enemy/GabuZouGroup.h"
 #include "Enemy/Gamane.h"
+#include "Enemy/Gotogoton.h"
+#include "Enemy/GrowerBug.h"
+#include "Enemy/GrowerWorm.h"
+#include "Enemy/Gunetter.h"
+#include "Enemy/Imomu.h"
+#include "Enemy/Jango/Jango.h"
 #include "Enemy/KaronWing.h"
 #include "Enemy/Kuribo2D.h"
 #include "Enemy/KuriboMini.h"
@@ -52,6 +66,7 @@
 #include "Enemy/Pecho.h"
 #include "Enemy/Togezo.h"
 #include "Enemy/Togezo2D.h"
+#include "Enemy/Tsukkun.h"
 #include "Item/Coin.h"
 #include "Item/Coin2D.h"
 #include "Item/Coin2DCityDirector.h"
@@ -169,7 +184,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BendLeafTree", nullptr},
     {"BgmPlayObj", nullptr},
     {"Bird", al::createActorFunction<Bird>},
-    {"BirdCarryMeat", nullptr},
+    {"BirdCarryMeat", al::createActorFunction<BirdCarryMeat>},
     {"BirdPlayerGlideCtrl", al::createActorFunction<BirdPlayerGlideCtrl>},
     {"BlockBrick", nullptr},
     {"BlockBrick2D", nullptr},
@@ -202,10 +217,10 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BreakablePole", al::createActorFunction<BreakablePole>},
     {"Breeda", nullptr},
     {"Bubble", al::createActorFunction<Bubble>},
-    {"Bubble2D", nullptr},
+    {"Bubble2D", al::createActorFunction<Bubble2D>},
     {"BubbleLauncher", nullptr},
-    {"Bull", nullptr},
-    {"Byugo", nullptr},
+    {"Bull", al::createActorFunction<Bull>},
+    {"Byugo", al::createActorFunction<Byugo>},
     {"Cactus", nullptr},
     {"CactusMini", nullptr},
     {"CageShine", nullptr},
@@ -249,7 +264,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"CatchBomb", al::createActorFunction<CatchBomb>},
     {"Chair", nullptr},
     {"CheckpointFlag", al::createActorFunction<CheckpointFlag>},
-    {"ChorobonHolder", nullptr},
+    {"ChorobonHolder", al::createActorFunction<ChorobonHolder>},
     {"ChurchDoor", al::createActorFunction<ChurchDoor>},
     {"CityBuilding", nullptr},
     {"CityStreetlight", nullptr},
@@ -302,7 +317,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"DokanMazeDirector", nullptr},
     {"DokanStageChange", nullptr},
     {"DonkeyKong2D", al::createActorFunction<DonkeyKong2D>},
-    {"Donsuke", nullptr},
+    {"Donsuke", al::createActorFunction<Donsuke>},
     {"Doshi", al::createActorFunction<Doshi>},
     {"DoorAreaChange", nullptr},
     {"DoorAreaChangeCap", nullptr},
@@ -351,25 +366,25 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"FukuwaraiWatcher", nullptr},
     {"ForestWorldEnergyStand", nullptr},
     {"ForestWorldFlowerCtrl", nullptr},
-    {"GabuZou", nullptr},
-    {"GabuZouGroup", nullptr},
+    {"GabuZou", al::createActorFunction<GabuZou>},
+    {"GabuZouGroup", al::createActorFunction<GabuZouGroup>},
     {"Gamane", al::createActorFunction<Gamane>},
     {"GiantWanderBoss", nullptr},
     {"GoalMark", nullptr},
     {"GolemClimb", nullptr},
-    {"Gotogoton", nullptr},
+    {"Gotogoton", al::createActorFunction<Gotogoton>},
     {"GotogotonGoal", nullptr},
     {"GraphicsObjShadowMaskCube", nullptr},
     {"GraphicsObjShadowMaskSphere", nullptr},
-    {"GrowerBug", nullptr},
-    {"GrowerWorm", nullptr},
+    {"GrowerBug", al::createActorFunction<GrowerBug>},
+    {"GrowerWorm", al::createActorFunction<GrowerWorm>},
     {"GrowFlowerCoin", nullptr},
     {"GrowFlowerWatcher", nullptr},
     {"GrowPlantGrowPlace", nullptr},
     {"GrowPlantSeed", nullptr},
     {"GrowPlantStartStage", nullptr},
     {"GrowPlantWatcher", nullptr},
-    {"Gunetter", nullptr},
+    {"Gunetter", al::createActorFunction<Gunetter>},
     {"GunetterMove", nullptr},
     {"HackCar", nullptr},
     {"HackFork", al::createActorFunction<HackFork>},
@@ -392,9 +407,9 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HomeShip", al::createActorFunction<HomeShip>},
     {"Hosui", nullptr},
     {"IcicleFall", nullptr},
-    {"Imomu", nullptr},
+    {"Imomu", al::createActorFunction<Imomu>},
     {"IndicatorDirector", nullptr},
-    {"Jango", nullptr},
+    {"Jango", al::createActorFunction<Jango>},
     {"Joku", nullptr},
     {"JugemFishing", nullptr},
     {"JumpingRopeNpc", nullptr},
@@ -653,7 +668,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"TRexPatrol", nullptr},
     {"TRexSleep", nullptr},
     {"TRexScrollBreakMapParts", nullptr},
-    {"Tsukkun", nullptr},
+    {"Tsukkun", al::createActorFunction<Tsukkun>},
     {"TsukkunHole", nullptr},
     {"TwistChainList", nullptr},
     {"Utsubo", nullptr},


### PR DESCRIPTION
This PR adds some enemy headers and actor factory entries as well as does some misc enemy related changes. The actor creation function for `Bull` mismatches because the ctor is inlined into that function and it isn't fully implemented yet. I didn't add `sizeof` asserts to these classes because `tools/check` automatically checks the sizes whenever there's code instanciating these actors (like in the creation functions)

This headers have been created using the following steps:
  * Running my new automatic header creation tool
  * Running the new linter on those headers to do stuff like automatically copying the param names for overriding functions
  * Manually verifying return types and typeinfo and clening the headers up

Some of the return types aren't that easy to figure out without decompiling the class, but I tried my best. I've also made the assumption that all functions that have a name starting with "is" return a boolean without manually checking them

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/945)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 6c230d2)

📈 **Matched code**: 15.15% (+0.01%, +732 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/Jango/JangoDirector` | `JangoDirector::JangoDirector()` | +64 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<GrowerBug>(char const*)` | +56 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BirdCarryMeat>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Bubble2D>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Byugo>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<ChorobonHolder>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Donsuke>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<GabuZou>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<GabuZouGroup>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Gotogoton>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<GrowerWorm>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Gunetter>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Imomu>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Jango>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Tsukkun>(char const*)` | +52 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::registerJango(Jango*)` | +28 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::placeCap()` | +12 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::isEnableCap() const` | +8 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::removeCap()` | +8 | 0.00% | 100.00% |
| `Enemy/Jango/JangoDirector` | `JangoDirector::~JangoDirector()` | +4 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 7 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/JangoDirector` | `JangoDirector::JangoDirector()` | -64 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::registerJango(Jango*)` | -28 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::placeCap()` | -12 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::getSceneObjName() const` | -12 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::isEnableCap() const` | -8 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::removeCap()` | -8 | 100.00% | 0.00% |
| `Enemy/JangoDirector` | `JangoDirector::~JangoDirector()` | -4 | 100.00% | 0.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Bull>(char const*)` | +43 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->