### PR TITLE
Scene: Implement `StageSceneStateCarryMeat`

### DIFF
--- a/src/Scene/StageSceneStateCarryMeat.cpp
+++ b/src/Scene/StageSceneStateCarryMeat.cpp
@@ -1,0 +1,82 @@
+#include "Scene/StageSceneStateCarryMeat.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneUtil.h"
+
+#include "Scene/StageScene.h"
+#include "Scene/StageSceneStateSkipDemo.h"
+#include "Util/DemoUtil.h"
+
+namespace {
+NERVE_IMPL(StageSceneStateCarryMeat, FindMeat);
+NERVE_IMPL(StageSceneStateCarryMeat, SkipDemoFindMeat);
+NERVE_IMPL(StageSceneStateCarryMeat, SkipDemoCarryMeat);
+NERVE_IMPL(StageSceneStateCarryMeat, CarryMeat);
+NERVES_MAKE_NOSTRUCT(StageSceneStateCarryMeat, FindMeat, SkipDemoFindMeat, SkipDemoCarryMeat,
+                     CarryMeat);
+}  // namespace
+
+StageSceneStateCarryMeat::StageSceneStateCarryMeat(const char* name, al::Scene* scene)
+    : al::HostStateBase<al::Scene>(name, scene) {
+    // NOTE: reserves space for 3 substates, but only assigns 2
+    initNerve(&FindMeat, 3);
+}
+
+void StageSceneStateCarryMeat::setState(StageSceneStateSkipDemo* skipDemo) {
+    mSkipDemo = skipDemo;
+    al::addNerveState(this, skipDemo, &SkipDemoFindMeat, "デモスキップ[肉発見]");
+    al::addNerveState(this, skipDemo, &SkipDemoCarryMeat, "デモスキップ[肉運び]");
+}
+
+void StageSceneStateCarryMeat::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &FindMeat);
+}
+
+void StageSceneStateCarryMeat::kill() {
+    al::NerveStateBase::kill();
+}
+
+void StageSceneStateCarryMeat::exeFindMeat() {
+    al::updateKitListPrev(getHost());
+    rs::updateKitListDemoNormalWithPauseEffect(getHost());
+    al::updateKitListPostDemoWithPauseNormalEffect(getHost());
+
+    if (rs::isActiveDemoBirdCarryMeat(getHost())) {
+        al::setNerve(this, &CarryMeat);
+        return;
+    }
+
+    mSkipDemo->tryAppearSkipDemoLayout();
+    if (mSkipDemo->tryStartSkipDemo())
+        al::setNerve(this, &SkipDemoFindMeat);
+}
+
+void StageSceneStateCarryMeat::exeCarryMeat() {
+    rs::updateBirdCarryMeat(getHost());
+    rs::updateDemoSystemOnly(getHost());
+
+    if (!rs::isActiveDemo(getHost()))
+        kill();
+
+    mSkipDemo->tryAppearSkipDemoLayout();
+    if (mSkipDemo->tryStartSkipDemo())
+        al::setNerve(this, &SkipDemoCarryMeat);
+}
+
+void StageSceneStateCarryMeat::exeSkipDemoFindMeat() {
+    if (al::updateNerveState(this)) {
+        if (mSkipDemo->isCancelSkip())
+            al::setNerve(this, &FindMeat);
+        else
+            al::setNerve(this, &CarryMeat);
+    }
+}
+
+void StageSceneStateCarryMeat::exeSkipDemoCarryMeat() {
+    if (al::updateNerveState(this)) {
+        mSkipDemo->isCancelSkip();
+        al::setNerve(this, &CarryMeat);
+    }
+}

--- a/src/Scene/StageSceneStateCarryMeat.h
+++ b/src/Scene/StageSceneStateCarryMeat.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class Scene;
+}
+class StageSceneStateSkipDemo;
+
+class StageSceneStateCarryMeat : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateCarryMeat(const char* name, al::Scene* scene);
+    void setState(StageSceneStateSkipDemo* skipDemo);
+    void appear() override;
+    void kill() override;
+    void exeFindMeat();
+    void exeCarryMeat();
+    void exeSkipDemoFindMeat();
+    void exeSkipDemoCarryMeat();
+
+private:
+    StageSceneStateSkipDemo* mSkipDemo = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateCarryMeat) == 0x28);

--- a/src/Scene/StageSceneStateSkipDemo.h
+++ b/src/Scene/StageSceneStateSkipDemo.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class Scene;
+class WindowConfirm;
+class WipeHolder;
+class DemoSyncedEventKeeper;
+}  // namespace al
+
+class PlayGuideSkip;
+class SceneAudioSystemPauseController;
+class StageSceneStateWorldMap;
+
+class StageSceneStateSkipDemo : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateSkipDemo(const char*, al::Scene*, al::WindowConfirm*, al::WipeHolder*,
+                            PlayGuideSkip*, SceneAudioSystemPauseController*,
+                            al::DemoSyncedEventKeeper*);
+    void setWorldMapState(StageSceneStateWorldMap*);
+    bool tryAppearSkipDemoLayout();
+    bool isDisableSkipByWorldMap() const;
+    bool tryStartSkipDemo();
+    bool isDemoCancelStageScene() const;
+    void tryEndForNoSkip();
+    bool isCancelSkip() const;
+    bool isConfirmingOfSkip() const;
+    void appear() override;
+    void kill() override;
+    void exeConfirmSkip();
+    void exeWaitConfirmClose();
+    void exeSkip();
+    void exeWaitSkipEnd();
+};


### PR DESCRIPTION
<!-- decomp.dev report start -->
### Report for 1.0 (76c3490 - cffe079)

📈 **Matched code**: 14.01% (+0.01%, +928 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::exeFindMeat()` | +128 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::exeCarryMeat()` | +120 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `(anonymous namespace)::StageSceneStateCarryMeatNrvCarryMeat::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `(anonymous namespace)::StageSceneStateCarryMeatNrvSkipDemoFindMeat::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::setState(StageSceneStateSkipDemo*)` | +88 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::exeSkipDemoFindMeat()` | +88 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `(anonymous namespace)::StageSceneStateCarryMeatNrvSkipDemoCarryMeat::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::StageSceneStateCarryMeat(char const*, al::Scene*)` | +72 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::exeSkipDemoCarryMeat()` | +72 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::~StageSceneStateCarryMeat()` | +36 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::appear()` | +16 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `StageSceneStateCarryMeat::kill()` | +12 | 0.00% | 100.00% |
| `Scene/StageSceneStateCarryMeat` | `(anonymous namespace)::StageSceneStateCarryMeatNrvFindMeat::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/981)
<!-- Reviewable:end -->
