### PR TITLE
Library/Yaml: Simplify `ParameterBase`

### DIFF
--- a/lib/al/Library/Light/DirectionParam.cpp
+++ b/lib/al/Library/Light/DirectionParam.cpp
@@ -151,7 +151,7 @@ void PlaneParam::initialize(const sead::Vector3f& direction, ParameterObj* param
     StringTmp<256> distance = {"%sDistance", planeName};
 
     initializeDir(direction, parameterObj, normal.cstr(), "平面法線");
-    mDistanceFromOrigin = new ParameterF32(distance.cstr(), "原点からの距離",
+    mDistanceFromOrigin = new ParameterF32(0.0f, distance.cstr(), "原点からの距離",
                                            "Min=-100000, Max=100000", parameterObj, true);
 }
 }  // namespace al

--- a/lib/al/Library/Screen/ScreenPointKeeper.cpp
+++ b/lib/al/Library/Screen/ScreenPointKeeper.cpp
@@ -24,7 +24,7 @@ ScreenPointKeeper::ScreenPointKeeper() {
     mOptions = new ParameterObj();
 
     mAddTargetNum =
-        new ParameterS32("AddTargetNum", "AddTargetNum", "Min=0, Max=10", mOptions, true);
+        new ParameterS32(0, "AddTargetNum", "AddTargetNum", "Min=0, Max=10", mOptions, true);
 
     mParameterIo->addObj(mOptions, "Options");
     mParameterIo->addArray(mTargets, "Targets");

--- a/lib/al/Library/Yaml/ParameterBase.h
+++ b/lib/al/Library/Yaml/ParameterBase.h
@@ -40,18 +40,10 @@ SEAD_ENUM(YamlParamType,
 #define PARAM_TYPE_DEF(Name, Type)                                                                 \
     class Parameter##Name : public Parameter<Type> {                                               \
     public:                                                                                        \
-        Parameter##Name(const sead::SafeString& name, const sead::SafeString& label,               \
-                        const sead::SafeString& meta, ParameterObj* obj, bool e)                   \
-            : Parameter(name, label, meta, obj, e) {}                                              \
-                                                                                                   \
         Parameter##Name(Type const& value, const sead::SafeString& name,                           \
                         const sead::SafeString& label, const sead::SafeString& meta,               \
                         ParameterObj* obj, bool e)                                                 \
             : Parameter(value, name, label, meta, obj, e) {}                                       \
-                                                                                                   \
-        Parameter##Name(const sead::SafeString& name, const sead::SafeString& label,               \
-                        const sead::SafeString& meta, ParameterList* list, bool e)                 \
-            : Parameter(name, label, meta, list, e) {}                                             \
                                                                                                    \
         Parameter##Name(Type const& value, const sead::SafeString& name,                           \
                         const sead::SafeString& label, const sead::SafeString& meta,               \
@@ -72,7 +64,7 @@ public:
     static u32 calcHash(const sead::SafeString& key);
 
     // TODO: rename parameter bool e in all functions
-    ParameterBase(bool e) { initialize("default", "parameter", "", e); }
+    ParameterBase() { initialize("default", "parameter", "", true); }
 
     ParameterBase(const sead::SafeString& name, const sead::SafeString& label,
                   const sead::SafeString& meta, ParameterObj* obj, bool e);
@@ -139,32 +131,16 @@ template <typename T>
 class Parameter : public ParameterBase {
 public:
     // TODO: rename parameter bool e in constructor
-    Parameter(const sead::SafeString& name, const sead::SafeString& label,
-              const sead::SafeString& meta, ParameterObj* obj, bool e)
-        : ParameterBase(e) {
+    Parameter(const T& value, const sead::SafeString& name, const sead::SafeString& label,
+              const sead::SafeString& meta, ParameterObj* obj, bool e) {
         initializeListNode(name, label, meta, obj, e);
-        mValue = T();
+        setValue(value);
     }
 
     Parameter(const T& value, const sead::SafeString& name, const sead::SafeString& label,
-              const sead::SafeString& meta, ParameterObj* obj, bool e)
-        : ParameterBase(e) {
-        initializeListNode(name, label, meta, obj, e);
-        mValue = value;
-    }
-
-    Parameter(const sead::SafeString& name, const sead::SafeString& label,
-              const sead::SafeString& meta, ParameterList* list, bool e)
-        : ParameterBase(e) {
+              const sead::SafeString& meta, ParameterList* list, bool e) {
         initializeListNode(name, label, meta, list, e);
-        mValue = T();
-    }
-
-    Parameter(const T& value, const sead::SafeString& name, const sead::SafeString& label,
-              const sead::SafeString& meta, ParameterList* list, bool e)
-        : ParameterBase(e) {
-        initializeListNode(name, label, meta, list, e);
-        mValue = value;
+        setValue(value);
     }
 
     const void* ptr() const override { return &mValue; };

--- a/lib/al/Library/Yaml/ParameterBase.h
+++ b/lib/al/Library/Yaml/ParameterBase.h
@@ -147,7 +147,25 @@ public:
 
     void* ptr() override { return &mValue; };
 
-    s32 size() const override { return sizeof(T); }
+    s32 size() const override {
+        // BUG: sead::FixedSafeString<128> is excluded from this list
+        if constexpr (std::is_same<T, sead::FixedSafeString<32>>())
+            return 32;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<64>>())
+            return 64;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<256>>())
+            return 256;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<512>>())
+            return 512;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<1024>>())
+            return 1024;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<2048>>())
+            return 2048;
+        else if constexpr (std::is_same<T, sead::FixedSafeString<4096>>())
+            return 4096;
+        else
+            return sizeof(T);
+    }
 
     const char* getParamTypeStr() const override {
         return YamlParamType::text(YamlParamType::Invalid);

--- a/lib/al/Library/Yaml/ParameterBase.h
+++ b/lib/al/Library/Yaml/ParameterBase.h
@@ -155,6 +155,7 @@ public:
             return 64;
         else if constexpr (std::is_same<T, sead::FixedSafeString<256>>())
             return 256;
+        // NOTE: from 512 onwards, no examples exist in the binary
         else if constexpr (std::is_same<T, sead::FixedSafeString<512>>())
             return 512;
         else if constexpr (std::is_same<T, sead::FixedSafeString<1024>>())

--- a/lib/al/Library/Yaml/ParameterBase.h
+++ b/lib/al/Library/Yaml/ParameterBase.h
@@ -63,9 +63,9 @@ class ParameterBase {
 public:
     static u32 calcHash(const sead::SafeString& key);
 
-    // TODO: rename parameter bool e in all functions
     ParameterBase() { initialize("default", "parameter", "", true); }
 
+    // TODO: rename parameter bool e in all functions
     ParameterBase(const sead::SafeString& name, const sead::SafeString& label,
                   const sead::SafeString& meta, ParameterObj* obj, bool e);
 


### PR DESCRIPTION
I been playing with ParameterBase implementations. We can simplify the logic here by removing duplicated code.

Additionally I found that ParameterBase default ctor doesn't take parameter `e` as seen in this symbol ->
`al::Parameter<sead::FixedSafeString<32> >::Parameter(sead::FixedSafeString<32> const&, sead::SafeStringBase<char> const&, sead::SafeStringBase<char> const&, sead::SafeStringBase<char> const&, al::ParameterObj*, bool)`

I found three new bugs. `ParameterV3f::setValue` is broken, ~~`ParameterString32::size` is incorrect~~ and stack is out of order. Not sure how to solve these so expect more changes in another PR. There's no proof of work for this one. Current implementations are broken and decompme won't detect these templates even when specialized.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1012)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (fcc4c87 - 566e377)

No changes

<!-- decomp.dev report end -->