### PR TITLE
Npc: Implement `TrafficRailWatcher`

### DIFF
--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -15,27 +15,28 @@ TrafficRailWatcher::TrafficRailWatcher(const al::PlacementInfo& placementInfo) {
 }
 
 void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
-    auto* info = new ActorInfo;
-    info->actor = actor;
-    info->status = ActorStatus::Normal;
-    mActors[mActorCount] = info;
+    mActors[mActorCount] = new ActorInfo(actor);
     mActorCount++;
 }
 
+inline TrafficRailWatcher::ActorInfo* getActor(TrafficRailWatcher::ActorInfo** actorList,
+                                               const al::LiveActor* actor) {
+    // BUG: No bounds checking. Requesting an actor that is not in the actor list will softlock the
+    // thread
+    for (s32 i = 0; true; i++) {
+        TrafficRailWatcher::ActorInfo* info = actorList[i];
+        if (info->actor == actor)
+            return info;
+    }
+    return nullptr;
+}
+
 void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
-    ActorInfo** p = mActors;
-    ActorInfo* info;
-    while (info = *p, info->actor != actor)
-        info = *p++;
-    info->status = ActorStatus::StoppedByTraffic;
+    getActor(mActors, actor)->status = ActorStatus::StoppedByTraffic;
 }
 
 void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
-    ActorInfo** p = mActors;
-    ActorInfo* info;
-    while (info = *p, info->actor != actor)
-        info = *p++;
-    info->status = ActorStatus::Normal;
+    getActor(mActors, actor)->status = ActorStatus::Normal;
 }
 
 bool TrafficRailWatcher::isEqual(const al::PlacementInfo& placementInfo) const {
@@ -51,6 +52,11 @@ bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
     return false;
 }
 
+// TODO: Add to sead as a math util
+inline f32 modLength(f32 value, f32 length) {
+    return al::modf(value + length, length) + 0.0f;
+}
+
 bool isNearOnTrafficRail(const al::LiveActor* actor,
                          const TrafficRailWatcher::ActorInfo* otherInfo) {
     if (otherInfo->status != TrafficRailWatcher::ActorStatus::StoppedByTraffic &&
@@ -63,28 +69,27 @@ bool isNearOnTrafficRail(const al::LiveActor* actor,
         return false;
 
     f32 actorCoord = al::getRailCoord(actor);
-    f32 nearBound = al::getRailCoord(actor) + 150.0f;
-    f32 totalLength = al::getRailTotalLength(actor);
-    f32 wrapped = al::modf(nearBound + totalLength, totalLength) + 0.0f;
+    f32 nextRailCoord = modLength(al::getRailCoord(actor) + 150.0f, al::getRailTotalLength(actor));
 
-    f32 low, high;
-    if (al::isRailGoingToEnd(actor)) {
-        low = actorCoord;
-        high = wrapped;
-    } else {
-        high = actorCoord;
-        low = wrapped;
+    f32 startCoord = actorCoord;
+    f32 endCoord = nextRailCoord;
+    if (!al::isRailGoingToEnd(actor)) {
+        // We are going backwards, revert direction
+        endCoord = actorCoord;
+        startCoord = nextRailCoord;
     }
 
-    if (al::isLoopRail(actor) && high < low) {
-        if (low < al::getRailCoord(other))
+    if (al::isLoopRail(actor) && endCoord < startCoord) {
+        if (startCoord < al::getRailCoord(other))
             return true;
-    } else {
-        if (!(low < al::getRailCoord(other)))
-            return false;
+        return al::getRailCoord(other) < endCoord;
     }
 
-    return al::getRailCoord(other) < high;
+    if (startCoord < al::getRailCoord(other))
+        return al::getRailCoord(other) < endCoord;
+    return false;
+
+    return al::getRailCoord(other) < endCoord;
 }
 
 bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {

--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -26,18 +26,16 @@ void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
 void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
     TrafficRailActorInfo** p = mActors;
     TrafficRailActorInfo* info;
-    do {
+    while (info = *p, info->actor != actor)
         info = *p++;
-    } while (info->actor != actor);
     info->status = 1;
 }
 
 void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
     TrafficRailActorInfo** p = mActors;
     TrafficRailActorInfo* info;
-    do {
+    while (info = *p, info->actor != actor)
         info = *p++;
-    } while (info->actor != actor);
     info->status = 0;
 }
 
@@ -54,28 +52,10 @@ bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
     return false;
 }
 
-bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
-    TrafficRailActorInfo* actorInfo = nullptr;
-    for (s32 i = 0; i < mActorCount; i++) {
-        if (mActors[i]->actor == actor) {
-            actorInfo = mActors[i];
-            break;
-        }
-    }
-
-    for (s32 j = 0; j < mActorCount; j++) {
-        if (mActors[j] != actorInfo) {
-            if (isNearOnTrafficRail(actor, mActors[j])) {
-                actorInfo->status = 2;
-                return true;
-            }
-        }
-    }
-    return false;
-}
-
-bool isNearOnTrafficRail(const al::LiveActor* actor, const TrafficRailActorInfo* otherEntry) {
-    if ((u32)(otherEntry->status - 1) > 1)
+// NON_MATCHING
+bool isNearOnTrafficRail(const al::LiveActor* actor,
+                         const TrafficRailWatcher::TrafficRailActorInfo* otherEntry) {
+    if (otherEntry->status != 1 && otherEntry->status != 2)
         return false;
 
     const al::LiveActor* otherActor = otherEntry->actor;
@@ -99,15 +79,35 @@ bool isNearOnTrafficRail(const al::LiveActor* actor, const TrafficRailActorInfo*
 
     bool isLoop = al::isLoopRail(actor);
     f32 otherCoord = al::getRailCoord(otherActor);
-
     if (isLoop && high < low) {
         if (low < otherCoord)
             return true;
-    } else if (low >= otherCoord) {
-        return false;
+    } else {
+        if (low >= otherCoord)
+            return false;
     }
 
     return al::getRailCoord(otherActor) < high;
+}
+
+bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
+    TrafficRailActorInfo* actorInfo = nullptr;
+    for (s32 i = 0; i < mActorCount; i++) {
+        if (mActors[i]->actor == actor) {
+            actorInfo = mActors[i];
+            break;
+        }
+    }
+
+    for (s32 j = 0; j < mActorCount; j++) {
+        if (mActors[j] != actorInfo) {
+            if (isNearOnTrafficRail(actor, mActors[j])) {
+                actorInfo->status = 2;
+                return true;
+            }
+        }
+    }
+    return false;
 }
 
 bool TrafficRailWatcher::tryRestartByOtherNpc(const al::LiveActor* actor) {

--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -7,36 +7,35 @@
 #include "Library/Placement/PlacementInfo.h"
 #include "Library/Rail/RailUtil.h"
 
-TrafficRailWatcher::TrafficRailWatcher(const al::PlacementInfo& placementInfo)
-    : mPlacementId(nullptr), mActorCount(0), mActors(nullptr) {
+TrafficRailWatcher::TrafficRailWatcher(const al::PlacementInfo& placementInfo) {
     mPlacementId = al::createPlacementId(placementInfo);
-    mActors = new TrafficRailActorInfo*[32];
+    mActors = new ActorInfo*[32];
     for (s32 i = 0; i < 32; i++)
         mActors[i] = nullptr;
 }
 
 void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
-    auto* info = new TrafficRailActorInfo;
+    auto* info = new ActorInfo;
     info->actor = actor;
-    info->status = 0;
+    info->status = ActorStatus::Normal;
     mActors[mActorCount] = info;
     mActorCount++;
 }
 
 void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
-    TrafficRailActorInfo** p = mActors;
-    TrafficRailActorInfo* info;
+    ActorInfo** p = mActors;
+    ActorInfo* info;
     while (info = *p, info->actor != actor)
         info = *p++;
-    info->status = 1;
+    info->status = ActorStatus::StoppedByTraffic;
 }
 
 void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
-    TrafficRailActorInfo** p = mActors;
-    TrafficRailActorInfo* info;
+    ActorInfo** p = mActors;
+    ActorInfo* info;
     while (info = *p, info->actor != actor)
         info = *p++;
-    info->status = 0;
+    info->status = ActorStatus::Normal;
 }
 
 bool TrafficRailWatcher::isEqual(const al::PlacementInfo& placementInfo) const {
@@ -52,46 +51,44 @@ bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
     return false;
 }
 
-// NON_MATCHING
 bool isNearOnTrafficRail(const al::LiveActor* actor,
-                         const TrafficRailWatcher::TrafficRailActorInfo* otherEntry) {
-    if (otherEntry->status != 1 && otherEntry->status != 2)
+                         const TrafficRailWatcher::ActorInfo* otherInfo) {
+    if (otherInfo->status != TrafficRailWatcher::ActorStatus::StoppedByTraffic &&
+        otherInfo->status != TrafficRailWatcher::ActorStatus::StoppedByNpc)
         return false;
 
-    const al::LiveActor* otherActor = otherEntry->actor;
+    const al::LiveActor* other = otherInfo->actor;
 
-    if (!al::isRailGoingToEnd(actor) && al::isRailGoingToEnd(otherActor))
+    if (!al::isRailGoingToEnd(actor) && al::isRailGoingToEnd(other))
         return false;
 
     f32 actorCoord = al::getRailCoord(actor);
     f32 nearBound = al::getRailCoord(actor) + 150.0f;
     f32 totalLength = al::getRailTotalLength(actor);
-    f32 wrapped = al::modf(nearBound + totalLength, totalLength);
+    f32 wrapped = al::modf(nearBound + totalLength, totalLength) + 0.0f;
 
     f32 low, high;
     if (al::isRailGoingToEnd(actor)) {
         low = actorCoord;
         high = wrapped;
     } else {
-        low = wrapped;
         high = actorCoord;
+        low = wrapped;
     }
 
-    bool isLoop = al::isLoopRail(actor);
-    f32 otherCoord = al::getRailCoord(otherActor);
-    if (isLoop && high < low) {
-        if (low < otherCoord)
+    if (al::isLoopRail(actor) && high < low) {
+        if (low < al::getRailCoord(other))
             return true;
     } else {
-        if (low >= otherCoord)
+        if (!(low < al::getRailCoord(other)))
             return false;
     }
 
-    return al::getRailCoord(otherActor) < high;
+    return al::getRailCoord(other) < high;
 }
 
 bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
-    TrafficRailActorInfo* actorInfo = nullptr;
+    ActorInfo* actorInfo = nullptr;
     for (s32 i = 0; i < mActorCount; i++) {
         if (mActors[i]->actor == actor) {
             actorInfo = mActors[i];
@@ -100,18 +97,16 @@ bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
     }
 
     for (s32 j = 0; j < mActorCount; j++) {
-        if (mActors[j] != actorInfo) {
-            if (isNearOnTrafficRail(actor, mActors[j])) {
-                actorInfo->status = 2;
-                return true;
-            }
+        if (mActors[j] != actorInfo && isNearOnTrafficRail(actor, mActors[j])) {
+            actorInfo->status = ActorStatus::StoppedByNpc;
+            return true;
         }
     }
     return false;
 }
 
 bool TrafficRailWatcher::tryRestartByOtherNpc(const al::LiveActor* actor) {
-    TrafficRailActorInfo* actorInfo = nullptr;
+    ActorInfo* actorInfo = nullptr;
     for (s32 i = 0; i < mActorCount; i++) {
         if (mActors[i]->actor == actor) {
             actorInfo = mActors[i];
@@ -119,12 +114,10 @@ bool TrafficRailWatcher::tryRestartByOtherNpc(const al::LiveActor* actor) {
         }
     }
 
-    for (s32 i = 0; i < mActorCount; i++) {
-        if (mActors[i] == actorInfo)
-            continue;
-        if (isNearOnTrafficRail(actor, mActors[i]))
+    for (s32 i = 0; i < mActorCount; i++)
+        if (mActors[i] != actorInfo && isNearOnTrafficRail(actor, mActors[i]))
             return false;
-    }
-    actorInfo->status = 0;
+
+    actorInfo->status = ActorStatus::Normal;
     return true;
 }

--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -1,0 +1,130 @@
+#include "Npc/TrafficRailWatcher.h"
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Rail/RailUtil.h"
+
+TrafficRailWatcher::TrafficRailWatcher(const al::PlacementInfo& placementInfo)
+    : mPlacementId(nullptr), mActorCount(0), mActors(nullptr) {
+    mPlacementId = al::createPlacementId(placementInfo);
+    mActors = new TrafficRailActorInfo*[32];
+    for (s32 i = 0; i < 32; i++)
+        mActors[i] = nullptr;
+}
+
+void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
+    auto* info = new TrafficRailActorInfo;
+    info->actor = actor;
+    info->status = 0;
+    mActors[mActorCount] = info;
+    mActorCount++;
+}
+
+void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
+    TrafficRailActorInfo** p = mActors;
+    TrafficRailActorInfo* info;
+    do {
+        info = *p++;
+    } while (info->actor != actor);
+    info->status = 1;
+}
+
+void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
+    TrafficRailActorInfo** p = mActors;
+    TrafficRailActorInfo* info;
+    do {
+        info = *p++;
+    } while (info->actor != actor);
+    info->status = 0;
+}
+
+bool TrafficRailWatcher::isEqual(const al::PlacementInfo& placementInfo) const {
+    al::PlacementId placementId;
+    al::getPlacementId(&placementId, placementInfo);
+    return al::isEqualPlacementId(*mPlacementId, placementId);
+}
+
+bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
+    for (s32 i = 0; i < mActorCount; i++)
+        if (mActors[i]->actor == actor)
+            return true;
+    return false;
+}
+
+bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
+    TrafficRailActorInfo* actorInfo = nullptr;
+    for (s32 i = 0; i < mActorCount; i++) {
+        if (mActors[i]->actor == actor) {
+            actorInfo = mActors[i];
+            break;
+        }
+    }
+
+    for (s32 j = 0; j < mActorCount; j++) {
+        if (mActors[j] != actorInfo) {
+            if (isNearOnTrafficRail(actor, mActors[j])) {
+                actorInfo->status = 2;
+                return true;
+            }
+        }
+    }
+    return false;
+}
+
+bool isNearOnTrafficRail(const al::LiveActor* actor, const TrafficRailActorInfo* otherEntry) {
+    if ((u32)(otherEntry->status - 1) > 1)
+        return false;
+
+    const al::LiveActor* otherActor = otherEntry->actor;
+
+    if (!al::isRailGoingToEnd(actor) && al::isRailGoingToEnd(otherActor))
+        return false;
+
+    f32 actorCoord = al::getRailCoord(actor);
+    f32 nearBound = al::getRailCoord(actor) + 150.0f;
+    f32 totalLength = al::getRailTotalLength(actor);
+    f32 wrapped = al::modf(nearBound + totalLength, totalLength);
+
+    f32 low, high;
+    if (al::isRailGoingToEnd(actor)) {
+        low = actorCoord;
+        high = wrapped;
+    } else {
+        low = wrapped;
+        high = actorCoord;
+    }
+
+    bool isLoop = al::isLoopRail(actor);
+    f32 otherCoord = al::getRailCoord(otherActor);
+
+    if (isLoop && high < low) {
+        if (low < otherCoord)
+            return true;
+    } else if (low >= otherCoord) {
+        return false;
+    }
+
+    return al::getRailCoord(otherActor) < high;
+}
+
+bool TrafficRailWatcher::tryRestartByOtherNpc(const al::LiveActor* actor) {
+    TrafficRailActorInfo* actorInfo = nullptr;
+    for (s32 i = 0; i < mActorCount; i++) {
+        if (mActors[i]->actor == actor) {
+            actorInfo = mActors[i];
+            break;
+        }
+    }
+
+    for (s32 i = 0; i < mActorCount; i++) {
+        if (mActors[i] == actorInfo)
+            continue;
+        if (isNearOnTrafficRail(actor, mActors[i]))
+            return false;
+    }
+    actorInfo->status = 0;
+    return true;
+}

--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -19,24 +19,26 @@ void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
     mActorCount++;
 }
 
-inline TrafficRailWatcher::ActorInfo* getActor(TrafficRailWatcher::ActorInfo** actorList,
-                                               const al::LiveActor* actor) {
+inline TrafficRailWatcher::ActorInfo* getActorInfo(TrafficRailWatcher::ActorInfo** actorList,
+                                                   const al::LiveActor* actor) {
     // BUG: No bounds checking. Requesting an actor that is not in the actor list will softlock the
     // thread
-    for (s32 i = 0; true; i++) {
-        TrafficRailWatcher::ActorInfo* info = actorList[i];
+    s32 i = 0;
+    while (true) {
+        TrafficRailWatcher::ActorInfo* info = actorList[i++];
         if (info->actor == actor)
             return info;
     }
+
     return nullptr;
 }
 
 void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
-    getActor(mActors, actor)->status = ActorStatus::StoppedByTraffic;
+    getActorInfo(mActors, actor)->status = ActorStatus::StoppedByTraffic;
 }
 
 void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
-    getActor(mActors, actor)->status = ActorStatus::Normal;
+    getActorInfo(mActors, actor)->status = ActorStatus::Normal;
 }
 
 bool TrafficRailWatcher::isEqual(const al::PlacementInfo& placementInfo) const {
@@ -52,7 +54,7 @@ bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
     return false;
 }
 
-// TODO: Add to sead as a math util
+// TODO: Add to al as a math util
 inline f32 modLength(f32 value, f32 length) {
     return al::modf(value + length, length) + 0.0f;
 }

--- a/src/Npc/TrafficRailWatcher.cpp
+++ b/src/Npc/TrafficRailWatcher.cpp
@@ -14,11 +14,6 @@ TrafficRailWatcher::TrafficRailWatcher(const al::PlacementInfo& placementInfo) {
         mActors[i] = nullptr;
 }
 
-void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
-    mActors[mActorCount] = new ActorInfo(actor);
-    mActorCount++;
-}
-
 inline TrafficRailWatcher::ActorInfo* getActorInfo(TrafficRailWatcher::ActorInfo** actorList,
                                                    const al::LiveActor* actor) {
     // BUG: No bounds checking. Requesting an actor that is not in the actor list will softlock the
@@ -33,18 +28,15 @@ inline TrafficRailWatcher::ActorInfo* getActorInfo(TrafficRailWatcher::ActorInfo
     return nullptr;
 }
 
-void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
-    getActorInfo(mActors, actor)->status = ActorStatus::StoppedByTraffic;
-}
-
-void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
-    getActorInfo(mActors, actor)->status = ActorStatus::Normal;
-}
-
 bool TrafficRailWatcher::isEqual(const al::PlacementInfo& placementInfo) const {
     al::PlacementId placementId;
     al::getPlacementId(&placementId, placementInfo);
     return al::isEqualPlacementId(*mPlacementId, placementId);
+}
+
+void TrafficRailWatcher::registerActor(const al::LiveActor* actor) {
+    mActors[mActorCount] = new ActorInfo(actor);
+    mActorCount++;
 }
 
 bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
@@ -54,9 +46,33 @@ bool TrafficRailWatcher::isExist(const al::LiveActor* actor) const {
     return false;
 }
 
-// TODO: Add to al as a math util
-inline f32 modLength(f32 value, f32 length) {
-    return al::modf(value + length, length) + 0.0f;
+void TrafficRailWatcher::stopByTraffic(const al::LiveActor* actor) {
+    getActorInfo(mActors, actor)->status = ActorStatus::StoppedByTraffic;
+}
+
+void TrafficRailWatcher::restartByTraffic(const al::LiveActor* actor) {
+    getActorInfo(mActors, actor)->status = ActorStatus::Normal;
+}
+
+bool isNearOnTrafficRail(const al::LiveActor* actor,
+                         const TrafficRailWatcher::ActorInfo* otherInfo);
+
+bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
+    ActorInfo* actorInfo = nullptr;
+    for (s32 i = 0; i < mActorCount; i++) {
+        if (mActors[i]->actor == actor) {
+            actorInfo = mActors[i];
+            break;
+        }
+    }
+
+    for (s32 j = 0; j < mActorCount; j++) {
+        if (mActors[j] != actorInfo && isNearOnTrafficRail(actor, mActors[j])) {
+            actorInfo->status = ActorStatus::StoppedByNpc;
+            return true;
+        }
+    }
+    return false;
 }
 
 bool isNearOnTrafficRail(const al::LiveActor* actor,
@@ -71,7 +87,8 @@ bool isNearOnTrafficRail(const al::LiveActor* actor,
         return false;
 
     f32 actorCoord = al::getRailCoord(actor);
-    f32 nextRailCoord = modLength(al::getRailCoord(actor) + 150.0f, al::getRailTotalLength(actor));
+    f32 nextRailCoord =
+        al::wrapValue(al::getRailCoord(actor) + 150.0f, al::getRailTotalLength(actor));
 
     f32 startCoord = actorCoord;
     f32 endCoord = nextRailCoord;
@@ -92,24 +109,6 @@ bool isNearOnTrafficRail(const al::LiveActor* actor,
     return false;
 
     return al::getRailCoord(other) < endCoord;
-}
-
-bool TrafficRailWatcher::tryStopByOtherNpc(const al::LiveActor* actor) {
-    ActorInfo* actorInfo = nullptr;
-    for (s32 i = 0; i < mActorCount; i++) {
-        if (mActors[i]->actor == actor) {
-            actorInfo = mActors[i];
-            break;
-        }
-    }
-
-    for (s32 j = 0; j < mActorCount; j++) {
-        if (mActors[j] != actorInfo && isNearOnTrafficRail(actor, mActors[j])) {
-            actorInfo->status = ActorStatus::StoppedByNpc;
-            return true;
-        }
-    }
-    return false;
 }
 
 bool TrafficRailWatcher::tryRestartByOtherNpc(const al::LiveActor* actor) {

--- a/src/Npc/TrafficRailWatcher.h
+++ b/src/Npc/TrafficRailWatcher.h
@@ -10,9 +10,11 @@ class PlacementInfo;
 
 class TrafficRailWatcher {
 public:
-    struct TrafficRailActorInfo {
+    enum class ActorStatus { Normal, StoppedByTraffic, StoppedByNpc };
+
+    struct ActorInfo {
         const al::LiveActor* actor;
-        s32 status;
+        ActorStatus status;
     };
 
     TrafficRailWatcher(const al::PlacementInfo& placementInfo);
@@ -26,9 +28,9 @@ public:
     bool tryRestartByOtherNpc(const al::LiveActor* actor);
 
 private:
-    al::PlacementId* mPlacementId;
-    s32 mActorCount;
-    TrafficRailActorInfo** mActors;
+    al::PlacementId* mPlacementId = nullptr;
+    s32 mActorCount = 0;
+    ActorInfo** mActors = nullptr;
 };
 
 static_assert(sizeof(TrafficRailWatcher) == 0x18);

--- a/src/Npc/TrafficRailWatcher.h
+++ b/src/Npc/TrafficRailWatcher.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+class PlacementId;
+class PlacementInfo;
+PlacementId* createPlacementId(const PlacementInfo& placementInfo);
+}  // namespace al
+
+struct TrafficRailActorInfo {
+    const al::LiveActor* actor;
+    s32 status;
+};
+
+class TrafficRailWatcher {
+public:
+    TrafficRailWatcher(const al::PlacementInfo& placementInfo);
+
+    void registerActor(const al::LiveActor* actor);
+    void stopByTraffic(const al::LiveActor* actor);
+    void restartByTraffic(const al::LiveActor* actor);
+    bool isEqual(const al::PlacementInfo& placementInfo) const;
+    bool isExist(const al::LiveActor* actor) const;
+    bool tryStopByOtherNpc(const al::LiveActor* actor);
+    bool tryRestartByOtherNpc(const al::LiveActor* actor);
+
+    al::PlacementId* mPlacementId;
+    s32 mActorCount;
+    TrafficRailActorInfo** mActors;
+};
+
+static_assert(sizeof(TrafficRailWatcher) == 0x18);
+
+bool isNearOnTrafficRail(const al::LiveActor* actor, const TrafficRailActorInfo* otherEntry);

--- a/src/Npc/TrafficRailWatcher.h
+++ b/src/Npc/TrafficRailWatcher.h
@@ -13,6 +13,11 @@ public:
     enum class ActorStatus { Normal, StoppedByTraffic, StoppedByNpc };
 
     struct ActorInfo {
+        ActorInfo(const al::LiveActor* liveActor) {
+            actor = liveActor;
+            status = ActorStatus::Normal;
+        }
+
         const al::LiveActor* actor;
         ActorStatus status;
     };

--- a/src/Npc/TrafficRailWatcher.h
+++ b/src/Npc/TrafficRailWatcher.h
@@ -6,16 +6,15 @@ namespace al {
 class LiveActor;
 class PlacementId;
 class PlacementInfo;
-PlacementId* createPlacementId(const PlacementInfo& placementInfo);
 }  // namespace al
-
-struct TrafficRailActorInfo {
-    const al::LiveActor* actor;
-    s32 status;
-};
 
 class TrafficRailWatcher {
 public:
+    struct TrafficRailActorInfo {
+        const al::LiveActor* actor;
+        s32 status;
+    };
+
     TrafficRailWatcher(const al::PlacementInfo& placementInfo);
 
     void registerActor(const al::LiveActor* actor);
@@ -26,11 +25,10 @@ public:
     bool tryStopByOtherNpc(const al::LiveActor* actor);
     bool tryRestartByOtherNpc(const al::LiveActor* actor);
 
+private:
     al::PlacementId* mPlacementId;
     s32 mActorCount;
     TrafficRailActorInfo** mActors;
 };
 
 static_assert(sizeof(TrafficRailWatcher) == 0x18);
-
-bool isNearOnTrafficRail(const al::LiveActor* actor, const TrafficRailActorInfo* otherEntry);

--- a/src/Npc/TrafficRailWatcher.h
+++ b/src/Npc/TrafficRailWatcher.h
@@ -24,11 +24,11 @@ public:
 
     TrafficRailWatcher(const al::PlacementInfo& placementInfo);
 
+    bool isEqual(const al::PlacementInfo& placementInfo) const;
     void registerActor(const al::LiveActor* actor);
+    bool isExist(const al::LiveActor* actor) const;
     void stopByTraffic(const al::LiveActor* actor);
     void restartByTraffic(const al::LiveActor* actor);
-    bool isEqual(const al::PlacementInfo& placementInfo) const;
-    bool isExist(const al::LiveActor* actor) const;
     bool tryStopByOtherNpc(const al::LiveActor* actor);
     bool tryRestartByOtherNpc(const al::LiveActor* actor);
 


### PR DESCRIPTION
With Claude's help

NOTE: I couldn't get this snippet to match any other way. `low >= al::getRailCoord(other)` creates a `b.ge` instead of a `b.pl`.
```c++
    if (al::isLoopRail(actor) && high < low) {
        if (low < al::getRailCoord(other))
            return true;
    } else {
        if (!(low < al::getRailCoord(other)))
            return false;
    }
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/967)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 45f030c)

📈 **Matched code**: 15.50% (+0.01%, +1196 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::TrafficRailWatcher(al::PlacementInfo const&)` | +304 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `isNearOnTrafficRail(al::LiveActor const*, TrafficRailWatcher::ActorInfo const*)` | +280 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::tryStopByOtherNpc(al::LiveActor const*)` | +172 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::tryRestartByOtherNpc(al::LiveActor const*)` | +160 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::isEqual(al::PlacementInfo const&) const` | +76 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::registerActor(al::LiveActor const*)` | +72 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::isExist(al::LiveActor const*) const` | +72 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::stopByTraffic(al::LiveActor const*)` | +32 | 0.00% | 100.00% |
| `Npc/TrafficRailWatcher` | `TrafficRailWatcher::restartByTraffic(al::LiveActor const*)` | +28 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->