### PR TITLE
Library/Bgm: Implement `BgmMusicalInfo` and `copyAudioInfoList`

### DIFF
--- a/lib/al/Library/Audio/AudioInfo.h
+++ b/lib/al/Library/Audio/AudioInfo.h
@@ -46,6 +46,8 @@ class AudioInfoList {
 public:
     static s32 compareInfoAndKey(const T* info, const char* key) { return strcmp(info->name, key); }
 
+    static s32 compareInfoAndId(const T* info, u32 id);
+
     AudioInfoList() = default;
 
     void init(s32 listSize) {
@@ -54,7 +56,21 @@ public:
         mList->allocBuffer((listSize == 0) ? 1 : listSize, nullptr);
     }
 
-    bool setInfo(const T* audioInfo) const { return mList->pushBack(audioInfo); }
+    bool setInfo(const T* info) const { return mList->pushBack(info); }
+
+    const T* getInfoAt(s32 index) const {
+        if (index >= 0)
+            return mList->unsafeAt(index);
+        return nullptr;
+    }
+
+    bool copyAndSetInfo(const T* info) const {
+        if (!info)
+            return false;
+
+        T* newInfo = new T(*info);
+        return setInfo(newInfo);
+    }
 
     void sort() const {
         if (mList->size() >= 10)
@@ -63,9 +79,13 @@ public:
             mList->sort(T::compareInfo);
     }
 
+    s32 getTotalSize() const { return mList->size(); }
+
+    bool isValidIndex(s32 index) const { return index < getTotalSize(); }
+
 private:
     sead::PtrArray<const T>* mList;
-    bool mIsLinearSearch;
+    bool mIsLinearSearch = false;
 };
 
 template <typename T>
@@ -93,10 +113,37 @@ public:
             mParts->at(i)->sort();
     }
 
+    const T* getInfoAt(s32 index) const {
+        if (AudioInfoList<T>::isValidIndex(index))
+            return AudioInfoList<T>::getInfoAt(index);
+        index -= AudioInfoList<T>::getTotalSize();
+
+        for (s32 i = 0; i < getPartsSize(); i++) {
+            const AudioInfoList<T>* part = mParts->at(i);
+            if (part->isValidIndex(index))
+                return part->getInfoAt(index);
+            index -= part->getTotalSize();
+        }
+
+        return nullptr;
+    }
+
     s32 getPartsSize() const {
         if (!mParts)
             return 0;
         return mParts->size();
+    }
+
+    s32 getTotalSize() const {
+        if (!mParts)
+            return AudioInfoList<T>::getTotalSize();
+
+        s32 size = AudioInfoList<T>::getTotalSize();
+        s32 partsSize = 0;
+        for (s32 i = 0; i < getPartsSize(); i++)
+            partsSize += mParts->at(i)->getTotalSize();
+
+        return size + partsSize;
     }
 
 private:
@@ -140,4 +187,23 @@ const T* tryFindAudioInfo(const AudioInfoListWithParts<T>* audioInfoList, const 
     return audioInfoList->tryFindInfo(name);
 }
 
+template <typename T>
+AudioInfoListWithParts<T>* copyAudioInfoList(const AudioInfoListWithParts<T>* audioInfoList,
+                                             s32 additionalSize) {
+    if (!audioInfoList)
+        return nullptr;
+
+    s32 originalSize = audioInfoList->getTotalSize();
+    s32 newSize = originalSize + additionalSize;
+
+    AudioInfoListWithParts<T>* newAudioInfoList = new AudioInfoListWithParts<T>;
+    newAudioInfoList->init(newSize, 0);
+
+    for (s32 i = 0; i < originalSize; i++) {
+        const T* info = audioInfoList->getInfoAt(i);
+        newAudioInfoList->copyAndSetInfo(info);
+    }
+
+    return newAudioInfoList;
+}
 }  // namespace al

--- a/lib/al/Library/Audio/AudioInfo.h
+++ b/lib/al/Library/Audio/AudioInfo.h
@@ -46,7 +46,7 @@ class AudioInfoList {
 public:
     static s32 compareInfoAndKey(const T* info, const char* key) { return strcmp(info->name, key); }
 
-    static s32 compareInfoAndId(const T* info, u32 id);
+    static s32 compareInfoAndId(const T* info, const u32* id);
 
     AudioInfoList() = default;
 
@@ -59,9 +59,9 @@ public:
     bool setInfo(const T* info) const { return mList->pushBack(info); }
 
     const T* getInfoAt(s32 index) const {
-        if (index >= 0)
-            return mList->unsafeAt(index);
-        return nullptr;
+        if (index < 0)
+            return nullptr;
+        return mList->unsafeAt(index);
     }
 
     bool copyAndSetInfo(const T* info) const {
@@ -79,9 +79,9 @@ public:
             mList->sort(T::compareInfo);
     }
 
-    s32 getTotalSize() const { return mList->size(); }
+    s32 getSize() const { return mList->size(); }
 
-    bool isValidIndex(s32 index) const { return index < getTotalSize(); }
+    bool isValidIndex(s32 index) const { return index < getSize(); }
 
 private:
     sead::PtrArray<const T>* mList;
@@ -116,13 +116,13 @@ public:
     const T* getInfoAt(s32 index) const {
         if (AudioInfoList<T>::isValidIndex(index))
             return AudioInfoList<T>::getInfoAt(index);
-        index -= AudioInfoList<T>::getTotalSize();
+        index -= AudioInfoList<T>::getSize();
 
         for (s32 i = 0; i < getPartsSize(); i++) {
             const AudioInfoList<T>* part = mParts->at(i);
             if (part->isValidIndex(index))
                 return part->getInfoAt(index);
-            index -= part->getTotalSize();
+            index -= part->getSize();
         }
 
         return nullptr;
@@ -134,14 +134,14 @@ public:
         return mParts->size();
     }
 
-    s32 getTotalSize() const {
+    s32 getSize() const {
         if (!mParts)
-            return AudioInfoList<T>::getTotalSize();
+            return AudioInfoList<T>::getSize();
 
-        s32 size = AudioInfoList<T>::getTotalSize();
+        s32 size = AudioInfoList<T>::getSize();
         s32 partsSize = 0;
         for (s32 i = 0; i < getPartsSize(); i++)
-            partsSize += mParts->at(i)->getTotalSize();
+            partsSize += mParts->at(i)->getSize();
 
         return size + partsSize;
     }
@@ -193,7 +193,7 @@ AudioInfoListWithParts<T>* copyAudioInfoList(const AudioInfoListWithParts<T>* au
     if (!audioInfoList)
         return nullptr;
 
-    s32 originalSize = audioInfoList->getTotalSize();
+    s32 originalSize = audioInfoList->getSize();
     s32 newSize = originalSize + additionalSize;
 
     AudioInfoListWithParts<T>* newAudioInfoList = new AudioInfoListWithParts<T>;

--- a/lib/al/Library/Bgm/BgmMusicalInfo.cpp
+++ b/lib/al/Library/Bgm/BgmMusicalInfo.cpp
@@ -1,0 +1,49 @@
+#include "Library/Bgm/BgmMusicalInfo.h"
+
+#include "Library/Audio/AudioInfo.h"
+#include "Library/Bgm/BgmResourceCategoryInfo.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Project/Bgm/BgmInfo.h"
+
+namespace al {
+
+BgmMusicalInfo* BgmMusicalInfo::createInfo(const ByamlIter& iter, const char* name) {
+    BgmMusicalInfo* info = new BgmMusicalInfo();
+    info->name = name;
+
+    ByamlIter animListIter;
+    if (iter.tryGetIterByKey(&animListIter, "AnimList"))
+        info->rhythmInfoList = createAudioInfoList<BgmRhythmInfo>(animListIter, 0);
+
+    ByamlIter chordListIter;
+    if (iter.tryGetIterByKey(&chordListIter, "ChordList"))
+        info->chordInfoList = createAudioInfoList<BgmChordInfo>(chordListIter, 0);
+
+    ByamlIter bpmListIter;
+    if (iter.tryGetIterByKey(&bpmListIter, "BpmInfoList"))
+        info->bpmInfoList = createAudioInfoList<BgmBpmInfo>(bpmListIter, 0);
+
+    ByamlIter timeSignatureListIter;
+    if (iter.tryGetIterByKey(&timeSignatureListIter, "TimeSignatureInfoList"))
+        info->timeSignatureInfoList =
+            createAudioInfoList<BgmTimeSignatureInfo>(timeSignatureListIter, 0);
+
+    iter.tryGetFloatByKey(&info->beatStartOffsetTime, "BeatStartOffsetTime");
+    return info;
+}
+
+s32 BgmMusicalInfo::compareInfo(const BgmMusicalInfo* lhs, const BgmMusicalInfo* rhs) {
+    return strcmp(lhs->name, rhs->name);
+}
+
+BgmMusicalInfo::BgmMusicalInfo() = default;
+
+BgmMusicalInfo::BgmMusicalInfo(const BgmMusicalInfo& info)
+    : name(info.name), beatStartOffsetTime(info.beatStartOffsetTime) {
+    rhythmInfoList = copyAudioInfoList(info.rhythmInfoList, 0);
+    chordInfoList = copyAudioInfoList(info.chordInfoList, 0);
+    bpmInfoList = copyAudioInfoList(info.bpmInfoList, 0);
+    timeSignatureInfoList = copyAudioInfoList(info.timeSignatureInfoList, 0);
+}
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmMusicalInfo.h
+++ b/lib/al/Library/Bgm/BgmMusicalInfo.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+template <typename T>
+class AudioInfoListWithParts;
+class ByamlIter;
+struct BgmRhythmInfo;
+struct BgmChordInfo;
+struct BgmBpmInfo;
+struct BgmTimeSignatureInfo;
+
+struct BgmMusicalInfo {
+    static BgmMusicalInfo* createInfo(const ByamlIter& iter, const char* name);
+    static s32 compareInfo(const BgmMusicalInfo* lhs, const BgmMusicalInfo* rhs);
+
+    BgmMusicalInfo();
+    BgmMusicalInfo(const BgmMusicalInfo&);
+
+    const char* name = nullptr;
+    AudioInfoListWithParts<BgmRhythmInfo>* rhythmInfoList = nullptr;
+    AudioInfoListWithParts<BgmChordInfo>* chordInfoList = nullptr;
+    AudioInfoListWithParts<BgmBpmInfo>* bpmInfoList = nullptr;
+    AudioInfoListWithParts<BgmTimeSignatureInfo>* timeSignatureInfoList = nullptr;
+    f32 beatStartOffsetTime = 0.0f;
+};
+
+static_assert(sizeof(BgmMusicalInfo) == 0x30);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmResourceCategoryInfo.h
+++ b/lib/al/Library/Bgm/BgmResourceCategoryInfo.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ByamlIter;
+
+struct BgmBpmInfo {
+    static BgmBpmInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmBpmInfo* lhs, const BgmBpmInfo* rhs);
+
+    BgmBpmInfo();
+    BgmBpmInfo(const BgmBpmInfo&);
+
+    f32 time = 0.0f;
+    f32 measureTime = 0.0f;
+    f32 bpm = 0.0f;
+    f32 measureStartBeat = 0.0f;
+};
+
+static_assert(sizeof(BgmBpmInfo) == 0x10);
+
+struct BgmTimeSignatureInfo {
+    static BgmTimeSignatureInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmTimeSignatureInfo* lhs, const BgmTimeSignatureInfo* rhs);
+
+    BgmTimeSignatureInfo();
+    BgmTimeSignatureInfo(const BgmTimeSignatureInfo&);
+
+    f32 time = 0.0f;
+    f32 beat = 0.0f;
+    s32 nn = 4;
+    s32 dd = 4;
+};
+
+static_assert(sizeof(BgmTimeSignatureInfo) == 0x10);
+
+}  // namespace al

--- a/lib/al/Project/Bgm/BgmInfo.h
+++ b/lib/al/Project/Bgm/BgmInfo.h
@@ -63,4 +63,36 @@ struct BgmUserInfo {
     AudioInfoListWithParts<BgmActionInfo>* bgmActionInfoList = nullptr;
     AudioInfoListWithParts<BgmSourceInfo>* bgmSourceInfoList = nullptr;
 };
+
+struct BgmRhythmInfo {
+    static BgmRhythmInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmRhythmInfo* lhs, const BgmRhythmInfo* rhs);
+
+    BgmRhythmInfo();
+    BgmRhythmInfo(const BgmRhythmInfo&);
+
+    f32 beat = 0.0f;
+    s32 animId = 0;
+};
+
+static_assert(sizeof(BgmRhythmInfo) == 0x8);
+
+struct BgmChordInfo {
+    static BgmChordInfo* createInfo(const ByamlIter& iter);
+    static BgmChordInfo* createInfoDefault();
+    static s32 compareInfo(const BgmChordInfo* lhs, const BgmChordInfo* rhs);
+
+    BgmChordInfo();
+    BgmChordInfo(const BgmChordInfo&);
+
+    f32 beat = 0.0f;
+    s32 root = 0;
+    s32 chordSize = 0;
+    s32 scaleSize = 0;
+    s32* chordList = nullptr;
+    s32* scaleList = nullptr;
+};
+
+static_assert(sizeof(BgmChordInfo) == 0x20);
+
 }  // namespace al


### PR DESCRIPTION
Seems like no one has pushed PR 1000. Let's celebrate this occasion with musical instruments! :tada: 

This PR implements `copyAudioInfoList`. This function was very difficult to match as it involves multiple layers of templates. But is fully matching and neatly looking.

Since this is a template function `BgmMusicalInfo` is here to validate that everything matches.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1000)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (fc21c02 - 1511b21)

📈 **Matched code**: 14.04% (+0.03%, +4140 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmRhythmInfo>* al::copyAudioInfoList<al::BgmRhythmInfo>(al::AudioInfoListWithParts<al::BgmRhythmInfo> const*, int)` | +488 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmChordInfo>* al::copyAudioInfoList<al::BgmChordInfo>(al::AudioInfoListWithParts<al::BgmChordInfo> const*, int)` | +488 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmBpmInfo>* al::copyAudioInfoList<al::BgmBpmInfo>(al::AudioInfoListWithParts<al::BgmBpmInfo> const*, int)` | +488 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmTimeSignatureInfo>* al::copyAudioInfoList<al::BgmTimeSignatureInfo>(al::AudioInfoListWithParts<al::BgmTimeSignatureInfo> const*, int)` | +488 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmRhythmInfo>* al::createAudioInfoList<al::BgmRhythmInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmChordInfo>* al::createAudioInfoList<al::BgmChordInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmBpmInfo>* al::createAudioInfoList<al::BgmBpmInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListWithParts<al::BgmTimeSignatureInfo>* al::createAudioInfoList<al::BgmTimeSignatureInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::BgmMusicalInfo::createInfo(al::ByamlIter const&, char const*)` | +292 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::BgmMusicalInfo::BgmMusicalInfo(al::BgmMusicalInfo const&)` | +120 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListCreateFunctor<al::BgmRhythmInfo>::tryCreateAudioInfoAndSetToList(al::ByamlIter const&)` | +104 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListCreateFunctor<al::BgmChordInfo>::tryCreateAudioInfoAndSetToList(al::ByamlIter const&)` | +104 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListCreateFunctor<al::BgmBpmInfo>::tryCreateAudioInfoAndSetToList(al::ByamlIter const&)` | +104 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::AudioInfoListCreateFunctor<al::BgmTimeSignatureInfo>::tryCreateAudioInfoAndSetToList(al::ByamlIter const&)` | +104 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::BgmMusicalInfo::BgmMusicalInfo()` | +20 | 0.00% | 100.00% |
| `Library/Bgm/BgmMusicalInfo` | `al::BgmMusicalInfo::compareInfo(al::BgmMusicalInfo const*, al::BgmMusicalInfo const*)` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->