### PR TITLE
MapObj: Implement `WorldMapPlayerIcon` and `WorldMapPartsFloat`

### DIFF
--- a/src/MapObj/ShineTowerRocket.h
+++ b/src/MapObj/ShineTowerRocket.h
@@ -19,7 +19,7 @@ void setupHomeMeter(al::LiveActor*);
 void setupHomeMeterFitherParam(al::LiveActor*, ShineTowerCommonKeeper*);
 void setupHomeSticker(al::LiveActor*);
 void setupHomeCompLight(al::LiveActor*);
-void getHomeArchiveName(const al::LiveActor*);
+const char* getHomeArchiveName(const al::LiveActor*);
 }  // namespace rs
 
 class ShineTowerRocket : public al::LiveActor,

--- a/src/MapObj/WorldMapParts.cpp
+++ b/src/MapObj/WorldMapParts.cpp
@@ -1,10 +1,13 @@
 #include "MapObj/WorldMapParts.h"
 
+#include <math/seadMathCalcCommon.h>
+
 #include "Library/LiveActor/ActorInitUtil.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/LiveActor/LiveActorFunction.h"
 #include "Library/Math/MathUtil.h"
+#include "Library/Matrix/MatrixUtil.h"
 
 void recursivelyInvalidateOcclusionQuery(al::LiveActor* actor) {
     al::invalidateOcclusionQuery(actor);
@@ -64,4 +67,23 @@ WorldMapParts* WorldMapParts::create(const char* name, const char* arcName,
     initParts(newParts, arcName, initInfo, worldMtx, localMtx, suffix);
 
     return newParts;
+}
+
+WorldMapPartsFloat::WorldMapPartsFloat(const char* name, const sead::Vector3f& offset, s32 period,
+                                       f32 amplitude)
+    : WorldMapParts(name), mFloatOffset(offset), mPeriod(period), mAmplitude(amplitude) {}
+
+void WorldMapPartsFloat::control() {
+    s32 frameCount = mFrameCount++;
+    f32 sinVal = sead::Mathf::sin((f32)(frameCount) / (f32)mPeriod * sead::Mathf::pi2());
+    mLocalMtx.setTranslation(mTranslation + sinVal * mUpDir * mAmplitude);
+    updatePose();
+}
+
+void WorldMapPartsFloat::setLocalMtx(const sead::Matrix34f& srcMtx) {
+    al::addTransMtxLocalOffset(&mLocalMtx, srcMtx, mFloatOffset);
+
+    mTranslation = mLocalMtx.getTranslation();
+
+    mUpDir = mLocalMtx.getBase(1);
 }

--- a/src/MapObj/WorldMapParts.h
+++ b/src/MapObj/WorldMapParts.h
@@ -21,7 +21,27 @@ public:
                                  const al::ActorInitInfo& initInfo, const sead::Matrix34f* worldMtx,
                                  const sead::Matrix34f& localMtx, const char* suffix);
 
-private:
+protected:
     const sead::Matrix34f* mWorldMtx = nullptr;
     sead::Matrix34f mLocalMtx = sead::Matrix34f::ident;
 };
+
+static_assert(sizeof(WorldMapParts) == 0x140);
+
+class WorldMapPartsFloat : public WorldMapParts {
+public:
+    WorldMapPartsFloat(const char* name, const sead::Vector3f& offset, s32 period, f32 amplitude);
+
+    void control() override;
+    void setLocalMtx(const sead::Matrix34f& srcMtx) override;
+
+private:
+    sead::Vector3f mTranslation = sead::Vector3f::zero;
+    sead::Vector3f mUpDir = sead::Vector3f::ey;
+    sead::Vector3f mFloatOffset;
+    s32 mFrameCount = 0;
+    s32 mPeriod;
+    f32 mAmplitude;
+};
+
+static_assert(sizeof(WorldMapPartsFloat) == 0x170);

--- a/src/MapObj/WorldMapPlayerIcon.cpp
+++ b/src/MapObj/WorldMapPlayerIcon.cpp
@@ -1,0 +1,51 @@
+#include "MapObj/WorldMapPlayerIcon.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+
+#include "MapObj/ShineTowerRocket.h"
+
+static void movementRecursive(al::LiveActor* actor) {
+    actor->movement();
+    if (al::isExistSubActorKeeper(actor))
+        for (s32 i = 0; i < al::getSubActorNum(actor); i++)
+            movementRecursive(al::getSubActor(actor, i));
+}
+
+static void calcAnimRecursive(al::LiveActor* actor) {
+    actor->calcAnim();
+    if (al::isExistSubActorKeeper(actor))
+        for (s32 i = 0; i < al::getSubActorNum(actor); i++)
+            calcAnimRecursive(al::getSubActor(actor, i));
+}
+
+static const sead::Vector3f sFloatOffset = {0.0f, 20.0f, 0.0f};
+
+WorldMapPlayerIcon* WorldMapPlayerIcon::create(const char* name, const al::ActorInitInfo& initInfo,
+                                               const sead::Matrix34f* worldMtx) {
+    WorldMapPlayerIcon* icon = new WorldMapPlayerIcon(name);
+    al::initActorSceneInfo(icon, initInfo);
+    const char* arcName = rs::getHomeArchiveName(icon);
+    initParts(icon, arcName, initInfo, worldMtx, sead::Matrix34f::ident, "WorldMap");
+    al::startAction(icon, "WaitWorldMap");
+    al::startAction(al::getSubActor(icon, "旗"), "After");
+    rs::setupHomeMeter(icon);
+    rs::setupHomeSticker(icon);
+    return icon;
+}
+
+WorldMapPlayerIcon::WorldMapPlayerIcon(const char* name)
+    : WorldMapPartsFloat(name, sFloatOffset, 360, 10.0f) {}
+
+void WorldMapPlayerIcon::movement() {
+    al::LiveActor::movement();
+    for (s32 i = 0; i < al::getSubActorNum(this); i++)
+        movementRecursive(al::getSubActor(this, i));
+}
+
+void WorldMapPlayerIcon::calcAnim() {
+    al::LiveActor::calcAnim();
+    for (s32 i = 0; i < al::getSubActorNum(this); i++)
+        calcAnimRecursive(al::getSubActor(this, i));
+}

--- a/src/MapObj/WorldMapPlayerIcon.h
+++ b/src/MapObj/WorldMapPlayerIcon.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "MapObj/WorldMapParts.h"
+
+namespace al {
+struct ActorInitInfo;
+}
+
+class WorldMapPlayerIcon : public WorldMapPartsFloat {
+public:
+    static WorldMapPlayerIcon* create(const char* name, const al::ActorInitInfo& initInfo,
+                                      const sead::Matrix34f* worldMtx);
+
+    WorldMapPlayerIcon(const char* name);
+
+    void movement() override;
+    void calcAnim() override;
+};
+
+static_assert(sizeof(WorldMapPlayerIcon) == 0x170);


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/972)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a3ed158 - 755a2fd)

📈 **Matched code**: 14.05% (+0.02%, +1992 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/WorldMapParts` | `WorldMapPartsFloat::WorldMapPartsFloat(char const*, sead::Vector3<float> const&, int, float)` | +332 | 0.00% | 100.00% |
| `MapObj/WorldMapParts` | `WorldMapPartsFloat::WorldMapPartsFloat(char const*, sead::Vector3<float> const&, int, float)` | +316 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `WorldMapPlayerIcon::create(char const*, al::ActorInitInfo const&, sead::Matrix34<float> const*)` | +292 | 0.00% | 100.00% |
| `MapObj/WorldMapParts` | `WorldMapPartsFloat::control()` | +288 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `WorldMapPlayerIcon::WorldMapPlayerIcon(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `WorldMapPlayerIcon::WorldMapPlayerIcon(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `movementRecursive(al::LiveActor*)` | +108 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `calcAnimRecursive(al::LiveActor*)` | +108 | 0.00% | 100.00% |
| `MapObj/WorldMapParts` | `WorldMapPartsFloat::setLocalMtx(sead::Matrix34<float> const&)` | +88 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `WorldMapPlayerIcon::movement()` | +88 | 0.00% | 100.00% |
| `MapObj/WorldMapPlayerIcon` | `WorldMapPlayerIcon::calcAnim()` | +88 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->