### PR TITLE
all: Add information from conflicting types in my decompiler

### DIFF
--- a/lib/al/Library/Audio/System/AudioKeeper.h
+++ b/lib/al/Library/Audio/System/AudioKeeper.h
@@ -16,7 +16,7 @@ class AudioMic;
 class SeKeeper;
 class BgmKeeper;
 
-class AudioKeeper : public IUseHioNode {
+class AudioKeeper : public HioNode {
 public:
     AudioKeeper(const AudioDirector*);
     virtual ~AudioKeeper();

--- a/lib/al/Library/Camera/CameraOffsetCtrlPreset.h
+++ b/lib/al/Library/Camera/CameraOffsetCtrlPreset.h
@@ -4,6 +4,7 @@
 
 namespace al {
 class ByamlIter;
+class CameraOffsetPreset;
 
 class CameraOffsetCtrlPreset : public CameraOffsetCtrl {
 public:
@@ -11,5 +12,10 @@ public:
 
     void load(const ByamlIter& iter) override;
     f32 getOffset() const override;
+
+private:
+    CameraOffsetPreset *mPreset;
 };
+
+static_assert(sizeof(CameraOffsetCtrlPreset) == 0x10);
 }  // namespace al

--- a/lib/al/Library/Camera/CameraOffsetCtrlPreset.h
+++ b/lib/al/Library/Camera/CameraOffsetCtrlPreset.h
@@ -14,7 +14,7 @@ public:
     f32 getOffset() const override;
 
 private:
-    CameraOffsetPreset *mPreset;
+    CameraOffsetPreset* mPreset;
 };
 
 static_assert(sizeof(CameraOffsetCtrlPreset) == 0x10);

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -231,7 +231,7 @@ protected:
     sead::Vector3f mTargetTrans = {0.0f, 0.0f, 500.0f};
     sead::Vector3f mCameraUp = sead::Vector3f::ey;
     f32 mFovyDegree = 35.0f;
-    f32 _64 = -1.0f;
+    f32 mNearClipDistance = -1.0f;
     sead::Matrix34f mViewMtx = sead::Matrix34f::ident;
     bool _98 = false;
     CameraPoserSceneInfo* mSceneInfo = nullptr;

--- a/lib/al/Library/Camera/CameraPoserFixPoint.h
+++ b/lib/al/Library/Camera/CameraPoserFixPoint.h
@@ -17,7 +17,11 @@ public:
     void makeLookAtCamera(sead::LookAtCamera* lookAtCam) const override;
 
 private:
-    char _140[24];
+    f32 mOffsetY;
+    sead::Vector3f mCameraPos;
+    bool mIsUsePrePoserPos;
+    bool mIsKeepDistanceFromLookAt;
+    f32 mKeepDistance;
 };
 
 static_assert(sizeof(CameraPoserFixPoint) == 0x158);

--- a/lib/al/Library/Collision/Collider.h
+++ b/lib/al/Library/Collision/Collider.h
@@ -45,7 +45,7 @@ public:
 
     CollisionDirector* getCollisionDirector() const override;
 
-    sead::Vector3f* get_30() const { return _30; }
+    const sead::Vector3f* getActorGravityPtr() const { return mActorGravityPtr; }
 
     f32 getRadius() { return mRadius; };
 
@@ -55,9 +55,9 @@ public:
 
     void setOffsetY(f32 offsetY) { mOffsetY = offsetY; };
 
-    s32 get_48() const { return _48; }
+    s32 getPlaneNum() const { return mPlaneNum; }
 
-    u32 getPlaneCount() const { return mPlaneCount; }
+    u32 getStoredPlaneNum() const { return mStoredPlaneNum; }
 
     const sead::Vector3f& getFixReaction() const { return mFixReaction; }
 
@@ -73,7 +73,7 @@ public:
 
     f32 get_260() const { return _260; }
 
-    u32 get_264() const { return _264; }
+    u32 getNoGroundCounter() const { return mNoGroundCounter; }
 
     void setReactMovePower(bool isEnabled) {
         mFlag &= ~1;
@@ -87,18 +87,18 @@ public:
     bool isCollidedWallFace() { return mFlag >> 5 & 1; }
 
 private:
-    CollisionDirector* _8;
-    TriangleFilterBase* _10;
-    CollisionPartsFilterBase* _18;
-    sead::Matrix34f* _20;
-    sead::Vector3f* _28;
-    sead::Vector3f* _30;
+    CollisionDirector* mCollisionDirector;
+    const TriangleFilterBase* mTriangleFilter;
+    const CollisionPartsFilterBase* mCollisionPartsFilter;
+    const sead::Matrix34f* mActorBaseMtxPtr;
+    const sead::Vector3f* mActorTransPtr;
+    const sead::Vector3f* mActorGravityPtr;
     f32 mRadius;
     f32 mOffsetY;
-    void* filler1;
-    u32 _48;
-    u32 mPlaneCount;
-    HitInfo* _50;
+    sead::Vector3f* _40;
+    u32 mPlaneNum;
+    u32 mStoredPlaneNum;
+    HitInfo* mPlanes;
     sead::Vector3f mFixReaction;
     sead::Vector3f _64;
     HitInfo mFloorHit;
@@ -109,12 +109,12 @@ private:
     char filler4[0x4];
     HitInfo mCeilingHit;
     f32 _260;
-    u32 _264;
-    sead::Vector3f _268;
+    u32 mNoGroundCounter;
+    sead::Vector3f mRecentOnGroundNormal;
     char _274;
     char mFlag;
-    sead::Vector3f _278;
-    f32 _284;
+    sead::Vector3f mCurrentTrans;
+    f32 mCurrentRadius;
 };
 
 static_assert(sizeof(Collider) == 0x288);

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -9,6 +9,9 @@ class CameraTicket;
 class LiveActor;
 class EventFlowEventData;
 class IUseCamera;
+class EventFlowRequestInfo;
+class EventFlowScareCtrlBase;
+class BalloonOrderGroup;
 
 class EventFlowDataHolder {
 public:
@@ -37,6 +40,18 @@ public:
     void endAllEventCamera(IUseCamera*);
     bool isEndInterpoleCamera(const IUseCamera*, const char*) const;
     bool isPlayingEventAnimCamera(const char*) const;
+
+private:
+    al::EventFlowRequestInfo* mRequestInfo;
+    void* _8[10];
+    void* _58;
+    void* _60[1];
+    al::EventFlowScareCtrlBase* mScareCtrl;
+    void* _70;
+    void* _78[2];
+    al::BalloonOrderGroup* mBalloonOrderGroup;
+    void* _90[15];
 };
+static_assert(sizeof(EventFlowDataHolder) == 0x108);
 
 }  // namespace al

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -42,14 +42,14 @@ public:
     bool isPlayingEventAnimCamera(const char*) const;
 
 private:
-    al::EventFlowRequestInfo* mRequestInfo;
+    EventFlowRequestInfo* mRequestInfo;
     void* _8[10];
     void* _58;
     void* _60[1];
-    al::EventFlowScareCtrlBase* mScareCtrl;
+    EventFlowScareCtrlBase* mScareCtrl;
     void* _70;
     void* _78[2];
-    al::BalloonOrderGroup* mBalloonOrderGroup;
+    BalloonOrderGroup* mBalloonOrderGroup;
     void* _90[15];
 };
 

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -43,14 +43,19 @@ public:
 
 private:
     EventFlowRequestInfo* mRequestInfo;
-    void* _8[10];
+    void* filler_8[10];
     void* _58;
-    void* _60[1];
+    void* filler_60[1];
     EventFlowScareCtrlBase* mScareCtrl;
     void* _70;
-    void* _78[2];
+    void* filler_78[2];
     BalloonOrderGroup* mBalloonOrderGroup;
-    void* _90[15];
+    sead::WFixedSafeString<32> _90;
+    void* filler_e8[1];
+    const char* mTalkSubActorName;
+    s32 mItemTypeCapacity;
+    s32 mItemTypeCount;
+    const char** mItemTypes;
 };
 
 static_assert(sizeof(EventFlowDataHolder) == 0x108);

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -52,6 +52,7 @@ private:
     al::BalloonOrderGroup* mBalloonOrderGroup;
     void* _90[15];
 };
+
 static_assert(sizeof(EventFlowDataHolder) == 0x108);
 
 }  // namespace al

--- a/lib/al/Library/Joint/JointControllerBase.h
+++ b/lib/al/Library/Joint/JointControllerBase.h
@@ -6,6 +6,7 @@
 
 #include "Library/HostIO/HioNode.h"
 
+// BUG: outside of `al` namespace
 class IJointController {
 public:
     virtual void calcJointCallback(s32, sead::Matrix34f*) = 0;

--- a/lib/al/Library/Layout/LayoutKeeper.h
+++ b/lib/al/Library/Layout/LayoutKeeper.h
@@ -34,9 +34,9 @@ private:
     CustomTagProcessor* mTagProcessor;
     nn::ui2d::DrawInfo* mDrawInfo;
     nn::ui2d::Layout* mLayout;
-    void* _18[2];
+    void* filler_18[2];
     eui::Screen* mScreen;
-    void* _30[1];
+    void* filler_30;
 };
 
 static_assert(sizeof(LayoutKeeper) == 0x38);

--- a/lib/al/Library/Layout/LayoutKeeper.h
+++ b/lib/al/Library/Layout/LayoutKeeper.h
@@ -29,5 +29,15 @@ public:
     s32 getGroupNum() const;
     void calcAnim(bool);
     void draw();
+
+private:
+    CustomTagProcessor* mTagProcessor;
+    nn::ui2d::DrawInfo* mDrawInfo;
+    nn::ui2d::Layout* mLayout;
+    void* _18[2];
+    eui::Screen* mScreen;
+    void* _30[1];
 };
+
+static_assert(sizeof(LayoutKeeper) == 0x38);
 }  // namespace al

--- a/lib/al/Library/LiveActor/ActorCollisionFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorCollisionFunction.cpp
@@ -117,7 +117,7 @@ void setSyncCollisionMtxPtr(LiveActor* actor, const sead::Matrix34f* mtx) {
 
 bool isOnGround(const LiveActor* actor, u32 coyoteTime) {
     Collider* collider = actor->getCollider();
-    if (!isCollidedGround(actor) && collider->get_264() > coyoteTime)
+    if (!isCollidedGround(actor) && collider->getNoGroundCounter() > coyoteTime)
         return false;
     return !(getVelocity(actor).dot(collider->getRecentOnGroundNormal(coyoteTime)) > 0.0f);
 }
@@ -137,15 +137,15 @@ bool isOnGroundNoVelocity(const LiveActor* actor, u32 coyoteTime) {
     if (isCollidedGround(actor))
         return true;
 
-    return actor->getCollider()->get_264() <= coyoteTime;
+    return actor->getCollider()->getNoGroundCounter() <= coyoteTime;
 }
 
 bool isOnGroundDegree(const LiveActor* actor, f32 angle, u32 coyoteTime) {
     Collider* collider = actor->getCollider();
-    if (!(isCollidedGround(actor) || collider->get_264() <= coyoteTime))
+    if (!(isCollidedGround(actor) || collider->getNoGroundCounter() <= coyoteTime))
         return false;
 
-    if (sead::Mathf::abs((*collider->get_30()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
+    if (sead::Mathf::abs((*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
         sead::Mathf::cos(sead::Mathf::deg2rad(angle)))
         return false;
 
@@ -161,10 +161,10 @@ bool isOnGroundNoVelocityDegree(const LiveActor* actor, f32 angle, u32 coyoteTim
     if (!collider)
         return getTrans(actor).y <= 0.0;
 
-    if (!(isCollidedGround(actor) || collider->get_264() <= coyoteTime))
+    if (!(isCollidedGround(actor) || collider->getNoGroundCounter() <= coyoteTime))
         return false;
 
-    if (sead::Mathf::abs((*collider->get_30()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
+    if (sead::Mathf::abs((*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
         sead::Mathf::cos(sead::Mathf::deg2rad(angle)))
         return false;
 
@@ -451,7 +451,7 @@ bool isCollidedFloorCode(const LiveActor* actor, const char* name) {
 
 bool isCollidedCollisionCode(const LiveActor* actor, const char* sensorName, const char* name) {
     Collider* collider = actor->getCollider();
-    if (collider->get_48() == 0) {
+    if (collider->getPlaneNum() == 0) {
         if (collider->get_110() >= 0.0f) {
             if (isEqualString(name,
                               getCollisionCodeName(collider->getFloorHit().triangle, sensorName))) {
@@ -473,7 +473,7 @@ bool isCollidedCollisionCode(const LiveActor* actor, const char* sensorName, con
         return false;
     }
 
-    u32 size = collider->getPlaneCount();
+    u32 size = collider->getStoredPlaneNum();
     for (u32 i = 0; i < size; i++)
         if (isEqualString(name, getCollisionCodeName(*collider->getPlane(i), sensorName)))
             return true;

--- a/lib/al/Library/LiveActor/ActorCollisionFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorCollisionFunction.cpp
@@ -145,7 +145,8 @@ bool isOnGroundDegree(const LiveActor* actor, f32 angle, u32 coyoteTime) {
     if (!(isCollidedGround(actor) || collider->getNoGroundCounter() <= coyoteTime))
         return false;
 
-    if (sead::Mathf::abs((*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
+    if (sead::Mathf::abs(
+            (*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
         sead::Mathf::cos(sead::Mathf::deg2rad(angle)))
         return false;
 
@@ -164,7 +165,8 @@ bool isOnGroundNoVelocityDegree(const LiveActor* actor, f32 angle, u32 coyoteTim
     if (!(isCollidedGround(actor) || collider->getNoGroundCounter() <= coyoteTime))
         return false;
 
-    if (sead::Mathf::abs((*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
+    if (sead::Mathf::abs(
+            (*collider->getActorGravityPtr()).dot(collider->getRecentOnGroundNormal(coyoteTime))) <
         sead::Mathf::cos(sead::Mathf::deg2rad(angle)))
         return false;
 

--- a/lib/al/Library/LiveActor/ActorMovementFunction.cpp
+++ b/lib/al/Library/LiveActor/ActorMovementFunction.cpp
@@ -773,8 +773,8 @@ bool reboundVelocityFromCollision(LiveActor* actor, f32 reboundStrength, f32 reb
 
 bool reboundVelocityFromTriangles(LiveActor* actor, f32 reboundStrength, f32 reboundMin) {
     Collider* collider = getActorCollider(actor);
-    s32 planeCount = collider->getPlaneCount();
-    if (collider->get_48() == 0)
+    s32 planeCount = collider->getStoredPlaneNum();
+    if (collider->getPlaneNum() == 0)
         return false;
 
     bool isRebound = false;

--- a/lib/al/Library/Play/Area/CameraStartParamArea.h
+++ b/lib/al/Library/Play/Area/CameraStartParamArea.h
@@ -14,6 +14,7 @@ public:
 
 private:
     bool mIsAlive = true;
+    bool mIsKillIfEnter = false;
     f32* mAngleH = nullptr;
     f32* mAngleV = nullptr;
 };

--- a/lib/al/Library/Se/SeKeeper.h
+++ b/lib/al/Library/Se/SeKeeper.h
@@ -54,5 +54,10 @@ public:
     void setEmitterPoseMtxPtr(const sead::Matrix34f*, const char*);
     void setEmitterPosePosPtr(const sead::Vector3f*, const char*);
     void loadSe(IAudioResourceLoader*);
+
+private:
+    void* _0[0x78/8];
 };
+
+static_assert(sizeof(SeKeeper) == 0x78);
 }  // namespace al

--- a/lib/al/Library/Se/SeKeeper.h
+++ b/lib/al/Library/Se/SeKeeper.h
@@ -56,7 +56,7 @@ public:
     void loadSe(IAudioResourceLoader*);
 
 private:
-    void* _0[0x78/8];
+    void* _0[0x78 / 8];
 };
 
 static_assert(sizeof(SeKeeper) == 0x78);

--- a/lib/al/Project/Camera/CameraAngleCtrlInfo.h
+++ b/lib/al/Project/Camera/CameraAngleCtrlInfo.h
@@ -25,10 +25,12 @@ public:
     void setAngleV(f32 angleV);
 
 private:
-    void* _0;
-    void* _8[1];
+    void* _0;  // object of size 0x14
+    void* _8;  // object of size 0x10
     bool mIsValidRotateH;
-    void* _18[1];
+    s32 _14;
+    f32 _18;
+    f32 _1c;
     f32 mMinAngleH;
     f32 mMaxAngleH;
     f32 _28;
@@ -36,10 +38,17 @@ private:
     f32 _30;
     f32 mMinAngleV;
     f32 mMaxAngleV;
-    f32 _3c[5];
+    f32 _3c;
+    f32 _40;
+    f32 _44;
+    f32 _48;
+    f32 _4c;
     bool mIsKeepPreAngleV;
     bool mIsSetResetAngleV;
     f32 mResetAngleV;
     bool mIsInvalidReceiveRequest;
 };
+
+static_assert(sizeof(CameraAngleCtrlInfo) == 0x60);
+
 }  // namespace al

--- a/lib/al/Project/Camera/CameraAngleCtrlInfo.h
+++ b/lib/al/Project/Camera/CameraAngleCtrlInfo.h
@@ -23,5 +23,23 @@ public:
 
     bool receiveRequestFromObject(const CameraObjectRequestInfo& info);
     void setAngleV(f32 angleV);
+
+private:
+    void* _0;
+    void* _8[1];
+    bool mIsValidRotateH;
+    void* _18[1];
+    f32 mMinAngleH;
+    f32 mMaxAngleH;
+    f32 _28;
+    f32 mAngleV;
+    f32 _30;
+    f32 mMinAngleV;
+    f32 mMaxAngleV;
+    f32 _3c[5];
+    bool mIsKeepPreAngleV;
+    bool mIsSetResetAngleV;
+    f32 mResetAngleV;
+    bool mIsInvalidReceiveRequest;
 };
 }  // namespace al

--- a/src/Enemy/KuriboMini.h
+++ b/src/Enemy/KuriboMini.h
@@ -77,7 +77,7 @@ private:
     s32 mCounterChase;
     s32 _12c;
     al::CollisionPartsFilterBase* mCollisionFilter;
-    void* _138[1];
+    void* _138;
     s32 _140;
     f32 mClippingRadius;
     PlayerPushReceiver* mPlayerPushReceiver;
@@ -92,3 +92,5 @@ private:
     bool mIsInvalidateClipping;
     sead::Matrix34f mColliderMtx;
 };
+
+static_assert(sizeof(KuriboMini) == 0x1b8);

--- a/src/Enemy/KuriboMini.h
+++ b/src/Enemy/KuriboMini.h
@@ -2,6 +2,17 @@
 
 #include "Library/LiveActor/LiveActor.h"
 
+namespace al {
+class EnemyStateBlowDown;
+class CollisionPartsFilterBase;
+}
+class ActorStateSandGeyser;
+class EnemyStateReset;
+class EnemyStateWander;
+class PlayerPushReceiver;
+class CollisionMultiShape;
+class CollisionShapeKeeper;
+
 class KuriboMini : public al::LiveActor {
 public:
     KuriboMini(const char* name);
@@ -59,5 +70,25 @@ public:
     void forceStartClipped();
 
 private:
-    void* filler[22];
+    EnemyStateReset* mStateReset;
+    EnemyStateWander* mStateWander;
+    ActorStateSandGeyser* mStateSandGeyser;
+    al::EnemyStateBlowDown* mStateBlowDown;
+    s32 mCounterChase;
+    s32 _12c;
+    al::CollisionPartsFilterBase* mCollisionFilter;
+    void* _138[1];
+    s32 _140;
+    f32 mClippingRadius;
+    PlayerPushReceiver* mPlayerPushReceiver;
+    CollisionMultiShape* mCollisionMultiShape;
+    CollisionShapeKeeper* mCollisionShapeKeeper;
+    f32 mJumpSink;
+    s32 mFramesSpecialPush;
+    s32 mShiftTypeOnGround;
+    al::LiveActor* _170;
+    sead::Vector3f _178;
+    bool mIsPopBack;
+    bool mIsInvalidateClipping;
+    sead::Matrix34f mColliderMtx;
 };

--- a/src/Enemy/KuriboMini.h
+++ b/src/Enemy/KuriboMini.h
@@ -5,7 +5,7 @@
 namespace al {
 class EnemyStateBlowDown;
 class CollisionPartsFilterBase;
-}
+}  // namespace al
 class ActorStateSandGeyser;
 class EnemyStateReset;
 class EnemyStateWander;

--- a/src/Layout/BootLayout.h
+++ b/src/Layout/BootLayout.h
@@ -29,3 +29,5 @@ public:
 private:
     al::LayoutActor* mParBg = nullptr;
 };
+
+static_assert(sizeof(BootLayout) == 0x138);

--- a/src/MapObj/CapHanger.h
+++ b/src/MapObj/CapHanger.h
@@ -9,6 +9,9 @@ struct ActorInitInfo;
 class HitSensor;
 class SensorMsg;
 }  // namespace al
+class CapTargetInfo;
+class ItemGenerator;
+class SaveObjInfo;
 
 class CapHanger : public al::LiveActor {
 public:
@@ -31,15 +34,15 @@ public:
     void setPeachCastleCap(const sead::Vector3f&);
 
 private:
-    void* _108;
+    CapTargetInfo* mCapTargetInfo;
     void* _110;
     s32 _118;
-    s32 _11c;
+    s32 mAppearItemNum;
     s32 _120;
-    void* _128;
-    bool _130;
+    ItemGenerator* mItemGenerator;
+    bool mIsEmitEffect;
     void* _138;
-    void* _140;
+    SaveObjInfo* _140;
     sead::Matrix34f _148;
     sead::Matrix34f _178;
     bool _1a8;

--- a/src/MapObj/PlayerStartInfoHolder.h
+++ b/src/MapObj/PlayerStartInfoHolder.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
 #include <math/seadQuat.h>
 #include <math/seadVector.h>
 
@@ -39,7 +40,8 @@ public:
     al::CameraDirector* getCameraDirector() const override;
 
 private:
-    char _10[0x18];
+    sead::PtrArray<PlayerStartInfo> mPlayerStartInfoList;
+    al::CameraDirector* mCameraDirector;
 };
 
 static_assert(sizeof(PlayerStartInfoHolder) == 0x28);

--- a/src/MapObj/TreasureBoxKeyOpener.h
+++ b/src/MapObj/TreasureBoxKeyOpener.h
@@ -8,6 +8,7 @@ namespace al {
 struct ActorInitInfo;
 class HitSensor;
 class SensorMsg;
+class MtxConnector;
 }  // namespace al
 
 class TreasureBoxKeyOpener : public al::LiveActor {
@@ -27,7 +28,12 @@ public:
     virtual void setHostForClipping(al::LiveActor*);
 
 private:
-    void* filler[4];
+    al::LiveActor* mHostForClipping;
+    al::MtxConnector* mMtxConnector;
+    f32 _118;
+    f32 _11c;
+    s32 _120;
+    s32 _124;
 };
 
 static_assert(sizeof(TreasureBoxKeyOpener) == 0x128);

--- a/src/Player/HackCap.h
+++ b/src/Player/HackCap.h
@@ -269,7 +269,7 @@ private:
     sead::Vector3f _4d4;
     sead::Vector3f _4e0;
     bool _4ec;
-    void* _4f0[1];
+    void* _4f0;
     PlayerExternalVelocity* mCapExternalVelocity;
     PlayerPushReceiver* mCapPushReceiver;
     al::HitSensor* mPlayerBodySensor;

--- a/src/Player/HackCap.h
+++ b/src/Player/HackCap.h
@@ -1,7 +1,14 @@
 #pragma once
 
+#include <prim/seadSafeString.h>
+
 #include "Library/LiveActor/LiveActor.h"
 
+namespace al {
+class ActorDitherAnimator;
+class WaterSurfaceFinder;
+class PadRumbleKeeper;
+}
 class PlayerInput;
 class PlayerAreaChecker;
 class PlayerWallActionHistory;
@@ -15,6 +22,15 @@ class PlayerJointControlKeeper;
 class HackCapJudgePreInputSeparateThrow;
 class HackCapJudgePreInputSeparateJump;
 class CapTargetInfo;
+class PlayerColliderHackCap;
+class HackCapTrigger;
+class HackCapAboveGroundChecker;
+class HackCapThrowParam;
+class HackCapJointControlKeeper;
+class PlayerExternalVelocity;
+class PlayerPushReceiver;
+class HackCapStateThrowStay;
+class HackCapStateHide;
 
 class HackCap : public al::LiveActor {
 public:
@@ -184,16 +200,103 @@ public:
     bool stayWallHit();
     void endHackThrow();
 
-    CapTargetInfo* getCapTargetInfo() const { return mCapTargetInfo; }
+    CapTargetInfo* getCapTargetInfo() const { return mCapTargetInfo1; }
 
 private:
-    unsigned char _108[0x10];
-    al::LiveActor* mActorA;
-    unsigned char _120[0x08];
-    al::LiveActor* mPlayerActor;
-    void* _130[0x1f];
-    CapTargetInfo* mCapTargetInfo;
-    void* _230[0x7c];
+    al::LiveActor* mEquipmentHat;
+    al::LiveActor* mEquipmentHatDepthShadow;
+    al::LiveActor* mLockOnCapEyes;
+    al::LiveActor* mThrowingHatEyes;
+    const al::LiveActor* mPlayerActor;
+    const IUsePlayerCollision* mPlayerCollision;
+    const char* mTypeName;
+    const PlayerAreaChecker* mPlayerAreaChecker;
+    const PlayerSeparateCapFlag* mPlayerSeparateCapFlag;
+    const IUsePlayerHeightCheck* mPlayerHeightCheck;
+    const PlayerWetControl* mPlayerWetControl;
+    const PlayerJointControlKeeper* mPlayerJointControlKeeper;
+    PlayerColliderHackCap* mPlayerColliderHackCap;
+    al::WaterSurfaceFinder* mWaterSurfaceFinder;
+    al::PadRumbleKeeper* mPadRumbleKeeper;
+    PlayerWetControl* mSelfPlayerWetControl;
+    HackCapTrigger* mHackCapTrigger;
+    al::ActorDitherAnimator* mActorDitherAnimator;
+    HackCapAboveGroundChecker* mHackCapAboveGroundChecker;
+    void* _1a0_arr;
+    u64 _1a0_capacity;
+    s32 _1a0_current;
+    void* _1b8_arr;
+    u64 _1b8_capacity;
+    s32 _1b8_current;
+    const al::HitSensor* _1d0;
+    al::HitSensor* mAttackSensor;
+    sead::Vector3f mSpiralTailPositions[5];
+    HackCapThrowParam* mHackCapThrowParam;
+    CapTargetInfo* mCapTargetInfo1;
+    CapTargetInfo* mCapTargetInfo2;
+    void* _238;
+    sead::Vector3f _240;
+    sead::Vector3f _24c;
+    sead::Vector3f _258;
+    f32 _264;
+    sead::Vector2f _268;
+    f32 _270;
+    s32 _274;
+    s32 _278;
+    s32 _27c;
+    f32 _280;
+    f32 _284;
+    f32 _288;
+    f32 _28c;
+    s32 _290;
+    s32 _298;
+    bool _2a0[17];
+    const PlayerWallActionHistory* mPlayerWallActionHistory;
+    const PlayerCapActionHistory* mPlayerCapActionHistory;
+    const PlayerInput* mInput;
+    PlayerEyeSensorHitHolder* mPlayerEyeSensorHitHolder;
+    PlayerEyeSensorHitHolder* mCapEyeSensorHitHolder;
+    f32 _2d8;
+    s32 _2dc;
+    HackCapJointControlKeeper* mHackCapJointControlKeeper;
+    void* _2e8[5];
+    sead::FixedSafeString<128> _310;
+    sead::FixedSafeString<128> _3a8;
+    sead::Matrix34f _440;
+    sead::Matrix34f _470;
+    sead::Matrix34f _4a0;
+    bool _4d0;
+    sead::Vector3f _4d4;
+    sead::Vector3f _4e0;
+    bool _4ec;
+    void* _4f0[1];
+    PlayerExternalVelocity* mCapExternalVelocity;
+    PlayerPushReceiver* mCapPushReceiver;
+    al::HitSensor* mPlayerBodySensor;
+    bool _510;
+    sead::Vector3f _514;
+    HackCapJudgePreInputSeparateThrow* mCapJudgePreInputSeparateThrow;
+    HackCapJudgePreInputSeparateJump* mCapJudgePreInputSeparateJump;
+    bool _530;
+    s32 _534;
+    sead::Vector3f mWallPos;
+    sead::Vector3f mWallNormal;
+    sead::Vector3f mWallVelocity;
+    void* _560[4];
+    s32 _580;
+    s32 mLockOnCounter;
+    sead::Matrix34f _588;
+    bool _5b8;
+    bool mIsHackDamageVisible;
+    bool _5ba;
+    bool _5bb;
+    s32 _5bc;
+    void* _5c0[7];
+    bool mIsPuppet;
+    bool _5f9;
+    bool mIsHidePuppetCapSilhouette;
+    HackCapStateThrowStay* mStateThrowStay;
+    HackCapStateHide* mStateHide;
 };
 
 static_assert(sizeof(HackCap) == 0x610);

--- a/src/Player/HackCap.h
+++ b/src/Player/HackCap.h
@@ -8,7 +8,7 @@ namespace al {
 class ActorDitherAnimator;
 class WaterSurfaceFinder;
 class PadRumbleKeeper;
-}
+}  // namespace al
 class PlayerInput;
 class PlayerAreaChecker;
 class PlayerWallActionHistory;

--- a/src/Player/PlayerAnimator.h
+++ b/src/Player/PlayerAnimator.h
@@ -100,7 +100,8 @@ private:
     bool mIsSubAnimPlaying;
     bool _1a3;
     bool mIsUpperBodyAnimHeadVisKeep;
-    bool _1a5[2];
+    bool _1a5;
+    bool _1a6;
     bool mIsSubAnimOnlyAir;
 };
 

--- a/src/Player/PlayerAnimator.h
+++ b/src/Player/PlayerAnimator.h
@@ -84,14 +84,24 @@ public:
 private:
     PlayerModelHolder* mModelHolder;
     al::LiveActor* mPlayerDeco;
-    void* _10;
+    al::LiveActor* mPlayer;
     PlayerAnimFrameCtrl* mAnimFrameCtrl;
     sead::FixedSafeString<64> mCurAnim;
     sead::FixedSafeString<64> mCurSubAnim;
     sead::FixedSafeString<64> mCurUpperBodyAnim;
     sead::FixedSafeString<64> _128;
-    char padding_180[0x1A2 - 0x180];
+    al::ActorDitherAnimator* mDitherAnim;
+    f32* mSklAnimBlendWeights;
+    void* _190;
+    f32 mRunStartAnimRate;
+    s32 _19c;
+    bool mIsNeedFullFaceAnim;
+    bool _1a1;
     bool mIsSubAnimPlaying;
+    bool _1a3;
+    bool mIsUpperBodyAnimHeadVisKeep;
+    bool _1a5[2];
+    bool mIsSubAnimOnlyAir;
 };
 
 static_assert(sizeof(PlayerAnimator) == 0x1a8);

--- a/src/Player/PlayerBindKeeper.h
+++ b/src/Player/PlayerBindKeeper.h
@@ -1,14 +1,44 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+
 namespace al {
 class HitSensor;
+class SensorMsg;
 }
+class PlayerBindableSensorList;
+class IUsePlayerPuppet;
 
 class PlayerBindKeeper {
 public:
+    PlayerBindKeeper(al::HitSensor*, IUsePlayerPuppet*);
+    bool sendStartMsg();
+    void clearBindableSensor();
+    void cancelBind();
+    bool receiveEndMsg(const al::SensorMsg*);
+    void clearBindImpl();
+    void cancelBindByDemo();
+    bool sendMsgBindDamage();
+    bool receiveRequestDamage();
+    bool sendMsgCollidedGround();
+    bool sendMsgEnableMapCheckPointWarp();
+    bool sendMsgBindKeepDemoStart();
+    bool sendMsgBindKeepDemoExecute();
+    bool sendMsgBindKeepDemoEnd();
+    bool sendMsgBindRecoveryLife() const;
+    bool collectBindableSensor(al::HitSensor*, al::HitSensor*);
+    void appendBindRequest(al::HitSensor*);
+    void resetInvalidTimer();
+
     al::HitSensor* getBindSensor() const { return mBindSensor; }
 
 private:
-    char padding[8];
+    al::HitSensor* mBodyHitSensor;
     al::HitSensor* mBindSensor;
+    PlayerBindableSensorList* mBindableSensorList;
+    IUsePlayerPuppet* mPuppet;
+    s32 _20;
+    bool _24;
 };
+
+static_assert(sizeof(PlayerBindKeeper) == 0x28);

--- a/src/Player/PlayerBindKeeper.h
+++ b/src/Player/PlayerBindKeeper.h
@@ -5,7 +5,7 @@
 namespace al {
 class HitSensor;
 class SensorMsg;
-}
+}  // namespace al
 class PlayerBindableSensorList;
 class IUsePlayerPuppet;
 

--- a/src/Player/PlayerCollider.h
+++ b/src/Player/PlayerCollider.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <container/seadPtrArray.h>
 #include <math/seadMatrix.h>
 #include <prim/seadBitFlag.h>
 
@@ -13,6 +14,7 @@ class SpherePoseInterpolator;
 }  // namespace al
 class CollidedShapeResult;
 class CollisionShapeKeeper;
+class CollisionMultiShape;
 
 class PlayerCollider : public al::HioNode, public al::IUseCollision {
 public:
@@ -58,12 +60,48 @@ public:
     void set1b0(f32 value) { _1b0 = value; }
 
 private:
-    void* filler[13];
+    al::CollisionDirector* mCollisionDirector;
+    const sead::Matrix34f* mMtxPtr;
+    const sead::Vector3f* mTransPtr;
+    const sead::Vector3f* mGravityPtr;
+    sead::Vector3f mTrans;
+    f32 mSize;
+    sead::Matrix34f mMtx;
+    al::HitInfo* _68;
     f32 _70;
-    void* filler2[37];
-    s32 _1a0;
+    al::HitInfo* _78;
+    f32 _7c;
+    al::HitInfo* _88;
+    f32 _8c;
+    sead::Vector3f mCollidedFixReaction;
+    bool _a0;
+    bool _a1;
+    sead::Vector3f mCollisionHitNormal;
+    sead::Vector3f mCollisionHitPos;
+    s32 mTimeInAir;
+    sead::Matrix34f mCollidePosMtx;
+    CollisionShapeKeeper* mCollisionShapeKeeper;
+    f32 mCollisionShapeScale;
+    CollisionMultiShape* mCollisionMultiShape;
+    s32 _108;
+    bool mIsInFastMoveCollisionArea;
+    bool mIsValidGroundSupport;
+    bool mIsDuringRecovery;
+    sead::Vector3f mCutCollideAffectDir;
+    s32 mWallBorderCheckType;
+    const al::CollisionPartsFilterBase* mCollisionPartsFilter;
+    sead::PtrArray<al::HitInfo> _128[3];
+    al::HitInfo* _158;
+    u32 _160;
+    s32 _164;
+    sead::PtrArray<al::HitInfo> _168;
+    s32 _178;
+    f32* _180;
+    s32 _188;
+    f32* _190;
+    sead::Vector3f _198;
     sead::Vector3f mCollidedGroundNormal;
     f32 _1b0;
 };
 
-static_assert(sizeof(PlayerCollider) == 0x1B8);
+static_assert(sizeof(PlayerCollider) == 0x1b8);

--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -1,7 +1,33 @@
 #pragma once
 
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+class ExternalForceKeeper;
+class IUsePlayerCollision;
+
 class PlayerExternalVelocity {
 public:
     bool isExistForce() const;
     bool isExistSnapForce() const;
+
+private:
+    ExternalForceKeeper* mExternalForceKeeper;
+    sead::Vector3f _8;
+    sead::Vector3f _14;
+    sead::Vector3f _20;
+    const al::LiveActor* mActor;
+    const IUsePlayerCollision* mCollision;
+    const sead::Vector3f* _38;
+    bool _40;
+    sead::Vector3f _44;
+    f32 _50[6];
+    sead::Vector3f mSnapForce;
+    s32 mApplyLastGroundInertia;
+    sead::Vector3f _80;
+    sead::Vector3f _8c;
 };
+
+static_assert(sizeof(PlayerExternalVelocity) == 0x98);

--- a/src/Sequence/HakoniwaSequence.h
+++ b/src/Sequence/HakoniwaSequence.h
@@ -106,6 +106,7 @@ private:
     sead::FixedSafeString<128> mCostumeName;
     al::SimpleAudioUser* mPlayerAudioUser;
     bool mIsHackEnd;
+    bool mIsWarpCheckpoint;
     TimeBalloonSequenceInfo* mBalloonSeqInfo;
     CollectBgmPlayer* mCollectBgmPlayer;
     sead::FixedSafeString<128> mLanguage;

--- a/src/System/GameDataFunction.cpp
+++ b/src/System/GameDataFunction.cpp
@@ -217,7 +217,7 @@ bool isMissEndPrevStageForSceneDead(GameDataHolderAccessor accessor) {
 }
 
 void reenterStage(GameDataHolderWriter writer) {
-    writer->set_4a();
+    writer->setStageEnding();
 }
 
 s32 getNextWorldId(GameDataHolderAccessor accessor) {

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -211,9 +211,9 @@ public:
 
     GameDataFile* getGameDataFile() const { return mPlayingFile; }
 
-    void set_49() { _49 = true; }
+    void setStageChanging() { mIsStageChanging = true; }
 
-    void set_4a() { _4a = true; }
+    void setStageEnding() { mIsStageEnding = true; }
 
     s64 getPlayTimeAcrossFile() const { return mPlayTimeAcrossFile; }
 
@@ -293,8 +293,8 @@ private:
     bool mIsRequireSave;
     u32 mRequireSaveFrame;
     bool mIsInvalidSaveForMoonGet;
-    bool _49;  // related to changeNextStage(WithWorldDemoWarp)
-    bool _4a;  // related to endStage
+    bool mIsStageChanging;
+    bool mIsStageEnding;
     sead::FixedSafeString<32> mLanguage;
     u64 mPlayTimeAcrossFile;
     sead::Heap* mSaveDataWriteThread;

--- a/src/System/MoonRockData.h
+++ b/src/System/MoonRockData.h
@@ -23,7 +23,12 @@ public:
     void read(const al::ByamlIter& save) override;
 
 private:
-    void* _padding[0x6];
+    bool mIsShowDemoOpenMoonRockFirst;
+    bool* mIsShowDemoOpenMoonRockWorld;
+    bool* mIsAppearedMoonRockTalkMessage;
+    bool mIsShowDemoAfterOpenMoonRockFirst;
+    bool* mIsShowDemoMoonRockMapWorld;
+    s32 mWorldNum;
 };
 
 static_assert(sizeof(MoonRockData) == 0x38);


### PR DESCRIPTION
I checked through all types that are listed in OdysseyDecomp, and compared them to what I have in my decompiler so far, deciding which one is "better" and importing types into the respective other information collection.

This PR contains my adjustments to OdysseyDecomp, where I believe that my information is better than what we have in the repo right now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1023)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b6f947c - 50c1fd4)

No changes

<!-- decomp.dev report end -->