### PR TITLE
MapObj: Implement MoonBasementMeteorPointObj

### DIFF
--- a/src/Boss/Koopa/KoopaHackStopCtrl.h
+++ b/src/Boss/Koopa/KoopaHackStopCtrl.h
@@ -28,6 +28,8 @@ public:
 
     bool isStop() const { return mStopActor != nullptr; }
 
+    const al::LiveActor* getStopActor() const { return mStopActor; }
+
     bool isStatusDemoForSceneKoopaHack() const { return mIsStatusDemoForSceneKoopaHack; }
 
     void setStatusDemoForSceneKoopaHack(bool status) { mIsStatusDemoForSceneKoopaHack = status; }

--- a/src/MapObj/MoonBasementFallObj.h
+++ b/src/MapObj/MoonBasementFallObj.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <math/seadQuat.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class LiveActorGroup;
+}  // namespace al
+
+class MoonBasementFallObj : public al::LiveActor {
+public:
+    MoonBasementFallObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void movement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    bool isEnableStartFall() const;
+    void exeFall();
+
+private:
+    al::LiveActorGroup* mFallObjPieces = nullptr;
+    sead::Quatf mStartQuat = sead::Quatf::unit;
+    bool mIsOnCalcEffect = false;
+    u8 _121[7] = {};
+};
+
+namespace MoonBasementFallObjFunction {
+void startOnOffCalcEffect(bool* isOnCalcEffect, al::LiveActor* actor);
+void updateOnOffCalcEffect(bool* isOnCalcEffect, al::LiveActor* actor);
+void forceOnCalcEffect(bool* isOnCalcEffect, al::LiveActor* actor);
+}  // namespace MoonBasementFallObjFunction
+
+static_assert(sizeof(MoonBasementFallObj) == 0x128);

--- a/src/MapObj/MoonBasementMeteorPointObj.cpp
+++ b/src/MapObj/MoonBasementMeteorPointObj.cpp
@@ -1,0 +1,152 @@
+#include "MapObj/MoonBasementMeteorPointObj.h"
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Boss/Koopa/KoopaHackStopCtrl.h"
+#include "MapObj/MoonBasementFallObj.h"
+
+void executeWaitNerveImpl(MoonBasementMeteorPointObj* actor);
+
+namespace {
+class MoonBasementMeteorPointObjNrvWait : public al::Nerve {
+public:
+    void execute(al::NerveKeeper* keeper) const override {
+        executeWaitNerveImpl(keeper->getParent<MoonBasementMeteorPointObj>());
+    }
+};
+
+NERVE_IMPL(MoonBasementMeteorPointObj, Stop)
+NERVE_IMPL(MoonBasementMeteorPointObj, Delay)
+
+NERVES_MAKE_NOSTRUCT(MoonBasementMeteorPointObj, Stop)
+
+struct {
+    MoonBasementMeteorPointObjNrvWait Wait;
+    MoonBasementMeteorPointObjNrvDelay Delay;
+} NrvMoonBasementMeteorPointObj;
+}  // namespace
+
+MoonBasementMeteorPointObj::MoonBasementMeteorPointObj(const char* name) : al::LiveActor(name) {
+    mFallObj = nullptr;
+    mIsUseChangeTrans = false;
+    mIntervalStep = 0;
+    mChangeTrans.z = 0.0f;
+    mDelayStep = 0;
+    mChangeTrans.x = 0.0f;
+    mChangeTrans.y = 0.0f;
+}
+
+inline void executeWaitNerveImpl(MoonBasementMeteorPointObj* actor) {
+    if (al::isFirstStep(actor) && actor->mFallObj->isEnableStartFall()) {
+        if (actor->mIsUseChangeTrans)
+            al::setTrans(actor->mFallObj, actor->mChangeTrans);
+        else
+            al::setTrans(actor->mFallObj, al::getTrans(actor));
+
+        actor->mFallObj->appear();
+    }
+
+    al::setNerveAtGreaterEqualStep(actor, &NrvMoonBasementMeteorPointObj.Wait,
+                                   actor->mIntervalStep);
+}
+
+void MoonBasementMeteorPointObj::init(const al::ActorInitInfo& info) {
+    using MoonBasementMeteorPointObjFunctor =
+        al::FunctorV0M<MoonBasementMeteorPointObj*, void (MoonBasementMeteorPointObj::*)()>;
+
+    al::IUseStageSwitch* stageSwitchUser;
+
+    al::initActorSceneInfo(this, info);
+    al::initActorPoseTRSV(this);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::invalidateClipping(this);
+    al::initExecutorWatchObj(this, info);
+    al::initStageSwitch(this, info);
+    al::initNerve(this, &NrvMoonBasementMeteorPointObj.Wait, 0);
+
+    mFallObj = new MoonBasementFallObj("崩落落石");
+    al::initCreateActorWithPlacementInfo(mFallObj, info);
+
+    al::getArg(&mIntervalStep, info, "IntervalStep");
+    if (al::tryGetArg(&mDelayStep, info, "DelayStep") && mDelayStep >= 1)
+        al::setNerve(this, &NrvMoonBasementMeteorPointObj.Delay);
+
+    if (al::isExistLinkChild(info, "FallChangePosition", 0)) {
+        al::getChildTrans(&mChangeTrans, info, "FallChangePosition");
+
+        stageSwitchUser = this;
+        al::listenStageSwitchOnOff(
+            stageSwitchUser, "FallChangePositionSwitch",
+            MoonBasementMeteorPointObjFunctor(this, &MoonBasementMeteorPointObj::onChangeTrans),
+            MoonBasementMeteorPointObjFunctor(this, &MoonBasementMeteorPointObj::offChangeTrans));
+    } else {
+        stageSwitchUser = this;
+    }
+
+    const MoonBasementMeteorPointObjFunctor onSwitchStartFunctor(
+        this, &MoonBasementMeteorPointObj::onSwitchStart);
+    const MoonBasementMeteorPointObjFunctor offSwitchStartFunctor(
+        this, &MoonBasementMeteorPointObj::offSwitchStart);
+
+    al::listenStageSwitchOnOffStart(stageSwitchUser, onSwitchStartFunctor, offSwitchStartFunctor);
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+void MoonBasementMeteorPointObj::onChangeTrans() {
+    mIsUseChangeTrans = true;
+}
+
+void MoonBasementMeteorPointObj::offChangeTrans() {
+    mIsUseChangeTrans = false;
+}
+
+void MoonBasementMeteorPointObj::onSwitchStart() {
+    al::invalidateClipping(this);
+
+    if (mDelayStep >= 1) {
+        al::setNerve(this, &NrvMoonBasementMeteorPointObj.Delay);
+        return;
+    }
+
+    al::setNerve(this, &NrvMoonBasementMeteorPointObj.Wait);
+}
+
+void MoonBasementMeteorPointObj::offSwitchStart() {
+    al::validateClipping(this);
+    al::setNerve(this, &Stop);
+}
+
+void MoonBasementMeteorPointObj::initAfterPlacement() {
+    if (!al::isValidSwitchStart(this))
+        return;
+
+    if (al::isOnSwitchStart(this))
+        return;
+
+    al::validateClipping(this);
+    al::setNerve(this, &Stop);
+}
+
+void MoonBasementMeteorPointObj::movement() {
+    if (!KoopaHackFunction::isStopKoopaHack(this))
+        al::LiveActor::movement();
+}
+
+void MoonBasementMeteorPointObj::exeDelay() {
+    al::setNerveAtGreaterEqualStep(this, &NrvMoonBasementMeteorPointObj.Wait, mDelayStep);
+}
+
+void MoonBasementMeteorPointObj::exeWait() {
+    executeWaitNerveImpl(this);
+}
+
+void MoonBasementMeteorPointObj::exeStop() {}

--- a/src/MapObj/MoonBasementMeteorPointObj.h
+++ b/src/MapObj/MoonBasementMeteorPointObj.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class MoonBasementFallObj;
+
+class MoonBasementMeteorPointObj : public al::LiveActor {
+public:
+    MoonBasementMeteorPointObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void movement() override;
+
+    void onChangeTrans();
+    void offChangeTrans();
+    void onSwitchStart();
+    void offSwitchStart();
+
+    void exeDelay();
+    void exeWait();
+    void exeStop();
+
+private:
+    friend void executeWaitNerveImpl(MoonBasementMeteorPointObj* actor);
+
+    MoonBasementFallObj* mFallObj;
+    bool mIsUseChangeTrans;
+    u8 _111[3];
+    sead::Vector3f mChangeTrans;
+    s32 mDelayStep;
+    s32 mIntervalStep;
+};
+
+static_assert(sizeof(MoonBasementMeteorPointObj) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -99,6 +99,7 @@
 #include "MapObj/MeganeMapParts.h"
 #include "MapObj/MoonBasementBreakParts.h"
 #include "MapObj/MoonBasementFloor.h"
+#include "MapObj/MoonBasementMeteorPointObj.h"
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/MoviePlayerMapParts.h"
@@ -716,3 +717,5 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
 ProjectActorFactory::ProjectActorFactory() : ActorFactory("アクター生成") {  //("繧｢繧ｯ繧ｿ繝ｼ逕滓")
     initFactory(sProjectActorFactoryEntries);
 }
+
+template al::LiveActor* al::createActorFunction<MoonBasementMeteorPointObj>(const char*);


### PR DESCRIPTION
<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1018)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - dde5155)

📈 **Matched code**: 14.67% (+0.01%, +1484 bytes)

<details>
<summary>✅ 19 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::init(al::ActorInitInfo const&)` | +452 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::MoonBasementMeteorPointObj(char const*)` | +160 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::MoonBasementMeteorPointObj(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `(anonymous namespace)::MoonBasementMeteorPointObjNrvWait::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::exeWait()` | +120 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::initAfterPlacement()` | +88 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `al::FunctorV0M<MoonBasementMeteorPointObj*, void (MoonBasementMeteorPointObj::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::onSwitchStart()` | +72 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::movement()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<MoonBasementMeteorPointObj>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::offSwitchStart()` | +44 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `al::FunctorV0M<MoonBasementMeteorPointObj*, void (MoonBasementMeteorPointObj::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `(anonymous namespace)::MoonBasementMeteorPointObjNrvDelay::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::exeDelay()` | +16 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::onChangeTrans()` | +12 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::offChangeTrans()` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `MoonBasementMeteorPointObj::exeStop()` | +4 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `(anonymous namespace)::MoonBasementMeteorPointObjNrvStop::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/MoonBasementMeteorPointObj` | `al::FunctorV0M<MoonBasementMeteorPointObj*, void (MoonBasementMeteorPointObj::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->