### PR TITLE
MapObj: Implement `DoorAreaChange`

### DIFF
--- a/src/MapObj/DoorAreaChange.cpp
+++ b/src/MapObj/DoorAreaChange.cpp
@@ -1,3 +1,4 @@
+// TODO: think about inlining
 #include "MapObj/DoorAreaChange.h"
 
 #include <prim/seadSafeString.h>
@@ -22,65 +23,69 @@
 #include "Util/SensorMsgFunction.h"
 
 namespace {
-using namespace al;
-
-NERVE_IMPL(DoorAreaChange, Wait);
-NERVE_IMPL(DoorAreaChange, Start);
-NERVE_IMPL(DoorAreaChange, OpenWait);
-NERVE_IMPL(DoorAreaChange, NoStart);
-NERVE_IMPL(DoorAreaChange, CloseBefore);
-NERVE_IMPL(DoorAreaChange, Open);
-NERVE_IMPL(DoorAreaChange, Close);
 NERVE_IMPL(DoorAreaChange, CloseWait);
 NERVE_IMPL(DoorAreaChange, NoStartWithMessage);
+NERVE_IMPL(DoorAreaChange, OpenWait);
+NERVE_IMPL(DoorAreaChange, NoStart);
+NERVE_IMPL(DoorAreaChange, Open);
+NERVE_IMPL(DoorAreaChange, CloseBefore);
+NERVE_IMPL(DoorAreaChange, Close);
 
-NERVES_MAKE_STRUCT(DoorAreaChange, Wait, OpenWait, NoStart, Open, CloseBefore, Start,
-                   NoStartWithMessage);
-NERVES_MAKE_NOSTRUCT(DoorAreaChange, Close, CloseWait);
+NERVES_MAKE_NOSTRUCT(DoorAreaChange, Close);
+NERVES_MAKE_STRUCT(DoorAreaChange, CloseWait, NoStartWithMessage, OpenWait, NoStart, Open,
+                   CloseBefore);
+
 }  // namespace
 
 DoorAreaChange::DoorAreaChange(const char* name) : al::LiveActor(name) {}
 
 void DoorAreaChange::init(const al::ActorInitInfo& info) {
-    using DoorAreaChangeFunctor = FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>;
+    using DoorAreaChangeFunctor = al::FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>;
 
     if (al::isObjectName(info, "ShineTowerRocket"))
-        initActorWithArchiveName(this, info, "DoorAreaChange", nullptr);
+        al::initActorWithArchiveName(this, info, "DoorAreaChange", nullptr);
     else
-        initActorWithArchiveName(this, info, "ShineTowerDoor", nullptr);
-    initNerve(this, &CloseWait, 0);
+        al::initActorWithArchiveName(this, info, "ShineTowerDoor", nullptr);
+
+    al::initNerve(this, &Close, 0);
     mSaveObjInfo = rs::createSaveObjInfoWriteSaveData(info);
-    listenStageSwitchOn(this, "SwitchCloseAgain",
-                        DoorAreaChangeFunctor(this, &DoorAreaChange::switchCloseAgain));
-    if (!rs::isInvalidChangeStage(this)) {
-        if (GameDataFunction::isPlayerStartLinkedObj(this, info, "NoDelete_DeadByPlayerStart")) {
-            setNerve(this, &NrvDoorAreaChange.OpenWait);
-            makeActorAlive();
-            return;
-        }
-        if (listenStageSwitchOnAppear(this, DoorAreaChangeFunctor(this, &DoorAreaChange::appear))) {
-            makeActorDead();
-            return;
-        }
-        if (listenStageSwitchOnStart(this, DoorAreaChangeFunctor(this, &DoorAreaChange::start))) {
-            makeActorAlive();
-            setNerve(this, &NrvDoorAreaChange.NoStart);
-            return;
-        }
-        s32 scenarioNo = 0;
-        if (tryGetArg(&scenarioNo, info, "FixScenarioNo"))
-            if (scenarioNo == GameDataFunction::getScenarioNo(this)) {
-                makeActorAlive();
-                setNerve(this, &NrvDoorAreaChange.NoStart);
-                return;
-            }
-        if (rs::isOnSaveObjInfo(mSaveObjInfo))
-            setNerve(this, &NrvDoorAreaChange.OpenWait);
-        if (tryGetArg(&mIsDoorClosed, info, "IsNeedAppearCapMessage") && mIsDoorClosed)
-            mIsDoorClosed = true;
-    } else {
-        setNerve(this, &NrvDoorAreaChange.Wait);
+    al::listenStageSwitchOn(this, "SwitchCloseAgain",
+                            DoorAreaChangeFunctor(this, &DoorAreaChange::switchCloseAgain));
+
+    if (rs::isInvalidChangeStage(this)) {
+        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
+        makeActorAlive();
+        return;
     }
+
+    if (GameDataFunction::isPlayerStartLinkedObj(this, info, "NoDelete_DeadByPlayerStart")) {
+        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+        makeActorAlive();
+        return;
+    }
+    if (al::listenStageSwitchOnAppear(this, DoorAreaChangeFunctor(this, &DoorAreaChange::appear))) {
+        makeActorDead();
+        return;
+    }
+    if (al::listenStageSwitchOnStart(this, DoorAreaChangeFunctor(this, &DoorAreaChange::start))) {
+        makeActorAlive();
+        al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+        return;
+    }
+    s32 scenarioNo = 0;
+    if (al::tryGetArg(&scenarioNo, info, "FixScenarioNo")) {
+        if (scenarioNo == GameDataFunction::getScenarioNo(this)) {
+            makeActorAlive();
+            al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+            return;
+        }
+    }
+    if (rs::isOnSaveObjInfo(mSaveObjInfo))
+        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+    if (al::tryGetArg(&mIsNeedAppearCapMessage, info, "IsNeedAppearCapMessage") &&
+        mIsNeedAppearCapMessage)
+        mIsNeedAppearCapMessage = true;
+
     makeActorAlive();
 }
 
@@ -90,7 +95,8 @@ bool DoorAreaChange::receiveMsg(const al::SensorMsg* message, al::HitSensor* oth
         return true;
     if (rs::isMsgKoopaRingBeamInvalidTouch(message))
         return true;
-    if (isNerve(this, &NrvDoorAreaChange.Open) || isNerve(this, &NrvDoorAreaChange.OpenWait)) {
+    if (al::isNerve(this, &NrvDoorAreaChange.NoStart) ||
+        al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage)) {
         if (rs::isMsgPlayerDisregardTargetMarker(message))
             return true;
         if (rs::isMsgPlayerDisregardHomingAttack(message))
@@ -99,57 +105,60 @@ bool DoorAreaChange::receiveMsg(const al::SensorMsg* message, al::HitSensor* oth
             return true;
     }
     if (rs::isMsgCapTouchWall(message)) {
-        if (isNerve(this, &NrvDoorAreaChange.Wait)) {
-            sead::Vector3f zero = sead::Vector3f::zero;
-            rs::tryGetCapTouchWallHitPos(&zero, message);
-            startHitReactionHitEffect(this, "ヒット", zero);
-            rs::requestHitReactionToAttacker(message, other, zero);
+        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
+            sead::Vector3f capTouchPos = sead::Vector3f::zero;
+            rs::tryGetCapTouchWallHitPos(&capTouchPos, message);
+            al::startHitReactionHitEffect(this, "ヒット", capTouchPos);
+            rs::requestHitReactionToAttacker(message, other, capTouchPos);
             return true;
         }
-        if (isNerve(this, &CloseWait)) {
+        if (al::isNerve(this, &Close)) {
             rs::onSaveObjInfo(mSaveObjInfo);
-            sead::Vector3f zero = sead::Vector3f::zero;
-            rs::tryGetCapTouchWallHitPos(&zero, message);
-            startHitReactionHitEffect(this, "ヒット", zero);
-            rs::requestHitReactionToAttacker(message, other, zero);
-            setNerve(this, &NrvDoorAreaChange.Open);
+            sead::Vector3f capTouchPos = sead::Vector3f::zero;
+            rs::tryGetCapTouchWallHitPos(&capTouchPos, message);
+            al::startHitReactionHitEffect(this, "ヒット", capTouchPos);
+            rs::requestHitReactionToAttacker(message, other, capTouchPos);
+            al::setNerve(this, &NrvDoorAreaChange.NoStart);
             return true;
         }
     }
-    if (!rs::isMsgCapReflect(message))
-        return false;
-    if (isNerve(this, &NrvDoorAreaChange.Wait)) {
-        startHitReactionHitEffect(this, "ヒット", other, self);
-        rs::requestHitReactionToAttacker(message, self, other);
-        rs::tryShowCapMsgWarpDisableInMiniGameDoorCap(this);
-        return true;
+    if (rs::isMsgCapReflect(message)) {
+        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
+            al::startHitReactionHitEffect(this, "ヒット", other, self);
+            rs::requestHitReactionToAttacker(message, self, other);
+            rs::tryShowCapMsgWarpDisableInMiniGameDoorCap(this);
+            return true;
+        }
+        if (al::isNerve(this, &Close)) {
+            rs::onSaveObjInfo(mSaveObjInfo);
+            al::startHitReactionHitEffect(this, "ヒット", other, self);
+            rs::requestHitReactionToAttacker(message, self, other);
+            al::setNerve(this, &NrvDoorAreaChange.NoStart);
+            return true;
+        }
     }
-    if (!isNerve(this, &CloseWait))
-        return false;
-    rs::onSaveObjInfo(mSaveObjInfo);
-    startHitReactionHitEffect(this, "ヒット", other, self);
-    rs::requestHitReactionToAttacker(message, self, other);
-    setNerve(this, &NrvDoorAreaChange.Open);
-    return true;
+    return false;
 }
+
+// TODO: continue below
 
 void DoorAreaChange::switchCloseAgain() {
     al::startAction(this, "Wait");
     al::validateCollisionParts(this);
-    al::setNerve(this, &CloseWait);
+    al::setNerve(this, &Close);
 }
 
 void DoorAreaChange::start() {
-    al::setNerve(this, &CloseWait);
+    al::setNerve(this, &Close);
 }
 
 void DoorAreaChange::setNoStart() {
-    setNerve(this, &NrvDoorAreaChange.NoStart);
+    al::setNerve(this, &NrvDoorAreaChange.OpenWait);
 }
 
 void DoorAreaChange::enableStart() {
-    if (isNerve(this, &NrvDoorAreaChange.NoStart))
-        setNerve(this, &CloseWait);
+    if (al::isNerve(this, &NrvDoorAreaChange.OpenWait))
+        al::setNerve(this, &Close);
 }
 
 void DoorAreaChange::appear() {
@@ -161,9 +170,8 @@ void DoorAreaChange::appear() {
 }
 
 bool DoorAreaChange::isOpen() const {
-    if (isNerve(this, &NrvDoorAreaChange.Open))
-        return true;
-    return isNerve(this, &NrvDoorAreaChange.OpenWait);
+    return al::isNerve(this, &NrvDoorAreaChange.NoStart) ||
+           al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
 }
 
 void DoorAreaChange::exeOpenWait() {
@@ -175,81 +183,81 @@ void DoorAreaChange::exeOpenWait() {
         if (GameDataFunction::isEnableCap(GameDataHolderAccessor(this)))
             return;
         al::validateCollisionParts(this);
-        al::setNerve(this, &CloseWait);
+        al::setNerve(this, &Close);
     }
 }
 
 void DoorAreaChange::exeNoStart() {
-    if (isFirstStep(this)) {
-        validateCollisionParts(this);
-        if (isExistAction(this, "CloseWait"))
-            startAction(this, "Wait");
+    if (al::isFirstStep(this)) {
+        al::validateCollisionParts(this);
+        if (al::isExistAction(this, "CloseWait"))
+            al::startAction(this, "Wait");
         else
-            startAction(this, "CloseWait");
+            al::startAction(this, "CloseWait");
     }
 }
 
 void DoorAreaChange::exeCloseBefore() {
-    if (isFirstStep(this)) {
-        startAction(this, "OpenWait");
-        validateCollisionParts(this);
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "OpenWait");
+        al::validateCollisionParts(this);
     }
-    if (isGreaterEqualStep(this, 30))
-        setNerve(this, &CloseWait);
+    if (al::isGreaterEqualStep(this, 30))
+        al::setNerve(this, &Close);
 }
 
 void DoorAreaChange::exeClose() {
-    if (isFirstStep(this)) {
-        startAction(this, "Close");
-        validateCollisionParts(this);
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Close");
+        al::validateCollisionParts(this);
     }
-    if (isActionEnd(this))
-        setNerve(this, &Close);
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Close);
 }
 
-void DoorAreaChange::setHomeDoor(bool b) {
+void DoorAreaChange::setHomeDoor(bool isHomeDoor) {
     mIsHomeDoorSet = true;
     makeActorAlive();
 
-    if (b)
-        setNerve(this, &NrvDoorAreaChange.CloseBefore);
+    if (isHomeDoor)
+        al::setNerve(this, &NrvDoorAreaChange.Open);
     else
-        setNerve(this, &CloseWait);
+        al::setNerve(this, &Close);
 }
 
 void DoorAreaChange::exeOpen() {
-    if (isFirstStep(this)) {
-        startAction(this, "Open");
-        invalidateCollisionParts(this);
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Open");
+        al::invalidateCollisionParts(this);
         rs::tryCancelCapMessage(this, "DoorAreaChangeFirst");
     }
-    if (isActionEnd(this)) {
+    if (al::isActionEnd(this)) {
         if (!mIsHomeDoorSet) {
-            startHitReaction(this, "消滅");
-            tryOnStageSwitch(this, "SwitchMoveOn");
+            al::startHitReaction(this, "消滅");
+            al::tryOnStageSwitch(this, "SwitchMoveOn");
         }
-        setNerve(this, &NrvDoorAreaChange.OpenWait);
+        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
     }
 }
 
 void DoorAreaChange::exeCloseWait() {
-    if (isFirstStep(this)) {
-        if (!isExistAction(this, "CloseWait"))
-            startAction(this, "Wait");
+    if (al::isFirstStep(this)) {
+        if (!al::isExistAction(this, "CloseWait"))
+            al::startAction(this, "Wait");
         else
-            startAction(this, "CloseWait");
+            al::startAction(this, "CloseWait");
     }
-    if (mIsDoorClosed && isNearPlayer(this, 500)) {
-        mIsDoorClosed = false;
+    if (mIsNeedAppearCapMessage && al::isNearPlayer(this, 500)) {
+        mIsNeedAppearCapMessage = false;
         rs::showCapMessage(this, "DoorAreaChangeFirst", 90, 600);
     }
 }
 
 void DoorAreaChange::exeNoStartWithMessage() {
-    if (isFirstStep(this)) {
-        if (!isExistAction(this, "CloseWait"))
-            startAction(this, "Wait");
+    if (al::isFirstStep(this)) {
+        if (!al::isExistAction(this, "CloseWait"))
+            al::startAction(this, "Wait");
         else
-            startAction(this, "CloseWait");
+            al::startAction(this, "CloseWait");
     }
 }

--- a/src/MapObj/DoorAreaChange.cpp
+++ b/src/MapObj/DoorAreaChange.cpp
@@ -1,0 +1,255 @@
+#include "MapObj/DoorAreaChange.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "MapObj/CapMessageShowInfo.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+#include "System/SaveObjInfo.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+using namespace al;
+
+NERVE_IMPL(DoorAreaChange, Wait);
+NERVE_IMPL(DoorAreaChange, Start);
+NERVE_IMPL(DoorAreaChange, OpenWait);
+NERVE_IMPL(DoorAreaChange, NoStart);
+NERVE_IMPL(DoorAreaChange, CloseBefore);
+NERVE_IMPL(DoorAreaChange, Open);
+NERVE_IMPL(DoorAreaChange, Close);
+NERVE_IMPL(DoorAreaChange, CloseWait);
+NERVE_IMPL(DoorAreaChange, NoStartWithMessage);
+
+NERVES_MAKE_STRUCT(DoorAreaChange, Wait, OpenWait, NoStart, Open, CloseBefore, Start,
+                   NoStartWithMessage);
+NERVES_MAKE_NOSTRUCT(DoorAreaChange, Close, CloseWait);
+}  // namespace
+
+DoorAreaChange::DoorAreaChange(const char* name) : al::LiveActor(name) {}
+
+void DoorAreaChange::init(const al::ActorInitInfo& info) {
+    using DoorAreaChangeFunctor = FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>;
+
+    if (al::isObjectName(info, "ShineTowerRocket"))
+        initActorWithArchiveName(this, info, "DoorAreaChange", nullptr);
+    else
+        initActorWithArchiveName(this, info, "ShineTowerDoor", nullptr);
+    initNerve(this, &CloseWait, 0);
+    mSaveObjInfo = rs::createSaveObjInfoWriteSaveData(info);
+    listenStageSwitchOn(this, "SwitchCloseAgain",
+                        DoorAreaChangeFunctor(this, &DoorAreaChange::switchCloseAgain));
+    if (!rs::isInvalidChangeStage(this)) {
+        if (GameDataFunction::isPlayerStartLinkedObj(this, info, "NoDelete_DeadByPlayerStart")) {
+            setNerve(this, &NrvDoorAreaChange.OpenWait);
+            makeActorAlive();
+            return;
+        }
+        if (listenStageSwitchOnAppear(this, DoorAreaChangeFunctor(this, &DoorAreaChange::appear))) {
+            makeActorDead();
+            return;
+        }
+        if (listenStageSwitchOnStart(this, DoorAreaChangeFunctor(this, &DoorAreaChange::start))) {
+            makeActorAlive();
+            setNerve(this, &NrvDoorAreaChange.NoStart);
+            return;
+        }
+        s32 scenarioNo = 0;
+        if (tryGetArg(&scenarioNo, info, "FixScenarioNo"))
+            if (scenarioNo == GameDataFunction::getScenarioNo(this)) {
+                makeActorAlive();
+                setNerve(this, &NrvDoorAreaChange.NoStart);
+                return;
+            }
+        if (rs::isOnSaveObjInfo(mSaveObjInfo))
+            setNerve(this, &NrvDoorAreaChange.OpenWait);
+        if (tryGetArg(&mIsDoorClosed, info, "IsNeedAppearCapMessage") && mIsDoorClosed)
+            mIsDoorClosed = true;
+    } else {
+        setNerve(this, &NrvDoorAreaChange.Wait);
+    }
+    makeActorAlive();
+}
+
+bool DoorAreaChange::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (rs::isMsgPlayerEyePriorityTarget(message))
+        return true;
+    if (rs::isMsgKoopaRingBeamInvalidTouch(message))
+        return true;
+    if (isNerve(this, &NrvDoorAreaChange.Open) || isNerve(this, &NrvDoorAreaChange.OpenWait)) {
+        if (rs::isMsgPlayerDisregardTargetMarker(message))
+            return true;
+        if (rs::isMsgPlayerDisregardHomingAttack(message))
+            return true;
+        if (isMsgPlayerDisregard(message))
+            return true;
+    }
+    if (rs::isMsgCapTouchWall(message)) {
+        if (isNerve(this, &NrvDoorAreaChange.Wait)) {
+            sead::Vector3f zero = sead::Vector3f::zero;
+            rs::tryGetCapTouchWallHitPos(&zero, message);
+            startHitReactionHitEffect(this, "ヒット", zero);
+            rs::requestHitReactionToAttacker(message, other, zero);
+            return true;
+        }
+        if (isNerve(this, &CloseWait)) {
+            rs::onSaveObjInfo(mSaveObjInfo);
+            sead::Vector3f zero = sead::Vector3f::zero;
+            rs::tryGetCapTouchWallHitPos(&zero, message);
+            startHitReactionHitEffect(this, "ヒット", zero);
+            rs::requestHitReactionToAttacker(message, other, zero);
+            setNerve(this, &NrvDoorAreaChange.Open);
+            return true;
+        }
+    }
+    if (!rs::isMsgCapReflect(message))
+        return false;
+    if (isNerve(this, &NrvDoorAreaChange.Wait)) {
+        startHitReactionHitEffect(this, "ヒット", other, self);
+        rs::requestHitReactionToAttacker(message, self, other);
+        rs::tryShowCapMsgWarpDisableInMiniGameDoorCap(this);
+        return true;
+    }
+    if (!isNerve(this, &CloseWait))
+        return false;
+    rs::onSaveObjInfo(mSaveObjInfo);
+    startHitReactionHitEffect(this, "ヒット", other, self);
+    rs::requestHitReactionToAttacker(message, self, other);
+    setNerve(this, &NrvDoorAreaChange.Open);
+    return true;
+}
+
+void DoorAreaChange::switchCloseAgain() {
+    al::startAction(this, "Wait");
+    al::validateCollisionParts(this);
+    al::setNerve(this, &CloseWait);
+}
+
+void DoorAreaChange::start() {
+    al::setNerve(this, &CloseWait);
+}
+
+void DoorAreaChange::setNoStart() {
+    setNerve(this, &NrvDoorAreaChange.NoStart);
+}
+
+void DoorAreaChange::enableStart() {
+    if (isNerve(this, &NrvDoorAreaChange.NoStart))
+        setNerve(this, &CloseWait);
+}
+
+void DoorAreaChange::appear() {
+    if (rs::isOnSaveObjInfo(mSaveObjInfo)) {
+        kill();
+        return;
+    }
+    al::LiveActor::appear();
+}
+
+bool DoorAreaChange::isOpen() const {
+    if (isNerve(this, &NrvDoorAreaChange.Open))
+        return true;
+    return isNerve(this, &NrvDoorAreaChange.OpenWait);
+}
+
+void DoorAreaChange::exeOpenWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "OpenWait");
+        al::invalidateCollisionParts(this);
+    }
+    if (mIsHomeDoorSet) {
+        if (GameDataFunction::isEnableCap(GameDataHolderAccessor(this)))
+            return;
+        al::validateCollisionParts(this);
+        al::setNerve(this, &CloseWait);
+    }
+}
+
+void DoorAreaChange::exeNoStart() {
+    if (isFirstStep(this)) {
+        validateCollisionParts(this);
+        if (isExistAction(this, "CloseWait"))
+            startAction(this, "Wait");
+        else
+            startAction(this, "CloseWait");
+    }
+}
+
+void DoorAreaChange::exeCloseBefore() {
+    if (isFirstStep(this)) {
+        startAction(this, "OpenWait");
+        validateCollisionParts(this);
+    }
+    if (isGreaterEqualStep(this, 30))
+        setNerve(this, &CloseWait);
+}
+
+void DoorAreaChange::exeClose() {
+    if (isFirstStep(this)) {
+        startAction(this, "Close");
+        validateCollisionParts(this);
+    }
+    if (isActionEnd(this))
+        setNerve(this, &Close);
+}
+
+void DoorAreaChange::setHomeDoor(bool b) {
+    mIsHomeDoorSet = true;
+    makeActorAlive();
+
+    if (b)
+        setNerve(this, &NrvDoorAreaChange.CloseBefore);
+    else
+        setNerve(this, &CloseWait);
+}
+
+void DoorAreaChange::exeOpen() {
+    if (isFirstStep(this)) {
+        startAction(this, "Open");
+        invalidateCollisionParts(this);
+        rs::tryCancelCapMessage(this, "DoorAreaChangeFirst");
+    }
+    if (isActionEnd(this)) {
+        if (!mIsHomeDoorSet) {
+            startHitReaction(this, "消滅");
+            tryOnStageSwitch(this, "SwitchMoveOn");
+        }
+        setNerve(this, &NrvDoorAreaChange.OpenWait);
+    }
+}
+
+void DoorAreaChange::exeCloseWait() {
+    if (isFirstStep(this)) {
+        if (!isExistAction(this, "CloseWait"))
+            startAction(this, "Wait");
+        else
+            startAction(this, "CloseWait");
+    }
+    if (mIsDoorClosed && isNearPlayer(this, 500)) {
+        mIsDoorClosed = false;
+        rs::showCapMessage(this, "DoorAreaChangeFirst", 90, 600);
+    }
+}
+
+void DoorAreaChange::exeNoStartWithMessage() {
+    if (isFirstStep(this)) {
+        if (!isExistAction(this, "CloseWait"))
+            startAction(this, "Wait");
+        else
+            startAction(this, "CloseWait");
+    }
+}

--- a/src/MapObj/DoorAreaChange.cpp
+++ b/src/MapObj/DoorAreaChange.cpp
@@ -1,4 +1,3 @@
-// TODO: think about inlining
 #include "MapObj/DoorAreaChange.h"
 
 #include <prim/seadSafeString.h>
@@ -34,7 +33,6 @@ NERVE_IMPL(DoorAreaChange, Close);
 NERVES_MAKE_NOSTRUCT(DoorAreaChange, Close);
 NERVES_MAKE_STRUCT(DoorAreaChange, CloseWait, NoStartWithMessage, OpenWait, NoStart, Open,
                    CloseBefore);
-
 }  // namespace
 
 DoorAreaChange::DoorAreaChange(const char* name) : al::LiveActor(name) {}
@@ -47,19 +45,19 @@ void DoorAreaChange::init(const al::ActorInitInfo& info) {
     else
         al::initActorWithArchiveName(this, info, "ShineTowerDoor", nullptr);
 
-    al::initNerve(this, &Close, 0);
+    al::initNerve(this, &NrvDoorAreaChange.CloseWait, 0);
     mSaveObjInfo = rs::createSaveObjInfoWriteSaveData(info);
     al::listenStageSwitchOn(this, "SwitchCloseAgain",
                             DoorAreaChangeFunctor(this, &DoorAreaChange::switchCloseAgain));
 
     if (rs::isInvalidChangeStage(this)) {
-        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
+        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
         makeActorAlive();
         return;
     }
 
     if (GameDataFunction::isPlayerStartLinkedObj(this, info, "NoDelete_DeadByPlayerStart")) {
-        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+        al::setNerve(this, &NrvDoorAreaChange.OpenWait);
         makeActorAlive();
         return;
     }
@@ -69,19 +67,20 @@ void DoorAreaChange::init(const al::ActorInitInfo& info) {
     }
     if (al::listenStageSwitchOnStart(this, DoorAreaChangeFunctor(this, &DoorAreaChange::start))) {
         makeActorAlive();
-        al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+        al::setNerve(this, &NrvDoorAreaChange.NoStart);
         return;
     }
     s32 scenarioNo = 0;
     if (al::tryGetArg(&scenarioNo, info, "FixScenarioNo")) {
         if (scenarioNo == GameDataFunction::getScenarioNo(this)) {
             makeActorAlive();
-            al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+            al::setNerve(this, &NrvDoorAreaChange.NoStart);
             return;
         }
     }
     if (rs::isOnSaveObjInfo(mSaveObjInfo))
-        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+        al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+
     if (al::tryGetArg(&mIsNeedAppearCapMessage, info, "IsNeedAppearCapMessage") &&
         mIsNeedAppearCapMessage)
         mIsNeedAppearCapMessage = true;
@@ -95,8 +94,9 @@ bool DoorAreaChange::receiveMsg(const al::SensorMsg* message, al::HitSensor* oth
         return true;
     if (rs::isMsgKoopaRingBeamInvalidTouch(message))
         return true;
-    if (al::isNerve(this, &NrvDoorAreaChange.NoStart) ||
-        al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage)) {
+
+    if (al::isNerve(this, &NrvDoorAreaChange.Open) ||
+        al::isNerve(this, &NrvDoorAreaChange.OpenWait)) {
         if (rs::isMsgPlayerDisregardTargetMarker(message))
             return true;
         if (rs::isMsgPlayerDisregardHomingAttack(message))
@@ -104,61 +104,61 @@ bool DoorAreaChange::receiveMsg(const al::SensorMsg* message, al::HitSensor* oth
         if (isMsgPlayerDisregard(message))
             return true;
     }
+
     if (rs::isMsgCapTouchWall(message)) {
-        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
+        if (al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage)) {
             sead::Vector3f capTouchPos = sead::Vector3f::zero;
             rs::tryGetCapTouchWallHitPos(&capTouchPos, message);
             al::startHitReactionHitEffect(this, "ヒット", capTouchPos);
             rs::requestHitReactionToAttacker(message, other, capTouchPos);
             return true;
         }
-        if (al::isNerve(this, &Close)) {
+        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
             rs::onSaveObjInfo(mSaveObjInfo);
             sead::Vector3f capTouchPos = sead::Vector3f::zero;
             rs::tryGetCapTouchWallHitPos(&capTouchPos, message);
             al::startHitReactionHitEffect(this, "ヒット", capTouchPos);
             rs::requestHitReactionToAttacker(message, other, capTouchPos);
-            al::setNerve(this, &NrvDoorAreaChange.NoStart);
+            al::setNerve(this, &NrvDoorAreaChange.Open);
             return true;
         }
     }
+
     if (rs::isMsgCapReflect(message)) {
-        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
+        if (al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage)) {
             al::startHitReactionHitEffect(this, "ヒット", other, self);
             rs::requestHitReactionToAttacker(message, self, other);
             rs::tryShowCapMsgWarpDisableInMiniGameDoorCap(this);
             return true;
         }
-        if (al::isNerve(this, &Close)) {
+        if (al::isNerve(this, &NrvDoorAreaChange.CloseWait)) {
             rs::onSaveObjInfo(mSaveObjInfo);
             al::startHitReactionHitEffect(this, "ヒット", other, self);
             rs::requestHitReactionToAttacker(message, self, other);
-            al::setNerve(this, &NrvDoorAreaChange.NoStart);
+            al::setNerve(this, &NrvDoorAreaChange.Open);
             return true;
         }
     }
     return false;
 }
 
-// TODO: continue below
-
 void DoorAreaChange::switchCloseAgain() {
     al::startAction(this, "Wait");
     al::validateCollisionParts(this);
-    al::setNerve(this, &Close);
+    al::setNerve(this, &NrvDoorAreaChange.CloseWait);
 }
 
 void DoorAreaChange::start() {
-    al::setNerve(this, &Close);
+    al::setNerve(this, &NrvDoorAreaChange.CloseWait);
 }
 
 void DoorAreaChange::setNoStart() {
-    al::setNerve(this, &NrvDoorAreaChange.OpenWait);
+    al::setNerve(this, &NrvDoorAreaChange.NoStart);
 }
 
 void DoorAreaChange::enableStart() {
-    if (al::isNerve(this, &NrvDoorAreaChange.OpenWait))
-        al::setNerve(this, &Close);
+    if (al::isNerve(this, &NrvDoorAreaChange.NoStart))
+        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
 }
 
 void DoorAreaChange::appear() {
@@ -170,8 +170,8 @@ void DoorAreaChange::appear() {
 }
 
 bool DoorAreaChange::isOpen() const {
-    return al::isNerve(this, &NrvDoorAreaChange.NoStart) ||
-           al::isNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+    return al::isNerve(this, &NrvDoorAreaChange.Open) ||
+           al::isNerve(this, &NrvDoorAreaChange.OpenWait);
 }
 
 void DoorAreaChange::exeOpenWait() {
@@ -183,7 +183,7 @@ void DoorAreaChange::exeOpenWait() {
         if (GameDataFunction::isEnableCap(GameDataHolderAccessor(this)))
             return;
         al::validateCollisionParts(this);
-        al::setNerve(this, &Close);
+        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
     }
 }
 
@@ -212,7 +212,7 @@ void DoorAreaChange::exeClose() {
         al::validateCollisionParts(this);
     }
     if (al::isActionEnd(this))
-        al::setNerve(this, &Close);
+        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
 }
 
 void DoorAreaChange::setHomeDoor(bool isHomeDoor) {
@@ -220,9 +220,9 @@ void DoorAreaChange::setHomeDoor(bool isHomeDoor) {
     makeActorAlive();
 
     if (isHomeDoor)
-        al::setNerve(this, &NrvDoorAreaChange.Open);
+        al::setNerve(this, &NrvDoorAreaChange.CloseBefore);
     else
-        al::setNerve(this, &Close);
+        al::setNerve(this, &NrvDoorAreaChange.CloseWait);
 }
 
 void DoorAreaChange::exeOpen() {
@@ -236,7 +236,7 @@ void DoorAreaChange::exeOpen() {
             al::startHitReaction(this, "消滅");
             al::tryOnStageSwitch(this, "SwitchMoveOn");
         }
-        al::setNerve(this, &NrvDoorAreaChange.NoStartWithMessage);
+        al::setNerve(this, &NrvDoorAreaChange.OpenWait);
     }
 }
 

--- a/src/MapObj/DoorAreaChange.h
+++ b/src/MapObj/DoorAreaChange.h
@@ -30,7 +30,6 @@ public:
 
 private:
     SaveObjInfo* mSaveObjInfo = nullptr;
-    // TODO: check these
     bool mIsHomeDoorSet = false;
     bool mIsNeedAppearCapMessage = false;
 };

--- a/src/MapObj/DoorAreaChange.h
+++ b/src/MapObj/DoorAreaChange.h
@@ -18,10 +18,8 @@ public:
 
     bool isOpen() const;
 
-    void setHomeDoor(bool b);
+    void setHomeDoor(bool isHomeDoor);
 
-    void exeWait();
-    void exeStart();
     void exeOpen();
     void exeOpenWait();
     void exeCloseWait();
@@ -32,6 +30,9 @@ public:
 
 private:
     SaveObjInfo* mSaveObjInfo = nullptr;
+    // TODO: check these
     bool mIsHomeDoorSet = false;
-    bool mIsDoorClosed = false;
+    bool mIsNeedAppearCapMessage = false;
 };
+
+static_assert(sizeof(DoorAreaChange) == 0x118);

--- a/src/MapObj/DoorAreaChange.h
+++ b/src/MapObj/DoorAreaChange.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class SaveObjInfo;
+
+class DoorAreaChange : public al::LiveActor {
+public:
+    DoorAreaChange(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void switchCloseAgain();
+    void start();
+    void setNoStart();
+    void enableStart();
+    void appear() override;
+
+    bool isOpen() const;
+
+    void setHomeDoor(bool b);
+
+    void exeWait();
+    void exeStart();
+    void exeOpen();
+    void exeOpenWait();
+    void exeCloseWait();
+    void exeNoStart();
+    void exeCloseBefore();
+    void exeClose();
+    void exeNoStartWithMessage();
+
+private:
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    bool mIsHomeDoorSet = false;
+    bool mIsDoorClosed = false;
+};

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -74,6 +74,7 @@
 #include "MapObj/ChurchDoor.h"
 #include "MapObj/CitySignal.h"
 #include "MapObj/CoinCollectHintObj.h"
+#include "MapObj/DoorAreaChange.h"
 #include "MapObj/Doshi.h"
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
@@ -267,7 +268,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"DonkeyKong2D", nullptr},
     {"Donsuke", nullptr},
     {"Doshi", al::createActorFunction<Doshi>},
-    {"DoorAreaChange", nullptr},
+    {"DoorAreaChange", al::createActorFunction<DoorAreaChange>},
     {"DoorAreaChangeCap", nullptr},
     {"DoorCity", nullptr},
     {"DoorSnow", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1004)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c66e7d2 - 7069928)

📈 **Matched code**: 14.13% (+0.03%, +3152 bytes)

<details>
<summary>✅ 29 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/DoorAreaChange` | `DoorAreaChange::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +560 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::init(al::ActorInitInfo const&)` | +544 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeOpen()` | +156 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeCloseWait()` | +148 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::DoorAreaChange(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::DoorAreaChange(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeOpenWait()` | +116 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvNoStart::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvCloseBefore::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeNoStart()` | +100 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeCloseBefore()` | +100 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvClose::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeClose()` | +96 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvNoStartWithMessage::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::exeNoStartWithMessage()` | +92 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::setHomeDoor(bool)` | +84 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `al::FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::isOpen() const` | +72 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::enableStart()` | +72 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::appear()` | +68 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::switchCloseAgain()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<DoorAreaChange>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `al::FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::setNoStart()` | +16 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `DoorAreaChange::start()` | +12 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvCloseWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvOpenWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `(anonymous namespace)::DoorAreaChangeNrvOpen::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/DoorAreaChange` | `al::FunctorV0M<DoorAreaChange*, void (DoorAreaChange::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->