### PR TITLE
Library/Se: Implement `SeDemoProcInfo` and children

### DIFF
--- a/lib/al/Library/Se/SeDemoProcInfo.cpp
+++ b/lib/al/Library/Se/SeDemoProcInfo.cpp
@@ -1,0 +1,261 @@
+#include "Library/Se/SeDemoProcInfo.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+
+namespace al {
+SeDemoProcInfo* SeDemoProcInfo::createInfo(const ByamlIter& iter) {
+    const char* name = nullptr;
+    if (!iter.tryGetStringByKey(&name, "Name"))
+        name = nullptr;
+
+    s32 triggerFrame = 0;
+    iter.tryGetIntByKey(&triggerFrame, "TriggerFrame");
+
+    s32 endFrame = -1;
+    iter.tryGetIntByKey(&endFrame, "EndFrame");
+
+    if (!name)
+        return nullptr;
+
+    if (SeDemoProcInfo::isChangeSituation(name))
+        return SeDemoSituationInfo::createInfo(iter, name, triggerFrame, endFrame);
+
+    if (SeDemoProcInfo::isPause(name))
+        return SeDemoPauseInfo::createInfo(iter, name, triggerFrame, endFrame);
+
+    if (SeDemoProcInfo::isStopOneShot(name))
+        return SeDemoStopOneShotInfo::createInfo(iter, name, triggerFrame, endFrame);
+
+    if (SeDemoProcInfo::isChnageListenerPoser(name))
+        return SeDemoListenerPoserInfo::createInfo(iter, name, triggerFrame, endFrame);
+
+    if (SeDemoProcInfo::isPlaySe(name))
+        return SeDemoPlaySeInfo::createInfo(iter, name, triggerFrame, endFrame);
+
+    return nullptr;
+}
+
+SeDemoProcInfo* SeDemoProcInfo::tryCreate(const char* name) {
+    if (!name)
+        return nullptr;
+
+    if (isChangeSituation(name)) {
+        SeDemoSituationInfo* info = new SeDemoSituationInfo();
+        info->name = name;
+        return info;
+    }
+
+    if (isPause(name)) {
+        SeDemoPauseInfo* info = new SeDemoPauseInfo();
+        info->name = name;
+        return info;
+    }
+
+    if (isStopOneShot(name)) {
+        SeDemoStopOneShotInfo* info = new SeDemoStopOneShotInfo();
+        info->name = name;
+        return info;
+    }
+
+    if (isChnageListenerPoser(name)) {
+        SeDemoListenerPoserInfo* info = new SeDemoListenerPoserInfo();
+        info->name = name;
+        return info;
+    }
+
+    if (isPlaySe(name)) {
+        SeDemoPlaySeInfo* info = new SeDemoPlaySeInfo();
+        info->name = name;
+        return info;
+    }
+
+    return nullptr;
+}
+
+s32 SeDemoProcInfo::compareInfo(const SeDemoProcInfo* lhs, const SeDemoProcInfo* rhs) {
+    return strcmp(lhs->name, rhs->name);
+}
+
+bool SeDemoProcInfo::isChangeSituation(const char* name) {
+    if (name)
+        return isEqualString(name, "ChnageSituation");
+    return false;
+}
+
+bool SeDemoProcInfo::isPause(const char* name) {
+    if (name)
+        return isEqualString(name, "Pause");
+    return false;
+}
+
+bool SeDemoProcInfo::isStopOneShot(const char* name) {
+    if (name)
+        return isEqualString(name, "StopOneShot");
+    return false;
+}
+
+bool SeDemoProcInfo::isChnageListenerPoser(const char* name) {
+    if (name)
+        return isEqualString(name, "ChnageListenerPoser");
+    return false;
+}
+
+bool SeDemoProcInfo::isPlaySe(const char* name) {
+    if (name)
+        return isEqualString(name, "PlaySe");
+    return false;
+}
+
+SeDemoProcInfo::SeDemoProcInfo() = default;
+
+SeDemoProcInfo::SeDemoProcInfo(const SeDemoProcInfo& info)
+    : name(info.name), triggerFrame(info.triggerFrame), endFrame(info.endFrame) {}
+
+SeDemoProcInfo::~SeDemoProcInfo() {
+    ;
+}
+
+void SeDemoProcInfo::dummy() {}
+
+SeDemoSituationInfo* SeDemoSituationInfo::createInfo(const ByamlIter& iter, const char* name,
+                                                     s32 triggerFrame, s32 endFrame) {
+    SeDemoSituationInfo* demoSituationInfo = new SeDemoSituationInfo();
+    demoSituationInfo->name = name;
+    demoSituationInfo->triggerFrame = triggerFrame;
+    demoSituationInfo->endFrame = endFrame;
+
+    if (!iter.tryGetStringByKey(&demoSituationInfo->situationName, "SituationName"))
+        demoSituationInfo->situationName = nullptr;
+
+    if (!iter.tryGetIntByKey(&demoSituationInfo->startFadeFrameNum, "StartFadeFrameNum"))
+        demoSituationInfo->startFadeFrameNum = -1;
+
+    if (!iter.tryGetIntByKey(&demoSituationInfo->endFadeFrameNum, "EndFadeFrameNum"))
+        demoSituationInfo->endFadeFrameNum = -1;
+
+    return demoSituationInfo;
+}
+
+s32 SeDemoSituationInfo::compareInfo(const SeDemoSituationInfo* lhs,
+                                     const SeDemoSituationInfo* rhs) {
+    return SeDemoProcInfo::compareInfo(lhs, rhs);
+}
+
+SeDemoSituationInfo::SeDemoSituationInfo() = default;
+
+SeDemoSituationInfo::SeDemoSituationInfo(const SeDemoSituationInfo& demoSituationInfo)
+    : SeDemoProcInfo(demoSituationInfo), situationName(demoSituationInfo.situationName),
+      startFadeFrameNum(demoSituationInfo.startFadeFrameNum),
+      endFadeFrameNum(demoSituationInfo.endFadeFrameNum) {}
+
+SeDemoPauseInfo* SeDemoPauseInfo::createInfo(const ByamlIter& iter, const char* name,
+                                             s32 triggerFrame, s32 endFrame) {
+    SeDemoPauseInfo* demoPauseInfo = new SeDemoPauseInfo();
+    demoPauseInfo->name = name;
+    demoPauseInfo->triggerFrame = triggerFrame;
+    demoPauseInfo->endFrame = endFrame;
+
+    if (!iter.tryGetIntByKey(&demoPauseInfo->fadeOutFrameNum, "FadeOutFrameNum"))
+        demoPauseInfo->fadeOutFrameNum = 0;
+
+    if (!iter.tryGetIntByKey(&demoPauseInfo->fadeInFrameNum, "FadeInFrameNum"))
+        demoPauseInfo->fadeInFrameNum = 0;
+
+    return demoPauseInfo;
+}
+
+s32 SeDemoPauseInfo::compareInfo(const SeDemoPauseInfo* lhs, const SeDemoPauseInfo* rhs) {
+    return SeDemoProcInfo::compareInfo(lhs, rhs);
+}
+
+SeDemoPauseInfo::SeDemoPauseInfo() = default;
+
+SeDemoPauseInfo::SeDemoPauseInfo(const SeDemoPauseInfo& demoPauseInfo)
+    : SeDemoProcInfo(demoPauseInfo), fadeOutFrameNum(demoPauseInfo.fadeOutFrameNum),
+      fadeInFrameNum(demoPauseInfo.fadeInFrameNum) {}
+
+SeDemoStopOneShotInfo* SeDemoStopOneShotInfo::createInfo(const ByamlIter& iter, const char* name,
+                                                         s32 triggerFrame, s32 endFrame) {
+    SeDemoStopOneShotInfo* demoStopOneShotInfo = new SeDemoStopOneShotInfo();
+    demoStopOneShotInfo->name = name;
+    demoStopOneShotInfo->triggerFrame = triggerFrame;
+    demoStopOneShotInfo->endFrame = endFrame;
+
+    if (!iter.tryGetIntByKey(&demoStopOneShotInfo->fadeOutFrameNum, "FadeOutFrameNum"))
+        demoStopOneShotInfo->fadeOutFrameNum = 45;
+
+    return demoStopOneShotInfo;
+}
+
+s32 SeDemoStopOneShotInfo::compareInfo(const SeDemoStopOneShotInfo* lhs,
+                                       const SeDemoStopOneShotInfo* rhs) {
+    return SeDemoProcInfo::compareInfo(lhs, rhs);
+}
+
+SeDemoStopOneShotInfo::SeDemoStopOneShotInfo() = default;
+
+SeDemoStopOneShotInfo::SeDemoStopOneShotInfo(const SeDemoStopOneShotInfo& demoStopOneShotInfo)
+    : SeDemoProcInfo(demoStopOneShotInfo), fadeOutFrameNum(demoStopOneShotInfo.fadeOutFrameNum) {}
+
+SeDemoListenerPoserInfo* SeDemoListenerPoserInfo::createInfo(const ByamlIter& iter,
+                                                             const char* name, s32 triggerFrame,
+                                                             s32 endFrame) {
+    SeDemoListenerPoserInfo* info = new SeDemoListenerPoserInfo();
+    info->name = name;
+    info->triggerFrame = triggerFrame;
+    info->endFrame = endFrame;
+
+    if (!iter.tryGetStringByKey(&info->poserName, "PoserName"))
+        info->name = nullptr;  // BUG: This should be info->poserName = nullptr;
+
+    if (!iter.tryGetIntByKey(&info->fadeOutFrameNum, "FadeOutFrameNum"))
+        info->fadeOutFrameNum = 0;
+
+    if (!iter.tryGetIntByKey(&info->fadeInFrameNum, "FadeInFrameNum"))
+        info->fadeInFrameNum = 0;
+
+    return info;
+}
+
+s32 SeDemoListenerPoserInfo::compareInfo(const SeDemoListenerPoserInfo* lhs,
+                                         const SeDemoListenerPoserInfo* rhs) {
+    return SeDemoProcInfo::compareInfo(lhs, rhs);
+}
+
+SeDemoListenerPoserInfo::SeDemoListenerPoserInfo() = default;
+
+SeDemoListenerPoserInfo::SeDemoListenerPoserInfo(
+    const SeDemoListenerPoserInfo& demoListenerPoserInfo)
+    : SeDemoProcInfo(demoListenerPoserInfo), poserName(demoListenerPoserInfo.poserName),
+      fadeOutFrameNum(demoListenerPoserInfo.fadeOutFrameNum),
+      fadeInFrameNum(demoListenerPoserInfo.fadeInFrameNum) {}
+
+SeDemoPlaySeInfo* SeDemoPlaySeInfo::createInfo(const ByamlIter& iter, const char* name,
+                                               s32 triggerFrame, s32 endFrame) {
+    SeDemoPlaySeInfo* demoPlaySeInfo = new SeDemoPlaySeInfo();
+    demoPlaySeInfo->name = name;
+    demoPlaySeInfo->triggerFrame = triggerFrame;
+    demoPlaySeInfo->endFrame = endFrame;
+
+    iter.tryGetStringByKey(&demoPlaySeInfo->playName, "SePlayName");
+    iter.tryGetBoolByKey(&demoPlaySeInfo->isStopSe, "IsStopSe");
+    iter.tryGetIntByKey(&demoPlaySeInfo->fadeOutFrameNum, "FadeOutFrameNum");
+    iter.tryGetBoolByKey(&demoPlaySeInfo->isStartSeEvenIfDemoSkip, "IsStartSeEvenIfDemoSkip");
+    iter.tryGetBoolByKey(&demoPlaySeInfo->isNotStopSeEvenIfDemoSkip, "IsNotStopSeEvenIfDemoSkip");
+
+    return demoPlaySeInfo;
+}
+
+s32 SeDemoPlaySeInfo::compareInfo(const SeDemoPlaySeInfo* lhs, const SeDemoPlaySeInfo* rhs) {
+    return SeDemoProcInfo::compareInfo(lhs, rhs);
+}
+
+SeDemoPlaySeInfo::SeDemoPlaySeInfo() = default;
+
+SeDemoPlaySeInfo::SeDemoPlaySeInfo(const SeDemoPlaySeInfo& demoPlaySeInfo)
+    : SeDemoProcInfo(demoPlaySeInfo), isStopSe(demoPlaySeInfo.isStopSe),
+      playName(demoPlaySeInfo.playName), fadeOutFrameNum(demoPlaySeInfo.fadeOutFrameNum),
+      isStartSeEvenIfDemoSkip(demoPlaySeInfo.isStartSeEvenIfDemoSkip),
+      isNotStopSeEvenIfDemoSkip(demoPlaySeInfo.isNotStopSeEvenIfDemoSkip) {}
+}  // namespace al

--- a/lib/al/Library/Se/SeDemoProcInfo.cpp
+++ b/lib/al/Library/Se/SeDemoProcInfo.cpp
@@ -78,45 +78,39 @@ s32 SeDemoProcInfo::compareInfo(const SeDemoProcInfo* lhs, const SeDemoProcInfo*
 }
 
 bool SeDemoProcInfo::isChangeSituation(const char* name) {
-    if (name)
-        return isEqualString(name, "ChnageSituation");
-    return false;
+    if (!name)
+        return false;
+    return isEqualString(name, "ChnageSituation");
 }
 
 bool SeDemoProcInfo::isPause(const char* name) {
-    if (name)
-        return isEqualString(name, "Pause");
-    return false;
+    if (!name)
+        return false;
+    return isEqualString(name, "Pause");
 }
 
 bool SeDemoProcInfo::isStopOneShot(const char* name) {
-    if (name)
-        return isEqualString(name, "StopOneShot");
-    return false;
+    if (!name)
+        return false;
+    return isEqualString(name, "StopOneShot");
 }
 
 bool SeDemoProcInfo::isChnageListenerPoser(const char* name) {
-    if (name)
-        return isEqualString(name, "ChnageListenerPoser");
-    return false;
+    if (!name)
+        return false;
+    return isEqualString(name, "ChnageListenerPoser");
 }
 
 bool SeDemoProcInfo::isPlaySe(const char* name) {
-    if (name)
-        return isEqualString(name, "PlaySe");
-    return false;
+    if (!name)
+        return false;
+    return isEqualString(name, "PlaySe");
 }
 
 SeDemoProcInfo::SeDemoProcInfo() = default;
 
 SeDemoProcInfo::SeDemoProcInfo(const SeDemoProcInfo& info)
     : name(info.name), triggerFrame(info.triggerFrame), endFrame(info.endFrame) {}
-
-SeDemoProcInfo::~SeDemoProcInfo() {
-    ;
-}
-
-void SeDemoProcInfo::dummy() {}
 
 SeDemoSituationInfo* SeDemoSituationInfo::createInfo(const ByamlIter& iter, const char* name,
                                                      s32 triggerFrame, s32 endFrame) {

--- a/lib/al/Library/Se/SeDemoProcInfo.h
+++ b/lib/al/Library/Se/SeDemoProcInfo.h
@@ -1,0 +1,105 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ByamlIter;
+
+struct SeDemoProcInfo {
+    static SeDemoProcInfo* createInfo(const ByamlIter& iter);
+    static SeDemoProcInfo* tryCreate(const char*);
+    static s32 compareInfo(const SeDemoProcInfo* lhs, const SeDemoProcInfo* rhs);
+    static bool isChangeSituation(const char* action);
+    static bool isPause(const char* action);
+    static bool isStopOneShot(const char* action);
+    static bool isChnageListenerPoser(const char* action);
+    static bool isPlaySe(const char* action);
+
+    SeDemoProcInfo();
+    SeDemoProcInfo(const SeDemoProcInfo&);
+
+    virtual ~SeDemoProcInfo();
+    virtual void dummy();
+
+    const char* name = nullptr;
+    s32 triggerFrame = 0;
+    s32 endFrame = -1;
+};
+
+static_assert(sizeof(SeDemoProcInfo) == 0x18);
+
+struct SeDemoSituationInfo : public SeDemoProcInfo {
+    static SeDemoSituationInfo* createInfo(const ByamlIter& iter, const char* name,
+                                           s32 triggerFrame, s32 endFrame);
+    static s32 compareInfo(const SeDemoSituationInfo* lhs, const SeDemoSituationInfo* rhs);
+
+    SeDemoSituationInfo();
+    SeDemoSituationInfo(const SeDemoSituationInfo& demoSituationInfo);
+
+    const char* situationName = nullptr;
+    s32 startFadeFrameNum = -1;
+    s32 endFadeFrameNum = -1;
+};
+
+static_assert(sizeof(SeDemoSituationInfo) == 0x28);
+
+struct SeDemoPauseInfo : public SeDemoProcInfo {
+    static SeDemoPauseInfo* createInfo(const ByamlIter& iter, const char* name, s32 triggerFrame,
+                                       s32 endFrame);
+    static s32 compareInfo(const SeDemoPauseInfo* lhs, const SeDemoPauseInfo* rhs);
+
+    SeDemoPauseInfo();
+    SeDemoPauseInfo(const SeDemoPauseInfo& demoPauseInfo);
+
+    s32 fadeOutFrameNum = 0;
+    s32 fadeInFrameNum = 0;
+};
+
+static_assert(sizeof(SeDemoPauseInfo) == 0x20);
+
+struct SeDemoStopOneShotInfo : public SeDemoProcInfo {
+    static SeDemoStopOneShotInfo* createInfo(const ByamlIter& iter, const char* name,
+                                             s32 triggerFrame, s32 endFrame);
+    static s32 compareInfo(const SeDemoStopOneShotInfo* lhs, const SeDemoStopOneShotInfo* rhs);
+
+    SeDemoStopOneShotInfo();
+    SeDemoStopOneShotInfo(const SeDemoStopOneShotInfo& demoStopOneShotInfo);
+
+    s32 fadeOutFrameNum = 45;
+};
+
+static_assert(sizeof(SeDemoStopOneShotInfo) == 0x20);
+
+struct SeDemoListenerPoserInfo : public SeDemoProcInfo {
+    static SeDemoListenerPoserInfo* createInfo(const ByamlIter& iter, const char* name,
+                                               s32 triggerFrame, s32 endFrame);
+    static s32 compareInfo(const SeDemoListenerPoserInfo* lhs, const SeDemoListenerPoserInfo* rhs);
+
+    SeDemoListenerPoserInfo();
+    SeDemoListenerPoserInfo(const SeDemoListenerPoserInfo& demoListenerPoserInfo);
+
+    const char* poserName = nullptr;
+    s32 fadeOutFrameNum = 0;
+    s32 fadeInFrameNum = 0;
+};
+
+static_assert(sizeof(SeDemoListenerPoserInfo) == 0x28);
+
+struct SeDemoPlaySeInfo : public SeDemoProcInfo {
+    static SeDemoPlaySeInfo* createInfo(const ByamlIter& iter, const char* name, s32 triggerFrame,
+                                        s32 endFrame);
+    static s32 compareInfo(const SeDemoPlaySeInfo* lhs, const SeDemoPlaySeInfo* rhs);
+
+    SeDemoPlaySeInfo();
+    SeDemoPlaySeInfo(const SeDemoPlaySeInfo& demoPlaySeInfo);
+
+    bool isStopSe = false;
+    const char* playName = nullptr;
+    s32 fadeOutFrameNum = -1;
+    bool isStartSeEvenIfDemoSkip = false;
+    bool isNotStopSeEvenIfDemoSkip = false;
+};
+
+static_assert(sizeof(SeDemoPlaySeInfo) == 0x30);
+
+}  // namespace al

--- a/lib/al/Library/Se/SeDemoProcInfo.h
+++ b/lib/al/Library/Se/SeDemoProcInfo.h
@@ -18,8 +18,9 @@ struct SeDemoProcInfo {
     SeDemoProcInfo();
     SeDemoProcInfo(const SeDemoProcInfo&);
 
-    virtual ~SeDemoProcInfo();
-    virtual void dummy();
+    virtual ~SeDemoProcInfo() { ; }
+
+    virtual void dummy() {}
 
     const char* name = nullptr;
     s32 triggerFrame = 0;


### PR DESCRIPTION
Another shotgun implementation. This time with typos and bugs. This implementation is done to help me implement `al::copyAudioInfoList` in the future.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/955)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (806645f - d5db765)

📈 **Matched code**: 14.77% (+0.03%, +3204 bytes)

<details>
<summary>✅ 38 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::createInfo(al::ByamlIter const&)` | +972 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::tryCreate(char const*)` | +356 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPlaySeInfo::createInfo(al::ByamlIter const&, char const*, int, int)` | +252 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoSituationInfo::createInfo(al::ByamlIter const&, char const*, int, int)` | +224 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoListenerPoserInfo::createInfo(al::ByamlIter const&, char const*, int, int)` | +196 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPauseInfo::createInfo(al::ByamlIter const&, char const*, int, int)` | +176 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoStopOneShotInfo::createInfo(al::ByamlIter const&, char const*, int, int)` | +144 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPlaySeInfo::SeDemoPlaySeInfo(al::SeDemoPlaySeInfo const&)` | +100 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoSituationInfo::SeDemoSituationInfo(al::SeDemoSituationInfo const&)` | +84 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoListenerPoserInfo::SeDemoListenerPoserInfo(al::SeDemoListenerPoserInfo const&)` | +84 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPauseInfo::SeDemoPauseInfo(al::SeDemoPauseInfo const&)` | +76 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoStopOneShotInfo::SeDemoStopOneShotInfo(al::SeDemoStopOneShotInfo const&)` | +68 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPlaySeInfo::SeDemoPlaySeInfo()` | +44 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::SeDemoProcInfo(al::SeDemoProcInfo const&)` | +44 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoSituationInfo::SeDemoSituationInfo()` | +36 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoStopOneShotInfo::SeDemoStopOneShotInfo()` | +36 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPauseInfo::SeDemoPauseInfo()` | +32 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoListenerPoserInfo::SeDemoListenerPoserInfo()` | +32 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::SeDemoProcInfo()` | +28 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::isChangeSituation(char const*)` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::isPause(char const*)` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::isStopOneShot(char const*)` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::isChnageListenerPoser(char const*)` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::isPlaySe(char const*)` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::~SeDemoProcInfo()` | +20 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoProcInfo::compareInfo(al::SeDemoProcInfo const*, al::SeDemoProcInfo const*)` | +12 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoSituationInfo::compareInfo(al::SeDemoSituationInfo const*, al::SeDemoSituationInfo const*)` | +12 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoPauseInfo::compareInfo(al::SeDemoPauseInfo const*, al::SeDemoPauseInfo const*)` | +12 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoStopOneShotInfo::compareInfo(al::SeDemoStopOneShotInfo const*, al::SeDemoStopOneShotInfo const*)` | +12 | 0.00% | 100.00% |
| `Library/Se/SeDemoProcInfo` | `al::SeDemoListenerPoserInfo::compareInfo(al::SeDemoListenerPoserInfo const*, al::SeDemoListenerPoserInfo const*)` | +12 | 0.00% | 100.00% |

...and 8 more new matches
</details>


<!-- decomp.dev report end -->