### PR TITLE
Boss/GolemClimb: Implement `GolemStandBreakState`

### DIFF
--- a/src/Boss/GolemClimb/GolemClimbWeakPoint.h
+++ b/src/Boss/GolemClimb/GolemClimbWeakPoint.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Obj/PartsModel.h"
+
+namespace al {
+class LiveActor;
+struct ActorInitInfo;
+class HitSensor;
+}  // namespace al
+
+class GolemClimbWeakPoint : public al::PartsModel {
+public:
+    GolemClimbWeakPoint(al::LiveActor*, const al::ActorInitInfo&, const char*, const char*,
+                        const char*, const char*, const char*, bool, bool);
+    void appear() override;
+    void kill() override;
+    void exeWait();
+    void exePanic();
+    void exeDamage();
+    void exeBreak();
+    void exeBlowDown();
+    void exeDemo();
+    void setWait();
+    void setPanic();
+    void receiveMsgThrust(al::HitSensor*, al::HitSensor*);
+    void receiveMsgHipDrop(al::HitSensor*, al::HitSensor*);
+    void startBreak();
+    void startDemo(const char*);
+    bool isBreak() const;
+};

--- a/src/Boss/GolemClimb/GolemShoutState.h
+++ b/src/Boss/GolemClimb/GolemShoutState.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class SensorMsg;
+class HitSensor;
+}  // namespace al
+
+class IUseGolemState;
+
+class GolemShoutState : public al::HostStateBase<IUseGolemState> {
+public:
+    GolemShoutState(const char* name, IUseGolemState* golemState);
+    void appear() override;
+    void kill() override;
+    void control() override;
+    bool receiveMsg(const al::SensorMsg*, al::HitSensor* self, al::HitSensor* other);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other);
+};

--- a/src/Boss/GolemClimb/GolemStandBreakState.cpp
+++ b/src/Boss/GolemClimb/GolemStandBreakState.cpp
@@ -1,0 +1,65 @@
+#include "Boss/GolemClimb/GolemStandBreakState.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/GolemClimb/GolemClimbWeakPoint.h"
+#include "Boss/GolemClimb/GolemShoutState.h"
+#include "Boss/GolemClimb/IUseGolemState.h"
+
+namespace {
+NERVE_IMPL(GolemStandBreakState, Damage);
+NERVE_IMPL(GolemStandBreakState, Shout);
+NERVE_IMPL(GolemStandBreakState, Recover);
+NERVES_MAKE_NOSTRUCT(GolemStandBreakState, Damage, Shout, Recover);
+}  // namespace
+
+GolemStandBreakState::GolemStandBreakState(const char* name, IUseGolemState* golemState,
+                                           GolemShoutState* shoutState)
+    : al::HostStateBase<IUseGolemState>(name, golemState), mShoutState(shoutState) {
+    initNerve(&Damage, 0);
+}
+
+void GolemStandBreakState::appear() {
+    al::setVelocityZero(getHost()->getActor());
+    al::startHitReaction(getHost()->getActor(), "弱点ヒット");
+    al::setNerve(this, &Damage);
+    NerveStateBase::appear();
+}
+
+void GolemStandBreakState::kill() {
+    mWeakPoint = nullptr;
+    NerveStateBase::kill();
+}
+
+void GolemStandBreakState::exeDamage() {
+    if (al::isFirstStep(this)) {
+        mWeakPoint->startBreak();
+        al::startAction(getHost()->getActor(), "StandDamageLast");
+    }
+    if (mWeakPoint->isBreak())
+        al::setNerve(this, &Shout);
+}
+
+void GolemStandBreakState::exeShout() {
+    if (al::isFirstStep(this))
+        mShoutState->appear();
+    mShoutState->control();
+    if (al::isStep(this, 120)) {
+        mShoutState->kill();
+        al::setNerve(this, &Recover);
+    }
+}
+
+void GolemStandBreakState::exeRecover() {
+    if (al::isFirstStep(this))
+        al::startAction(getHost()->getActor(), "StandRecover");
+    if (al::isActionEnd(getHost()->getActor()))
+        kill();
+}
+
+void GolemStandBreakState::startBreak(GolemClimbWeakPoint* weakPoint) {
+    mWeakPoint = weakPoint;
+}

--- a/src/Boss/GolemClimb/GolemStandBreakState.h
+++ b/src/Boss/GolemClimb/GolemStandBreakState.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class GolemClimbWeakPoint;
+class GolemShoutState;
+class IUseGolemState;
+
+class GolemStandBreakState : public al::HostStateBase<IUseGolemState> {
+public:
+    GolemStandBreakState(const char* name, IUseGolemState* golemState, GolemShoutState* shoutState);
+    void appear() override;
+    void kill() override;
+    void exeDamage();
+    void exeShout();
+    void exeRecover();
+    void startBreak(GolemClimbWeakPoint* weakPoint);
+
+private:
+    GolemShoutState* mShoutState = nullptr;
+    GolemClimbWeakPoint* mWeakPoint = nullptr;
+};
+
+static_assert(sizeof(GolemStandBreakState) == 0x30);

--- a/src/Boss/GolemClimb/IUseGolemState.h
+++ b/src/Boss/GolemClimb/IUseGolemState.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+
+class GolemClimbThrustPoint;
+class GolemClimbWeakPoint;
+class GolemJointIKRootCtrl;
+class IUseDemoSkip;
+
+class IUseGolemState {
+public:
+    virtual void updateLookAt() = 0;
+    virtual void throwSearchBomb() = 0;
+    virtual void throwReflectBomb() = 0;
+    virtual void throwTsukkun() = 0;
+    virtual void startDemo() = 0;
+    virtual void endDemo() = 0;
+    virtual void replaceDemoPlayer() = 0;
+    virtual al::LiveActor* getActor() = 0;
+    virtual al::LiveActor* getSkeleton() = 0;
+    virtual void getShoutPos(sead::Vector3f*) const = 0;
+    virtual GolemJointIKRootCtrl* getFootRootL() const = 0;
+    virtual GolemJointIKRootCtrl* getFootRootR() const = 0;
+    virtual GolemClimbThrustPoint* getThrustPointL() const = 0;
+    virtual GolemClimbThrustPoint* getThrustPointR() const = 0;
+    virtual GolemClimbWeakPoint* getWeakPoint(s32) const = 0;
+    virtual bool isPrepareShout() const = 0;
+    virtual void startShout() = 0;
+    virtual void endShout() = 0;
+    virtual IUseDemoSkip* getDemoSkip() = 0;
+    virtual void stampFoot(const sead::Vector3f&, const sead::Quatf&) = 0;
+    virtual void showDamageArea() = 0;
+    virtual void hideDamageArea() = 0;
+    virtual void setDamageAreaPose(const sead::Matrix34f&) = 0;
+    virtual bool isInFootL() = 0;
+    virtual bool isInFootR() = 0;
+    virtual bool isMoon() = 0;
+    virtual void updatePushSensor() = 0;
+    virtual void endPushSensor() = 0;
+    virtual bool tryNextPushSensor() const = 0;
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/984)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (025cd8a - 4cc1c29)

📈 **Matched code**: 14.06% (+0.01%, +944 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/GolemClimb/GolemStandBreakState` | `(anonymous namespace)::GolemStandBreakStateNrvShout::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::exeShout()` | +124 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `(anonymous namespace)::GolemStandBreakStateNrvRecover::execute(al::NerveKeeper*) const` | +116 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::exeRecover()` | +112 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `(anonymous namespace)::GolemStandBreakStateNrvDamage::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::exeDamage()` | +108 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::appear()` | +96 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::GolemStandBreakState(char const*, IUseGolemState*, GolemShoutState*)` | +88 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::~GolemStandBreakState()` | +36 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::kill()` | +16 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemStandBreakState` | `GolemStandBreakState::startBreak(GolemClimbWeakPoint*)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->