### PR TITLE
Boss/Koopa: Implement `KoopaLandPointHolder`

### DIFF
--- a/src/Boss/Koopa/KoopaLandPointHolder.cpp
+++ b/src/Boss/Koopa/KoopaLandPointHolder.cpp
@@ -65,8 +65,8 @@ void KoopaLandPointHolder::decidePointEitherFarSide(const sead::Vector3f& pos) {
     }
 
     mInvalidPoints[mCurrentLandPoint] = false;
-    s32 prevPoint = al::modi(mCurrentLandPoint + mLandPoints - 1, mLandPoints);
-    s32 nextPoint = al::modi(mCurrentLandPoint + mLandPoints + 1, mLandPoints);
+    s32 prevPoint = al::modi(mCurrentLandPoint - 1 + mLandPoints, mLandPoints);
+    s32 nextPoint = al::modi(mCurrentLandPoint + 1 + mLandPoints, mLandPoints);
 
     f32 prevDist = getKoopaLandPointDistance(mPointsTrans[prevPoint], pos);
     f32 nextDist = getKoopaLandPointDistance(mPointsTrans[nextPoint], pos);
@@ -102,6 +102,7 @@ void KoopaLandPointHolder::reset() {
         mInvalidPoints[i] = false;
 }
 
+// NOTE: does not care about `mInvalidPoints`
 const sead::Vector3f& KoopaLandPointHolder::findNearestPointTrans(const sead::Vector3f& pos) const {
     f32 minDistance = getKoopaLandPointDistance(mPointsTrans[0], pos);
     s32 selectedPoint = 0;

--- a/src/Boss/Koopa/KoopaLandPointHolder.cpp
+++ b/src/Boss/Koopa/KoopaLandPointHolder.cpp
@@ -1,0 +1,119 @@
+#include "Boss/Koopa/KoopaLandPointHolder.h"
+
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+
+KoopaLandPointHolder::KoopaLandPointHolder(const al::ActorInitInfo& initInfo) {
+    al::getTrans(&mTrans, initInfo);
+    al::getQuat(&mQuat, initInfo);
+    mLandPoints = al::calcLinkChildNum(initInfo, "LandPoint");
+
+    if (mLandPoints <= 0)
+        return;
+
+    mPointsQuat = new sead::Quatf[mLandPoints];
+    mPointsTrans = new sead::Vector3f[mLandPoints];
+    mInvalidPoints = new bool[mLandPoints];
+
+    for (s32 i = 0; i < mLandPoints; i++) {
+        mInvalidPoints[i] = false;
+
+        al::PlacementInfo placementInfo;
+        al::getLinksInfoByIndex(&placementInfo, initInfo, "LandPoint", i);
+        al::getQuat(&mPointsQuat[i], placementInfo);
+        al::getTrans(&mPointsTrans[i], placementInfo);
+    }
+}
+
+inline f32 getKoopaLandPointDistance(const sead::Vector3f& posA, const sead::Vector3f& posB) {
+    sead::Vector3f distance = posA - posB;
+    return sead::Mathf::sqrt(distance.x * distance.x + distance.z * distance.z);
+}
+
+void KoopaLandPointHolder::decidePointFarFrom(const sead::Vector3f& pos) {
+    s32 selectedPoint = -1;
+    f32 maxDistance = 0.0f;
+
+    for (s32 i = 0; i < mLandPoints; i++) {
+        if (mInvalidPoints[i])
+            continue;
+
+        f32 dist = getKoopaLandPointDistance(mPointsTrans[i], pos);
+
+        if (selectedPoint < 0 || maxDistance < dist) {
+            selectedPoint = i;
+            maxDistance = dist;
+        }
+    }
+
+    invalidatePoint(selectedPoint);
+    mCurrentLandPoint = selectedPoint;
+}
+
+void KoopaLandPointHolder::invalidatePoint(s32 index) {
+    mInvalidPoints[index] = true;
+
+    if (mCurrentLandPoint > -1)
+        mInvalidPoints[mCurrentLandPoint] = false;
+}
+
+void KoopaLandPointHolder::decidePointEitherFarSide(const sead::Vector3f& pos) {
+    if (mCurrentLandPoint < 0) {
+        decidePointFarFrom(pos);
+        return;
+    }
+
+    mInvalidPoints[mCurrentLandPoint] = false;
+    s32 prevPoint = al::modi(mCurrentLandPoint + mLandPoints - 1, mLandPoints);
+    s32 nextPoint = al::modi(mCurrentLandPoint + mLandPoints + 1, mLandPoints);
+
+    f32 prevDist = getKoopaLandPointDistance(mPointsTrans[prevPoint], pos);
+    f32 nextDist = getKoopaLandPointDistance(mPointsTrans[nextPoint], pos);
+
+    if (prevDist < nextDist)
+        mCurrentLandPoint = nextPoint;
+    else
+        mCurrentLandPoint = prevPoint;
+}
+
+void KoopaLandPointHolder::decidePointNearFrom(const sead::Vector3f& pos) {
+    s32 selectedPoint = -1;
+    f32 minDistance = 0.0f;
+
+    for (s32 i = 0; i < mLandPoints; i++) {
+        if (mInvalidPoints[i])
+            continue;
+
+        f32 dist = getKoopaLandPointDistance(mPointsTrans[i], pos);
+
+        if (selectedPoint < 0 || dist < minDistance) {
+            selectedPoint = i;
+            minDistance = dist;
+        }
+    }
+
+    invalidatePoint(selectedPoint);
+    mCurrentLandPoint = selectedPoint;
+}
+
+void KoopaLandPointHolder::reset() {
+    for (s32 i = 0; i < mLandPoints; i++)
+        mInvalidPoints[i] = false;
+}
+
+const sead::Vector3f& KoopaLandPointHolder::findNearestPointTrans(const sead::Vector3f& pos) const {
+    f32 minDistance = getKoopaLandPointDistance(mPointsTrans[0], pos);
+    s32 selectedPoint = 0;
+
+    for (s32 i = 1; i < mLandPoints; i++) {
+        f32 dist = getKoopaLandPointDistance(mPointsTrans[i], pos);
+
+        if (dist < minDistance) {
+            selectedPoint = i;
+            minDistance = dist;
+        }
+    }
+
+    return mPointsTrans[selectedPoint];
+}

--- a/src/Boss/Koopa/KoopaLandPointHolder.h
+++ b/src/Boss/Koopa/KoopaLandPointHolder.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class KoopaLandPointHolder {
+public:
+    KoopaLandPointHolder(const al::ActorInitInfo& initInfo);
+
+    void decidePointFarFrom(const sead::Vector3f& pos);
+    void invalidatePoint(s32 index);
+    void decidePointEitherFarSide(const sead::Vector3f& pos);
+    void decidePointNearFrom(const sead::Vector3f& pos);
+    void reset();
+    const sead::Vector3f& findNearestPointTrans(const sead::Vector3f& pos) const;
+
+private:
+    sead::Vector3f mTrans = {0.0f, 0.0f, 0.0f};
+    sead::Quatf mQuat = sead::Quatf::unit;
+    s32 mCurrentLandPoint = -1;
+    s32 mLandPoints = 0;
+    sead::Quatf* mPointsQuat = nullptr;
+    sead::Vector3f* mPointsTrans = nullptr;
+    bool* mInvalidPoints = nullptr;
+};
+
+static_assert(sizeof(KoopaLandPointHolder) == 0x40);


### PR DESCRIPTION
This is a helper class that let you get the nearest or farthest land point of a koopa based on the given position. Some land points can be invalided, this prevents the koopa from jumping into that spot.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1010)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (f63c31b - af3a6b8)

📈 **Matched code**: 14.13% (+0.01%, +1640 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::decidePointEitherFarSide(sead::Vector3<float> const&)` | +452 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::KoopaLandPointHolder(al::ActorInitInfo const&)` | +344 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::findNearestPointTrans(sead::Vector3<float> const&) const` | +264 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::decidePointFarFrom(sead::Vector3<float> const&)` | +252 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::decidePointNearFrom(sead::Vector3<float> const&)` | +252 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::reset()` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaLandPointHolder` | `KoopaLandPointHolder::invalidatePoint(int)` | +32 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->