### PR TITLE
MapObj: Implement `FastenerObjSpace`

### DIFF
--- a/src/MapObj/FastenerObjSpace.cpp
+++ b/src/MapObj/FastenerObjSpace.cpp
@@ -1,0 +1,44 @@
+#include "MapObj/FastenerObjSpace.h"
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(FastenerObjSpace, Wait);
+NERVE_IMPL(FastenerObjSpace, Disappear);
+NERVES_MAKE_NOSTRUCT(FastenerObjSpace, Wait, Disappear);
+}  // namespace
+
+FastenerObjSpace::FastenerObjSpace(const char* name) : al::LiveActor(name) {}
+
+void FastenerObjSpace::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "FastenerSpace", nullptr);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+}
+
+void FastenerObjSpace::appear() {
+    al::LiveActor::appear();
+    al::setModelAlphaMask(this, 1.0f);
+    al::setNerve(this, &Wait);
+}
+
+void FastenerObjSpace::disappear() {
+    al::invalidateClipping(this);
+    al::setNerve(this, &Disappear);
+}
+
+void FastenerObjSpace::exeWait() {
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void FastenerObjSpace::exeDisappear() {
+    f32 rate = al::calcNerveRate(this, 60);
+    al::setModelAlphaMask(this, 1.0f - rate);
+    if (al::isGreaterStep(this, 60))
+        kill();
+}

--- a/src/MapObj/FastenerObjSpace.h
+++ b/src/MapObj/FastenerObjSpace.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class FastenerObjSpace : public al::LiveActor {
+public:
+    FastenerObjSpace(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void disappear();
+    void exeWait();
+    void exeDisappear();
+
+private:
+    al::LiveActor* mLinkActor = nullptr;
+};
+
+static_assert(sizeof(FastenerObjSpace) == 0x110);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/995)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6161aae - 9658b44)

📈 **Matched code**: 14.09% (+0.01%, +672 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::FastenerObjSpace(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::FastenerObjSpace(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `(anonymous namespace)::FastenerObjSpaceNrvDisappear::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::exeDisappear()` | +92 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::appear()` | +56 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::disappear()` | +44 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `(anonymous namespace)::FastenerObjSpaceNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/FastenerObjSpace` | `FastenerObjSpace::exeWait()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->