### PR TITLE
Audio: Implement `DemoSoundSynchronizer`

### DIFF
--- a/lib/al/Library/Application/ApplicationMessageReceiver.h
+++ b/lib/al/Library/Application/ApplicationMessageReceiver.h
@@ -14,6 +14,8 @@ public:
     void procMessage(u32 message);
     void update();
 
+    nn::oe::OperationMode getCachedOperationMode() const { return mOperationMode; }
+
 private:
     bool mIsUpdatedOperationMode = false;
     bool mIsUpdatedPerformanceMode = false;

--- a/lib/al/Library/Se/SeKeeper.h
+++ b/lib/al/Library/Se/SeKeeper.h
@@ -33,7 +33,7 @@ public:
     void setLifeTimeForHoldCall(const char*, u32, const char*);
     void stopAll(s32, const char*);
     void separatePlayingSePosFromEmitter();
-    void tryGetCurrentStreamSamplePos(const char*, const char*) const;
+    s32 tryGetCurrentStreamSamplePos(const char*, const char*) const;
     bool isPlaying(const char*);
     void checkIsPlayingSe(const char*, const char*);
     void validate();

--- a/src/Audio/DemoSoundSynchronizer.cpp
+++ b/src/Audio/DemoSoundSynchronizer.cpp
@@ -1,0 +1,97 @@
+#include "Audio/DemoSoundSynchronizer.h"
+
+#include <nn/oe.h>
+
+#include "Library/Application/ApplicationMessageReceiver.h"
+#include "Library/Audio/AudioDirector.h"
+#include "Library/Demo/DemoSyncedEventKeeper.h"
+#include "Library/Demo/DemoSyncedSeCtrl.h"
+#include "Library/Se/SeKeeper.h"
+
+DemoSoundSynchronizer::DemoSoundSynchronizer(const al::ApplicationMessageReceiver* receiver,
+                                             al::AudioDirector* audioDirector)
+    : mApplicationMessageReceiver(receiver), mAudioDirector(audioDirector) {}
+
+void DemoSoundSynchronizer::startSync() {
+    mIsHandheld =
+        mApplicationMessageReceiver->getCachedOperationMode() == nn::oe::OperationMode_Handheld;
+    mIsSyncActive = true;
+}
+
+void DemoSoundSynchronizer::endSync() {
+    mIsHandheld = false;
+
+    if (!mIsSyncActive)
+        return;
+
+    resume(0);
+    mIsSyncActive = false;
+}
+
+void DemoSoundSynchronizer::resume(s32 delay) {
+    if (!mIsPaused)
+        return;
+
+    mResumeDelay = delay;
+    tryResume();
+}
+
+void DemoSoundSynchronizer::update() {
+    if (mResumeDelay <= -1)
+        return;
+    tryResume();
+    mResumeDelay -= 1;
+}
+
+void DemoSoundSynchronizer::tryResume() {
+    if (mResumeDelay != 0)
+        return;
+
+    mAudioDirector->pauseSystem(false, "サウンド同期ポーズ", true, 0.0, false, false, true);
+    mIsPaused = false;
+    mResumeDelay = -1;
+}
+
+void DemoSoundSynchronizer::trySync(s32 currentTime, al::DemoSyncedEventKeeper* syncedEventKeeper) {
+    if (!mIsSyncActive)
+        return;
+
+    al::DemoSyncedSeCtrl* seCtrl = syncedEventKeeper->getDemoSyncedSeCtrl();
+    if (!seCtrl)
+        return;
+
+    const char* name = seCtrl->getCurPlayingSeName();
+    if (!name)
+        return;
+
+    al::SeKeeper* seKeeper = seCtrl->getSeKeeper();
+
+    trySyncCommon(currentTime, seCtrl->getCurPlayingSeStartFrame(),
+                  seKeeper->tryGetCurrentStreamSamplePos(name, nullptr));
+}
+
+void DemoSoundSynchronizer::trySyncCommon(s32 currentTime, s32 seStartFrame, s64 sample) {
+    mIsHandheld =
+        mApplicationMessageReceiver->getCachedOperationMode() == nn::oe::OperationMode_Handheld;
+
+    if (!mAudioDirector->isPpausedSystem("システムポーズ") && sample >= 0) {
+        s32 resumeDelay = s32((f32(sample) / 48000.0f) * 60.0f) + (seStartFrame - currentTime);
+        if (resumeDelay > 4) {
+            pause();
+            mResumeDelay = resumeDelay;
+        }
+    }
+}
+
+void DemoSoundSynchronizer::trySync(s32 currentTime, s32 seStartFrame, s64 sample) {
+    if (mIsSyncActive)
+        trySyncCommon(currentTime, seStartFrame, sample);
+}
+
+void DemoSoundSynchronizer::pause() {
+    if (!mIsPaused) {
+        mAudioDirector->pauseSystem(true, "サウンド同期ポーズ", true, 0.0, false, false, true);
+        mIsPaused = true;
+    } else
+        mResumeDelay = -1;
+}

--- a/src/Audio/DemoSoundSynchronizer.h
+++ b/src/Audio/DemoSoundSynchronizer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ApplicationMessageReceiver;
+class AudioDirector;
+class DemoSyncedEventKeeper;
+}  // namespace al
+
+class DemoSoundSynchronizer {
+public:
+    DemoSoundSynchronizer(const al::ApplicationMessageReceiver* receiver,
+                          al::AudioDirector* audioDirector);
+
+    void startSync();
+    void endSync();
+    void resume(s32 delay);
+    void update();
+    void tryResume();
+    void trySync(s32 currentTime, al::DemoSyncedEventKeeper* syncedEventKeeper);
+    void trySyncCommon(s32 currentTime, s32 delayFrames, s64 sample);
+    void trySync(s32 currentTime, s32 delayFrames, s64 sample);
+    void pause();
+
+private:
+    const al::ApplicationMessageReceiver* mApplicationMessageReceiver = nullptr;
+    al::AudioDirector* mAudioDirector = nullptr;
+    bool mIsHandheld = false;
+    bool mIsSyncActive = false;
+    s32 mResumeDelay = -1;
+    bool mIsPaused = false;
+};
+
+static_assert(sizeof(DemoSoundSynchronizer) == 0x20, "DemoSoundSynchronizer size");

--- a/src/Audio/DemoSoundSynchronizer.h
+++ b/src/Audio/DemoSoundSynchronizer.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ApplicationMessageReceiver;
+class AudioDirector;
+class DemoSyncedEventKeeper;
+}  // namespace al
+
+class DemoSoundSynchronizer {
+public:
+    DemoSoundSynchronizer(const al::ApplicationMessageReceiver* receiver,
+                          al::AudioDirector* audioDirector);
+
+    void startSync();
+    void endSync();
+    void resume(s32 delay);
+    void update();
+    void tryResume();
+    void trySync(s32 currentTime, al::DemoSyncedEventKeeper* syncedEventKeeper);
+    void trySyncCommon(s32 currentTime, s32 seStartFrame, s64 sample);
+    void trySync(s32 currentTime, s32 seStartFrame, s64 sample);
+    void pause();
+
+private:
+    const al::ApplicationMessageReceiver* mApplicationMessageReceiver = nullptr;
+    al::AudioDirector* mAudioDirector = nullptr;
+    bool mIsHandheld = false;
+    bool mIsSyncActive = false;
+    s32 mResumeDelay = -1;
+    bool mIsPaused = false;
+};
+
+static_assert(sizeof(DemoSoundSynchronizer) == 0x20, "DemoSoundSynchronizer size");


### PR DESCRIPTION
Depends on #964

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/966)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (2da9983 - 2d09955)

📈 **Matched code**: 14.77% (+0.01%, +1336 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::trySync(int, al::DemoSyncedEventKeeper*)` | +300 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::trySync(int, int, long)` | +232 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::trySyncCommon(int, int, long)` | +224 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::endSync()` | +116 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::update()` | +108 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::pause()` | +104 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::resume(int)` | +100 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::tryResume()` | +96 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::startSync()` | +32 | 0.00% | 100.00% |
| `Audio/DemoSoundSynchronizer` | `DemoSoundSynchronizer::DemoSoundSynchronizer(al::ApplicationMessageReceiver const*, al::AudioDirector*)` | +24 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->