### PR TITLE
Boss/Koopa: Implement `KoopaFireBeamGround`

### DIFF
--- a/src/Boss/Koopa/KoopaFireBeamGround.cpp
+++ b/src/Boss/Koopa/KoopaFireBeamGround.cpp
@@ -1,0 +1,56 @@
+#include "Boss/Koopa/KoopaFireBeamGround.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(KoopaFireBeamGround, AppearSign)
+NERVE_IMPL(KoopaFireBeamGround, Wait)
+
+NERVES_MAKE_NOSTRUCT(KoopaFireBeamGround, AppearSign, Wait)
+}  // namespace
+
+KoopaFireBeamGround::KoopaFireBeamGround(const char* name) : al::LiveActor(name) {}
+
+void KoopaFireBeamGround::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "KoopaFireBeamGround", nullptr);
+    al::initNerve(this, &AppearSign, 0);
+    makeActorDead();
+}
+
+void KoopaFireBeamGround::appearSign() {
+    al::LiveActor::appear();
+    al::setNerve(this, &AppearSign);
+}
+
+void KoopaFireBeamGround::appear() {
+    al::LiveActor::appear();
+    al::setNerve(this, &Wait);
+}
+
+void KoopaFireBeamGround::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (!al::isNerve(this, &AppearSign) && rs::isPlayerOnGround(this))
+        al::sendMsgEnemyAttackFire(other, self, nullptr);
+}
+
+bool KoopaFireBeamGround::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                     al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    return false;
+}
+
+void KoopaFireBeamGround::exeAppearSign() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "AppearSign");
+}
+
+void KoopaFireBeamGround::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}

--- a/src/Boss/Koopa/KoopaFireBeamGround.h
+++ b/src/Boss/Koopa/KoopaFireBeamGround.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class KoopaFireBeamGround : public al::LiveActor {
+public:
+    KoopaFireBeamGround(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void appearSign();
+
+    void exeAppearSign();
+    void exeWait();
+};
+
+static_assert(sizeof(KoopaFireBeamGround) == 0x108);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/983)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a3ed158 - 725c1e2)

📈 **Matched code**: 14.04% (+0.01%, +808 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::KoopaFireBeamGround(char const*)` | +132 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::KoopaFireBeamGround(char const*)` | +120 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::attackSensor(al::HitSensor*, al::HitSensor*)` | +100 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `(anonymous namespace)::KoopaFireBeamGroundNrvAppearSign::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `(anonymous namespace)::KoopaFireBeamGroundNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::exeAppearSign()` | +60 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::exeWait()` | +60 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::appearSign()` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::appear()` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaFireBeamGround` | `KoopaFireBeamGround::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->