### PR TITLE
Boss/Koopa: Implement `KoopaStateHitPunch`

### DIFF
--- a/src/Boss/Koopa/KoopaFlag.h
+++ b/src/Boss/Koopa/KoopaFlag.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaFlag {
+public:
+    KoopaFlag();
+    bool tryStartPunchHitFirst();
+    bool trySkipJumpSign();
+
+    bool hasHitEnd() const { return mHasHitEnd; }
+
+    void setHasHitEnd() { mHasHitEnd = true; }
+
+private:
+    bool _0 = false;
+    bool _1 = false;
+    bool _2 = false;
+    bool mHasHitEnd = false;
+    bool _4 = false;
+    bool _5 = false;
+    bool _6 = false;
+    bool _7 = true;
+};

--- a/src/Boss/Koopa/KoopaFunction.h
+++ b/src/Boss/Koopa/KoopaFunction.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+class LiveActorGroup;
+struct ActorInitInfo;
+class HitSensor;
+struct EnemyStateBlowDownParam;
+class EventFlowExecutor;
+}  // namespace al
+
+class KoopaCap;
+class KoopaNumberCounter;
+class KoopaItemHolder;
+class KoopaCameraCtrl;
+class KoopaDemoExecutor;
+class KoopaDemoDummy;
+class Peach;
+
+namespace KoopaFunction {
+void initActorKoopa(al::LiveActor*, const al::ActorInitInfo&);
+void invalidateTailSensors(al::LiveActor*);
+void initActorKoopaDemoModel(al::LiveActor*, const al::ActorInitInfo&);
+al::LiveActor* initAndCreateDemoModel(const al::ActorInitInfo&);
+Peach* initAndCreateLinksPeach(const al::ActorInitInfo&);
+al::LiveActor* initAndCreateDemoPeachRing(const al::ActorInitInfo&);
+al::LiveActorGroup* initAndCreateWeaponCapGroup(const al::ActorInitInfo&, KoopaItemHolder*);
+al::LiveActorGroup* initAndCreateDamageBallGroup(const al::ActorInitInfo&, KoopaItemHolder*,
+                                                 const sead::Matrix34f*);
+al::LiveActorGroup* initAndCreateDamageBallBombGroup(const al::ActorInitInfo&, KoopaItemHolder*,
+                                                     const sead::Matrix34f*);
+KoopaDemoExecutor* initAndCreateDemoExecutorLv1(al::LiveActor*, const al::ActorInitInfo&,
+                                                KoopaCameraCtrl*, al::LiveActor*, KoopaCap*,
+                                                Peach*);
+KoopaDemoExecutor* initAndCreateDemoExecutorLv2(al::LiveActor*, const al::ActorInitInfo&,
+                                                KoopaCameraCtrl*, al::LiveActor*, KoopaCap*,
+                                                Peach*);
+al::EventFlowExecutor* initAndCreateDemoEventChurch(al::LiveActor*, const al::ActorInitInfo&);
+const al::LiveActor* tryGetDemoKoopaSubActor(const al::LiveActor*);
+const al::LiveActor* tryGetDemoPeachSubActor(const al::LiveActor*);
+void validateTailSensors(al::LiveActor*);
+bool isTailSensor(const al::HitSensor*);
+void calcAnimPost(al::LiveActor*, KoopaCap*);
+void startCapOnAnim(al::LiveActor*);
+void startCapOffAnim(al::LiveActor*);
+void updateFallVelocityToGravity(al::LiveActor*);
+void updateOnGroundVelocity(al::LiveActor*);
+void addVelocityToGravityFitCurvedSurface(al::LiveActor*, f32);
+void turnKoopaToTrans(al::LiveActor*, const sead::Vector3f*);
+void turnKoopaToPlayer(al::LiveActor*);
+void initCapJointSideRotator(al::LiveActor*, f32*);
+const al::EnemyStateBlowDownParam& getCapBlowDownParam();
+void updateCapBlowDownSideDegree(f32*, const al::LiveActor*);
+f32 getCapGravityTurnRate();
+f32 getCapPushLimit();
+s32 getLevel1();
+s32 getLevel2();
+s32 getLevel3();
+bool isLevel1(const KoopaNumberCounter*);
+bool isLevel2(const KoopaNumberCounter*);
+bool isLevelGreater2(const KoopaNumberCounter*);
+bool isLevel3(const KoopaNumberCounter*);
+void onSwitchBattleKeepOn(al::LiveActor*);
+void offSwitchBattleKeepOn(al::LiveActor*);
+void onSwitchGraphicsLevelByHp(al::LiveActor*, s32);
+void onSwitchGraphicsLevelBattleEnd(al::LiveActor*);
+KoopaDemoDummy* createAndInitLinksKoopaDemoModelSkyWorld(const al::ActorInitInfo&, const char*,
+                                                         s32);
+void startHitReactionPunchHitInvincible(al::LiveActor*);
+}  // namespace KoopaFunction

--- a/src/Boss/Koopa/KoopaNumberCounter.h
+++ b/src/Boss/Koopa/KoopaNumberCounter.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+
+namespace al {
+class LiveActor;
+struct ActorInitInfo;
+}  // namespace al
+
+class KoopaCap;
+
+class KoopaNumberCounter {
+public:
+    KoopaNumberCounter(const al::ActorInitInfo&);
+    bool isValidFireBeam() const;
+    s32 getDamage() const;
+    bool isShowCapWide() const;
+    void startBeam();
+    bool isFirstBeam() const;
+    bool isLastBeam() const;
+    bool addBeamCountAndCheckEnd();
+    bool isEnableStartDamageBall() const;
+    bool tryStartDamageBall();
+    bool isBombDamageBall(s32) const;
+    bool addDamageBallCountAndCheckEnd();
+    bool addDamageBallContinueSkipCountAndCheckSkip();
+    bool isDamageBallContinueSkipped() const;
+    bool tryStartAttackTail(KoopaCap*);
+    bool isExecuteAttackTailTwice() const;
+    bool addAttackTailCountAndCheckEnd();
+    bool isGuardPunchHitAction() const;
+    f32* getPunchHitSeParamPtr() const;
+    void addPunchHitCountAndPowerUpCap(KoopaCap*);
+    void recoverPunchHitCount(KoopaCap*);
+    void startPunchHitAction(al::LiveActor*) const;
+    void makeDamageAnimSeName(sead::BufferedSafeString*) const;
+    bool receiveDamageAndCheckDead(KoopaCap*);
+};

--- a/src/Boss/Koopa/KoopaStateHitPunch.cpp
+++ b/src/Boss/Koopa/KoopaStateHitPunch.cpp
@@ -1,0 +1,59 @@
+#include "Boss/Koopa/KoopaStateHitPunch.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/Koopa/KoopaFlag.h"
+#include "Boss/Koopa/KoopaFunction.h"
+#include "Boss/Koopa/KoopaNumberCounter.h"
+
+namespace {
+NERVE_IMPL(KoopaStateHitPunch, Hit);
+NERVE_IMPL(KoopaStateHitPunch, HitFirst);
+NERVE_IMPL(KoopaStateHitPunch, HitEnd);
+NERVES_MAKE_NOSTRUCT(KoopaStateHitPunch, Hit, HitFirst, HitEnd);
+}  // namespace
+
+KoopaStateHitPunch::KoopaStateHitPunch(al::LiveActor* actor, KoopaCap* cap, KoopaFlag* flag,
+                                       KoopaNumberCounter* counter)
+    : al::ActorStateBase("パンチヒット", actor), mCap(cap), mFlag(flag), mCounter(counter) {
+    initNerve(&Hit, 0);
+}
+
+void KoopaStateHitPunch::appear() {
+    NerveStateBase::appear();
+    if (mFlag->tryStartPunchHitFirst())
+        al::setNerve(this, &HitFirst);
+    else
+        al::setNerve(this, &Hit);
+}
+
+void KoopaStateHitPunch::exeHitFirst() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GuardFirst");
+    KoopaFunction::updateOnGroundVelocity(mActor);
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Hit);
+}
+
+void KoopaStateHitPunch::exeHit() {
+    if (al::isFirstStep(this))
+        mCounter->startPunchHitAction(mActor);
+    KoopaFunction::updateOnGroundVelocity(mActor);
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &HitEnd);
+}
+
+void KoopaStateHitPunch::exeHitEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GuardEnd");
+    KoopaFunction::updateOnGroundVelocity(mActor);
+    if (al::isActionEnd(mActor)) {
+        mFlag->setHasHitEnd();
+        mCounter->recoverPunchHitCount(mCap);
+        al::setVelocityZero(mActor);
+        kill();
+    }
+}

--- a/src/Boss/Koopa/KoopaStateHitPunch.h
+++ b/src/Boss/Koopa/KoopaStateHitPunch.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaCap;
+class KoopaFlag;
+class KoopaNumberCounter;
+
+class KoopaStateHitPunch : public al::ActorStateBase {
+public:
+    KoopaStateHitPunch(al::LiveActor* actor, KoopaCap* cap, KoopaFlag* flag,
+                       KoopaNumberCounter* counter);
+    void appear() override;
+    void exeHitFirst();
+    void exeHit();
+    void exeHitEnd();
+
+private:
+    KoopaCap* mCap = nullptr;
+    KoopaFlag* mFlag = nullptr;
+    KoopaNumberCounter* mCounter = nullptr;
+};
+
+static_assert(sizeof(KoopaStateHitPunch) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/988)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (025cd8a - 3d056d5)

📈 **Matched code**: 14.06% (+0.01%, +760 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::exeHitEnd()` | +128 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::KoopaStateHitPunch(al::LiveActor*, KoopaCap*, KoopaFlag*, KoopaNumberCounter*)` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `(anonymous namespace)::KoopaStateHitPunchNrvHit::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::exeHit()` | +104 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `(anonymous namespace)::KoopaStateHitPunchNrvHitFirst::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::exeHitFirst()` | +96 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::appear()` | +72 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `KoopaStateHitPunch::~KoopaStateHitPunch()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHitPunch` | `(anonymous namespace)::KoopaStateHitPunchNrvHitEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->