### PR TITLE
MapObj: Implement `BlockEmpty2D`

### DIFF
--- a/src/MapObj/BlockEmpty2D.cpp
+++ b/src/MapObj/BlockEmpty2D.cpp
@@ -1,0 +1,74 @@
+#include "MapObj/BlockEmpty2D.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+
+#include "Util/ActorDimensionUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+BlockEmpty2D::BlockEmpty2D(const char* name) : al::LiveActor(name) {}
+
+void BlockEmpty2D::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "BlockEmpty2D", nullptr);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    if (mMtxConnector)
+        al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    if (!rs::isIn2DArea(this)) {
+        al::PlacementId placementId;
+        al::tryGetPlacementId(&placementId, info);
+        al::StringTmp<128> str;
+        placementId.makeString(&str);
+        kill();
+        return;
+    }
+
+    rs::snap2DParallelizeFront(this, this, 500.0f);
+    makeActorAlive();
+}
+
+void BlockEmpty2D::initAfterPlacement() {
+    if (mMtxConnector) {
+        if (mIsConnectToCollisionBack) {
+            sead::Vector3f frontDir = sead::Vector3f::zero;
+            al::calcFrontDir(&frontDir, this);
+            al::attachMtxConnectorToCollision(
+                mMtxConnector, this, al::getTrans(this) + 50.0f * frontDir, -400.0f * frontDir);
+        } else {
+            al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
+        }
+    }
+}
+
+void BlockEmpty2D::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void BlockEmpty2D::appear() {
+    al::LiveActor::appear();
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+bool BlockEmpty2D::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isMsgAskSafetyPoint(msg))
+        return true;
+    if (al::isMsgPlayerDisregard(msg))
+        return true;
+    if (rs::isMsgPlayerUpperPunch2D(msg))
+        al::startHitReaction(this, "アッパーパンチ");
+    return false;
+}
+
+ActorDimensionKeeper* BlockEmpty2D::getActorDimensionKeeper() const {
+    return mDimensionKeeper;
+}

--- a/src/MapObj/BlockEmpty2D.h
+++ b/src/MapObj/BlockEmpty2D.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+class ActorDimensionKeeper;
+
+namespace al {
+class MtxConnector;
+}  // namespace al
+
+class BlockEmpty2D : public al::LiveActor, public IUseDimension {
+public:
+    BlockEmpty2D(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void control() override;
+    void appear() override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+
+private:
+    bool mIsConnectToCollisionBack = false;
+    al::MtxConnector* mMtxConnector = nullptr;
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+};
+
+static_assert(sizeof(BlockEmpty2D) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -67,6 +67,7 @@
 #include "Item/LifeUpItem2D.h"
 #include "MapObj/AllDeadWatcherWithShine.h"
 #include "MapObj/AnagramAlphabet.h"
+#include "MapObj/BlockEmpty2D.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -137,7 +138,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BlockBrick2D", nullptr},
     {"BlockBrickBig2D", nullptr},
     {"BlockEmpty", nullptr},
-    {"BlockEmpty2D", nullptr},
+    {"BlockEmpty2D", al::createActorFunction<BlockEmpty2D>},
     {"BlockHard", nullptr},
     {"ClashWorldBlockHard", nullptr},
     {"BlockQuestion", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/974)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (76c3490 - 063819d)

📈 **Matched code**: 14.01% (+0.01%, +1104 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::init(al::ActorInitInfo const&)` | +320 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::initAfterPlacement()` | +240 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::BlockEmpty2D(char const*)` | +152 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::BlockEmpty2D(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +104 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::appear()` | +56 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BlockEmpty2D>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::control()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `BlockEmpty2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/BlockEmpty2D` | `non-virtual thunk to BlockEmpty2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->