### PR TITLE
MapObj: Implement `ReactionMapParts`

### DIFF
--- a/src/MapObj/ReactionMapParts.cpp
+++ b/src/MapObj/ReactionMapParts.cpp
@@ -1,0 +1,44 @@
+#include "MapObj/ReactionMapParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(ReactionMapParts, Wait)
+NERVE_IMPL(ReactionMapParts, Reaction)
+
+NERVES_MAKE_NOSTRUCT(ReactionMapParts, Wait, Reaction)
+}  // namespace
+
+ReactionMapParts::ReactionMapParts(const char* actorName) : al::LiveActor(actorName) {}
+
+void ReactionMapParts::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+bool ReactionMapParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self) {
+    if (rs::isMsgCapTouchWall(message) || rs::isMsgPlayerRollingWallHitDown(message)) {
+        al::setNerve(this, &Reaction);
+        return true;
+    }
+    return false;
+}
+
+void ReactionMapParts::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void ReactionMapParts::exeReaction() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Reaction");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}

--- a/src/MapObj/ReactionMapParts.h
+++ b/src/MapObj/ReactionMapParts.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class ReactionMapParts : public al::LiveActor {
+public:
+    ReactionMapParts(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeReaction();
+};
+
+static_assert(sizeof(ReactionMapParts) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -85,6 +85,7 @@
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PoleGrabCeil.h"
+#include "MapObj/ReactionMapParts.h"
 #include "MapObj/RiseMapPartsHolder.h"
 #include "MapObj/RouletteSwitch.h"
 #include "MapObj/SaveFlagCheckObj.h"
@@ -660,7 +661,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"RailCollision", nullptr},
     {"RailMoveMapParts", al::createActorFunction<al::RailMoveMapParts>},
     {"RiseMapParts", nullptr},
-    {"ReactionMapParts", nullptr},
+    {"ReactionMapParts", al::createActorFunction<ReactionMapParts>},
     {"RiseMapPartsHolder", al::createActorFunction<RiseMapPartsHolder>},
     {"RocketFlower", nullptr},
     {"RollingCubeMapParts", al::createActorFunction<al::RollingCubeMapParts>},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/993)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6161aae - 02e1ab2)

📈 **Matched code**: 14.09% (+0.01%, +752 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ReactionMapParts` | `ReactionMapParts::ReactionMapParts(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `ReactionMapParts::ReactionMapParts(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `(anonymous namespace)::ReactionMapPartsNrvReaction::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `ReactionMapParts::exeReaction()` | +88 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `ReactionMapParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +84 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `(anonymous namespace)::ReactionMapPartsNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `ReactionMapParts::init(al::ActorInitInfo const&)` | +60 | 0.00% | 100.00% |
| `MapObj/ReactionMapParts` | `ReactionMapParts::exeWait()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<ReactionMapParts>(char const*)` | +52 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->