### PR TITLE
MapObj: Implement `RocketFlower`

### DIFF
--- a/src/MapObj/RocketFlower.cpp
+++ b/src/MapObj/RocketFlower.cpp
@@ -1,0 +1,237 @@
+#include "MapObj/RocketFlower.h"
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/RocketFlowerFunction.h"
+#include "Util/PlayerUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(RocketFlower, Wait);
+NERVE_IMPL(RocketFlower, Attach);
+NERVE_IMPL(RocketFlower, WaitFollow);
+NERVE_IMPL(RocketFlower, Follow);
+NERVE_IMPL(RocketFlower, WaitAttach);
+
+NERVES_MAKE_STRUCT(RocketFlower, Wait, Attach, WaitFollow, Follow, WaitAttach);
+}  // namespace
+
+RocketFlower::RocketFlower(const char* name) : al::LiveActor(name) {}
+
+void RocketFlower::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &NrvRocketFlower.Wait, 0);
+    makeActorAlive();
+
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+
+    mFlowerSub = new al::LiveActor("ロケットフラワーの花");
+    al::initChildActorWithArchiveNameNoPlacementInfo(mFlowerSub, info, "RocketFlowerDash", nullptr);
+    al::startAction(mFlowerSub, "Wait");
+    mFlowerSub->makeActorDead();
+
+    RocketFlowerFunction::createRocketFlowerEquipWatcherIfNotExist(this, info);
+    al::setHitSensorPosPtr(this, "Equip", al::getTransPtr(mFlowerSub));
+    al::startAction(this, "Wait");
+}
+
+void RocketFlower::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+void RocketFlower::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (!al::isSensorName(self, "Equip"))
+        return;
+
+    if (isEnableEquip()) {
+        if (rs::sendMsgRocketFlowerExtension(other, self))
+            al::setNerve(this, &NrvRocketFlower.Attach);
+    }
+}
+
+bool RocketFlower::isEnableEquip() const {
+    if (al::isNerve(this, &NrvRocketFlower.Follow) && !al::isNewNerve(this))
+        return true;
+
+    return al::isNerve(this, &NrvRocketFlower.WaitAttach);
+}
+
+bool RocketFlower::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                              al::HitSensor* self) {
+    if (al::isMsgPlayerSpinAttack(message)) {
+        if (al::isNerve(this, &NrvRocketFlower.Wait)) {
+            al::invalidateClipping(this);
+            al::setNerve(this, &NrvRocketFlower.WaitFollow);
+        }
+    } else if (rs::isMsgCapItemGet(message)) {
+        if (al::isNerve(this, &NrvRocketFlower.Wait)) {
+            al::invalidateClipping(this);
+            al::setNerve(this, &NrvRocketFlower.Follow);
+            return true;
+        }
+    } else if (al::isMsgPlayerObjTouch(message) || rs::isMsgBlowObjAttack(message) ||
+               rs::isMsgFireDamageAll(message) || rs::isMsgHammerBrosHammerEnemyAttack(message) ||
+               rs::isMsgHammerBrosHammerHackAttack(message) || rs::isMsgHosuiAttack(message) ||
+               al::isMsgEnemyAttack(message) || al::isMsgKickStoneAttack(message) ||
+               rs::isMsgRadishAttack(message) || rs::isMsgSeedAttack(message) ||
+               rs::isMsgTankBullet(message) || rs::isMsgGamaneBulletThrough(message) ||
+               rs::isMsgHackAttackPoison(message) || rs::isMsgYoshiTongueAttack(message)) {
+        if (al::isSensorMapObj(self)) {
+            if (mReactionFrame == 0)
+                al::startAction(this, "Reaction");
+
+            mReactionFrame = 30;
+        }
+    } else if (rs::isMsgCapAttack(message)) {
+        if (al::isSensorMapObj(self) && !al::isNerve(this, &NrvRocketFlower.Wait) &&
+            !al::isNerve(this, &NrvRocketFlower.WaitFollow)) {
+            if (mReactionFrame == 0)
+                al::startAction(this, "Reaction");
+
+            mReactionFrame = 30;
+        }
+    } else if (al::isMsgPlayerPutOnEquipment(message) && al::isSensorName(self, "Equip") &&
+               isEnableEquip()) {
+        if (RocketFlowerFunction::requestEquipRocketFlower(this, other)) {
+            al::setNerve(this, &NrvRocketFlower.Attach);
+            return true;
+        }
+
+        terminateFollow();
+    }
+
+    return false;
+}
+
+void RocketFlower::terminateFollow() {
+    al::invalidateHitSensor(this, "Equip");
+    al::validateClipping(this);
+    mFlowerSub->kill();
+    al::startAction(this, "Appear");
+    mReactionFrame = 30;
+    al::startHitReaction(this, "復帰");
+    al::setNerve(this, &NrvRocketFlower.Wait);
+}
+
+void RocketFlower::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::startVisAnim(this, "Show");
+        al::invalidateHitSensor(this, "Equip");
+    }
+}
+
+void RocketFlower::exeWaitFollow() {
+    if (trySyncFlyingCapPos()) {
+        al::setNerve(this, &NrvRocketFlower.Follow);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 30)) {
+        al::validateClipping(this);
+        al::setNerve(this, &NrvRocketFlower.Wait);
+    }
+}
+
+bool RocketFlower::trySyncFlyingCapPos() {
+    sead::Vector3f flyingCapPos;
+    if (!rs::tryGetFlyingCapPos(&flyingCapPos, this))
+        return false;
+
+    flyingCapPos += 50.0f * sead::Vector3f::ey;
+    al::resetPosition(mFlowerSub, flyingCapPos);
+
+    sead::Vector3f toPlayerHead = rs::getPlayerHeadPos(this) - flyingCapPos;
+    if (al::tryNormalizeOrZero(&toPlayerHead)) {
+        sead::Quatf quat;
+        quat.makeVectorRotation(sead::Vector3f::ez, toPlayerHead);
+        al::setQuat(mFlowerSub, quat);
+    }
+
+    return true;
+}
+
+void RocketFlower::exeFollow() {
+    if (al::isFirstStep(this)) {
+        appearFlowerSub();
+        mFollowLostFrame = 0;
+    }
+
+    if (trySyncFlyingCapPos()) {
+        mFollowLostFrame = 0;
+        return;
+    }
+
+    if (rs::isEquipCapCatched(this)) {
+        al::validateHitSensor(this, "Equip");
+        al::setNerve(this, &NrvRocketFlower.WaitAttach);
+        return;
+    }
+
+    if (mFollowLostFrame >= 16)
+        terminateFollow();
+
+    mFollowLostFrame++;
+}
+
+void RocketFlower::appearFlowerSub() {
+    al::startVisAnim(this, "Hide");
+    mFlowerSub->appear();
+    al::startAction(mFlowerSub, "Wait");
+    al::startAction(this, "ReactionCap");
+    mReactionFrame = 30;
+    al::startHitReaction(this, "花が取れた");
+}
+
+void RocketFlower::exeWaitAttach() {
+    rs::tryCalcPlayerModelHeadJointPos(al::getTransPtr(mFlowerSub), this);
+
+    if (al::isGreaterEqualStep(this, 20))
+        terminateFollow();
+}
+
+void RocketFlower::exeAttach() {
+    if (al::isFirstStep(this))
+        al::startAction(mFlowerSub, "Dash");
+}
+
+void RocketFlower::setFollowFlowerPose(const sead::Quatf& quat, const sead::Vector3f& trans) {
+    al::setQuat(mFlowerSub, quat);
+    al::resetPosition(mFlowerSub, trans);
+}
+
+void RocketFlower::disappear() {
+    al::startHitReaction(mFlowerSub, "消滅");
+}
+
+void RocketFlower::disappearForce() {
+    al::tryKillEmitterAndParticleAll(mFlowerSub);
+    al::invalidateHitSensor(this, "Equip");
+    al::validateClipping(this);
+    mFlowerSub->kill();
+    al::startAction(this, "Wait");
+    mReactionFrame = 30;
+    al::setNerve(this, &NrvRocketFlower.Wait);
+}
+
+void RocketFlower::control() {
+    if (al::isActionOneTime(this) && al::isActionEnd(this))
+        al::startAction(this, "Wait");
+
+    if (mReactionFrame != 0)
+        mReactionFrame--;
+
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}

--- a/src/MapObj/RocketFlower.h
+++ b/src/MapObj/RocketFlower.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class RocketFlower : public al::LiveActor {
+public:
+    RocketFlower(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    bool isEnableEquip() const;
+    void terminateFollow();
+
+    void exeWait();
+    void exeWaitFollow();
+    bool trySyncFlyingCapPos();
+    void exeFollow();
+    void appearFlowerSub();
+    void exeWaitAttach();
+    void exeAttach();
+
+    void setFollowFlowerPose(const sead::Quatf& quat, const sead::Vector3f& trans);
+    void disappear();
+    void disappearForce();
+
+private:
+    al::MtxConnector* mMtxConnector = nullptr;
+    al::LiveActor* mFlowerSub = nullptr;
+    s32 mReactionFrame = 0;
+    u32 mFollowLostFrame = 0;
+};
+
+static_assert(sizeof(RocketFlower) == 0x120);

--- a/src/MapObj/RocketFlowerFunction.h
+++ b/src/MapObj/RocketFlowerFunction.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class LiveActor;
+}  // namespace al
+
+class RocketFlower;
+
+namespace RocketFlowerFunction {
+
+void createRocketFlowerEquipWatcherIfNotExist(const al::LiveActor* actor,
+                                              const al::ActorInitInfo& info);
+bool requestEquipRocketFlower(RocketFlower* flower, al::HitSensor* sensor);
+
+}  // namespace RocketFlowerFunction

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -89,6 +89,7 @@
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PoleGrabCeil.h"
 #include "MapObj/RiseMapPartsHolder.h"
+#include "MapObj/RocketFlower.h"
 #include "MapObj/RouletteSwitch.h"
 #include "MapObj/SaveFlagCheckObj.h"
 #include "MapObj/ShineTowerRocket.h"
@@ -666,7 +667,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"RiseMapParts", nullptr},
     {"ReactionMapParts", nullptr},
     {"RiseMapPartsHolder", al::createActorFunction<RiseMapPartsHolder>},
-    {"RocketFlower", nullptr},
+    {"RocketFlower", al::createActorFunction<RocketFlower>},
     {"RollingCubeMapParts", al::createActorFunction<al::RollingCubeMapParts>},
     {"RippleFixMapParts", nullptr},
     {"RotateMapParts", al::createActorFunction<al::RotateMapParts>},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1024)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - b0417f2)

📈 **Matched code**: 14.22% (+0.03%, +3436 bytes)

<details>
<summary>✅ 25 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/RocketFlower` | `RocketFlower::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +664 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::trySyncFlyingCapPos()` | +412 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::exeFollow()` | +324 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::init(al::ActorInitInfo const&)` | +268 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::exeWaitAttach()` | +164 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::attackSensor(al::HitSensor*, al::HitSensor*)` | +156 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::RocketFlower(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::RocketFlower(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::disappearForce()` | +124 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::terminateFollow()` | +116 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::appearFlowerSub()` | +108 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::control()` | +104 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `(anonymous namespace)::RocketFlowerNrvWaitFollow::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::exeWaitFollow()` | +100 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::isEnableEquip() const` | +84 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `(anonymous namespace)::RocketFlowerNrvWait::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::exeWait()` | +76 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `(anonymous namespace)::RocketFlowerNrvAttach::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::exeAttach()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<RocketFlower>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::setFollowFlowerPose(sead::Quat<float> const&, sead::Vector3<float> const&)` | +48 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::initAfterPlacement()` | +28 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `RocketFlower::disappear()` | +16 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `(anonymous namespace)::RocketFlowerNrvFollow::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/RocketFlower` | `(anonymous namespace)::RocketFlowerNrvWaitAttach::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->