### PR TITLE
MapObj: Implement `FixMapPartsBgmChangeAction`

### DIFF
--- a/src/MapObj/FixMapPartsBgmChangeAction.cpp
+++ b/src/MapObj/FixMapPartsBgmChangeAction.cpp
@@ -1,0 +1,42 @@
+#include "MapObj/FixMapPartsBgmChangeAction.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+namespace {
+NERVE_ACTION_IMPL(FixMapPartsBgmChangeAction, Wait)
+NERVE_ACTION_IMPL(FixMapPartsBgmChangeAction, PlayingBgm)
+
+NERVE_ACTIONS_MAKE_STRUCT(FixMapPartsBgmChangeAction, Wait, PlayingBgm)
+}  // namespace
+
+FixMapPartsBgmChangeAction::FixMapPartsBgmChangeAction(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void FixMapPartsBgmChangeAction::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Wait", &NrvFixMapPartsBgmChangeAction.collector, 0);
+    al::initMapPartsActor(this, info, nullptr);
+    al::getStringArg(&mChangeBgm, info, "ChangeBgm");
+    makeActorAlive();
+}
+
+bool FixMapPartsBgmChangeAction::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                            al::HitSensor* self) {
+    if (al::isMsgAskSafetyPoint(message))
+        return true;
+    return false;
+}
+
+void FixMapPartsBgmChangeAction::exeWait() {
+    if (al::isRunningBgm(this, mChangeBgm))
+        al::startNerveAction(this, "PlayingBgm");
+}
+
+void FixMapPartsBgmChangeAction::exePlayingBgm() {
+    if (!al::isRunningBgm(this, mChangeBgm))
+        al::startNerveAction(this, "Wait");
+}

--- a/src/MapObj/FixMapPartsBgmChangeAction.h
+++ b/src/MapObj/FixMapPartsBgmChangeAction.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class FixMapPartsBgmChangeAction : public al::LiveActor {
+public:
+    FixMapPartsBgmChangeAction(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exePlayingBgm();
+
+private:
+    const char* mChangeBgm = nullptr;
+};
+
+static_assert(sizeof(FixMapPartsBgmChangeAction) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -76,6 +76,7 @@
 #include "MapObj/Doshi.h"
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
+#include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
 #include "MapObj/HipDropSwitch.h"
 #include "MapObj/KoopaShip.h"
@@ -296,7 +297,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"FishingFish", nullptr},
     {"FixMapParts2D", nullptr},
     {"FixMapPartsAppearKillAsync", nullptr},
-    {"FixMapPartsBgmChangeAction", nullptr},
+    {"FixMapPartsBgmChangeAction", al::createActorFunction<FixMapPartsBgmChangeAction>},
     {"FixMapPartsCapHanger", nullptr},
     {"FixMapPartsDitherAppear", nullptr},
     {"FixMapPartsForceSafetyPoint", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/990)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (025cd8a - be17740)

📈 **Matched code**: 14.06% (+0.01%, +812 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::FixMapPartsBgmChangeAction(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::FixMapPartsBgmChangeAction(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::init(al::ActorInitInfo const&)` | +108 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `_GLOBAL__sub_I_FixMapPartsBgmChangeAction.cpp` | +88 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::exeWait()` | +68 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::exePlayingBgm()` | +68 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `(anonymous namespace)::FixMapPartsBgmChangeActionNrvWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `(anonymous namespace)::FixMapPartsBgmChangeActionNrvPlayingBgm::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<FixMapPartsBgmChangeAction>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `(anonymous namespace)::FixMapPartsBgmChangeActionNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `(anonymous namespace)::FixMapPartsBgmChangeActionNrvPlayingBgm::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/FixMapPartsBgmChangeAction` | `FixMapPartsBgmChangeAction::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->