### PR TITLE
MapObj: Implement `DoorCity`

### DIFF
--- a/src/MapObj/DoorCity.cpp
+++ b/src/MapObj/DoorCity.cpp
@@ -1,0 +1,77 @@
+#include "MapObj/DoorCity.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "System/GameDataFunction.h"
+
+namespace {
+NERVE_IMPL(DoorCity, Open);
+NERVE_IMPL(DoorCity, WaitOpen);
+NERVE_IMPL(DoorCity, WaitClose);
+
+NERVES_MAKE_NOSTRUCT(DoorCity, Open, WaitOpen, WaitClose);
+}  // namespace
+
+DoorCity::DoorCity(const char* name) : al::LiveActor(name) {}
+
+void DoorCity::init(const al::ActorInitInfo& info) {
+    using DoorCityFunctor = al::FunctorV0M<DoorCity*, void (DoorCity::*)()>;
+
+    al::initActor(this, info);
+    const char* initState = nullptr;
+    al::getStringArg(&initState, info, "InitState");
+
+    if (al::isEqualString(initState, "Open")) {
+        al::initNerve(this, &WaitOpen, 0);
+        al::invalidateCollisionParts(this);
+    } else if (al::isEqualString(initState, "Close")) {
+        al::initNerve(this, &WaitClose, 0);
+        al::listenStageSwitchOnStart(this, DoorCityFunctor(this, &DoorCity::onStageSwitch));
+    } else {
+        kill();
+        return;
+    }
+
+    makeActorAlive();
+
+    al::listenStageSwitchOn(this, "SwitchLightOff",
+                            DoorCityFunctor(this, &DoorCity::listenSwitchOff));
+}
+
+void DoorCity::onStageSwitch() {
+    al::setNerve(this, &Open);
+}
+
+void DoorCity::listenSwitchOff() {}
+
+void DoorCity::exeWaitOpen() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "OpenWait");
+}
+
+void DoorCity::exeOpen() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Open");
+
+    if (al::isActionEnd(this)) {
+        al::invalidateCollisionParts(this);
+        al::setNerve(this, &WaitOpen);
+    }
+}
+
+void DoorCity::exeWaitClose() {
+    if (al::isFirstStep(this)) {
+        if (GameDataFunction::getScenarioNo(this) == 1)
+            al::tryStartAction(this, "Blink");
+        else
+            al::tryStartAction(this, "CloseWait");
+    }
+}

--- a/src/MapObj/DoorCity.h
+++ b/src/MapObj/DoorCity.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class DoorCity : public al::LiveActor {
+public:
+    DoorCity(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void onStageSwitch();
+    void listenSwitchOff();
+    void exeWaitOpen();
+    void exeOpen();
+    void exeWaitClose();
+};
+
+static_assert(sizeof(DoorCity) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -75,6 +75,7 @@
 #include "MapObj/ChurchDoor.h"
 #include "MapObj/CitySignal.h"
 #include "MapObj/CoinCollectHintObj.h"
+#include "MapObj/DoorCity.h"
 #include "MapObj/Doshi.h"
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
@@ -272,7 +273,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"Doshi", al::createActorFunction<Doshi>},
     {"DoorAreaChange", nullptr},
     {"DoorAreaChangeCap", nullptr},
-    {"DoorCity", nullptr},
+    {"DoorCity", al::createActorFunction<DoorCity>},
     {"DoorSnow", nullptr},
     {"DoorWarp", nullptr},
     {"DoorWarpStageChange", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1019)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b6f947c - a13e099)

📈 **Matched code**: 14.20% (+0.01%, +1232 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/DoorCity` | `DoorCity::init(al::ActorInitInfo const&)` | +304 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::DoorCity(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::DoorCity(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `(anonymous namespace)::DoorCityNrvOpen::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::exeOpen()` | +96 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `(anonymous namespace)::DoorCityNrvWaitClose::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::exeWaitClose()` | +88 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `al::FunctorV0M<DoorCity*, void (DoorCity::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `(anonymous namespace)::DoorCityNrvWaitOpen::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::exeWaitOpen()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<DoorCity>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `al::FunctorV0M<DoorCity*, void (DoorCity::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::onStageSwitch()` | +12 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `DoorCity::listenSwitchOff()` | +4 | 0.00% | 100.00% |
| `MapObj/DoorCity` | `al::FunctorV0M<DoorCity*, void (DoorCity::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->