### PR TITLE
ModeBalloon: Implement `TimeBalloonStateShowResult`

### DIFF
--- a/src/ModeBalloon/TimeBalloonAchievementLayout.h
+++ b/src/ModeBalloon/TimeBalloonAchievementLayout.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+
+class IBalloonFindMyAchievementHolder;
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class TimeBalloonAchievementLayout : public al::SimpleLayoutAppearWaitEnd {
+public:
+    TimeBalloonAchievementLayout(const al::LayoutInitInfo& info);
+
+    void appear() override;
+    void update();
+    void setAchievement(const IBalloonFindMyAchievementHolder* holder);
+
+private:
+    u8 _130[0x288 - 0x130];
+};
+
+static_assert(sizeof(TimeBalloonAchievementLayout) == 0x288);

--- a/src/ModeBalloon/TimeBalloonData.h
+++ b/src/ModeBalloon/TimeBalloonData.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+class FriendsProfileDataHolder;
+
+namespace al {
+class FriendsProfileData;
+}  // namespace al
+
+namespace nn::nex {
+template <typename K, typename V>
+class qMap;
+template <typename T>
+class qVector;
+class qBuffer;
+struct DataStoreRatingInfo;
+struct DataStoreSearchBalloonResult;
+}  // namespace nn::nex
+
+namespace TimeBalloon {
+class BalloonDataServer {
+public:
+    BalloonDataServer();
+    virtual ~BalloonDataServer();
+};
+
+class BalloonData {
+public:
+    void setRatingInfo(const nn::nex::qMap<s8, nn::nex::DataStoreRatingInfo>& ratingInfoMap);
+    void setGotIdList(const nn::nex::qVector<nn::nex::qBuffer>& gotIdList);
+    void setPlayedIdList(const nn::nex::qVector<nn::nex::qBuffer>& playedIdList);
+    const nn::nex::qVector<nn::nex::qBuffer>& getGotIdList() const;
+    const nn::nex::qVector<nn::nex::qBuffer>& getPlayedIdList() const;
+};
+
+struct BalloonDataMetaBinary;
+
+class RankAchievement {
+public:
+    void end();
+};
+
+void initBalloonDataServer(BalloonDataServer* server);
+
+bool isGotBalloon(const BalloonData& balloonData);
+s32 getPlayerRank(const BalloonData& balloonData);
+s64 getPlayedNum(const BalloonData& balloonData);
+s32 calcGotCoin(const BalloonData& balloonData);
+s32 calcProtectNum(const BalloonData& balloonData);
+s64 calcProtectCoin(const BalloonData& balloonData);
+s64 calcProtectCoin(s32 protectNum);
+al::FriendsProfileData* tryGetProfileData(const BalloonData& balloonData);
+void tryGetNickName(const char** outNickName, const BalloonData& balloonData);
+const char* tryGetNickName(const BalloonData& balloonData);
+void getBalloonPos(sead::Vector3f* outBalloonPos, const BalloonData& balloonData);
+
+void setRatingInfo(BalloonData* balloonData,
+                   const nn::nex::qMap<s8, nn::nex::DataStoreRatingInfo>& ratingInfoMap);
+void createBalloonData(BalloonData* balloonData,
+                       const nn::nex::DataStoreSearchBalloonResult& searchBalloonResult,
+                       FriendsProfileDataHolder* profileDataHolder, bool isGotBalloon);
+void createBalloonData(BalloonData* balloonData, u64 dataId, u64 ownerId, u16 playerRank,
+                       const nn::nex::qMap<s8, nn::nex::DataStoreRatingInfo>& ratingInfoMap,
+                       const BalloonDataMetaBinary* metaBinary,
+                       FriendsProfileDataHolder* profileDataHolder, bool isGotBalloon);
+
+s32 getBalloonGotSlotId();
+s32 getBalloonPlayedSlotId();
+
+}  // namespace TimeBalloon

--- a/src/ModeBalloon/TimeBalloonStateShowResult.cpp
+++ b/src/ModeBalloon/TimeBalloonStateShowResult.cpp
@@ -1,0 +1,59 @@
+#include "ModeBalloon/TimeBalloonStateShowResult.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "ModeBalloon/TimeBalloonAchievementLayout.h"
+#include "Util/StageInputFunction.h"
+
+namespace {
+NERVE_IMPL(TimeBalloonStateShowResult, Appear)
+NERVE_IMPL(TimeBalloonStateShowResult, Wait)
+NERVE_IMPL(TimeBalloonStateShowResult, End)
+
+NERVES_MAKE_NOSTRUCT(TimeBalloonStateShowResult, Appear, Wait, End)
+}  // namespace
+
+TimeBalloonStateShowResult::TimeBalloonStateShowResult(
+    StageSceneStateTimeBalloon* timeBalloon, al::SimpleLayoutAppearWaitEnd* layout,
+    const IBalloonFindMyAchievementHolder* achievementHolder, const al::LayoutInitInfo& info)
+    : al::HostStateBase<StageSceneStateTimeBalloon>("結果を見る(風船割りゲーム)", timeBalloon),
+      mAchievementHolder(achievementHolder) {
+    mAchievementLayout = new TimeBalloonAchievementLayout(info);
+}
+
+void TimeBalloonStateShowResult::init() {
+    initNerve(&Appear, 0);
+}
+
+void TimeBalloonStateShowResult::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Appear);
+}
+
+void TimeBalloonStateShowResult::exeAppear() {
+    if (al::isFirstStep(this)) {
+        mAchievementLayout->setAchievement(mAchievementHolder);
+        mAchievementLayout->appear();
+    }
+    mAchievementLayout->update();
+    if (mAchievementLayout->isWait())
+        al::setNerve(this, &Wait);
+}
+
+void TimeBalloonStateShowResult::exeWait() {
+    mAchievementLayout->update();
+    if (rs::isTriggerUiCancel(mAchievementLayout))
+        al::setNerve(this, &End);
+}
+
+void TimeBalloonStateShowResult::exeEnd() {
+    if (al::isFirstStep(this))
+        mAchievementLayout->end();
+    if (!mAchievementLayout->isAlive())
+        kill();
+}
+
+void TimeBalloonStateShowResult::setNerveWait() {
+    al::setNerve(this, &Wait);
+}

--- a/src/ModeBalloon/TimeBalloonStateShowResult.h
+++ b/src/ModeBalloon/TimeBalloonStateShowResult.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LayoutInitInfo;
+class SimpleLayoutAppearWaitEnd;
+}  // namespace al
+
+class IBalloonFindMyAchievementHolder;
+class StageSceneStateTimeBalloon;
+class TimeBalloonAchievementLayout;
+
+class TimeBalloonStateShowResult : public al::HostStateBase<StageSceneStateTimeBalloon> {
+public:
+    TimeBalloonStateShowResult(StageSceneStateTimeBalloon* timeBalloon,
+                               al::SimpleLayoutAppearWaitEnd* layout,
+                               const IBalloonFindMyAchievementHolder* achievementHolder,
+                               const al::LayoutInitInfo& info);
+
+    void init() override;
+    void appear() override;
+
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+
+    void setNerveWait();
+
+private:
+    const IBalloonFindMyAchievementHolder* mAchievementHolder = nullptr;
+    TimeBalloonAchievementLayout* mAchievementLayout = nullptr;
+};
+
+static_assert(sizeof(TimeBalloonStateShowResult) == 0x30);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/994)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (68a58e9 - 4213d46)

📈 **Matched code**: 14.11% (+0.01%, +732 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::TimeBalloonStateShowResult(StageSceneStateTimeBalloon*, al::SimpleLayoutAppearWaitEnd*, IBalloonFindMyAchievementHolder const*, al::LayoutInitInfo const&)` | +108 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `(anonymous namespace)::TimeBalloonStateShowResultNrvAppear::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::exeAppear()` | +104 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::exeWait()` | +84 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `(anonymous namespace)::TimeBalloonStateShowResultNrvWait::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `(anonymous namespace)::TimeBalloonStateShowResultNrvEnd::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::exeEnd()` | +80 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::~TimeBalloonStateShowResult()` | +36 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::init()` | +16 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::appear()` | +16 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateShowResult` | `TimeBalloonStateShowResult::setNerveWait()` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->