### PR TITLE
workflow: Update build artifact on `compile-check`

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -66,3 +66,9 @@ jobs:
           cat errfile | tr '\n' '\f' | sed 's/Stack backtrace:.*//' | tr '\f' '\n'
           exit 1
         fi
+    - name: Upload build artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: odyssey
+        path: build/odyssey
+        if-no-files-found: error


### PR DESCRIPTION
This uploads a build of the repo as workflow artifact, so people can download "debug symbols" for the game without requiring to build the repo yourself.

To download the latest artifact, `gh` can be used:
```
gh run download $(gh run list -w .github/workflows/compile-check.yml --json conclusion,headBranch,databaseId --jq 'first(.[] | select(.conclusion | contains("success")) | select(.headBranch | contains("master"))) | .databaseId' -R MonsterDruide1/OdysseyDecomp) -n odyssey -D $OUTPUT_DIR -R MonsterDruide1/OdysseyDecomp
```
(note, does not work yet, as `master` doesn't upload this artifact yet - replace `master` with `workflow-upload-build` until this PR is merged)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1005)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (76c3490 - 496d567)

No changes

<!-- decomp.dev report end -->