### PR TITLE
MapObj: Implement `BlockQuestion2D`

### DIFF
--- a/src/MapObj/BlockEmpty2D.h
+++ b/src/MapObj/BlockEmpty2D.h
@@ -20,6 +20,8 @@ public:
     bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
     ActorDimensionKeeper* getActorDimensionKeeper() const override;
 
+    void setMtxConnector(al::MtxConnector* mtxConnector) { mMtxConnector = mtxConnector; }
+
 private:
     bool mIsConnectToCollisionBack = false;
     al::MtxConnector* mMtxConnector = nullptr;

--- a/src/MapObj/BlockQuestion2D.cpp
+++ b/src/MapObj/BlockQuestion2D.cpp
@@ -1,0 +1,155 @@
+#include "MapObj/BlockQuestion2D.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Stage/StageRhythm.h"
+
+#include "MapObj/BlockEmpty2D.h"
+#include "MapObj/BlockStateSingleItem.h"
+#include "MapObj/BlockStateTenCoin.h"
+#include "Util/ActorDimensionKeeper.h"
+#include "Util/ActorDimensionUtil.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BlockQuestion2D, TenCoin);
+NERVE_IMPL(BlockQuestion2D, SingleItem);
+
+NERVES_MAKE_STRUCT(BlockQuestion2D, TenCoin, SingleItem);
+}  // namespace
+
+BlockQuestion2D::BlockQuestion2D(const char* name) : al::LiveActor(name) {}
+
+void BlockQuestion2D::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "BlockQuestion2D", nullptr);
+    mItemType = rs::getItemType(info);
+
+    if (mItemType < 0) {
+        mSingleItemState = new BlockStateSingleItem(this, mItemType, true);
+        al::initNerve(this, &NrvBlockQuestion2D.SingleItem, 1);
+        al::initNerveState(this, mSingleItemState, &NrvBlockQuestion2D.SingleItem, "アイテム");
+    } else {
+        rs::initItem2DByPlacementInfo(this, info);
+        if (mItemType == rs::ItemType::Coin10) {
+            mTenCoinState = new BlockStateTenCoin(this, true);
+            al::initNerve(this, &NrvBlockQuestion2D.TenCoin, 1);
+            al::initNerveState(this, mTenCoinState, &NrvBlockQuestion2D.TenCoin, "10コイン");
+        } else {
+            mSingleItemState = new BlockStateSingleItem(this, mItemType, true);
+            al::initNerve(this, &NrvBlockQuestion2D.SingleItem, 1);
+            al::initNerveState(this, mSingleItemState, &NrvBlockQuestion2D.SingleItem, "アイテム");
+        }
+    }
+
+    al::startAction(this, "Wait");
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+
+    if (!rs::isIn2DArea(this)) {
+        al::PlacementId placementId;
+        al::tryGetPlacementId(&placementId, info);
+        al::StringTmp<128> str;
+        placementId.makeString(&str);
+        kill();
+        return;
+    }
+
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    if (mMtxConnector)
+        al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
+
+    rs::snap2DParallelizeFront(this, this, 500.0f);
+    mEmptyBlock2D = new BlockEmpty2D("空ブロック2D");
+    al::initCreateActorWithPlacementInfo(mEmptyBlock2D, info);
+    mEmptyBlock2D->makeActorDead();
+    makeActorAlive();
+}
+
+void BlockQuestion2D::initAfterPlacement() {
+    if (!mMtxConnector)
+        return;
+
+    if (mIsConnectToCollisionBack) {
+        sead::Vector3f frontDir = {0.0f, 0.0f, 0.0f};
+        al::calcFrontDir(&frontDir, this);
+        al::attachMtxConnectorToCollision(
+            mMtxConnector, this, al::getTrans(this) + 50.0f * frontDir, -400.0f * frontDir);
+    } else {
+        al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
+    }
+}
+
+void BlockQuestion2D::appear() {
+    al::LiveActor::appear();
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void BlockQuestion2D::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void BlockQuestion2D::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvBlockQuestion2D.SingleItem) && mSingleItemState->isReaction()) {
+        rs::sendMsgBlockUpperPunch2D(other, self);
+        return;
+    }
+
+    if (al::isNerve(this, &NrvBlockQuestion2D.TenCoin) && mTenCoinState->isReaction())
+        rs::sendMsgBlockUpperPunch2D(other, self);
+}
+
+bool BlockQuestion2D::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+
+    if (rs::isMsgBlockReaction2D(message) && !al::isSensorName(self, "UpperPunch")) {
+        if (al::isNerve(this, &NrvBlockQuestion2D.SingleItem)) {
+            mSingleItemState->setItemOffsetY(200.0f);
+            return mSingleItemState->receiveMsg(message, other, self);
+        }
+
+        if (al::isNerve(this, &NrvBlockQuestion2D.TenCoin)) {
+            mTenCoinState->setItemOffsetY(200.0f);
+            return mTenCoinState->receiveMsg(message, other, self);
+        }
+    }
+    return false;
+}
+
+void BlockQuestion2D::endClipped() {
+    s32 syncCounter = al::getSceneObj<al::StageSyncCounter>(this)->getCounter();
+    s32 frameMax = al::getVisAnimFrameMax(this, "Wait");
+    al::setVisAnimFrameForAction(this, syncCounter % frameMax);
+    al::LiveActor::endClipped();
+}
+
+void BlockQuestion2D::exeSingleItem() {
+    if (al::updateNerveState(this)) {
+        mEmptyBlock2D->appear();
+        mEmptyBlock2D->setMtxConnector(mMtxConnector);
+        kill();
+    }
+}
+
+void BlockQuestion2D::exeTenCoin() {
+    if (al::updateNerveState(this)) {
+        mEmptyBlock2D->appear();
+        // BUG: missing `mEmptyBlock2D->setMtxConnector(mMtxConnector)`
+        kill();
+    }
+}

--- a/src/MapObj/BlockQuestion2D.h
+++ b/src/MapObj/BlockQuestion2D.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class ActorDimensionKeeper;
+class BlockEmpty2D;
+class BlockStateSingleItem;
+class BlockStateTenCoin;
+
+class BlockQuestion2D : public al::LiveActor, public IUseDimension {
+public:
+    BlockQuestion2D(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void appear() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void endClipped() override;
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override { return mDimensionKeeper; }
+
+    void exeSingleItem();
+    void exeTenCoin();
+
+private:
+    s32 mItemType = -1;
+    BlockStateTenCoin* mTenCoinState = nullptr;
+    BlockStateSingleItem* mSingleItemState = nullptr;
+    BlockEmpty2D* mEmptyBlock2D = nullptr;
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    al::MtxConnector* mMtxConnector = nullptr;
+    bool mIsConnectToCollisionBack = false;
+};
+
+static_assert(sizeof(BlockQuestion2D) == 0x148);

--- a/src/MapObj/BlockStateSingleItem.h
+++ b/src/MapObj/BlockStateSingleItem.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class BlockStateSingleItem : public al::ActorStateBase {
+public:
+    BlockStateSingleItem(al::LiveActor* actor, s32 itemType, bool isSkipStartWaitAction);
+
+    void init() override;
+
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    bool isReaction() const;
+    bool isEnableAppearItem() const;
+    void setItemOffsetY(f32 itemOffsetY);
+    void autoGet(al::HitSensor* sensor);
+    void exeWait();
+    void exeReaction();
+    void exeReactionHipDrop();
+
+private:
+    s32 mItemType = 0;
+    bool mIsNoWaitAction = false;
+    al::HitSensor* mAttackedSensor = nullptr;
+    f32 mItemOffsetY = 0.0f;
+};
+
+static_assert(sizeof(BlockStateSingleItem) == 0x38);

--- a/src/MapObj/BlockStateTenCoin.h
+++ b/src/MapObj/BlockStateTenCoin.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class BlockStateTenCoin : public al::ActorStateBase {
+public:
+    BlockStateTenCoin(al::LiveActor* actor, bool isSkipStartWaitAction);
+
+    void init() override;
+    void control() override;
+
+    void autoGet(al::HitSensor* sensor);
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    bool isReaction() const;
+    bool isEnableAppearItem() const;
+
+    void setItemOffsetY(f32 itemOffsetY) { mItemOffsetY = itemOffsetY; }
+
+    void exeWait();
+    void exeReaction();
+    void exeReactionHipDrop();
+    void exeGetAuto();
+
+private:
+    s32 mCoinCount = 10;
+    s32 mTimer = 130;
+    s32 mReactionCooldown = 0;
+    bool mIsWaitSyncStage = false;
+    al::HitSensor* mAttackedSensor = nullptr;
+    f32 mItemOffsetY = 0.0f;
+};
+
+static_assert(sizeof(BlockStateTenCoin) == 0x40);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -68,6 +68,7 @@
 #include "MapObj/AllDeadWatcherWithShine.h"
 #include "MapObj/AnagramAlphabet.h"
 #include "MapObj/BlockEmpty2D.h"
+#include "MapObj/BlockQuestion2D.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -146,7 +147,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"ClashWorldBlockHard", nullptr},
     {"BlockQuestion", nullptr},
     {"CityBlockQuestion", nullptr},
-    {"BlockQuestion2D", nullptr},
+    {"BlockQuestion2D", al::createActorFunction<BlockQuestion2D>},
     {"BlockTransparent", nullptr},
     {"BlockTransparent2D", nullptr},
     {"BlowObjBeans", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1026)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f550e5 - 9079545)

📈 **Matched code**: 14.32% (+0.02%, +2092 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::init(al::ActorInitInfo const&)` | +588 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +240 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::initAfterPlacement()` | +224 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::BlockQuestion2D(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::BlockQuestion2D(char const*)` | +164 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::attackSensor(al::HitSensor*, al::HitSensor*)` | +132 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::endClipped()` | +100 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `(anonymous namespace)::BlockQuestion2DNrvSingleItem::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::exeSingleItem()` | +88 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `(anonymous namespace)::BlockQuestion2DNrvTenCoin::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::exeTenCoin()` | +76 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::appear()` | +56 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BlockQuestion2D>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::control()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `BlockQuestion2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/BlockQuestion2D` | `non-virtual thunk to BlockQuestion2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->