### PR TITLE
Layout: Implement StageSceneLayout

### DIFF
--- a/src/Item/ShineChipWatcherHolder.h
+++ b/src/Item/ShineChipWatcherHolder.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+namespace al {
+class IUseSceneObjHolder;
+class LiveActor;
+}  // namespace al
+
+class ShineChipWatcher;
+
+class ShineChipWatcherHolder : public al::ISceneObj {
+public:
+    ShineChipWatcherHolder();
+
+    const char* getSceneObjName() const override;
+    ~ShineChipWatcherHolder() override;
+
+    void entry(ShineChipWatcher* watcher);
+    void notify(ShineChipWatcher* watcher);
+    bool tryStartAppearShine();
+    ShineChipWatcher* getCurrentWatcher() const;
+    bool tryUpdateCurrentWatcher(const al::LiveActor* actor);
+
+private:
+    sead::PtrArray<ShineChipWatcher> mWatchers;
+    s32 mCurrentWatcherIndex = 0;
+};
+
+static_assert(sizeof(ShineChipWatcherHolder) == 0x20);
+
+namespace ShineChipLocalFunction {
+bool tryCreateShineChipWatcherHolder(const al::IUseSceneObjHolder* user);
+void entryShineChipWatcher(ShineChipWatcher* watcher);
+void notifyShineChipGet(ShineChipWatcher* watcher);
+void notifyShineChipGet(const al::LiveActor* actor);
+}  // namespace ShineChipLocalFunction
+
+namespace rs {
+bool isExistShineChipWatcher(const al::IUseSceneObjHolder* user);
+bool isCompleteShineChip(const al::IUseSceneObjHolder* user);
+s32 getShineChipCount(const al::IUseSceneObjHolder* user);
+s32 getCurrentShineChipWatcherIndex(const al::IUseSceneObjHolder* user);
+bool isCurrentShineChipWatcherTypeEmpty(const al::IUseSceneObjHolder* user);
+bool isAppearedShineChipShine(const al::IUseSceneObjHolder* user);
+void addDemoActorShineChipWatcher(const al::IUseSceneObjHolder* user);
+bool isEnableStartShineChipCompleteDemo(const al::IUseSceneObjHolder* user);
+bool tryStartAppearShineChipShine(const al::IUseSceneObjHolder* user);
+bool isInAreaCurrentShineChipWatcher(const al::IUseSceneObjHolder* user);
+}  // namespace rs

--- a/src/Layout/CoinCounter.h
+++ b/src/Layout/CoinCounter.h
@@ -33,6 +33,8 @@ public:
     void exeCountAnimAdd();
     void exeCountAnimSub();
 
+    void setUpdateCount(bool isUpdateCount) { mIsUpdateCount = isUpdateCount; }
+
 private:
     s32 mPrevCoinCount = 0;
     s32 mCoinNum = 0;

--- a/src/Layout/MapMini.h
+++ b/src/Layout/MapMini.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+class PlayerHolder;
+}  // namespace al
+
+class MapMini : public al::LayoutActor {
+public:
+    MapMini(const al::LayoutInitInfo& info, const al::PlayerHolder* playerHolder);
+
+    void appearSlideIn();
+    void end();
+    bool isEnd() const;
+
+    void exeAppear();
+    void exeWait();
+    void calcNearHintTrans();
+    void exeEnd();
+
+private:
+    const al::PlayerHolder* mPlayerHolder;
+    f32 mCameraAngle = 0.0f;
+    al::LayoutActor* mPlayerIconLayout = nullptr;
+    sead::PtrArray<al::LayoutActor> mHintIconLayouts;
+    s32 mHintIconNum = 0;
+};
+
+static_assert(sizeof(MapMini) == 0x160);

--- a/src/Layout/ShineChipLayoutParts.h
+++ b/src/Layout/ShineChipLayoutParts.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+class Nerve;
+}  // namespace al
+
+class ShineChipLayoutParts : public al::LayoutActor {
+public:
+    ShineChipLayoutParts(const al::LayoutInitInfo& info, const char* layoutName);
+
+    void appear() override;
+
+    bool isInArea() const;
+    bool tryUpdateCount(s32 currentCount, s32 prevCount);
+    bool isEndCompleteAnim() const;
+
+    void exeAppear();
+    void exeWait();
+    void exeAdd();
+    void exeAddNoAnim();
+    void exeComplete();
+    void exeEnd();
+
+private:
+    s32 mCurrentCount = -1;
+    s32 mPrevCount = -1;
+    const al::Nerve* mNextNerve = nullptr;
+};
+
+static_assert(sizeof(ShineChipLayoutParts) == 0x140);
+
+namespace rs {
+bool tryUpdateShineChipLayoutCount(ShineChipLayoutParts* parts);
+}  // namespace rs

--- a/src/Layout/ShineCounter.h
+++ b/src/Layout/ShineCounter.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class ShineCounter : public al::LayoutActor {
+public:
+    ShineCounter(const char* name, const al::LayoutInitInfo& info);
+
+    void kill() override;
+
+    void tryStart();
+    void tryStartWait();
+    void tryEnd();
+    void startCountAnim(bool isAddTenShines);
+    bool isEndCountAnim() const;
+
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void exeShineCountAppear();
+    void exeShineCountWait();
+    void exeShineCountAdd();
+
+private:
+    s32 mCurrentShineNum = 0;
+};
+
+static_assert(sizeof(ShineCounter) == 0x130);

--- a/src/Layout/StageSceneLayout.cpp
+++ b/src/Layout/StageSceneLayout.cpp
@@ -1,0 +1,393 @@
+#include "Layout/StageSceneLayout.h"
+
+#include <nn/ui2d/Layout.h>
+#include <nn/ui2d/Pane.h>
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Layout/LayoutKeeper.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+#include "Library/Player/PlayerUtil.h"
+
+#include "Item/ShineChipWatcherHolder.h"
+#include "Layout/CoinCounter.h"
+#include "Layout/CounterLifeCtrl.h"
+#include "Layout/KidsModeLayoutAccessor.h"
+#include "Layout/MapMini.h"
+#include "Layout/PlayGuideBgm.h"
+#include "Layout/PlayGuideCamera.h"
+#include "Layout/ShineChipLayoutParts.h"
+#include "Layout/ShineCounter.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+#include "Util/GamePadPlayStyleInfo.h"
+#include "Util/SpecialBuildUtil.h"
+#include "Util/StageInputFunction.h"
+#include "eui/TextBoxEx.h"
+
+namespace {
+NERVE_IMPL(StageSceneLayout, End);
+NERVE_IMPL(StageSceneLayout, Appear);
+NERVE_IMPL(StageSceneLayout, EndWithoutCoin);
+NERVE_IMPL(StageSceneLayout, Wait);
+NERVE_IMPL(StageSceneLayout, CoinCountAnim);
+NERVE_IMPL(StageSceneLayout, ShineChipComplete);
+NERVE_IMPL(StageSceneLayout, ShineCountAppear);
+
+NERVES_MAKE_NOSTRUCT(StageSceneLayout, End, Appear, EndWithoutCoin, Wait, CoinCountAnim,
+                     ShineChipComplete, ShineCountAppear);
+}  // namespace
+
+StageSceneLayout::StageSceneLayout(const char* name, const al::LayoutInitInfo& initInfo,
+                                   const al::PlayerHolder* playerHolder,
+                                   const al::SubCameraRenderer* subCameraRenderer)
+    : al::NerveStateBase(name), mPlayerHolder(playerHolder) {
+    initNerve(&End, 0);
+
+    mCoinCounter = new CoinCounter("[シーン情報]コインカウンタ", initInfo, true);
+    mCoinCollectCounter = new CoinCounter("[シーン情報]コインコレクトカウンタ", initInfo, false);
+    mCounterLifeCtrl = new CounterLifeCtrl(initInfo, mPlayerHolder, subCameraRenderer);
+    mShineCounter = new ShineCounter("[シーン情報]シャインカウンタ", initInfo);
+    mShineChipLayoutParts = new ShineChipLayoutParts(initInfo, "CounterPiece");
+    mPlayGuideCamera = new PlayGuideCamera("[シーン情報]カメラ操作レイアウト", initInfo,
+                                           al::getPlayerActor(mPlayerHolder, 0));
+    mPlayGuideBgm = new PlayGuideBgm("[シーン情報]BGM再生レイアウト更新", initInfo);
+    mPlayGuideMenu = new al::SimpleLayoutAppearWaitEnd("[シーン情報]メニューガイド",
+                                                       "PlayGuideMenu", initInfo, nullptr, false);
+    al::setPaneString(
+        mPlayGuideMenu, "TxtGuideSh",
+        al::getLayoutMessageString(mPlayGuideMenu, "PlayGuideMenu", "PlayGuideMenu_Guide"));
+    mPlayGuideMenu->kill();
+
+    mMapMini = new MapMini(initInfo, mPlayerHolder);
+    startActionAll("Wait");
+
+    mGamePadPlayStyleInfo = new GamePadPlayStyleInfo{0, 5, 5};
+    rs::recordGamePadPlayStyleInfo(mGamePadPlayStyleInfo, mPlayGuideMenu);
+
+    mLayoutActorKidsMode = new al::LayoutActor("キッズモード");
+    al::initLayoutActor(mLayoutActorKidsMode, initInfo, "KidsMode");
+    al::startAction(mLayoutActorKidsMode, "Wait");
+    mLayoutActorKidsMode->kill();
+
+    kill();
+}
+
+void StageSceneLayout::startActionAll(const char* actionName) {
+    if (rs::isExistShineChipWatcher(mShineChipLayoutParts) &&
+        !rs::isAppearedShineChipShine(mShineChipLayoutParts)) {
+        al::startAction(mShineChipLayoutParts, actionName);
+    }
+}
+
+void StageSceneLayout::control() {
+    mPlayGuideBgm->update();
+}
+
+void StageSceneLayout::updatePlayGuideMenuText() {
+    if (rs::tryUpdateGamePadPlayStyleInfo(mGamePadPlayStyleInfo, mPlayGuideMenu)) {
+        nn::ui2d::Pane* rootPane = mPlayGuideMenu->getLayoutKeeper()->getLayout()->GetPane();
+        eui::TextBoxEx* textBox = nn::ui2d::DynamicCast<eui::TextBoxEx*, nn::ui2d::Pane>(
+            rootPane->FindPaneByName("TxtGuide", true));
+        textBox->mDirtyFlags |= 4;
+        textBox = nn::ui2d::DynamicCast<eui::TextBoxEx*, nn::ui2d::Pane>(
+            rootPane->FindPaneByName("TxtGuideSh", true));
+        textBox->mDirtyFlags |= 4;
+        al::requestCaptureRecursive(mPlayGuideMenu);
+    }
+}
+
+void StageSceneLayout::setDirtyFlagForPlayGuideMenu() {
+    nn::ui2d::Pane* rootPane = mPlayGuideMenu->getLayoutKeeper()->getLayout()->GetPane();
+    eui::TextBoxEx* textBox = nn::ui2d::DynamicCast<eui::TextBoxEx*, nn::ui2d::Pane>(
+        rootPane->FindPaneByName("TxtGuide", true));
+    textBox->mDirtyFlags |= 4;
+    textBox = nn::ui2d::DynamicCast<eui::TextBoxEx*, nn::ui2d::Pane>(
+        rootPane->FindPaneByName("TxtGuideSh", true));
+    textBox->mDirtyFlags |= 4;
+    al::requestCaptureRecursive(mPlayGuideMenu);
+}
+
+void StageSceneLayout::start() {
+    updateCounterParts();
+
+    al::LayoutActor* kidsModeLayout = mLayoutActorKidsMode;
+    if (rs::isKidsMode(kidsModeLayout))
+        al::appearLayoutIfDead(kidsModeLayout);
+
+    mCounterLifeCtrl->appear();
+
+    if (!rs::isModeE3Rom() && !rs::isModeE3LiveRom())
+        mMapMini->appearSlideIn();
+
+    mCoinCounter->tryStart();
+
+    tryAppearCoinCollectCounter();
+
+    if (rs::isExistShineChipWatcher(mShineChipLayoutParts) &&
+        rs::getShineChipCount(mShineChipLayoutParts) >= 1 &&
+        rs::getShineChipCount(mShineChipLayoutParts) <= 4 &&
+        !rs::isAppearedShineChipShine(mShineChipLayoutParts) &&
+        !rs::isCurrentShineChipWatcherTypeEmpty(mShineChipLayoutParts)) {
+        al::appearLayoutIfDead(mShineChipLayoutParts);
+    }
+
+    mShineCounter->tryStart();
+    mPlayGuideBgm->start();
+
+    if (!rs::isModeE3Rom() && !rs::isModeE3LiveRom())
+        al::appearLayoutIfDead(mPlayGuideMenu);
+
+    al::NerveStateBase::appear();
+    mCoinCounter->setUpdateCount(true);
+    mCoinCollectCounter->setUpdateCount(true);
+    al::setNerve(this, &Appear);
+}
+
+void StageSceneLayout::updateCounterParts() {
+    rs::tryUpdateShineChipLayoutCount(mShineChipLayoutParts);
+}
+
+void StageSceneLayout::tryAppearCoinCollectCounter() {
+    if (GameDataFunction::getCoinCollectNumMax(mCoinCollectCounter) != 0)
+        mCoinCollectCounter->tryStart();
+    else
+        al::killLayoutIfActive(mCoinCollectCounter);
+}
+
+void StageSceneLayout::startOnlyCoin(bool isOnlyCoin) {
+    if (!al::isNerve(this, &EndWithoutCoin)) {
+        mIsOnlyCoin = isOnlyCoin;
+        appear();
+        al::setNerve(this, &EndWithoutCoin);
+    }
+}
+
+void StageSceneLayout::endWithoutCoin(bool isOnlyCoin) {
+    if (!al::isNerve(this, &EndWithoutCoin)) {
+        mIsOnlyCoin = isOnlyCoin;
+        appear();
+        al::setNerve(this, &EndWithoutCoin);
+    }
+}
+
+void StageSceneLayout::end() {
+    al::setNerve(this, &End);
+}
+
+bool StageSceneLayout::isEnd() const {
+    return isDead() || al::isNerve(this, &End);
+}
+
+bool StageSceneLayout::isWait() const {
+    return !isDead() && al::isNerve(this, &Wait);
+}
+
+bool StageSceneLayout::isActive() const {
+    return !isDead();
+}
+
+bool StageSceneLayout::isEndLifeDemo() const {
+    return mCounterLifeCtrl->isEndLifeDemo();
+}
+
+bool StageSceneLayout::tryStartLifeDemo() {
+    return mCounterLifeCtrl->tryUpdateCount(
+        GameDataFunction::getPlayerHitPointMaxCurrent(mCoinCounter));
+}
+
+void StageSceneLayout::startCoinCountAnim(s32 coinNum) {
+    mCoinCounter->startCountAnim(coinNum);
+    al::setNerve(this, &CoinCountAnim);
+}
+
+void StageSceneLayout::startCoinCollectCountAnim(s32 coinNum) {
+    mCoinCollectCounter->startCountAnim(coinNum);
+    al::setNerve(this, &CoinCountAnim);
+}
+
+void StageSceneLayout::appearCoinCounterForDemo() {
+    mCoinCounter->tryStart();
+    mCoinCounter->setUpdateCount(false);
+
+    tryAppearCoinCollectCounter();
+
+    mCoinCollectCounter->setUpdateCount(false);
+}
+
+bool StageSceneLayout::isEndCoinCountAnim() const {
+    if (!mCoinCounter->isWait())
+        return false;
+
+    return al::isDead(mCoinCollectCounter) || mCoinCollectCounter->isWait();
+}
+
+bool StageSceneLayout::isEndShineChipCompleteAnim() const {
+    return mShineChipLayoutParts->isEndCompleteAnim();
+}
+
+void StageSceneLayout::startShineChipCompleteAnim() {
+    mCoinCounter->tryEnd();
+    mCoinCollectCounter->tryEnd();
+    mShineCounter->tryEnd();
+    mPlayGuideBgm->end();
+    mCounterLifeCtrl->end();
+    mPlayGuideMenu->end();
+    al::setNerve(this, &ShineChipComplete);
+}
+
+void StageSceneLayout::endShineChipCompleteAnim() {
+    mCoinCounter->tryStart();
+    mCoinCollectCounter->tryStart();
+    mShineCounter->tryStart();
+    mPlayGuideBgm->end();
+    mCounterLifeCtrl->appear();
+    mPlayGuideMenu->appear();
+    mCoinCounter->setUpdateCount(true);
+    mCoinCollectCounter->setUpdateCount(true);
+    al::setNerve(this, &Appear);
+}
+
+bool StageSceneLayout::tryStartDemoGetLifeMaxUpItem(bool isHackKoopa) {
+    return mCounterLifeCtrl->tryStartDemoLifeUp(isHackKoopa);
+}
+
+bool StageSceneLayout::isEndDemoGetLifeMaxUpItem() const {
+    return mCounterLifeCtrl->isEndLifeDemo();
+}
+
+void StageSceneLayout::killShineCount() {
+    al::killLayoutIfActive(mShineCounter);
+}
+
+void StageSceneLayout::appearShineCountWait() {
+    mShineCounter->tryStartWait();
+}
+
+void StageSceneLayout::startCloset() {
+    al::killLayoutIfActive(mShineCounter);
+}
+
+void StageSceneLayout::endCloset() {
+    mShineCounter->tryStart();
+}
+
+void StageSceneLayout::missEnd() {
+    al::killLayoutIfActive(mCoinCounter);
+    al::killLayoutIfActive(mCoinCollectCounter);
+    mCounterLifeCtrl->kill();
+    al::killLayoutIfActive(mShineCounter);
+    mPlayGuideBgm->endImmediate();
+    al::killLayoutIfActive(mShineChipLayoutParts);
+    al::killLayoutIfActive(mPlayGuideMenu);
+
+    if (!rs::isModeE3Rom() && !rs::isModeE3LiveRom())
+        al::killLayoutIfActive(mMapMini);
+}
+
+void StageSceneLayout::appearPlayGuideCamera() {
+    mPlayGuideCamera->start();
+}
+
+void StageSceneLayout::exeAppear() {
+    if (mCoinCounter->isAlive()) {
+        const al::IUseLayoutAction& layoutAction = *mCoinCounter;
+        if (al::isActionEnd(&layoutAction))
+            al::setNerve(this, &Wait);
+    }
+}
+
+bool StageSceneLayout::isActionEndAll() const {
+    if (mCoinCounter->isAlive()) {
+        const al::IUseLayoutAction& layoutAction = *mCoinCounter;
+        return al::isActionEnd(&layoutAction);
+    }
+
+    return false;
+}
+
+void StageSceneLayout::exeWait() {
+    if (al::isFirstStep(this))
+        startActionAll("Wait");
+}
+
+void StageSceneLayout::exeEnd() {
+    if (al::isFirstStep(this)) {
+        startActionAll("End");
+
+        mPlayGuideMenu->end();
+        mCounterLifeCtrl->end();
+
+        if (!rs::isModeE3Rom() && !rs::isModeE3LiveRom())
+            mMapMini->end();
+
+        mPlayGuideBgm->end();
+        mShineCounter->tryEnd();
+        mCoinCounter->tryEnd();
+        mCoinCollectCounter->tryEnd();
+        al::killLayoutIfActive(mLayoutActorKidsMode);
+    }
+
+    if (isActionEndAll())
+        al::killLayoutIfActive(mShineChipLayoutParts);
+}
+
+void StageSceneLayout::exeEndWithoutCoin() {
+    if (!al::isFirstStep(this))
+        return;
+
+    appearCoinCounterForDemo();
+
+    mShineCounter->tryEnd();
+
+    startActionAll("End");
+
+    mPlayGuideMenu->end();
+
+    if (!rs::isModeE3Rom() && !rs::isModeE3LiveRom())
+        mMapMini->end();
+
+    mPlayGuideBgm->end();
+
+    if (!mIsOnlyCoin)
+        mCounterLifeCtrl->end();
+}
+
+void StageSceneLayout::exeCoinCountAnim() {}
+
+void StageSceneLayout::exeShineChipComplete() {}
+
+void StageSceneLayout::exeShineCountAppear() {}
+
+void StageSceneLayout::updateLifeCounter() {
+    mCounterLifeCtrl->updateNerve();
+}
+
+void StageSceneLayout::updateKidsModeLayout() {
+    if (rs::isKidsModeLayoutDisable(mLayoutActorKidsMode)) {
+        al::killLayoutIfActive(mLayoutActorKidsMode);
+        return;
+    }
+
+    if (al::isNerve(this, &Wait)) {
+        al::LayoutActor* kidsModeLayout = mLayoutActorKidsMode;
+        if (rs::isKidsMode(kidsModeLayout))
+            al::appearLayoutIfDead(kidsModeLayout);
+    }
+}
+
+void StageSceneLayout::startShineCountAnim(bool isAddTenShines) {
+    al::NerveStateBase::appear();
+    mShineCounter->startCountAnim(isAddTenShines);
+    al::setNerve(this, &ShineCountAppear);
+}
+
+bool StageSceneLayout::isEndShineCountAnim() const {
+    return mShineCounter->isEndCountAnim();
+}

--- a/src/Layout/StageSceneLayout.h
+++ b/src/Layout/StageSceneLayout.h
@@ -6,6 +6,7 @@ namespace al {
 class PlayerHolder;
 class LayoutActor;
 class LayoutInitInfo;
+class SimpleLayoutAppearWaitEnd;
 class SubCameraRenderer;
 }  // namespace al
 
@@ -16,38 +17,37 @@ class ShineChipLayoutParts;
 class PlayGuideCamera;
 class PlayGuideBgm;
 class MapMini;
-class SimpleLayoutAppearWaitEnd;
 class GamePadPlayStyleInfo;
 
 class StageSceneLayout : public al::NerveStateBase {
 public:
-    StageSceneLayout(const char*, const al::LayoutInitInfo&, const al::PlayerHolder*,
-                     const al::SubCameraRenderer*);
-    ~StageSceneLayout();
+    StageSceneLayout(const char* name, const al::LayoutInitInfo& initInfo,
+                     const al::PlayerHolder* playerHolder,
+                     const al::SubCameraRenderer* subCameraRenderer);
 
-    void startActionAll(const char*);
+    void startActionAll(const char* actionName);
     void control() override;
     void updatePlayGuideMenuText();
     void setDirtyFlagForPlayGuideMenu();
     void start();
     void updateCounterParts();
     void tryAppearCoinCollectCounter();
-    void startOnlyCoin(bool);
-    void endWithoutCoin(bool);
+    void startOnlyCoin(bool isOnlyCoin);
+    void endWithoutCoin(bool isOnlyCoin);
     void end();
     bool isEnd() const;
     bool isWait() const;
     bool isActive() const;
     bool isEndLifeDemo() const;
     bool tryStartLifeDemo();
-    void startCoinCountAnim(s32);
-    void startCoinCollectCountAnim(s32);
+    void startCoinCountAnim(s32 coinNum);
+    void startCoinCollectCountAnim(s32 coinNum);
     void appearCoinCounterForDemo();
     bool isEndCoinCountAnim() const;
     bool isEndShineChipCompleteAnim() const;
     void startShineChipCompleteAnim();
     void endShineChipCompleteAnim();
-    bool tryStartDemoGetLifeMaxUpItem(bool);
+    bool tryStartDemoGetLifeMaxUpItem(bool isHackKoopa);
     bool isEndDemoGetLifeMaxUpItem() const;
     void killShineCount();
     void appearShineCountWait();
@@ -56,7 +56,7 @@ public:
     void missEnd();
     void appearPlayGuideCamera();
     void exeAppear();
-    bool isActionEndAll();
+    bool isActionEndAll() const;
     void exeWait();
     void exeEnd();
     void exeEndWithoutCoin();
@@ -69,19 +69,19 @@ public:
     bool isEndShineCountAnim() const;
 
 private:
-    CoinCounter* mCoinCounter;
-    CounterLifeCtrl* mCounterLifeCtrl;
-    ShineCounter* mShineCounter;
-    CoinCounter* mCoinCollectCounter;
-    ShineChipLayoutParts* mShineChipLayoutParts;
-    PlayGuideCamera* mPlayGuideCamera;
-    PlayGuideBgm* mPlayGuideBgm;
-    MapMini* mMapMini;
-    const al::PlayerHolder* mPlayerHolder;
-    bool _60;
-    SimpleLayoutAppearWaitEnd* mPlayGuideMenu;
-    GamePadPlayStyleInfo* mGamePadPlayStyleInfo;
-    al::LayoutActor* mLayoutActorKidsMode;
+    CoinCounter* mCoinCounter = nullptr;
+    CounterLifeCtrl* mCounterLifeCtrl = nullptr;
+    ShineCounter* mShineCounter = nullptr;
+    CoinCounter* mCoinCollectCounter = nullptr;
+    ShineChipLayoutParts* mShineChipLayoutParts = nullptr;
+    PlayGuideCamera* mPlayGuideCamera = nullptr;
+    PlayGuideBgm* mPlayGuideBgm = nullptr;
+    MapMini* mMapMini = nullptr;
+    const al::PlayerHolder* mPlayerHolder = nullptr;
+    bool mIsOnlyCoin = false;
+    al::SimpleLayoutAppearWaitEnd* mPlayGuideMenu = nullptr;
+    GamePadPlayStyleInfo* mGamePadPlayStyleInfo = nullptr;
+    al::LayoutActor* mLayoutActorKidsMode = nullptr;
 };
 
 static_assert(sizeof(StageSceneLayout) == 0x80);

--- a/src/Library/Layout/LayoutKeeper.h
+++ b/src/Library/Layout/LayoutKeeper.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace eui {
+class Screen;
+}  // namespace eui
+
+namespace nn::ui2d {
+class DrawInfo;
+class Layout;
+}  // namespace nn::ui2d
+
+namespace al {
+
+class LayoutPaneGroup;
+class LayoutResource;
+class CustomTagProcessor;
+
+class LayoutKeeper {
+public:
+    LayoutKeeper();
+
+    void initScreen(eui::Screen* screen);
+    void initLayout(nn::ui2d::Layout* layout, LayoutResource* resource);
+    void initDrawInfo(nn::ui2d::DrawInfo* drawInfo);
+    void initTagProcessor(CustomTagProcessor* tagProcessor);
+    LayoutPaneGroup* getGroup(const char* groupName) const;
+    LayoutPaneGroup* getGroup(s32 groupIndex) const;
+    s32 getGroupNum() const;
+    void calcAnim(bool isStep);
+    void draw();
+
+    nn::ui2d::Layout* getLayout() const { return mLayout; }
+
+private:
+    void* _0;
+    void* _8;
+    nn::ui2d::Layout* mLayout;
+};
+}  // namespace al

--- a/src/Util/GamePadPlayStyleInfo.h
+++ b/src/Util/GamePadPlayStyleInfo.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class GamePadPlayStyleInfo {
+public:
+    s32 mPadCount;
+    s32 mPlayerOneStyle;
+    s32 mPlayerTwoStyle;
+};
+
+static_assert(sizeof(GamePadPlayStyleInfo) == 0xc);

--- a/src/eui/TextBoxEx.h
+++ b/src/eui/TextBoxEx.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <nn/ui2d/Pane.h>
+
+namespace eui {
+class TextBoxEx {
+public:
+    u8 _0[0x11c];
+    u8 mDirtyFlags;
+};
+}  // namespace eui
+
+namespace nn::ui2d {
+template <typename T, typename U>
+T DynamicCast(U* pane);
+
+template <>
+eui::TextBoxEx* DynamicCast<eui::TextBoxEx*, nn::ui2d::Pane>(nn::ui2d::Pane* pane);
+}  // namespace nn::ui2d


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1013)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4f8518a - f3f7857)

📈 **Matched code**: 14.13% (+0.03%, +3924 bytes)

<details>
<summary>✅ 51 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Layout/StageSceneLayout` | `StageSceneLayout::StageSceneLayout(char const*, al::LayoutInitInfo const&, al::PlayerHolder const*, al::SubCameraRenderer const*)` | +756 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::start()` | +380 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::exeEndWithoutCoin()` | +260 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::exeEnd()` | +252 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::updatePlayGuideMenuText()` | +168 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::setDirtyFlagForPlayGuideMenu()` | +144 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `(anonymous namespace)::StageSceneLayoutNrvWait::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::exeWait()` | +124 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::updateKidsModeLayout()` | +120 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startActionAll(char const*)` | +116 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::endShineChipCompleteAnim()` | +116 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::missEnd()` | +116 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::appearCoinCounterForDemo()` | +108 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startOnlyCoin(bool)` | +96 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::endWithoutCoin(bool)` | +96 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startShineChipCompleteAnim()` | +88 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::tryAppearCoinCollectCounter()` | +84 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::isEndCoinCountAnim() const` | +80 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::exeAppear()` | +80 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `(anonymous namespace)::StageSceneLayoutNrvAppear::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::tryStartLifeDemo()` | +72 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startShineCountAnim(bool)` | +56 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startCoinCountAnim(int)` | +48 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::startCoinCollectCountAnim(int)` | +48 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::~StageSceneLayout()` | +36 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::isActionEndAll() const` | +32 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::isEnd() const` | +28 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::isWait() const` | +28 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::control()` | +16 | 0.00% | 100.00% |
| `Layout/StageSceneLayout` | `StageSceneLayout::isActive() const` | +16 | 0.00% | 100.00% |

...and 21 more new matches
</details>


<!-- decomp.dev report end -->