### PR TITLE
MapObj: Implement `LavaFryingPan`

### DIFF
--- a/lib/al/Library/Fluid/RippleCtrl.h
+++ b/lib/al/Library/Fluid/RippleCtrl.h
@@ -35,7 +35,13 @@ public:
     const char* getTypeName() const override;
     void forceResetCount();
 
+    void set_110(bool update) { _110 = update; }
+
 private:
-    unsigned char padding[0x128 - sizeof(IUseFluidSurface)];
+    unsigned char _8[0x108];
+    bool _110 = false;
+    unsigned char _111[0x17];
 };
+
+static_assert(sizeof(RippleCtrl) == 0x128);
 }  // namespace al

--- a/lib/al/Library/Movement/ClockMovement.h
+++ b/lib/al/Library/Movement/ClockMovement.h
@@ -10,6 +10,7 @@ struct ActorInitInfo;
 class ClockMovement : public NerveExecutor {
 public:
     ClockMovement(const ActorInitInfo& info);
+
     void exeDelay();
     void exeRotateSign();
     void exeRotate();
@@ -18,6 +19,8 @@ public:
     bool isFirstStepRotateSign() const;
     bool isFirstStepRotate() const;
     bool isFirstStepWait() const;
+
+    const sead::Quatf& getCurrentQuat() const { return mCurrentQuat; }
 
 private:
     sead::Quatf mCurrentQuat = sead::Quatf::unit;

--- a/src/MapObj/LavaFryingPan.cpp
+++ b/src/MapObj/LavaFryingPan.cpp
@@ -1,0 +1,71 @@
+#include "MapObj/LavaFryingPan.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Fluid/RippleCtrl.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Movement/ClockMovement.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+
+namespace {
+NERVE_ACTION_IMPL(LavaFryingPan, Delay)
+NERVE_ACTION_IMPL(LavaFryingPan, RotateSign)
+NERVE_ACTION_IMPL(LavaFryingPan, Rotate)
+NERVE_ACTION_IMPL(LavaFryingPan, WaitUp)
+NERVE_ACTION_IMPL(LavaFryingPan, WaitDown)
+
+NERVE_ACTIONS_MAKE_STRUCT(LavaFryingPan, Delay, RotateSign, Rotate, WaitUp, WaitDown)
+}  // namespace
+
+LavaFryingPan::LavaFryingPan(const char* name) : al::LiveActor(name) {}
+
+void LavaFryingPan::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Rotate", &NrvLavaFryingPan.collector, 0);
+    al::initActor(this, info);
+    mClockMovement = new al::ClockMovement(info);
+    mRippleCtrl = al::RippleCtrl::tryCreate(this);
+
+    if (mRippleCtrl) {
+        mRippleCtrl->init(info);
+        mRippleCtrl->set_110(true);
+    }
+
+    makeActorAlive();
+}
+
+void LavaFryingPan::exeDelay() {}
+
+void LavaFryingPan::exeRotateSign() {}
+
+void LavaFryingPan::exeRotate() {}
+
+void LavaFryingPan::exeWaitUp() {}
+
+void LavaFryingPan::exeWaitDown() {}
+
+void LavaFryingPan::control() {
+    mClockMovement->updateNerve();
+    al::setQuat(this, mClockMovement->getCurrentQuat());
+
+    if (mRippleCtrl)
+        mRippleCtrl->update();
+
+    if (mClockMovement->isFirstStepRotateSign()) {
+        al::startNerveAction(this, "RotateSign");
+        return;
+    }
+
+    if (mClockMovement->isFirstStepRotate()) {
+        al::startNerveAction(this, "Rotate");
+        return;
+    }
+
+    if (mClockMovement->isFirstStepWait()) {
+        if (al::isUpDir(this, sead::Vector3f::ey))
+            al::startNerveAction(this, "WaitUp");
+        else
+            al::startNerveAction(this, "WaitDown");
+    }
+}

--- a/src/MapObj/LavaFryingPan.h
+++ b/src/MapObj/LavaFryingPan.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class ClockMovement;
+class RippleCtrl;
+}  // namespace al
+
+class LavaFryingPan : public al::LiveActor {
+public:
+    LavaFryingPan(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void control() override;
+    void exeDelay();
+    void exeRotateSign();
+    void exeRotate();
+    void exeWaitUp();
+    void exeWaitDown();
+
+private:
+    al::ClockMovement* mClockMovement = nullptr;
+    al::RippleCtrl* mRippleCtrl = nullptr;
+};
+
+static_assert(sizeof(LavaFryingPan) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -87,6 +87,7 @@
 #include "MapObj/HipDropRepairParts.h"
 #include "MapObj/HipDropSwitch.h"
 #include "MapObj/KoopaShip.h"
+#include "MapObj/LavaFryingPan.h"
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
 #include "MapObj/MoonBasementBreakParts.h"
@@ -396,7 +397,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"KuriboMini", al::createActorFunction<KuriboMini>},
     {"KuriboTowerSwitch", nullptr},
     {"KuriboWing", nullptr},
-    {"LavaFryingPan", nullptr},
+    {"LavaFryingPan", al::createActorFunction<LavaFryingPan>},
     {"LavaStewVeget", nullptr},
     {"LavaPan", al::createActorFunction<LavaPan>},
     {"LavaWave", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1020)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3f414ea - b2a48d6)

📈 **Matched code**: 14.50% (+0.01%, +908 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/LavaFryingPan` | `LavaFryingPan::control()` | +180 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `_GLOBAL__sub_I_LavaFryingPan.cpp` | +164 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::init(al::ActorInitInfo const&)` | +152 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::LavaFryingPan(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::LavaFryingPan(char const*)` | +124 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<LavaFryingPan>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvDelay::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvRotateSign::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvRotate::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvWaitUp::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvWaitDown::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::exeDelay()` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::exeRotateSign()` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::exeRotate()` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::exeWaitUp()` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `LavaFryingPan::exeWaitDown()` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvDelay::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvRotateSign::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvRotate::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvWaitUp::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/LavaFryingPan` | `(anonymous namespace)::LavaFryingPanNrvWaitDown::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->