### PR TITLE
OdysseyHeaders: Improve `HeadersCMakeLists.txt`

### DIFF
--- a/.github/files/HeadersCMakeLists.txt
+++ b/.github/files/HeadersCMakeLists.txt
@@ -1,14 +1,23 @@
 add_library(OdysseyHeaders INTERFACE)
+target_compile_definitions(OdysseyHeaders INTERFACE
+        NN_SDK_MAJOR=3
+        NN_SDK_MINOR=5
+        NN_SDK_PATCH=1
+        NN_WARE_MAJOR=3
+        NN_WARE_MINOR=5
+        NN_WARE_PATCH=1
+        NNSDK
+        SEAD_VERSION=SEAD_VERSION_SMO
+)
 target_include_directories(OdysseyHeaders INTERFACE
-    ${CMAKE_CURRENT_LIST_DIR}
-    ${CMAKE_CURRENT_LIST_DIR}/game
-    ${CMAKE_CURRENT_LIST_DIR}/al
-    ${CMAKE_CURRENT_LIST_DIR}/agl
-    ${CMAKE_CURRENT_LIST_DIR}/eui
-    ${CMAKE_CURRENT_LIST_DIR}/sead
-    ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK
-    ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/RendezVous/Core
-    ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/RendezVous
-    ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/OnlineCore
-    ${CMAKE_CURRENT_LIST_DIR}/aarch64
+        ${CMAKE_CURRENT_LIST_DIR}/aarch64
+        ${CMAKE_CURRENT_LIST_DIR}/agl
+        ${CMAKE_CURRENT_LIST_DIR}/al
+        ${CMAKE_CURRENT_LIST_DIR}/eui
+        ${CMAKE_CURRENT_LIST_DIR}/game
+        ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK
+        ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/OnlineCore
+        ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/RendezVous
+        ${CMAKE_CURRENT_LIST_DIR}/NintendoSDK-NEX/RendezVous/Core
+        ${CMAKE_CURRENT_LIST_DIR}/sead
 )


### PR DESCRIPTION
This PR add `target_compile_definitions` to `HeadersCMakeLists.txt` so mods don't have to configure `nn` and `sead` to use correct version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1006)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a3ed158 - ea5a566)

No changes

<!-- decomp.dev report end -->