### PR TITLE
Boss: Implement `BossForest`

### DIFF
--- a/lib/al/Library/Joint/JointControllerKeeper.h
+++ b/lib/al/Library/Joint/JointControllerKeeper.h
@@ -58,7 +58,7 @@ void initJointMasher(const LiveActor*, const bool*, s32);
 void appendMashJoint(JointMasher*, const char*, f32);
 void initJointRumbler(const LiveActor*, const char*, f32, f32, u32, s32);
 void initJointLocalQuatRotator(const LiveActor*, const char*, const sead::Quatf*);
-void initJointLookAtController(const LiveActor*, s32);
+JointLookAtController* initJointLookAtController(const LiveActor*, s32);
 void appendJointLookAtController(JointLookAtController*, const LiveActor*, const char*, f32,
                                  const sead::Vector2f&, const sead::Vector2f&,
                                  const sead::Vector3f&, const sead::Vector3f&);

--- a/lib/al/Library/Joint/JointLookAtController.h
+++ b/lib/al/Library/Joint/JointLookAtController.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Joint/JointControllerBase.h"
+
+namespace al {
+
+class JointLookAtParam {
+public:
+    JointLookAtParam();
+    JointLookAtParam(s32 jointIndex, f32 rate, const sead::Vector2f& limitAngle1,
+                     const sead::Vector2f& limitAngle2, const sead::Vector3f& localFront,
+                     const sead::Vector3f& localUp);
+
+private:
+    s32 mJointIndex;
+    f32 mRate;
+    sead::Vector2f mLimitAngle1;
+    sead::Vector2f mLimitAngle2;
+    sead::Vector3f mLocalFront;
+    sead::Vector3f mLocalUp;
+    sead::Vector3f mLocalRight;
+};
+
+static_assert(sizeof(JointLookAtParam) == 0x3c);
+
+class JointLookAtInfo {
+private:
+    JointLookAtParam* mParam;
+    sead::Quatf _08;
+    sead::Quatf _18;
+    bool _28;
+    bool mIsInvalid;
+    bool mIsNoJudge;
+    bool mIsNoOverLimitYaw;
+    const sead::Matrix34f* _30;
+    sead::Vector3f _38;
+    sead::Vector3f _44;
+    sead::Vector3f _50;
+    sead::Vector3f _5c;
+};
+
+static_assert(sizeof(JointLookAtInfo) == 0x68);
+
+class JointLookAtController : public JointControllerBase {
+public:
+    JointLookAtController(s32 jointInfoNumMax, const sead::Matrix34f* defaultMtx);
+
+    void calcJointCallback(s32 jointIndex, sead::Matrix34f* mtx) override;
+    void appendJoint(JointLookAtInfo* info);
+    void requestJointLookAt(const sead::Vector3f& targetTrans);
+    bool invalidJoint(s32 jointIndex);
+    void validAllJoint();
+    const char* getCtrlTypeName() const override;
+
+    void setIsFlipped(bool isFlipped) { mIsFlipped = isFlipped; }
+
+private:
+    sead::Vector3f mTargetTrans;
+    const sead::Matrix34f* mDefaultMtx;
+    s32 mJointInfoNumMax;
+    s32 mJointInfoNum;
+    JointLookAtInfo** mJointInfos;
+    bool mHasRequest;
+    bool _51;
+    bool mIsFlipped;
+    bool mIsLookAtRequestEnabled;
+    bool _54;
+};
+
+static_assert(sizeof(JointLookAtController) == 0x58);
+
+}  // namespace al

--- a/src/Boss/BossForest/BossForest.cpp
+++ b/src/Boss/BossForest/BossForest.cpp
@@ -1,0 +1,349 @@
+#include "Boss/BossForest/BossForest.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/Joint/JointLookAtController.h"
+#include "Library/Joint/JointSpringControllerHolder.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/PostProcessing/CameraBlurController.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Boss/BossForest/BossForestBarrierCtrl.h"
+#include "Boss/BossForest/BossForestBattlePhase.h"
+#include "Boss/BossForest/BossForestCameraController.h"
+#include "Boss/BossForest/BossForestLocalFunction.h"
+#include "Boss/BossForest/BossForestSatelliteController.h"
+#include "Boss/BossForest/BossForestSatelliteHolder.h"
+#include "Boss/BossForest/BossForestStateDemoBattleEnd.h"
+#include "Boss/BossForest/BossForestStateDemoBattleStart.h"
+#include "Boss/BossForest/BossForestStateWaitBattleStart.h"
+#include "Boss/BossUtil/BossUtil.h"
+#include "Enemy/Senobi.h"
+#include "Enemy/SenobiGeneratePoint.h"
+#include "MapObj/CapMessageShowInfo.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_HOST_TYPE_IMPL(BossForest, Die)
+NERVE_HOST_TYPE_IMPL(BossForest, WaitForBattleStart)
+NERVE_HOST_TYPE_IMPL(BossForest, BattlePhase1)
+NERVE_HOST_TYPE_IMPL(BossForest, BattlePhase2)
+NERVE_HOST_TYPE_IMPL(BossForest, BattlePhase3)
+NERVE_HOST_TYPE_IMPL(BossForest, DemoBattleStart)
+NERVE_HOST_TYPE_IMPL(BossForest, DemoBattleEnd)
+
+NERVES_MAKE_NOSTRUCT(HostType, Die)
+NERVES_MAKE_STRUCT(HostType, WaitForBattleStart, BattlePhase1, BattlePhase2, BattlePhase3,
+                   DemoBattleStart, DemoBattleEnd)
+}  // namespace
+
+BossForest::BossForest(const char* name) : al::LiveActor(name) {}
+
+void BossForest::init(const al::ActorInitInfo& initInfo) {
+    al::initActorWithArchiveName(this, initInfo, sead::SafeString("BossForest"), nullptr);
+    mIsLv2 = al::isObjectName(initInfo, "BossForestLv2");
+    BossForestLocalFunction::createCollisionParts(this, initInfo, &mCollisionMtx);
+    al::getTrans(&mInitTrans, initInfo);
+
+    sead::Vector3f displayOffset = sead::Vector3f::zero;
+    al::tryGetDisplayOffset(&displayOffset, initInfo);
+    mInitTrans += displayOffset;
+    al::setTrans(this, mInitTrans);
+
+    mBattleEyePos = sead::Vector3f::ey * 700.0f + mInitTrans;
+
+    al::initJointControllerKeeper(this, 5);
+    mJointLookAtController = al::initJointLookAtController(this, 1);
+    mJointLookAtController->setIsFlipped(true);
+
+    al::appendJointLookAtControllerNoJudge(mJointLookAtController, this, "Head", 0.1f,
+                                           {-179.0f, 180.0f}, {0.0f, 0.0f}, {0.0f, 0.0f, 1.0f},
+                                           {1.0f, 0.0f, 0.0f});
+
+    mJointSpringControllerHolder = new al::JointSpringControllerHolder();
+    mJointSpringControllerHolder->init(this, "InitJointSpringCtrl");
+
+    mCameraTargetPos.set(mBattleEyePos);
+
+    mCameraController = new BossForestCameraController(this, initInfo, &mCameraTargetPos);
+
+    mSatelliteHolder = new BossForestSatelliteHolder(this);
+    mSatelliteHolder->init(initInfo);
+
+    mBarrierCtrl = new BossForestBarrierCtrl(this);
+
+    al::initNerve(this, &NrvHostType.WaitForBattleStart, 8);
+
+    mBattlePhase1 = new BossForestBattlePhase(this, initInfo, 0);
+    al::initNerveState(this, mBattlePhase1, &NrvHostType.BattlePhase1, "バトルフェーズ1");
+
+    mBattlePhase2 = new BossForestBattlePhase(this, initInfo, 1);
+    al::initNerveState(this, mBattlePhase2, &NrvHostType.BattlePhase2, "バトルフェーズ2");
+
+    mBattlePhase3 = new BossForestBattlePhase(this, initInfo, 2);
+    al::initNerveState(this, mBattlePhase3, &NrvHostType.BattlePhase3, "バトルフェーズ3");
+
+    mStateWaitBattleStart = new BossForestStateWaitBattleStart(this, initInfo);
+    al::initNerveState(this, mStateWaitBattleStart, &NrvHostType.WaitForBattleStart,
+                       "バトル開始前");
+
+    mCameraTicket = al::initDemoAnimCamera(this, initInfo, "Anim");
+
+    mStateDemoBattleStart = new BossForestStateDemoBattleStart(this, initInfo, mCameraTicket);
+    al::initNerveState(this, mStateDemoBattleStart, &NrvHostType.DemoBattleStart, "バトル開始デモ");
+
+    al::initNerveState(this, new BossForestStateDemoBattleEnd(this, initInfo, mCameraTicket),
+                       &NrvHostType.DemoBattleEnd, "バトル終了デモ");
+
+    s32 senobiCount = al::calcLinkChildNum(initInfo, "SenobiGeneratePoint");
+    if (senobiCount > 0)
+        mSenobiGeneratePoints.allocBuffer(senobiCount, nullptr);
+    for (s32 i = 0; i < senobiCount; i++) {
+        SenobiGeneratePoint* point = (SenobiGeneratePoint*)al::createLinksActorFromFactory(
+            initInfo, "SenobiGeneratePoint", i);
+        point->getSenobi()->setBossGenerated(true);
+        mSenobiGeneratePoints.pushBack(point);
+    }
+
+    f32 domeDamage = 0.0f;
+    if (al::isNerve(this, &NrvHostType.WaitForBattleStart))
+        domeDamage = 4.0f;
+    else if (al::isNerve(this, &NrvHostType.DemoBattleStart) ||
+             al::isNerve(this, &NrvHostType.BattlePhase1))
+        domeDamage = 3.0f;
+    else if (al::isNerve(this, &NrvHostType.BattlePhase2))
+        domeDamage = 2.0f;
+    else
+        domeDamage = al::isNerve(this, &NrvHostType.BattlePhase3);
+
+    BossForestLocalFunction::setVisAnimDomeDamage(this, domeDamage);
+    BossForestLocalFunction::appearLifeParts(this);
+    al::emitEffect(this, "HeadPetal", nullptr);
+
+    BossForestLocalFunction::setupLifePartsEffectMtx(this, mLifePartsMtxArray.emplaceBack(), 0);
+    BossForestLocalFunction::setupLifePartsEffectMtx(this, mLifePartsMtxArray.emplaceBack(), 1);
+    BossForestLocalFunction::setupLifePartsEffectMtx(this, mLifePartsMtxArray.emplaceBack(), 2);
+
+    al::setEffectNamedMtxPtr(this, "AttackRingBeamLaserGround", &mAttackRingMtx);
+
+    s32 wallCount = al::calcLinkChildNum(initInfo, "ForestWorldBossGroundWall");
+    if (wallCount <= 0) {
+        makeActorAlive();
+        return;
+    }
+
+    mFieldWalls.allocBuffer(wallCount, nullptr);
+    for (s32 i = 0; i < wallCount; i++) {
+        al::LiveActor* wall =
+            al::createLinksActorFromFactory(initInfo, "ForestWorldBossGroundWall", i);
+        mFieldWalls.pushBack(wall);
+    }
+    makeActorAlive();
+}
+
+bool BossForest::isFirstDemo() const {
+    return !rs::isAlreadyShowDemoBossBattleStart(this, 5, 1);
+}
+
+bool BossForest::isEnableSkipDemo() const {
+    return true;
+}
+
+void BossForest::skipDemo() {
+    if (al::isNerve(this, &NrvHostType.DemoBattleStart))
+        return mStateDemoBattleStart->skipDemo();
+}
+
+void BossForest::updateSatellitesPose(const sead::Quatf& quat) {
+    f32 rotSpeed = getCurrentSatelliteController()->getRotAngle();
+
+    sead::Vector3f upDir;
+    al::calcUpDir(&upDir, this);
+    al::rotateQuatRadian(al::getQuatPtr(this), quat, upDir, sead::Mathf::deg2rad(rotSpeed));
+}
+
+BossForestSatelliteController* BossForest::getCurrentSatelliteController() const {
+    if (al::isNerve(this, &NrvHostType.BattlePhase1))
+        return mBattlePhase1->getSatelliteController();
+    if (al::isNerve(this, &NrvHostType.BattlePhase2))
+        return mBattlePhase2->getSatelliteController();
+    if (al::isNerve(this, &NrvHostType.BattlePhase3))
+        return mBattlePhase3->getSatelliteController();
+    return nullptr;
+}
+
+SenobiGeneratePoint* BossForest::getSenobiGeneratePoint(s32 index) const {
+    return mSenobiGeneratePoints[index];
+}
+
+const sead::PtrArray<al::LiveActor>& BossForest::getFieldWalls() {
+    return mFieldWalls;
+}
+
+void BossForest::control() {
+    mCameraController->updateNerve();
+    mBarrierCtrl->updateNerve();
+    if (mHasCollisionParts) {
+        sead::Matrix34f* dest = &mCollisionMtx;
+        sead::Matrix34f* jointMtx = al::getJointMtxPtr(this, "JointRoot");
+        *dest = *jointMtx;
+    }
+}
+
+void BossForest::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (isStateBodyAttack() && al::isSensorEnemyAttack(self) &&
+        !al::isSensorName(self, "LineBeam")) {
+        if (al::isSensorName(self, "AttackFront")) {
+            sead::Vector3f upDir;
+            al::calcUpDir(&upDir, this);
+            if (!al::isHitPlaneSensor(other, self, upDir, 150.0f))
+                return;
+        }
+        al::sendMsgEnemyAttack(other, self);
+    }
+
+    if (al::isNerve(this, &NrvHostType.BattlePhase1))
+        mBattlePhase1->attackSensor(self, other);
+    if (al::isNerve(this, &NrvHostType.BattlePhase2))
+        mBattlePhase2->attackSensor(self, other);
+    if (al::isNerve(this, &NrvHostType.BattlePhase3))
+        mBattlePhase3->attackSensor(self, other);
+
+    if (al::isSensorName(self, "EyePush") || al::isSensorName(self, "EyePushL") ||
+        al::isSensorName(self, "EyePushR")) {
+        if (!al::sendMsgPush(other, self))
+            rs::sendMsgPushToPlayer(other, self);
+    }
+}
+
+bool BossForest::isStateBodyAttack() const {
+    if (al::isNerve(this, &NrvHostType.BattlePhase1))
+        return mBattlePhase1->isStateAttackable();
+    if (al::isNerve(this, &NrvHostType.BattlePhase2))
+        return mBattlePhase2->isStateAttackable();
+    if (al::isNerve(this, &NrvHostType.BattlePhase3))
+        return mBattlePhase3->isStateAttackable();
+    return false;
+}
+
+void BossForest::setStateDemoBattleEnd() {
+    al::endBgmSituation(this, "BossForestKnockOver", false);
+    al::setNerve(this, &NrvHostType.DemoBattleEnd);
+}
+
+bool BossForest::receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvHostType.WaitForBattleStart))
+        return mStateWaitBattleStart->receiveMsg(msg, self, other);
+    if (al::isNerve(this, &NrvHostType.BattlePhase1))
+        return mBattlePhase1->receiveMsg(msg, self, other);
+    if (al::isNerve(this, &NrvHostType.BattlePhase2))
+        return mBattlePhase2->receiveMsg(msg, self, other);
+    if (al::isNerve(this, &NrvHostType.BattlePhase3))
+        return mBattlePhase3->receiveMsg(msg, self, other);
+    return false;
+}
+
+sead::Matrix34f* BossForest::getLifePartsEffectMtx(const char* name) {
+    if (al::isEqualString(name, "ライフパーツ00"))
+        return mLifePartsMtxArray[0];
+    else if (al::isEqualString(name, "ライフパーツ01"))
+        return mLifePartsMtxArray[1];
+    else if (al::isEqualString(name, "ライフパーツ02"))
+        return mLifePartsMtxArray[2];
+    return nullptr;
+}
+
+void BossForest::updateOnlyDemoGraphics() {}
+
+void BossForest::exeWaitForBattleStart() {
+    if (al::isFirstStep(this)) {
+        f32 domeDamage;
+        if (al::isNerve(this, &NrvHostType.WaitForBattleStart))
+            domeDamage = 4.0f;
+        else if (al::isNerve(this, &NrvHostType.DemoBattleStart) ||
+                 al::isNerve(this, &NrvHostType.BattlePhase1))
+            domeDamage = 3.0f;
+        else if (al::isNerve(this, &NrvHostType.BattlePhase2))
+            domeDamage = 2.0f;
+        else
+            domeDamage = al::isNerve(this, &NrvHostType.BattlePhase3);
+        BossForestLocalFunction::setVisAnimDomeDamage(this, domeDamage);
+    }
+    al::updateNerveStateAndNextNerve(this, &NrvHostType.DemoBattleStart);
+}
+
+void BossForest::exeDemoBattleStart() {
+    if (al::isFirstStep(this)) {
+        al::tryOnStageSwitch(this, "SwitchBattleStartOn");
+        f32 domeDamage;
+        if (al::isNerve(this, &NrvHostType.WaitForBattleStart))
+            domeDamage = 4.0f;
+        else if (al::isNerve(this, &NrvHostType.DemoBattleStart) ||
+                 al::isNerve(this, &NrvHostType.BattlePhase1))
+            domeDamage = 3.0f;
+        else if (al::isNerve(this, &NrvHostType.BattlePhase2))
+            domeDamage = 2.0f;
+        else
+            domeDamage = al::isNerve(this, &NrvHostType.BattlePhase3);
+        BossForestLocalFunction::setVisAnimDomeDamage(this, domeDamage);
+        BossForestLocalFunction::offEyesJointControl(this);
+        al::stopAllBgm(this, 5);
+    }
+    al::getNerveStep(this);
+    if (al::updateNerveStateAndNextNerve(this, &NrvHostType.BattlePhase1)) {
+        BossForestLocalFunction::onEyesJointControl(this);
+        alCameraBlurFunction::setCameraBlurName(this, "BossCameraBlur");
+        al::setTrans(this, mBattleEyePos);
+        mCameraController->tryStartCamera();
+    }
+}
+
+void BossForest::exeBattlePhase1() {
+    if (!mIsHintShown && !mIsLv2 && al::isNerve(this, &NrvHostType.BattlePhase1) &&
+        !al::isLessStep(this, 1800) &&
+        BossForestLocalFunction::countActiveSatellitesNum(this) >= 3) {
+        rs::showCapMessageBossHint(this, "BossForest_Hint", 90, 0);
+        mIsHintShown = true;
+    }
+    if (al::updateNerveState(this))
+        al::setNerve(this, &NrvHostType.BattlePhase2);
+}
+
+void BossForest::exeBattlePhase2() {
+    if (al::updateNerveState(this))
+        al::setNerve(this, &NrvHostType.BattlePhase3);
+}
+
+void BossForest::exeBattlePhase3() {
+    if (al::updateNerveState(this))
+        setStateDemoBattleEnd();
+}
+
+void BossForest::exeDemoBattleEnd() {
+    if (al::isFirstStep(this)) {
+        BossForestLocalFunction::offEyesJointControl(this);
+        al::stopAllBgm(this, 5);
+    }
+    mCameraController->tryEndCamera();
+    if (al::updateNerveStateAndNextNerve(this, &Die)) {
+        for (s32 i = 0; i < mSenobiGeneratePoints.size(); i++)
+            mSenobiGeneratePoints.unsafeAt(i)->forceKill();
+        al::tryOffStageSwitch(this, "SwitchBossBattleOn");
+        alCameraBlurFunction::resetCameraBlurName(this);
+        kill();
+    }
+}
+
+void BossForest::exeDie() {}

--- a/src/Boss/BossForest/BossForest.h
+++ b/src/Boss/BossForest/BossForest.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <container/seadObjArray.h>
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class HitSensor;
+class JointLookAtController;
+class JointSpringControllerHolder;
+class SensorMsg;
+}  // namespace al
+
+class BossForestBarrierCtrl;
+class BossForestBattlePhase;
+class BossForestCameraController;
+class SenobiGeneratePoint;
+class BossForestSatelliteController;
+class BossForestSatelliteHolder;
+class BossForestStateDemoBattleStart;
+class BossForestStateWaitBattleStart;
+
+class BossForest : public al::LiveActor, public IUseDemoSkip {
+public:
+    BossForest(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other) override;
+
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+    void updateOnlyDemoGraphics() override;
+
+    void updateSatellitesPose(const sead::Quatf& quat);
+    BossForestSatelliteController* getCurrentSatelliteController() const;
+    SenobiGeneratePoint* getSenobiGeneratePoint(s32 index) const;
+    const sead::PtrArray<al::LiveActor>& getFieldWalls();
+    bool isStateBodyAttack() const;
+    void setStateDemoBattleEnd();
+    sead::Matrix34f* getLifePartsEffectMtx(const char* name);
+
+    bool isBattleLv2() const { return mIsLv2 != 0; }
+
+    BossForestBarrierCtrl* getBarrierCtrl() const { return mBarrierCtrl; }
+
+    BossForestCameraController* getCameraController() const { return mCameraController; }
+
+    BossForestSatelliteHolder* getSatelliteHolder() const { return mSatelliteHolder; }
+
+    const sead::Vector3f& getInitTrans() const { return mInitTrans; }
+
+    const sead::Vector3f& getBattleEyePos() const { return mBattleEyePos; }
+
+    al::JointLookAtController* getJointLookAtController() const { return mJointLookAtController; }
+
+    al::JointSpringControllerHolder* getJointSpringControllerHolder() const {
+        return mJointSpringControllerHolder;
+    }
+
+    void setHasCollisionParts(bool hasCollisionParts) { mHasCollisionParts = hasCollisionParts; }
+
+    bool hasCollisionParts() const { return mHasCollisionParts; }
+
+    sead::Matrix34f* getAttackRingMtxPtr() { return &mAttackRingMtx; }
+
+    void exeWaitForBattleStart();
+    void exeDemoBattleStart();
+    void exeBattlePhase1();
+    void exeBattlePhase2();
+    void exeBattlePhase3();
+    void exeDemoBattleEnd();
+    void exeDie();
+
+private:
+    u8 mIsLv2 = 0;
+    BossForestStateWaitBattleStart* mStateWaitBattleStart = nullptr;
+    BossForestStateDemoBattleStart* mStateDemoBattleStart = nullptr;
+    BossForestBattlePhase* mBattlePhase1 = nullptr;
+    BossForestBattlePhase* mBattlePhase2 = nullptr;
+    BossForestBattlePhase* mBattlePhase3 = nullptr;
+    BossForestBarrierCtrl* mBarrierCtrl = nullptr;
+    BossForestCameraController* mCameraController = nullptr;
+    al::CameraTicket* mCameraTicket = nullptr;
+    BossForestSatelliteHolder* mSatelliteHolder = nullptr;
+    sead::PtrArray<SenobiGeneratePoint> mSenobiGeneratePoints;
+    sead::Vector3f mInitTrans = sead::Vector3f::zero;
+    sead::Vector3f mBattleEyePos = sead::Vector3f::zero;
+    sead::Vector3f mCameraTargetPos = sead::Vector3f::zero;
+    al::JointLookAtController* mJointLookAtController = nullptr;
+    al::JointSpringControllerHolder* mJointSpringControllerHolder = nullptr;
+    bool mIsHintShown = false;
+    bool mHasCollisionParts = false;
+    sead::Matrix34f mCollisionMtx = sead::Matrix34f::ident;
+    sead::FixedObjArray<sead::Matrix34f, 3> mLifePartsMtxArray;
+    sead::Matrix34f mAttackRingMtx = sead::Matrix34f::ident;
+    sead::PtrArray<al::LiveActor> mFieldWalls;
+};
+
+static_assert(sizeof(BossForest) == 0x2E8);

--- a/src/Boss/BossForest/BossForestBarrierCtrl.h
+++ b/src/Boss/BossForest/BossForestBarrierCtrl.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+}
+
+class BossForestBarrierCtrl : public al::NerveExecutor {
+public:
+    BossForestBarrierCtrl(al::LiveActor* actor);
+
+    void appear();
+    void doBreak();
+    void doWait();
+    al::LiveActor* getBarrierModel() const;
+    bool isAppeared() const;
+
+    void exeHidden();
+    void exeAppear();
+    void exeWait();
+    void exeBreak();
+
+private:
+    al::LiveActor* mActor = nullptr;
+};
+
+static_assert(sizeof(BossForestBarrierCtrl) == 0x18);

--- a/src/Boss/BossForest/BossForestBattlePhase.h
+++ b/src/Boss/BossForest/BossForestBattlePhase.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <math/seadQuat.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+struct ActorParamS32;
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class BossForest;
+class BossForestSatelliteController;
+class BossForestStateKnockOver;
+class BossForestStateAttack;
+class BossForestStateRingBeamAttack;
+class BossForestStateRecovery;
+
+class BossForestBattlePhase : public al::HostStateBase<BossForest> {
+public:
+    BossForestBattlePhase(BossForest* boss, const al::ActorInitInfo& initInfo, s32 phaseIndex);
+    ~BossForestBattlePhase() override;
+
+    void appear() override;
+    bool isStateAttackable() const;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other);
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self);
+    bool tryAttack();
+    void updateEyeJoint();
+
+    BossForestSatelliteController* getSatelliteController() const { return mSatelliteController; }
+
+    void exeWait();
+    void exeAttack();
+    void exeRingBeamAttack();
+    void exeKnockOver();
+    void exeRecover();
+    void exeReactionCoreBreak();
+    void exeLastDamage();
+    bool tryTransitionCoreBreak();
+
+private:
+    s32 mPhaseIndex = 0;
+    al::LiveActor* mPhaseActor = nullptr;
+    al::ActorParamS32** mBeamParams = nullptr;
+    BossForestStateKnockOver* mStateKnockOver = nullptr;
+    BossForestStateAttack* mStateAttack = nullptr;
+    BossForestStateRingBeamAttack* mStateRingBeamAttack = nullptr;
+    BossForestStateRecovery* mStateRecovery = nullptr;
+    BossForestSatelliteController* mSatelliteController = nullptr;
+    bool _60 = false;
+    bool mHasAttacked = false;
+    sead::Quatf mQuat = sead::Quatf::unit;
+};
+
+static_assert(sizeof(BossForestBattlePhase) == 0x78);

--- a/src/Boss/BossForest/BossForestCameraController.h
+++ b/src/Boss/BossForest/BossForestCameraController.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+}  // namespace al
+
+class BossForest;
+
+class BossForestCameraController : public al::NerveExecutor {
+public:
+    BossForestCameraController(BossForest* boss, const al::ActorInitInfo& initInfo,
+                               const sead::Vector3f* targetPos);
+    ~BossForestCameraController() override;
+
+    sead::Vector3f calcCameraTargetPos() const;
+    bool tryStartCamera();
+    bool tryStartCameraOld();
+    bool tryEndCamera();
+    bool tryEndCameraOld();
+    bool tryRestartCamera();
+    bool tryRestartCameraOld();
+    void allowNearCamera();
+    void allowNearCameraOld();
+    void disallowNearCamera();
+    void disallowNearCameraOld();
+    void control();
+
+    void exeOld();
+    void endOld();
+    void exeTower();
+    void endTower();
+
+private:
+    BossForest* mBoss = nullptr;
+    al::CameraTicket* mBossBattleCameraTicket = nullptr;
+    al::CameraTicket* mTowerCameraTicket = nullptr;
+    const sead::Vector3f* mTargetPos = nullptr;
+    bool mIsNearCameraAllowed = false;
+    sead::Vector3f mTowerCameraOffset = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(BossForestCameraController) == 0x40);

--- a/src/Boss/BossForest/BossForestLocalFunction.h
+++ b/src/Boss/BossForest/BossForestLocalFunction.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class BossForest;
+
+namespace BossForestLocalFunction {
+void createCollisionParts(BossForest* bossForest, const al::ActorInitInfo& initInfo,
+                          sead::Matrix34f* collisionMtx);
+void setVisAnimDomeDamage(al::LiveActor* actor, f32 domeDamage);
+void appearLifeParts(al::LiveActor* actor);
+void setupLifePartsEffectMtx(BossForest* bossForest, const sead::Matrix34f* jointMtx, s32 index);
+void offEyesJointControl(BossForest* bossForest);
+void onEyesJointControl(BossForest* bossForest);
+s32 countActiveSatellitesNum(const BossForest* bossForest);
+}  // namespace BossForestLocalFunction

--- a/src/Boss/BossForest/BossForestSatelliteController.h
+++ b/src/Boss/BossForest/BossForestSatelliteController.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+struct ActorParamF32;
+struct ActorParamS32;
+}  // namespace al
+
+class BossForestSatellite;
+
+struct BossForestSatelliteControllerParam {
+    al::ActorParamF32* rotSpeed;
+    al::ActorParamS32* waitTime;
+    al::ActorParamS32* moveTime;
+};
+
+class BossForestSatelliteController : public al::LiveActor {
+public:
+    BossForestSatelliteController(s32 phaseIndex);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void appear() override;
+    bool isDead() const;
+    bool checkCoreBroken(al::LiveActor** outBrokenCore) const;
+    bool isWait() const;
+    bool isAppeared() const;
+    void doMove();
+    void doWait();
+    s32 countActiveSatellitesNum() const;
+    void updateSatellitesPos(f32 angle);
+
+    void exeAppear();
+    void exeWait();
+    void exeMove();
+
+    void addSatellite(BossForestSatellite* satellite) { mSatellites.pushBack(satellite); }
+
+    f32 getRotAngle() const { return mRotAngle; }
+
+private:
+    sead::FixedPtrArray<BossForestSatellite, 3> mSatellites;
+    f32 mRotAngle = 0;
+    BossForestSatelliteControllerParam* mParams = nullptr;
+    s32 mPhaseIndex = 0;
+    bool mIsFirstPhase = false;
+};
+
+static_assert(sizeof(BossForestSatelliteController) == 0x148);

--- a/src/Boss/BossForest/BossForestSatelliteHolder.h
+++ b/src/Boss/BossForest/BossForestSatelliteHolder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}
+
+class BossForest;
+class BossForestSatellite;
+
+class BossForestSatelliteHolder : public al::LiveActor {
+public:
+    BossForestSatelliteHolder(BossForest* boss);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    BossForestSatellite* findSatellite(s32 phase, s32 index) const;
+    void makeActorDead() override;
+
+private:
+    BossForest* mBoss = nullptr;
+    sead::PtrArray<BossForestSatellite> mSatellites;
+    BossForestSatellite* mSatelliteBuffer[9];
+};
+
+static_assert(sizeof(BossForestSatelliteHolder) == 0x168);

--- a/src/Boss/BossForest/BossForestStateDemoBattleEnd.h
+++ b/src/Boss/BossForest/BossForestStateDemoBattleEnd.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class LiveActor;
+}  // namespace al
+
+class BossForest;
+class Shine;
+
+class BossForestStateDemoBattleEnd : public al::HostStateBase<BossForest> {
+public:
+    BossForestStateDemoBattleEnd(BossForest* boss, const al::ActorInitInfo& initInfo,
+                                 al::CameraTicket* cameraTicket);
+
+    void appear() override;
+    void kill() override;
+
+    void exeRequestStartDemo();
+    void exeDemo();
+    void exeEndDemo();
+
+private:
+    Shine* mShine = nullptr;
+    al::LiveActor* mPartsActor = nullptr;
+    al::CameraTicket* mCameraTicket = nullptr;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    sead::Quatf mQuat = sead::Quatf::unit;
+    sead::Vector3f mAfterPlayerPos = sead::Vector3f::zero;
+    sead::Quatf mAfterPlayerQuat = sead::Quatf::unit;
+};
+
+static_assert(sizeof(BossForestStateDemoBattleEnd) == 0x70);

--- a/src/Boss/BossForest/BossForestStateDemoBattleStart.h
+++ b/src/Boss/BossForest/BossForestStateDemoBattleStart.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class LiveActor;
+}  // namespace al
+
+class BossForest;
+
+class BossForestStateDemoBattleStart : public al::HostStateBase<BossForest> {
+public:
+    BossForestStateDemoBattleStart(BossForest* boss, const al::ActorInitInfo& initInfo,
+                                   al::CameraTicket* cameraTicket);
+
+    void appear() override;
+    void kill() override;
+
+    void skipDemo();
+
+    void exeRequestStartDemo();
+    void exeDemo();
+    void exeEndDemo();
+
+private:
+    al::CameraTicket* mCameraTicket = nullptr;
+    sead::PtrArray<al::LiveActor> mCoreActors;
+    sead::Vector3f _38 = sead::Vector3f::zero;
+    sead::Quatf _44 = sead::Quatf::unit;
+    sead::Vector3f _54 = sead::Vector3f::zero;
+    sead::Quatf _60 = sead::Quatf::unit;
+    bool _70 = false;
+    void* _78 = nullptr;
+    bool _80 = false;
+};
+
+static_assert(sizeof(BossForestStateDemoBattleStart) == 0x88);

--- a/src/Boss/BossForest/BossForestStateWaitBattleStart.h
+++ b/src/Boss/BossForest/BossForestStateWaitBattleStart.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BossForest;
+class CapTargetInfo;
+
+class BossForestStateWaitBattleStart : public al::HostStateBase<BossForest> {
+public:
+    BossForestStateWaitBattleStart(BossForest* boss, const al::ActorInitInfo& initInfo);
+
+    void appear() override;
+    void kill() override;
+
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other);
+
+    void exeWait();
+    void exeCapKeepOn();
+    void endCapKeepOn();
+    void exeDamage();
+    void exeKnockOver();
+    void exeDamageEnd();
+
+private:
+    CapTargetInfo* mCapTargetInfo = nullptr;
+    s32 mDamageCount = 0;
+    s32 mInvincibleTimer = 0;
+    bool mHasItemDropped = false;
+};
+
+static_assert(sizeof(BossForestStateWaitBattleStart) == 0x38);

--- a/src/Enemy/Senobi.h
+++ b/src/Enemy/Senobi.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class JointSpringControllerHolder;
+class SensorMsg;
+}  // namespace al
+
+class CapTargetInfo;
+class EnemyCap;
+class IUsePlayerHack;
+class SenobiStateEnemy;
+class SenobiStateHack;
+
+class Senobi : public al::LiveActor {
+public:
+    const char* getStretchJointName();
+    s32 getStretchSensorNum();
+    const sead::Vector3f& getStretchJointLocalOffset();
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void makeActorDead() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+    void movement() override;
+    void calcAnim() override;
+    void updateCollider() override;
+    f32 getStretchRate() const;
+    void rebirth(const sead::Vector3f& trans, const sead::Vector3f& front);
+    void resetCounter();
+    void exeEnemy();
+    void exeReset();
+    void exeHack();
+
+    void setBossGenerated(bool val) { mIsBossGenerated = val; }
+
+private:
+    void* mLeafParamHolder = nullptr;
+    IUsePlayerHack* mPlayerHack = nullptr;
+    CapTargetInfo* mCapTargetInfo = nullptr;
+    EnemyCap* mEnemyCap = nullptr;
+    SenobiStateEnemy* mStateEnemy = nullptr;
+    SenobiStateHack* mStateHack = nullptr;
+    al::JointSpringControllerHolder* mJointSpringControllerHolder = nullptr;
+    f32 mStretchLength = 0.0f;
+    u8 _144 = 0;
+    bool mIsBossGenerated = false;
+    u8 _146[0x2];
+};
+
+static_assert(sizeof(Senobi) == 0x148);

--- a/src/Enemy/SenobiGeneratePoint.h
+++ b/src/Enemy/SenobiGeneratePoint.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <math/seadVectorFwd.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Senobi;
+
+class SenobiGeneratePoint : public al::LiveActor {
+public:
+    using LiveActor::LiveActor;
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void forceKill();
+    bool tryGenerate();
+
+    void exeStandby();
+    void exeWait();
+    void exeEnd();
+    void exeGenerate();
+
+    Senobi* getSenobi() const { return mSenobi; }
+
+private:
+    Senobi* mSenobi = nullptr;
+    sead::Vector3f mInitTrans = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(SenobiGeneratePoint) == 0x120);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1007)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (68a58e9 - b693f75)

📈 **Matched code**: 14.14% (+0.04%, +4484 bytes)

<details>
<summary>✅ 32 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossForest/BossForest` | `BossForest::init(al::ActorInitInfo const&)` | +1672 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::attackSensor(al::HitSensor*, al::HitSensor*)` | +420 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeDemoBattleStart()` | +292 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +216 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeWaitForBattleStart()` | +184 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::updateSatellitesPose(sead::Quat<float> const&)` | +180 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeDemoBattleEnd()` | +176 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeBattlePhase1()` | +172 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::getLifePartsEffectMtx(char const*)` | +164 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::isStateBodyAttack() const` | +116 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::getCurrentSatelliteController() const` | +112 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::control()` | +104 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvBattlePhase3::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeBattlePhase3()` | +84 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `non-virtual thunk to BossForest::skipDemo()` | +68 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvBattlePhase2::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::skipDemo()` | +64 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::setStateDemoBattleEnd()` | +64 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeBattlePhase2()` | +64 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `non-virtual thunk to BossForest::isFirstDemo() const` | +40 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::isFirstDemo() const` | +36 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::getSenobiGeneratePoint(int) const` | +32 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `non-virtual thunk to BossForest::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::getFieldWalls()` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvWaitForBattleStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvBattlePhase1::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvDemoBattleStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `(anonymous namespace)::HostTypeNrvDemoBattleEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `BossForest::exeDie()` | +4 | 0.00% | 100.00% |

...and 2 more new matches
</details>


<!-- decomp.dev report end -->