### PR TITLE
Scene: Add some headers and complete factory

### DIFF
--- a/src/Scene/DemoChangeWorldScene.h
+++ b/src/Scene/DemoChangeWorldScene.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+class WipeHolder;
+class GamePadSystem;
+class StageInfo;
+}  // namespace al
+
+class DemoChangeWorldGraphicsDataHolder;
+
+class DemoChangeWorldScene : public al::Scene {
+public:
+    DemoChangeWorldScene(al::WipeHolder* wipeHolder = nullptr);
+    ~DemoChangeWorldScene() override;
+
+    void setGraphicsDataHolder(const DemoChangeWorldGraphicsDataHolder*);
+    void init(const al::SceneInitInfo& info) override;
+    void initPlacement(const al::GamePadSystem*, const al::ActorInitInfo&);
+    u32 decideScenario(s32, s32, s32, s32);
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void drawMain() const override;
+
+    void exeFirstDemo();
+    void exeDemoBegin();
+    bool isTypeOnlyDemoBegin() const;
+    void endDemoBegin();
+    void exeTalk();
+    void exeDemoEnd();
+    void requestScreenCoverNerveDemoEnd();
+    void exeSkipDemo();
+
+    void initPlacementSky(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementObject(const al::StageInfo*, const al::ActorInitInfo&, const char*);
+
+private:
+    s8 filler_d8[0x358 - sizeof(al::Scene)];
+};

--- a/src/Scene/DemoChangeWorldScene.h
+++ b/src/Scene/DemoChangeWorldScene.h
@@ -39,3 +39,5 @@ public:
 private:
     s8 filler_d8[0x358 - sizeof(al::Scene)];
 };
+
+static_assert(sizeof(DemoChangeWorldScene) == 0x358);

--- a/src/Scene/DemoScene.h
+++ b/src/Scene/DemoScene.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+class WipeHolder;
+class StageInfo;
+}  // namespace al
+
+class DemoScene : public al::Scene {
+public:
+    DemoScene(al::WipeHolder* wipeHolder = nullptr);
+    ~DemoScene() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void initPlacement(const al::ActorInitInfo&);
+    void appear() override;
+    void control() override;
+    void kill() override;
+    void drawMain() const override;
+    virtual void exePlay();
+    bool isLoadEnd() const;
+    void exeSkipProc();
+    virtual void initLayout(const al::LayoutInitInfo&);
+
+    void initPlacementSky(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementDemo(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementObject(const al::StageInfo*, const al::ActorInitInfo&, const char*);
+
+private:
+    s8 filler_d8[0x198 - sizeof(al::Scene)];
+};

--- a/src/Scene/DemoScene.h
+++ b/src/Scene/DemoScene.h
@@ -30,3 +30,5 @@ public:
 private:
     s8 filler_d8[0x198 - sizeof(al::Scene)];
 };
+
+static_assert(sizeof(DemoScene) == 0x198);

--- a/src/Scene/DemoSceneWithCinemaCaption.h
+++ b/src/Scene/DemoSceneWithCinemaCaption.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "Scene/DemoScene.h"
+
+class DemoSceneWithCinemaCaption : public DemoScene {
+public:
+    DemoSceneWithCinemaCaption(al::WipeHolder* wipeHolder = nullptr);
+    ~DemoSceneWithCinemaCaption() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void exePlay() override;
+    void initLayout(const al::LayoutInitInfo&) override;
+
+private:
+    s8 filler_198[0x1A8 - sizeof(DemoScene)];
+};

--- a/src/Scene/DemoSceneWithCinemaCaption.h
+++ b/src/Scene/DemoSceneWithCinemaCaption.h
@@ -14,3 +14,5 @@ public:
 private:
     s8 filler_198[0x1A8 - sizeof(DemoScene)];
 };
+
+static_assert(sizeof(DemoSceneWithCinemaCaption) == 0x1A8);

--- a/src/Scene/EndingScene.h
+++ b/src/Scene/EndingScene.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+class StageInfo;
+class WipeHolder;
+}  // namespace al
+
+class EndingScene : public al::Scene {
+public:
+    EndingScene(al::WipeHolder* wipeHolder = nullptr);
+    ~EndingScene() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void initPlacement(const al::ActorInitInfo&);
+    void appear() override;
+    void control() override;
+    void kill() override;
+    void drawMain() const override;
+    virtual void exePlay();
+    bool isLoadEnd() const;
+    void exeSkipProc();
+    virtual void initLayout(const al::LayoutInitInfo&);
+
+    void initPlacementSky(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementDemo(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementObject(const al::StageInfo*, const al::ActorInitInfo&, const char*);
+
+private:
+    s8 filler_d8[0x190 - sizeof(al::Scene)];
+};

--- a/src/Scene/EndingScene.h
+++ b/src/Scene/EndingScene.h
@@ -30,3 +30,5 @@ public:
 private:
     s8 filler_d8[0x190 - sizeof(al::Scene)];
 };
+
+static_assert(sizeof(EndingScene) == 0x190);

--- a/src/Scene/ProjectSceneFactory.cpp
+++ b/src/Scene/ProjectSceneFactory.cpp
@@ -2,19 +2,26 @@
 
 #include "Library/Scene/CreateSceneFunc.h"
 
+#include "Scene/DemoChangeWorldScene.h"
+#include "Scene/DemoScene.h"
+#include "Scene/DemoSceneWithCinemaCaption.h"
+#include "Scene/EndingScene.h"
 #include "Scene/FirstSequenceScene.h"
+#include "Scene/StaffRollScene.h"
+#include "Scene/StageScene.h"
 #include "Scene/TitleMenuScene.h"
+#include "Scene/WorldWarpHoleScene.h"
 
 const al::NameToCreator<alSceneFunction::SceneCreatorFunction> sProjectSceneFactoryEntries[] = {
-    {"DemoChangeWorldScene", nullptr},
-    {"DemoScene", nullptr},
-    {"DemoSceneWithCinemaCaption", nullptr},
-    {"EndingScene", nullptr},
+    {"DemoChangeWorldScene", alSceneFunction::createSceneFunc<DemoChangeWorldScene>},
+    {"DemoScene", alSceneFunction::createSceneFunc<DemoScene>},
+    {"DemoSceneWithCinemaCaption", alSceneFunction::createSceneFunc<DemoSceneWithCinemaCaption>},
+    {"EndingScene", alSceneFunction::createSceneFunc<EndingScene>},
     {"FirstSequenceScene", alSceneFunction::createSceneFunc<FirstSequenceScene>},
-    {"StageScene", nullptr},
-    {"StaffRollScene", nullptr},
+    {"StageScene", alSceneFunction::createSceneFunc<StageScene>},
+    {"StaffRollScene", alSceneFunction::createSceneFunc<StaffRollScene>},
     {"TitleMenuScene", alSceneFunction::createSceneFunc<TitleMenuScene>},
-    {"WorldWarpHoleScene", nullptr}};
+    {"WorldWarpHoleScene", alSceneFunction::createSceneFunc<WorldWarpHoleScene>}};
 
 ProjectSceneFactory::ProjectSceneFactory() : SceneFactory("シーン生成") {
     initFactory(sProjectSceneFactoryEntries);

--- a/src/Scene/StaffRollScene.h
+++ b/src/Scene/StaffRollScene.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Library/Message/IUseMessageSystem.h"
+#include "Library/Scene/Scene.h"
+
+namespace al {
+class WipeHolder;
+class StageInfo;
+}  // namespace al
+
+class StaffRollScene : public al::Scene, public al::IUseMessageSystem {
+public:
+    StaffRollScene(al::WipeHolder* wipeHolder = nullptr);
+    ~StaffRollScene() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void initRollLineData();
+    void appear() override;
+    void control() override;
+    void kill() override;
+    void drawMain() const override;
+
+    void exeTitleLogo();
+    void exeRollLine();
+    void initCurrentRollLines();
+    void initSlideShowFrame();
+    void updateRollLine();
+    void updateSlideShow();
+    bool tryChangeToSkipConfirm(const al::Nerve*);
+    void exeThank();
+    void dropAllRollLine();
+    void exeShowPicture();
+    void exeRight();
+    void exeConfirm();
+    void exeSkipProc();
+    void exeSkipWipe();
+    void killRollLine();
+    u32 getMyNerveStep() const;
+    virtual void initLayout(const al::LayoutInitInfo&);
+    f32 calcNameRollTimeRate(f32);
+    void dropCurrentToStock();
+    void initPlacement(const al::ActorInitInfo&);
+    void initPlacementSky(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementObject(const al::StageInfo*, const al::ActorInitInfo&, const char*);
+    void initPlacementDemo(const al::StageInfo*, const al::ActorInitInfo&);
+    bool isCanSkip();
+
+    const al::MessageSystem* getMessageSystem() const override;
+
+private:
+    s8 filler_e0[0x6250 - sizeof(al::Scene) - sizeof(al::IUseMessageSystem)];
+};

--- a/src/Scene/StaffRollScene.h
+++ b/src/Scene/StaffRollScene.h
@@ -50,3 +50,5 @@ public:
 private:
     s8 filler_e0[0x6250 - sizeof(al::Scene) - sizeof(al::IUseMessageSystem)];
 };
+
+static_assert(sizeof(StaffRollScene) == 0x6250);

--- a/src/Scene/WorldWarpHoleScene.h
+++ b/src/Scene/WorldWarpHoleScene.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+class StageInfo;
+class WipeHolder;
+}  // namespace al
+
+class WorldWarpHoleScene : public al::Scene {
+public:
+    WorldWarpHoleScene(al::WipeHolder* wipeHolder = nullptr);
+    ~WorldWarpHoleScene() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void initPlacement(const al::ActorInitInfo&);
+    void appear() override;
+    void control() override;
+    void drawMain() const override;
+    bool tryEnd();
+    bool isEnableEndLoop() const;
+
+    void exeStart();
+    void exeLoop();
+    void exeEnd();
+    void exeSkipProc();
+
+    void initPlacementSky(const al::StageInfo*, const al::ActorInitInfo&);
+    void initPlacementObject(const al::StageInfo*, const al::ActorInitInfo&, const char*);
+    void initPlacementDemo(const al::StageInfo*, const al::ActorInitInfo&);
+
+private:
+    s8 filler_d8[0x1D0 - sizeof(al::Scene)];
+};

--- a/src/Scene/WorldWarpHoleScene.h
+++ b/src/Scene/WorldWarpHoleScene.h
@@ -32,3 +32,5 @@ public:
 private:
     s8 filler_d8[0x1D0 - sizeof(al::Scene)];
 };
+
+static_assert(sizeof(WorldWarpHoleScene) == 0x1D0);


### PR DESCRIPTION
This PR and some Scene related headers and completes the `ProjectSceneFactory`. These headers were made in a similar way #945 with the difference being that the vtable and typeinfo stuff is also now automated

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/946)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 7c03a94)

📈 **Matched code**: 15.15% (+0.00%, +332 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<DemoChangeWorldScene>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<DemoScene>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<DemoSceneWithCinemaCaption>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<EndingScene>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<StaffRollScene>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<WorldWarpHoleScene>()` | +48 | 0.00% | 100.00% |
| `Scene/ProjectSceneFactory` | `al::Scene* alSceneFunction::createSceneFunc<StageScene>()` | +44 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->