### PR TITLE
MapObj: Implement `BossKnuckleFix`

### DIFF
--- a/src/MapObj/BossKnuckleFix.cpp
+++ b/src/MapObj/BossKnuckleFix.cpp
@@ -1,0 +1,89 @@
+#include "MapObj/BossKnuckleFix.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorResourceFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BossKnuckleFix, Wait);
+NERVE_IMPL(BossKnuckleFix, ReactionLarge);
+NERVE_IMPL(BossKnuckleFix, Reaction);
+
+NERVES_MAKE_STRUCT(BossKnuckleFix, Wait, ReactionLarge, Reaction);
+}  // namespace
+
+BossKnuckleFix::BossKnuckleFix(const char* name) : al::LiveActor(name) {}
+
+void BossKnuckleFix::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "BossKnuckleBody", "Fix");
+    al::initNerve(this, &NrvBossKnuckleFix.Wait, 0);
+    // NOTE: color of embedded grand shine is hardcoded to 5 (Sand)
+    al::startMclAnimAndSetFrameAndStop(al::getSubActor(this, "グランドシャイン"), "Color", 5.0f);
+    al::trySyncStageSwitchKill(this);
+    makeActorAlive();
+
+    mCollisionObj = new al::CollisionObj(info, al::getModelResource(this), "MoveLimit",
+                                         al::getHitSensor(this, "Body"), nullptr, nullptr);
+    al::setCollisionPartsSpecialPurposeName(mCollisionObj, "MoveLimit");
+    al::setTrans(mCollisionObj, al::getTrans(this));
+    al::setRotate(mCollisionObj, {0.0f, 90.0f, 0.0f});
+    mCollisionObj->makeActorAlive();
+}
+
+bool BossKnuckleFix::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+
+    if (al::isNerve(this, &NrvBossKnuckleFix.Wait) &&
+        (rs::isMsgSphinxRideAttackTouch(message) || rs::isMsgPlayerAndCapHipDropAll(message))) {
+        rs::requestHitReactionToAttacker(message, self, other);
+
+        mReactionCount++;
+        if (mReactionCount >= 3) {
+            mReactionCount = 0;
+            al::setNerve(this, &NrvBossKnuckleFix.ReactionLarge);
+        } else
+            al::setNerve(this, &NrvBossKnuckleFix.Reaction);
+
+        return !rs::isMsgPlayerAndCapHipDropAll(message);
+    }
+
+    return false;
+}
+
+void BossKnuckleFix::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "MapWait");
+}
+
+void BossKnuckleFix::exeReaction() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "MapReaction");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvBossKnuckleFix.Wait);
+}
+
+void BossKnuckleFix::exeReactionLarge() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "MapReactionLarge");
+        al::tryOnStageSwitch(this, "ReactionOn");
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvBossKnuckleFix.Wait);
+}

--- a/src/MapObj/BossKnuckleFix.h
+++ b/src/MapObj/BossKnuckleFix.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class CollisionObj;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BossKnuckleFix : public al::LiveActor {
+public:
+    BossKnuckleFix(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeReaction();
+    void exeReactionLarge();
+
+private:
+    al::CollisionObj* mCollisionObj = nullptr;
+    s32 mReactionCount = 0;
+};
+
+static_assert(sizeof(BossKnuckleFix) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -68,6 +68,7 @@
 #include "MapObj/AllDeadWatcherWithShine.h"
 #include "MapObj/AnagramAlphabet.h"
 #include "MapObj/BlockEmpty2D.h"
+#include "MapObj/BossKnuckleFix.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -160,7 +161,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BossForestWander", al::createActorFunction<BossForestWander>},
     {"BossKnuckle", nullptr},
     {"BossKnuckleCounterGround", nullptr},
-    {"BossKnuckleFix", nullptr},
+    {"BossKnuckleFix", al::createActorFunction<BossKnuckleFix>},
     {"BossMagma", nullptr},
     {"BossRaid", nullptr},
     {"BossRaidNpc", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1021)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 5e8270b)

📈 **Matched code**: 14.20% (+0.01%, +1380 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | +336 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +208 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | +104 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | +88 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | +52 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->