### PR TITLE
MapObj: Implement `MoonBasementFloor`

### DIFF
--- a/src/Boss/Koopa/KoopaHackStopCtrl.h
+++ b/src/Boss/Koopa/KoopaHackStopCtrl.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaHackStopCtrl : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_KoopaStopHackCtrl;
+
+    KoopaHackStopCtrl();
+
+    const char* getSceneObjName() const override { return "崩落クッパの停止制御"; }
+
+    void startStop(const al::LiveActor* actor);
+    void endStop(const al::LiveActor* actor);
+    void resetPosture(const al::LiveActor* actor, const sead::Quatf& quat,
+                      const sead::Vector3f& trans);
+    bool tryResetPosture(al::LiveActor* actor);
+
+private:
+    const al::LiveActor* mStopActor = nullptr;
+    bool mIsNeedResetPosture = false;
+    sead::Quatf mResetQuat = sead::Quatf::unit;
+    sead::Vector3f mResetTrans = sead::Vector3f::zero;
+    bool mIsStatusDemoForSceneKoopaHack = false;
+};
+
+static_assert(sizeof(KoopaHackStopCtrl) == 0x38, "KoopaHackStopCtrl");
+
+namespace KoopaHackFunction {
+void startStopKoopaHack(al::LiveActor* actor);
+void endStopKoopaHack(al::LiveActor* actor);
+void resetPostureKoopaHack(al::LiveActor* actor, const sead::Quatf& quat,
+                           const sead::Vector3f& trans);
+bool isStopKoopaHack(const al::LiveActor* actor);
+bool isStatusDemoForSceneKoopaHack(const al::LiveActor* actor);
+void setStatusDemoForSceneKoopaHack(const al::LiveActor* actor);
+void resetStatusDemoForSceneKoopaHack(const al::LiveActor* actor);
+}  // namespace KoopaHackFunction

--- a/src/MapObj/MoonBasementFloor.cpp
+++ b/src/MapObj/MoonBasementFloor.cpp
@@ -1,0 +1,165 @@
+#include "MapObj/MoonBasementFloor.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Boss/Koopa/KoopaHackStopCtrl.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(MoonBasementFloor, Wait)
+NERVE_IMPL(MoonBasementFloor, FallSignStart)
+NERVE_IMPL_(MoonBasementFloor, FallSignStartByMeteor, FallSignStart)
+NERVE_IMPL_(MoonBasementFloor, FallSignStartBySwitch, FallSignStart)
+NERVE_IMPL(MoonBasementFloor, FallSignBySwitch)
+NERVE_IMPL_(MoonBasementFloor, FallByMeteor, Fall)
+NERVE_IMPL(MoonBasementFloor, FallSign)
+NERVE_IMPL(MoonBasementFloor, Fall)
+
+NERVES_MAKE_STRUCT(MoonBasementFloor, Wait, FallSignStart, FallSignStartByMeteor,
+                   FallSignStartBySwitch, FallSignBySwitch, FallByMeteor, FallSign, Fall)
+
+const f32 sFallGravity = 0.2f;
+const f32 sFallScale = 0.95f;
+const f32 sFallGravityByMeteor = 0.2f;
+const f32 sFallScaleByMeteor = 0.95f;
+
+struct MoonFallParams {
+    const f32* gravity;
+    const f32* scale;
+};
+
+const MoonFallParams sFallParams{&sFallGravity, &sFallScale};
+const MoonFallParams sFallParamsByMeteor{&sFallGravityByMeteor, &sFallScaleByMeteor};
+
+inline const MoonFallParams& getMoonFallParams(al::LiveActor* actor) {
+    return al::isNerve(actor, &NrvMoonBasementFloor.FallByMeteor) ? sFallParamsByMeteor :
+                                                                    sFallParams;
+}
+}  // namespace
+
+MoonBasementFloor::MoonBasementFloor(const char* name) : al::LiveActor(name) {}
+
+void MoonBasementFloor::init(const al::ActorInitInfo& info) {
+    using MoonBasementFloorFunctor =
+        al::FunctorV0M<MoonBasementFloor*, void (MoonBasementFloor::*)()>;
+
+    al::initActorChangeModel(this, info);
+    al::initNerve(this, &NrvMoonBasementFloor.Wait, 0);
+
+    f32 rotate = sead::Mathf::floor(al::getRandom(0.0f, 3.99f));
+    al::addRotateAndRepeatY(this, rotate * 90.0);
+
+    if (al::listenStageSwitchOn(
+            this, "SwitchFallStart",
+            MoonBasementFloorFunctor(this, &MoonBasementFloor::startFallBySwitch))) {
+        al::tryGetArg(&mFallSignStepBySwitch, info, "FallSignStepBySwitch");
+    }
+
+    al::trySyncStageSwitchKill(this);
+}
+
+void MoonBasementFloor::startFallBySwitch() {
+    if (!al::isAlive(this))
+        return;
+
+    if (al::isNerve(this, &NrvMoonBasementFloor.Fall))
+        return;
+
+    if (al::isNerve(this, &NrvMoonBasementFloor.FallByMeteor))
+        return;
+
+    s32 fallSignStepBySwitch = mFallSignStepBySwitch;
+    al::invalidateClipping(this);
+
+    if (fallSignStepBySwitch == 0)
+        al::setNerve(this, &NrvMoonBasementFloor.FallSignStart);
+    else
+        al::setNerve(this, &NrvMoonBasementFloor.FallSignStartBySwitch);
+}
+
+void MoonBasementFloor::movement() {
+    if (!KoopaHackFunction::isStopKoopaHack(this))
+        al::LiveActor::movement();
+}
+
+bool MoonBasementFloor::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    if (!al::isNerve(this, &NrvMoonBasementFloor.Wait))
+        return false;
+
+    if (rs::isMsgKoopaTouchFloor(message)) {
+        al::startHitReaction(this, "クッパ着地");
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvMoonBasementFloor.FallSignStart);
+        return true;
+    }
+
+    if (rs::isMsgMoonBasementAttackMeteor(message)) {
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvMoonBasementFloor.FallSignStartByMeteor);
+        return true;
+    }
+
+    return false;
+}
+
+void MoonBasementFloor::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MoonBasementFloor::exeFallSignStart() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "FallSignStart");
+
+    if (al::isActionEnd(this)) {
+        if (al::isNerve(this, &NrvMoonBasementFloor.FallSignStartBySwitch))
+            al::setNerve(this, &NrvMoonBasementFloor.FallSignBySwitch);
+        else if (al::isNerve(this, &NrvMoonBasementFloor.FallSignStartByMeteor))
+            al::setNerve(this, &NrvMoonBasementFloor.FallByMeteor);
+        else
+            al::setNerve(this, &NrvMoonBasementFloor.FallSign);
+    }
+}
+
+void MoonBasementFloor::exeFallSign() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "FallSign");
+
+    al::setNerveAtActionEnd(this, &NrvMoonBasementFloor.Fall);
+}
+
+void MoonBasementFloor::exeFallSignBySwitch() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "FallSignBySwitch");
+
+    s32 fallSignStep = mFallSignStepBySwitch;
+    if (fallSignStep < 0)
+        fallSignStep = 30;
+
+    al::setNerveAtGreaterEqualStep(this, &NrvMoonBasementFloor.Fall, fallSignStep);
+}
+
+void MoonBasementFloor::exeFall() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Fall");
+
+    al::addVelocityToGravity(this, *getMoonFallParams(this).gravity);
+    al::scaleVelocity(this, *getMoonFallParams(this).scale);
+
+    if (al::isGreaterEqualStep(this, 300)) {
+        al::startHitReaction(this, "消滅");
+        kill();
+    }
+}

--- a/src/MapObj/MoonBasementFloor.h
+++ b/src/MapObj/MoonBasementFloor.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class MoonBasementFloor : public al::LiveActor {
+public:
+    MoonBasementFloor(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void movement() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void startFallBySwitch();
+
+    void exeWait();
+    void exeFallSignStart();
+    void exeFallSign();
+    void exeFallSignBySwitch();
+    void exeFall();
+
+private:
+    s32 mFallSignStepBySwitch = -1;
+};
+
+static_assert(sizeof(MoonBasementFloor) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -86,6 +86,7 @@
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
 #include "MapObj/MoonBasementBreakParts.h"
+#include "MapObj/MoonBasementFloor.h"
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/PeachWorldTree.h"
@@ -410,7 +411,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"MoonBasementFallObj", nullptr},
     {"MoonBasementFinalGate", nullptr},
     {"MoonBasementFallObjDecoration", nullptr},
-    {"MoonBasementFloor", nullptr},
+    {"MoonBasementFloor", al::createActorFunction<MoonBasementFloor>},
     {"MoonBasementGate", nullptr},
     {"MoonBasementMeteorAreaObj", nullptr},
     {"MoonBasementPillar", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1022)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 92049e4)

📈 **Matched code**: 14.21% (+0.01%, +1812 bytes)

<details>
<summary>✅ 23 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::exeFall()` | +220 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::init(al::ActorInitInfo const&)` | +216 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +148 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::MoonBasementFloor(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::exeFallSignStart()` | +140 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::startFallBySwitch()` | +132 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::MoonBasementFloor(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallSignBySwitch::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::exeFallSignBySwitch()` | +84 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `al::FunctorV0M<MoonBasementFloor*, void (MoonBasementFloor::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallSign::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::exeFallSign()` | +68 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::exeWait()` | +60 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `MoonBasementFloor::movement()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<MoonBasementFloor>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `al::FunctorV0M<MoonBasementFloor*, void (MoonBasementFloor::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallSignStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallSignStartByMeteor::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallSignStartBySwitch::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFallByMeteor::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `(anonymous namespace)::MoonBasementFloorNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MoonBasementFloor` | `al::FunctorV0M<MoonBasementFloor*, void (MoonBasementFloor::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->