### PR TITLE
Scene: Implement `StageScene::isIgnoreAddPlayTime()`

### DIFF
--- a/src/Scene/StageScene.cpp
+++ b/src/Scene/StageScene.cpp
@@ -85,9 +85,9 @@ NERVES_MAKE_STRUCT(StageScene, StartStageBgm, CollectBgm, CollectionList, MiniGa
 }  // namespace
 
 bool StageScene::isIgnoreAddPlayTime() const {
-    if (mStateSnapShot->isDead())
-        return al::isNerve(this, &NrvStageScene.Pause);
-    return true;
+    if (!mStateSnapShot->isDead())
+        return true;
+    return al::isNerve(this, &NrvStageScene.Pause);
 }
 
 void StageScene::exeDemoGetLifeMaxUpItem() {

--- a/src/Scene/StageScene.cpp
+++ b/src/Scene/StageScene.cpp
@@ -6,6 +6,7 @@
 
 #include "Layout/KidsModeLayoutAccessor.h"
 #include "Layout/StageSceneLayout.h"
+#include "Scene/StageSceneStateSnapShot.h"
 #include "System/GameDataFunction.h"
 #include "System/GameDataHolderAccessor.h"
 #include "Util/AmiiboUtil.h"
@@ -82,6 +83,12 @@ NERVES_MAKE_STRUCT(StageScene, StartStageBgm, CollectBgm, CollectionList, MiniGa
                    Amiibo, DemoStageStartElectricDemo, WaitStartWarpForSession, DemoCountCoin,
                    WarpToCheckpoint, DemoAppearFromHome, DemoRisePyramid, WaitWarpToCheckpoint)
 }  // namespace
+
+bool StageScene::isIgnoreAddPlayTime() const {
+    if (mStateSnapShot->isDead())
+        return al::isNerve(this, &NrvStageScene.Pause);
+    return true;
+}
 
 void StageScene::exeDemoGetLifeMaxUpItem() {
     if (mIsUpdateKitAndGraphics) {

--- a/src/Scene/StageSceneStateSnapShot.h
+++ b/src/Scene/StageSceneStateSnapShot.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class Scene;
+}  // namespace al
+
+class ControllerGuideSnapShotCtrl;
+class InputSeparator;
+class NpcEventDirector;
+class SceneAudioSystemPauseController;
+
+class StageSceneStateSnapShot : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateSnapShot(const char*, al::Scene*, ControllerGuideSnapShotCtrl*,
+                            SceneAudioSystemPauseController*, InputSeparator*, NpcEventDirector*);
+    void appear() override;
+    void kill() override;
+    bool tryStart();
+    void exeWait();
+
+private:
+    ControllerGuideSnapShotCtrl* mControllerGuideSnapShotCtrl;
+    SceneAudioSystemPauseController* mAudioSystemPauseController;
+    InputSeparator* mInputSeparator;
+    NpcEventDirector* mNpcEventDirector;
+};

--- a/src/Scene/StageSceneStateSnapShot.h
+++ b/src/Scene/StageSceneStateSnapShot.h
@@ -21,11 +21,10 @@ public:
     void exeWait();
 
 private:
-    al::Scene* mScene;
     ControllerGuideSnapShotCtrl* mControllerGuideSnapShotCtrl;
     SceneAudioSystemPauseController* mAudioSystemPauseController;
     InputSeparator* mInputSeparator;
     NpcEventDirector* mNpcEventDirector;
 };
 
-static_assert(sizeof(StageSceneStateSnapShot) == 0x48);
+static_assert(sizeof(StageSceneStateSnapShot) == 0x40);

--- a/src/Scene/StageSceneStateSnapShot.h
+++ b/src/Scene/StageSceneStateSnapShot.h
@@ -21,8 +21,11 @@ public:
     void exeWait();
 
 private:
+    al::Scene* mScene;
     ControllerGuideSnapShotCtrl* mControllerGuideSnapShotCtrl;
     SceneAudioSystemPauseController* mAudioSystemPauseController;
     InputSeparator* mInputSeparator;
     NpcEventDirector* mNpcEventDirector;
 };
+
+static_assert(sizeof(StageSceneStateSnapShot) == 0x48);


### PR DESCRIPTION
First time I try decompilation on a switch game, so if I did something absolutely wrong, I feel sorry by advance, and I think you can safely decline my pr. :)

So this first attempt is a good occasion to discover the contribution workflow and familiarize with C++ decompilation on IDA Pro 9.

I wanted first to decompile StageScene::isIgnoreAddPlayTime(), but to make it compile I needed to create a minimal header for StageSceneStateSnapShot, bc of the mStateSnapShot public var. The header is probably incomplete and was filled with some infos I got on its constructor by looking on IDA.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1014)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (fcc4c87 - a80d1f1)

📈 **Matched code**: 14.13% (+0.00%, +36 bytes)

<details>
<summary>✅ 1 new match</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/StageScene` | `StageScene::isIgnoreAddPlayTime() const` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->