### PR TITLE
MapObj: Implement `ElectricTargetInfo`

### DIFF
--- a/src/MapObj/ElectricTargetInfo.cpp
+++ b/src/MapObj/ElectricTargetInfo.cpp
@@ -1,0 +1,77 @@
+#include "MapObj/ElectricTargetInfo.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/LiveActor/ActorPoseUtil.h"
+
+f32 TargetInfo::dist() const {
+    sead::Vector3f targetPos = al::getTrans(target);
+    const sead::Vector3f& actorPos = al::getTrans(actor);
+    return (targetPos - actorPos).length();
+}
+
+TargetInfoList::TargetInfoList() {
+    mInfos = new sead::PtrArray<TargetInfo>();
+    mPool = new sead::PtrArray<TargetInfo>();
+    mInfos->allocBuffer(8, nullptr);
+    mPool->allocBuffer(8, nullptr);
+    for (s32 i = 0; i < 8; i++)
+        mPool->pushBack(new TargetInfo());
+}
+
+void TargetInfoList::clear() {
+    while (mInfos->size() != 0)
+        mPool->pushBack(mInfos->popBack());
+}
+
+void TargetInfoList::append(const al::LiveActor* actor, const al::LiveActor* target, s32 timer) {
+    if (mPool->isEmpty())
+        return;
+
+    TargetInfo* info = mPool->popBack();
+    info->actor = actor;
+    info->target = target;
+    info->timer = timer;
+    mInfos->pushBack(info);
+}
+
+void TargetInfoList::remove(const al::LiveActor* actor) {
+    for (s32 i = 0; i < mInfos->size(); i++) {
+        if ((*mInfos)[i]->actor == actor) {
+            remove(i);
+            return;
+        }
+    }
+}
+
+void TargetInfoList::remove(s32 index) {
+    mPool->pushBack((*mInfos)[index]);
+    mInfos->erase(index);
+}
+
+bool TargetInfoList::isInclude(const al::LiveActor* actor) const {
+    for (s32 i = 0; i < mInfos->size(); i++)
+        if ((*mInfos)[i]->actor == actor)
+            return true;
+    return false;
+}
+
+void TargetInfoList::elapse() {
+    for (s32 i = 0; i < mInfos->size(); i++) {
+        TargetInfo* info = (*mInfos)[i];
+        if (info->timer != 0)
+            info->timer--;
+    }
+}
+
+void TargetInfoList::survive() {
+    for (s32 i = 0; i < mInfos->size();)
+        if ((*mInfos)[i]->timer != 0)
+            i++;
+        else
+            remove(i);
+}
+
+void TargetInfoList::sort() {
+    mInfos->sort();
+}

--- a/src/MapObj/ElectricTargetInfo.h
+++ b/src/MapObj/ElectricTargetInfo.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+
+struct TargetInfo {
+    TargetInfo() {}
+
+    f32 dist() const;
+
+    bool operator<(const TargetInfo& other) const { return dist() < other.dist(); }
+
+    const al::LiveActor* actor = nullptr;
+    s32 timer = 0;
+    const al::LiveActor* target = nullptr;
+};
+
+static_assert(sizeof(TargetInfo) == 0x18);
+
+class TargetInfoList {
+public:
+    TargetInfoList();
+    void clear();
+    void append(const al::LiveActor* actor, const al::LiveActor* target, s32 timer);
+    void remove(const al::LiveActor* actor);
+    void remove(s32 index);
+    bool isInclude(const al::LiveActor* actor) const;
+    void elapse();
+    void survive();
+    void sort();
+
+private:
+    sead::PtrArray<TargetInfo>* mInfos;
+    sead::PtrArray<TargetInfo>* mPool;
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/978)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (76c3490 - 440071e)

📈 **Matched code**: 14.02% (+0.01%, +1536 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ElectricWire` | `sead::PtrArray<TargetInfo>::compareT(TargetInfo const*, TargetInfo const*)` | +408 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::TargetInfoList()` | +188 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::survive()` | +180 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfo::dist() const` | +144 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::remove(al::LiveActor const*)` | +144 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::append(al::LiveActor const*, al::LiveActor const*, int)` | +104 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::clear()` | +100 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::remove(int)` | +88 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::elapse()` | +88 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::isInclude(al::LiveActor const*) const` | +76 | 0.00% | 100.00% |
| `MapObj/ElectricTargetInfo` | `TargetInfoList::sort()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->