### PR TITLE
MapObj: Implement `MoonBasementBreakParts`

### DIFF
--- a/src/MapObj/MoonBasementBreakParts.cpp
+++ b/src/MapObj/MoonBasementBreakParts.cpp
@@ -1,0 +1,41 @@
+#include "MapObj/MoonBasementBreakParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(MoonBasementBreakParts, Wait)
+NERVE_IMPL(MoonBasementBreakParts, Break)
+
+NERVES_MAKE_NOSTRUCT(MoonBasementBreakParts, Wait, Break)
+}  // namespace
+
+MoonBasementBreakParts::MoonBasementBreakParts(const char* actorName) : al::LiveActor(actorName) {}
+
+void MoonBasementBreakParts::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "MoonWorldBasementBreakParts000", nullptr);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+}
+
+void MoonBasementBreakParts::appear() {
+    al::setNerve(this, &Wait);
+    al::LiveActor::appear();
+}
+
+void MoonBasementBreakParts::kill() {
+    al::startAction(this, "Break");
+    al::setNerve(this, &Break);
+}
+
+void MoonBasementBreakParts::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MoonBasementBreakParts::exeBreak() {
+    if (al::isActionEnd(this))
+        al::LiveActor::kill();
+}

--- a/src/MapObj/MoonBasementBreakParts.h
+++ b/src/MapObj/MoonBasementBreakParts.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class MoonBasementBreakParts : public al::LiveActor {
+public:
+    MoonBasementBreakParts(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+
+    void exeWait();
+    void exeBreak();
+};
+
+static_assert(sizeof(MoonBasementBreakParts) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -81,6 +81,7 @@
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
+#include "MapObj/MoonBasementBreakParts.h"
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/PeachWorldTree.h"
@@ -398,7 +399,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"MeganeKeyMoveMapParts", nullptr},
     {"MeganeMapParts", al::createActorFunction<MeganeMapParts>},
     {"Mirror", nullptr},
-    {"MoonBasementBreakParts", nullptr},
+    {"MoonBasementBreakParts", al::createActorFunction<MoonBasementBreakParts>},
     {"MoonBasementClimaxWatcher", nullptr},
     {"MoonBasementFallObj", nullptr},
     {"MoonBasementFinalGate", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/991)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (025cd8a - 12ab46a)

📈 **Matched code**: 14.06% (+0.01%, +744 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::MoonBasementBreakParts(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::MoonBasementBreakParts(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `(anonymous namespace)::MoonBasementBreakPartsNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::exeWait()` | +60 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `(anonymous namespace)::MoonBasementBreakPartsNrvBreak::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::kill()` | +52 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::exeBreak()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<MoonBasementBreakParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/MoonBasementBreakParts` | `MoonBasementBreakParts::appear()` | +44 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->