### PR TITLE
Npc: Implement `FlyObject`

### DIFF
--- a/src/MapObj/FukankunZoomTargetFunction.h
+++ b/src/MapObj/FukankunZoomTargetFunction.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+class PlacementInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class Fukankun;
+class FukankunZoomObj;
+
+namespace FukankunZoomTargetFunction {
+void declareUseFukankunZoomTargetActor(const al::LiveActor*);
+void registerFukankunZoomTargetActor(const al::LiveActor*, s32, const sead::Vector3f&, const char*);
+s32 getWatchCount(const al::LiveActor*);
+s32 getFukankunWatchCountDefault();
+f32 getFukankunCameraNearDistThres();
+Fukankun* tryGetActiveFukankunLinkedShineMtx(const sead::Matrix34f**, const al::LiveActor*);
+FukankunZoomObj* tryGetFukankunZoomObj(const al::IUseSceneObjHolder*, const al::PlacementInfo&);
+void registerFukankunZoomObj(const al::LiveActor*, const al::PlacementInfo&);
+s32 getFukankunZoomTargetActorNum(const al::IUseSceneObjHolder*);
+al::LiveActor* tryGetFukankunZoomTargetActor(const al::IUseSceneObjHolder*, s32);
+bool tryGetFukankunZoomTargetActorIsNoZoomOn(const al::IUseSceneObjHolder*, s32);
+s32 tryGetFukankunZoomTargetActorZoomType(const al::IUseSceneObjHolder*, s32);
+const sead::Vector3f& tryGetFukankunZoomTargetActorOffset(const al::IUseSceneObjHolder*, s32);
+const char* tryGetFukankunZoomTargetActorTargetJointName(const al::IUseSceneObjHolder*, s32);
+void declareWatchFukankunZoomTargetActor(const Fukankun*, s32);
+}  // namespace FukankunZoomTargetFunction

--- a/src/MapObj/FukankunZoomTargetFunction.h
+++ b/src/MapObj/FukankunZoomTargetFunction.h
@@ -19,7 +19,7 @@ void registerFukankunZoomTargetActor(const al::LiveActor*, s32, const sead::Vect
 s32 getWatchCount(const al::LiveActor*);
 s32 getFukankunWatchCountDefault();
 f32 getFukankunCameraNearDistThres();
-Fukankun* tryGetActiveFukankunLinkedShineMtx(const sead::Matrix34f**, const al::LiveActor*);
+bool tryGetActiveFukankunLinkedShineMtx(const sead::Matrix34f**, const al::LiveActor*);
 FukankunZoomObj* tryGetFukankunZoomObj(const al::IUseSceneObjHolder*, const al::PlacementInfo&);
 void registerFukankunZoomObj(const al::LiveActor*, const al::PlacementInfo&);
 s32 getFukankunZoomTargetActorNum(const al::IUseSceneObjHolder*);

--- a/src/Npc/FlyObject.cpp
+++ b/src/Npc/FlyObject.cpp
@@ -127,14 +127,14 @@ void FukanKunShineHolder::interact(FlyObject* flyObject) {
 FlyObject::FlyObject(const char* name) : al::LiveActor(name) {}
 
 inline FukanKunInteractionEmpty* createFukanKunInteraction(const al::ActorInitInfo& info) {
-    s32 interactionType = 0;
-    if (al::tryGetArg(&interactionType, info, "FukanKunInteractionType")) {
+    FukanKunInteractionType interactionType = FukanKunInteractionType::None;
+    if (al::tryGetArg((s32*)&interactionType, info, "FukanKunInteractionType")) {
         switch (interactionType) {
-        case 0:
+        case FukanKunInteractionType::None:
             return new FukanKunInteractionEmpty();
-        case 1:
+        case FukanKunInteractionType::Message:
             return new FukanKunMessageHolder();
-        case 2:
+        case FukanKunInteractionType::Shine:
             return new FukanKunShineHolder();
         default:
             return nullptr;
@@ -147,13 +147,13 @@ inline FukanKunInteractionEmpty* createFukanKunInteraction(const al::ActorInitIn
 void FlyObject::init(const al::ActorInitInfo& info) {
     al::initActor(this, info);
     if (al::isExistRail(this))
-        mBehaviour = new OnRails();
+        mBehavior = new OnRails();
     else
-        mBehaviour = new Stationary();
+        mBehavior = new Stationary();
 
     al::tryGetArg(&mMovementSpeed, info, "MovementSpeed");
-    al::tryGetArg(mBehaviour->getWaveController()->getVerticalSpeedPtr(), info, "VerticalSpeed");
-    al::tryGetArg(mBehaviour->getWaveController()->getVerticalAmplitudePtr(), info,
+    al::tryGetArg(mBehavior->getWaveController()->getVerticalSpeedPtr(), info, "VerticalSpeed");
+    al::tryGetArg(mBehavior->getWaveController()->getVerticalAmplitudePtr(), info,
                   "VerticalAmplitude");
 
     FukanKunInteractionEmpty* interaction = createFukanKunInteraction(info);
@@ -177,7 +177,7 @@ void FlyObject::init(const al::ActorInitInfo& info) {
 
 void FlyObject::initAfterPlacement() {
     mFukanKunInteraction->setUp(this);
-    mBehaviour->setUp(this);
+    mBehavior->setUp(this);
 }
 
 void FlyObject::control() {
@@ -191,7 +191,7 @@ al::MessageSystem* FlyObject::getMessageSystem() const {
 void FlyObject::exeFly() {
     if (al::isFirstStep(this))
         al::startAction(this, "Fly");
-    mBehaviour->move(this, mMovementSpeed);
+    mBehavior->move(this, mMovementSpeed);
 }
 
 void FlyObject::exeDisappear() {

--- a/src/Npc/FlyObject.cpp
+++ b/src/Npc/FlyObject.cpp
@@ -1,0 +1,192 @@
+#include "Npc/FlyObject.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Rail/RailUtil.h"
+
+#include "MapObj/CapMessageShowInfo.h"
+#include "MapObj/FukankunZoomTargetFunction.h"
+#include "Util/ItemUtil.h"
+
+namespace {
+NERVE_IMPL(FlyObject, Fly)
+NERVE_IMPL(FlyObject, Disappear)
+
+NERVES_MAKE_NOSTRUCT(FlyObject, Fly, Disappear)
+}  // namespace
+
+WaveMovementController::WaveMovementController() = default;
+
+f32 WaveMovementController::calcUpdatedYCoord(const sead::Vector3f& trans) {
+    if (mVerticalSpeed == 0.0f || mVerticalAmplitude == 0.0f)
+        return trans.y;
+
+    f32 nextAngle = mVerticalSpeed * (1.0f / 60.0f) + mVerticalAngle;
+    if (nextAngle > sead::Mathf::pi2())
+        nextAngle = 0.0f;
+
+    mVerticalAngle = nextAngle;
+    return trans.y + sead::Mathf::sin(mVerticalAngle) * mVerticalAmplitude;
+}
+
+void Stationary::setUp(al::LiveActor* actor) {
+    mTrans = al::getTrans(actor);
+}
+
+void Stationary::move(al::LiveActor* actor, f32 speed) {
+    al::setTransY(actor, getWaveController()->calcUpdatedYCoord(mTrans));
+}
+
+void OnRails::setUp(al::LiveActor* actor) {
+    al::setSyncRailToNearestRailControlPoint(actor);
+
+    mMoveSyncRail = al::isLoopRail(actor) ? al::moveSyncRailLoop : al::moveSyncRail;
+}
+
+void OnRails::move(al::LiveActor* actor, f32 speed) {
+    mMoveSyncRail(actor, speed);
+    al::setTransY(actor, getWaveController()->calcUpdatedYCoord(al::getTrans(actor)));
+
+    sead::Vector3f railDir = al::getRailDir(actor);
+    const sead::Vector3f& up = -al::getGravity(actor);
+
+    sead::Vector3f front = railDir - railDir.dot(up) * up;
+    if (al::tryNormalizeOrZero(&front))
+        al::setFront(actor, front);
+
+    if (al::isRailReachedEnd(actor) && !al::isLoopRail(actor))
+        al::setNerve(actor, &Disappear);
+}
+
+FukanKunInteractionEmpty::FukanKunInteractionEmpty() {}
+
+void FukanKunInteractionEmpty::init(FlyObject* flyObject, const al::ActorInitInfo& info) {}
+
+void FukanKunInteractionEmpty::setUp(FlyObject* flyObject) {}
+
+void FukanKunInteractionEmpty::control(FlyObject* flyObject) {}
+
+al::MessageSystem* FukanKunInteractionEmpty::getMessageSystem() const {
+    return nullptr;
+}
+
+FukanKunInteractionBase::FukanKunInteractionBase(s32 displayTime) : mDisplayTime(displayTime) {}
+
+void FukanKunInteractionBase::init(FlyObject* flyObject, const al::ActorInitInfo& info) {
+    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(flyObject);
+}
+
+void FukanKunInteractionBase::setUp(FlyObject* flyObject) {
+    FukankunZoomTargetFunction::registerFukankunZoomTargetActor(flyObject, 0, sead::Vector3f::zero,
+                                                                nullptr);
+}
+
+void FukanKunInteractionBase::control(FlyObject* flyObject) {
+    if (mHasInteraction && mDisplayTime < FukankunZoomTargetFunction::getWatchCount(flyObject)) {
+        interact(flyObject);
+        mHasInteraction = false;
+    }
+}
+
+FukanKunMessageHolder::FukanKunMessageHolder() : FukanKunInteractionBase(180) {}
+
+void FukanKunMessageHolder::init(FlyObject* flyObject, const al::ActorInitInfo& info) {
+    mMessageSystem = al::getLayoutInitInfo(info).getMessageSystem();
+    mCapMsg = al::StringTmp<64>("CapMsg_%s", al::createPlacementId(info)->getId());
+    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(flyObject);
+}
+
+al::MessageSystem* FukanKunMessageHolder::getMessageSystem() const {
+    return mMessageSystem;
+}
+
+void FukanKunMessageHolder::interact(FlyObject* flyObject) {
+    rs::tryShowCapMessageFromCurrentStageMsg(flyObject, mCapMsg.cstr(), 90, 0);
+}
+
+FukanKunShineHolder::FukanKunShineHolder() : FukanKunInteractionBase(120) {}
+
+void FukanKunShineHolder::init(FlyObject* flyObject, const al::ActorInitInfo& info) {
+    mShine = rs::tryInitLinkShine(info, "ShineActor", 0);
+    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(flyObject);
+}
+
+void FukanKunShineHolder::interact(FlyObject* flyObject) {
+    rs::appearPopupShine(mShine, flyObject);
+}
+
+FlyObject::FlyObject(const char* name) : al::LiveActor(name) {}
+
+ALWAYS_INLINE FukanKunInteractionEmpty* createFukanKunInteraction(const al::ActorInitInfo& info) {
+    FukanKunInteractionType interactionType = FukanKunInteractionType::None;
+    if (al::tryGetArg((s32*)&interactionType, info, "FukanKunInteractionType")) {
+        switch (interactionType) {
+        case FukanKunInteractionType::None:
+            return new FukanKunInteractionEmpty();
+        case FukanKunInteractionType::Message:
+            return new FukanKunMessageHolder();
+        case FukanKunInteractionType::Shine:
+            return new FukanKunShineHolder();
+        }
+    }
+
+    bool isFukanKunMessageNeed = false;
+    al::tryGetArg(&isFukanKunMessageNeed, info, "IsFukanKunMessageNeed");
+    if (isFukanKunMessageNeed)
+        return new FukanKunMessageHolder();
+
+    return new FukanKunInteractionEmpty();
+}
+
+// NON_MATCHING: Missing duplicated block https://decomp.me/scratch/eX4WB
+void FlyObject::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    if (al::isExistRail(this))
+        mBehaviour = new OnRails();
+    else
+        mBehaviour = new Stationary();
+
+    al::tryGetArg(&mMovementSpeed, info, "MovementSpeed");
+    al::tryGetArg(mBehaviour->getWaveController()->getVerticalSpeedPtr(), info, "VerticalSpeed");
+    al::tryGetArg(mBehaviour->getWaveController()->getVerticalAmplitudePtr(), info,
+                  "VerticalAmplitude");
+
+    mFukanKunInteraction = createFukanKunInteraction(info);
+    mFukanKunInteraction->init(this, info);
+
+    al::initNerve(this, &Fly, 0);
+    al::invalidateClipping(this);
+    al::trySyncStageSwitchAppear(this);
+}
+
+void FlyObject::initAfterPlacement() {
+    mFukanKunInteraction->setUp(this);
+    mBehaviour->setUp(this);
+}
+
+void FlyObject::control() {
+    mFukanKunInteraction->control(this);
+}
+
+al::MessageSystem* FlyObject::getMessageSystem() const {
+    return mFukanKunInteraction->getMessageSystem();
+}
+
+void FlyObject::exeFly() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Fly");
+    mBehaviour->move(this, mMovementSpeed);
+}
+
+void FlyObject::exeDisappear() {
+    makeActorDead();
+}

--- a/src/Npc/FlyObject.cpp
+++ b/src/Npc/FlyObject.cpp
@@ -126,28 +126,24 @@ void FukanKunShineHolder::interact(FlyObject* flyObject) {
 
 FlyObject::FlyObject(const char* name) : al::LiveActor(name) {}
 
-ALWAYS_INLINE FukanKunInteractionEmpty* createFukanKunInteraction(const al::ActorInitInfo& info) {
-    FukanKunInteractionType interactionType = FukanKunInteractionType::None;
-    if (al::tryGetArg((s32*)&interactionType, info, "FukanKunInteractionType")) {
+inline FukanKunInteractionEmpty* createFukanKunInteraction(const al::ActorInitInfo& info) {
+    s32 interactionType = 0;
+    if (al::tryGetArg(&interactionType, info, "FukanKunInteractionType")) {
         switch (interactionType) {
-        case FukanKunInteractionType::None:
+        case 0:
             return new FukanKunInteractionEmpty();
-        case FukanKunInteractionType::Message:
+        case 1:
             return new FukanKunMessageHolder();
-        case FukanKunInteractionType::Shine:
+        case 2:
             return new FukanKunShineHolder();
+        default:
+            return nullptr;
         }
     }
-
-    bool isFukanKunMessageNeed = false;
-    al::tryGetArg(&isFukanKunMessageNeed, info, "IsFukanKunMessageNeed");
-    if (isFukanKunMessageNeed)
-        return new FukanKunMessageHolder();
-
-    return new FukanKunInteractionEmpty();
+    return nullptr;
 }
 
-// NON_MATCHING: Missing duplicated block https://decomp.me/scratch/eX4WB
+// NON_MATCHING: Bad load order https://decomp.me/scratch/4Q3he
 void FlyObject::init(const al::ActorInitInfo& info) {
     al::initActor(this, info);
     if (al::isExistRail(this))
@@ -160,7 +156,18 @@ void FlyObject::init(const al::ActorInitInfo& info) {
     al::tryGetArg(mBehaviour->getWaveController()->getVerticalAmplitudePtr(), info,
                   "VerticalAmplitude");
 
-    mFukanKunInteraction = createFukanKunInteraction(info);
+    FukanKunInteractionEmpty* interaction = createFukanKunInteraction(info);
+    if (interaction) {
+        mFukanKunInteraction = interaction;
+    } else {
+        bool isFukanKunMessageNeed = false;
+        al::tryGetArg(&isFukanKunMessageNeed, info, "IsFukanKunMessageNeed");
+        if (isFukanKunMessageNeed)
+            mFukanKunInteraction = new FukanKunMessageHolder();
+        else
+            mFukanKunInteraction = new FukanKunInteractionEmpty();
+    }
+
     mFukanKunInteraction->init(this, info);
 
     al::initNerve(this, &Fly, 0);

--- a/src/Npc/FlyObject.cpp
+++ b/src/Npc/FlyObject.cpp
@@ -18,10 +18,10 @@
 #include "Util/ItemUtil.h"
 
 namespace {
-NERVE_IMPL(FlyObject, Fly)
 NERVE_IMPL(FlyObject, Disappear)
+NERVE_IMPL(FlyObject, Fly)
 
-NERVES_MAKE_NOSTRUCT(FlyObject, Fly, Disappear)
+NERVES_MAKE_NOSTRUCT(FlyObject, Disappear, Fly)
 }  // namespace
 
 WaveMovementController::WaveMovementController() = default;
@@ -67,17 +67,11 @@ void OnRails::move(al::LiveActor* actor, f32 speed) {
         al::setNerve(actor, &Disappear);
 }
 
-FukanKunInteractionEmpty::FukanKunInteractionEmpty() {}
-
 void FukanKunInteractionEmpty::init(FlyObject* flyObject, const al::ActorInitInfo& info) {}
 
 void FukanKunInteractionEmpty::setUp(FlyObject* flyObject) {}
 
 void FukanKunInteractionEmpty::control(FlyObject* flyObject) {}
-
-al::MessageSystem* FukanKunInteractionEmpty::getMessageSystem() const {
-    return nullptr;
-}
 
 FukanKunInteractionBase::FukanKunInteractionBase(s32 displayTime) : mDisplayTime(displayTime) {}
 
@@ -102,7 +96,7 @@ FukanKunMessageHolder::FukanKunMessageHolder() : FukanKunInteractionBase(180) {}
 void FukanKunMessageHolder::init(FlyObject* flyObject, const al::ActorInitInfo& info) {
     mMessageSystem = al::getLayoutInitInfo(info).getMessageSystem();
     mCapMsg = al::StringTmp<64>("CapMsg_%s", al::createPlacementId(info)->getId());
-    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(flyObject);
+    FukanKunInteractionBase::init(flyObject, info);
 }
 
 al::MessageSystem* FukanKunMessageHolder::getMessageSystem() const {
@@ -117,7 +111,7 @@ FukanKunShineHolder::FukanKunShineHolder() : FukanKunInteractionBase(120) {}
 
 void FukanKunShineHolder::init(FlyObject* flyObject, const al::ActorInitInfo& info) {
     mShine = rs::tryInitLinkShine(info, "ShineActor", 0);
-    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(flyObject);
+    FukanKunInteractionBase::init(flyObject, info);
 }
 
 void FukanKunShineHolder::interact(FlyObject* flyObject) {

--- a/src/Npc/FlyObject.h
+++ b/src/Npc/FlyObject.h
@@ -32,6 +32,8 @@ private:
     f32 mVerticalAngle = 0.0f;
 };
 
+static_assert(sizeof(WaveMovementController) == 0xc);
+
 class Behavior {
 public:
     virtual void setUp(al::LiveActor* actor) = 0;
@@ -43,6 +45,8 @@ public:
 private:
     WaveMovementController mWaveController;
 };
+
+static_assert(sizeof(Behavior) == 0x18);
 
 class Stationary : public Behavior {
 public:
@@ -70,14 +74,16 @@ static_assert(sizeof(OnRails) == 0x20);
 
 class FukanKunInteractionEmpty {
 public:
-    FukanKunInteractionEmpty();
+    FukanKunInteractionEmpty() = default;
 
     virtual void init(FlyObject* flyObject, const al::ActorInitInfo& info);
     virtual void setUp(FlyObject* flyObject);
     virtual void control(FlyObject* flyObject);
-    virtual al::MessageSystem* getMessageSystem() const;
-    virtual void interact(FlyObject* flyObject);
+
+    virtual al::MessageSystem* getMessageSystem() const { return nullptr; }
 };
+
+static_assert(sizeof(FukanKunInteractionEmpty) == 0x8);
 
 class FukanKunInteractionBase : public FukanKunInteractionEmpty {
 public:
@@ -86,11 +92,14 @@ public:
     void init(FlyObject* flyObject, const al::ActorInitInfo& info) override;
     void setUp(FlyObject* flyObject) override;
     void control(FlyObject* flyObject) override;
+    virtual void interact(FlyObject* flyObject) = 0;
 
 private:
     bool mHasInteraction = true;
     s32 mDisplayTime;
 };
+
+static_assert(sizeof(FukanKunInteractionBase) == 0x10);
 
 class FukanKunMessageHolder : public FukanKunInteractionBase {
 public:

--- a/src/Npc/FlyObject.h
+++ b/src/Npc/FlyObject.h
@@ -32,11 +32,11 @@ private:
     f32 mVerticalAngle = 0.0f;
 };
 
-class Behaviour {
+class Behavior {
 public:
     virtual void setUp(al::LiveActor* actor) = 0;
     virtual void move(al::LiveActor* actor, f32 speed) = 0;
-    virtual ~Behaviour() = default;
+    virtual ~Behavior() = default;
 
     WaveMovementController* getWaveController() { return &mWaveController; }
 
@@ -44,7 +44,7 @@ private:
     WaveMovementController mWaveController;
 };
 
-class Stationary : public Behaviour {
+class Stationary : public Behavior {
 public:
     void setUp(al::LiveActor* actor) override;
     void move(al::LiveActor* actor, f32 speed) override;
@@ -55,7 +55,7 @@ private:
 
 static_assert(sizeof(Stationary) == 0x20);
 
-class OnRails : public Behaviour {
+class OnRails : public Behavior {
 public:
     void setUp(al::LiveActor* actor) override;
     void move(al::LiveActor* actor, f32 speed) override;
@@ -132,7 +132,7 @@ public:
     void exeDisappear();
 
 private:
-    Behaviour* mBehaviour = nullptr;
+    Behavior* mBehavior = nullptr;
     f32 mMovementSpeed = 22.0f;
     FukanKunInteractionEmpty* mFukanKunInteraction = nullptr;
 };

--- a/src/Npc/FlyObject.h
+++ b/src/Npc/FlyObject.h
@@ -1,0 +1,140 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Message/IUseMessageSystem.h"
+
+namespace al {
+struct ActorInitInfo;
+}
+class FlyObject;
+class Shine;
+
+enum class FukanKunInteractionType : s32 {
+    None,
+    Message,
+    Shine,
+};
+
+class WaveMovementController {
+public:
+    WaveMovementController();
+    f32 calcUpdatedYCoord(const sead::Vector3f&);
+
+    f32* getVerticalSpeedPtr() { return &mVerticalSpeed; }
+
+    f32* getVerticalAmplitudePtr() { return &mVerticalAmplitude; }
+
+private:
+    f32 mVerticalSpeed = 2.0f;
+    f32 mVerticalAmplitude = 350.0f;
+    f32 mVerticalAngle = 0.0f;
+};
+
+class Behaviour {
+public:
+    virtual void setUp(al::LiveActor* actor) = 0;
+    virtual void move(al::LiveActor* actor, f32 speed) = 0;
+    virtual ~Behaviour() = default;
+
+    WaveMovementController* getWaveController() { return &mWaveController; }
+
+private:
+    WaveMovementController mWaveController;
+};
+
+class Stationary : public Behaviour {
+public:
+    void setUp(al::LiveActor* actor) override;
+    void move(al::LiveActor* actor, f32 speed) override;
+
+private:
+    sead::Vector3f mTrans;
+};
+
+static_assert(sizeof(Stationary) == 0x20);
+
+class OnRails : public Behaviour {
+public:
+    void setUp(al::LiveActor* actor) override;
+    void move(al::LiveActor* actor, f32 speed) override;
+
+private:
+    using MoveSyncRail = bool(al::LiveActor*, f32);
+
+    MoveSyncRail* mMoveSyncRail = nullptr;
+};
+
+static_assert(sizeof(OnRails) == 0x20);
+
+class FukanKunInteractionEmpty {
+public:
+    FukanKunInteractionEmpty();
+
+    virtual void init(FlyObject* flyObject, const al::ActorInitInfo& info);
+    virtual void setUp(FlyObject* flyObject);
+    virtual void control(FlyObject* flyObject);
+    virtual al::MessageSystem* getMessageSystem() const;
+    virtual void interact(FlyObject* flyObject);
+};
+
+class FukanKunInteractionBase : public FukanKunInteractionEmpty {
+public:
+    FukanKunInteractionBase(s32 displayTime);
+
+    void init(FlyObject* flyObject, const al::ActorInitInfo& info) override;
+    void setUp(FlyObject* flyObject) override;
+    void control(FlyObject* flyObject) override;
+
+private:
+    bool mHasInteraction = true;
+    s32 mDisplayTime;
+};
+
+class FukanKunMessageHolder : public FukanKunInteractionBase {
+public:
+    FukanKunMessageHolder();
+    void init(FlyObject* flyObject, const al::ActorInitInfo& info) override;
+    al::MessageSystem* getMessageSystem() const override;
+    void interact(FlyObject* flyObject) override;
+
+private:
+    al::MessageSystem* mMessageSystem = nullptr;
+    sead::FixedSafeString<64> mCapMsg;
+};
+
+static_assert(sizeof(FukanKunMessageHolder) == 0x70);
+
+class FukanKunShineHolder : public FukanKunInteractionBase {
+public:
+    FukanKunShineHolder();
+    void init(FlyObject* flyObject, const al::ActorInitInfo& info) override;
+    void interact(FlyObject* flyObject) override;
+
+private:
+    Shine* mShine = nullptr;
+};
+
+static_assert(sizeof(FukanKunShineHolder) == 0x18);
+
+class FlyObject : public al::LiveActor, public al::IUseMessageSystem {
+public:
+    FlyObject(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void control() override;
+
+    al::MessageSystem* getMessageSystem() const override;
+
+    void exeFly();
+    void exeDisappear();
+
+private:
+    Behaviour* mBehaviour = nullptr;
+    f32 mMovementSpeed = 22.0f;
+    FukanKunInteractionEmpty* mFukanKunInteraction = nullptr;
+};
+
+static_assert(sizeof(FlyObject) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -105,6 +105,7 @@
 #include "MapObj/WorldWarpHole.h"
 #include "Npc/Bird.h"
 #include "Npc/BirdPlayerGlideCtrl.h"
+#include "Npc/FlyObject.h"
 #include "Npc/KuriboGirl.h"
 #include "Npc/RaceAudienceNpc.h"
 #include "Npc/VocalMike.h"
@@ -303,7 +304,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"FixMapPartsForceSafetyPoint", nullptr},
     {"FixMapPartsFukankunZoomCapMessage", nullptr},
     {"FixMapPartsScenarioAction", nullptr},
-    {"FlyObject", nullptr},
+    {"FlyObject", al::createActorFunction<FlyObject>},
     {"ForestManSeed", nullptr},
     {"ForestWorldHomeBreakParts000", nullptr},
     {"FogRequester", nullptr},

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -446,8 +446,8 @@ def header_check_line(line, path, visibility, should_start_class, is_in_struct):
         var_name = newline.split(" : ")[0].split(" ")[-1]
         var_type = " ".join(newline.split(" ")[0:-1])
 
-        if var_type.startswith("enum") or var_type.startswith("friend"):
-            return  # Allow enum and friend class
+        if var_type.startswith("enum") or var_type.startswith("friend") or var_type.startswith("using"):
+            return  # Allow enum, friend class and using
 
         PREFIXES = ["pad", "field", "unk", "gap", "_", "filler"]
 


### PR DESCRIPTION
There was some interesting design choices here. `FukanKunInteractionBase` is not the base class. `OnRails` takes as parameter a function ptr but is not a functor. `FukanKunInteractionEmpty` is not abstract but doesn't implement `interact`. There's something called `WatchCount` but the values doesn't reflect on the name. It uses hardcoded values of multiples of 60,  my guess is that is measured on frames.

FlyObject use WaveMovementController which basically makes the object move in a sinusoidal wave.


`FlyObject::init` Missing duplicated block https://decomp.me/scratch/eX4WB
~~`_ZN8BehaviorD2Ev` Is not generated~~ Typo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/969)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (fc21c02 - 63fc9fa)

📈 **Matched code**: 14.02% (+0.02%, +2260 bytes)

<details>
<summary>✅ 35 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/FlyObject` | `OnRails::move(al::LiveActor*, float)` | +344 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunMessageHolder::init(FlyObject*, al::ActorInitInfo const&)` | +300 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::FlyObject(char const*)` | +156 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::FlyObject(char const*)` | +152 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunMessageHolder::FukanKunMessageHolder()` | +144 | 0.00% | 100.00% |
| `Npc/FlyObject` | `Stationary::move(al::LiveActor*, float)` | +140 | 0.00% | 100.00% |
| `Npc/FlyObject` | `WaveMovementController::calcUpdatedYCoord(sead::Vector3<float> const&)` | +132 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunInteractionBase::control(FlyObject*)` | +96 | 0.00% | 100.00% |
| `Npc/FlyObject` | `OnRails::setUp(al::LiveActor*)` | +84 | 0.00% | 100.00% |
| `Npc/FlyObject` | `(anonymous namespace)::FlyObjectNrvFly::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunMessageHolder::interact(FlyObject*)` | +72 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::exeFly()` | +72 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::initAfterPlacement()` | +64 | 0.00% | 100.00% |
| `Npc/FlyObject` | `Stationary::setUp(al::LiveActor*)` | +60 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunShineHolder::init(FlyObject*, al::ActorInitInfo const&)` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<FlyObject>(char const*)` | +52 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunShineHolder::FukanKunShineHolder()` | +40 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunInteractionBase::FukanKunInteractionBase(int)` | +32 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunInteractionBase::setUp(FlyObject*)` | +24 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::control()` | +24 | 0.00% | 100.00% |
| `Npc/FlyObject` | `WaveMovementController::WaveMovementController()` | +20 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::getMessageSystem() const` | +16 | 0.00% | 100.00% |
| `Npc/FlyObject` | `non-virtual thunk to FlyObject::getMessageSystem() const` | +16 | 0.00% | 100.00% |
| `Npc/FlyObject` | `(anonymous namespace)::FlyObjectNrvDisappear::execute(al::NerveKeeper*) const` | +16 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FlyObject::exeDisappear()` | +12 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunInteractionBase::init(FlyObject*, al::ActorInitInfo const&)` | +8 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunShineHolder::interact(FlyObject*)` | +8 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunInteractionEmpty::getMessageSystem() const` | +8 | 0.00% | 100.00% |
| `Npc/FlyObject` | `FukanKunMessageHolder::getMessageSystem() const` | +8 | 0.00% | 100.00% |
| `Npc/FlyObject` | `OnRails::~OnRails()` | +4 | 0.00% | 100.00% |

...and 5 more new matches
</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/FlyObject` | `FlyObject::init(al::ActorInitInfo const&)` | +171 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->