### PR TITLE
MapObj: Implement `PeachTrunk`

### DIFF
--- a/src/MapObj/PeachTrunk.cpp
+++ b/src/MapObj/PeachTrunk.cpp
@@ -1,0 +1,47 @@
+#include "MapObj/PeachTrunk.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(PeachTrunk, Wait)
+NERVE_IMPL(PeachTrunk, ReactionCap)
+
+NERVES_MAKE_NOSTRUCT(PeachTrunk, Wait, ReactionCap)
+}  // namespace
+
+PeachTrunk::PeachTrunk(const char* actorName) : al::LiveActor(actorName) {}
+
+void PeachTrunk::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "PeachTrunk", nullptr);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+}
+
+bool PeachTrunk::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                            al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    if (rs::isMsgNpcCapReactionAll(message)) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::setNerve(this, &ReactionCap);
+        return true;
+    }
+    return false;
+}
+
+void PeachTrunk::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void PeachTrunk::exeReactionCap() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "ReactionCap");
+    al::setNerveAtActionEnd(this, &Wait);
+}

--- a/src/MapObj/PeachTrunk.h
+++ b/src/MapObj/PeachTrunk.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class PeachTrunk : public al::LiveActor {
+public:
+    PeachTrunk(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeReactionCap();
+};
+
+static_assert(sizeof(PeachTrunk) == 0x108);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/992)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (025cd8a - 627577c)

📈 **Matched code**: 14.06% (+0.01%, +736 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PeachTrunk` | `PeachTrunk::PeachTrunk(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `PeachTrunk::PeachTrunk(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `PeachTrunk::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +116 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `PeachTrunk::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `(anonymous namespace)::PeachTrunkNrvReactionCap::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `PeachTrunk::exeReactionCap()` | +64 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `(anonymous namespace)::PeachTrunkNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/PeachTrunk` | `PeachTrunk::exeWait()` | +60 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->