### PR TITLE
Enemy: Implement `BrosWeaponBase`

### DIFF
--- a/src/Enemy/Bros.cpp
+++ b/src/Enemy/Bros.cpp
@@ -33,9 +33,9 @@ void BrosWeaponBase::calcAttachMtx(sead::Matrix34f* attachMtx, const sead::Matri
     sead::Matrix34f rotationMatrix;
     rotationMatrix.makeRT(rotation, sead::Vector3f::zero);
 
-    sead::Matrix34f poseMatrix = rotationMatrix * translationMatrix;
-    sead::Matrix34f copy = *poseMtx;
-    al::normalize(&copy);
+    sead::Matrix34f mtxRT = rotationMatrix * translationMatrix;
+    sead::Matrix34f poseMtxNorm = *poseMtx;
+    al::normalize(&poseMtxNorm);
 
-    attachMtx->setMul(copy, poseMatrix);
+    attachMtx->setMul(poseMtxNorm, mtxRT);
 }

--- a/src/Enemy/Bros.cpp
+++ b/src/Enemy/Bros.cpp
@@ -1,0 +1,41 @@
+#include "Enemy/Bros.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+
+BrosWeaponBase::BrosWeaponBase(const char* name, const al::LiveActor* bros)
+    : al::LiveActor(name), mBros(bros) {}
+
+void BrosWeaponBase::attach(const sead::Matrix34f* poseMtx, const sead::Vector3f& trans,
+                            const sead::Vector3f& rotation, const char* actionName) {
+    mPoseMtx = poseMtx;
+    mTrans.set(trans);
+    mRotation.set(rotation);
+
+    sead::Matrix34f attachMtx;
+    calcAttachMtx(&attachMtx, poseMtx, trans, rotation);
+    al::updatePoseMtx(this, &attachMtx);
+    al::invalidateClipping(this);
+    al::offCollide(this);
+    if (actionName)
+        al::startAction(this, actionName);
+    appear();
+}
+
+void BrosWeaponBase::calcAttachMtx(sead::Matrix34f* attachMtx, const sead::Matrix34f* poseMtx,
+                                   const sead::Vector3f& trans, const sead::Vector3f& rotation) {
+    sead::Matrix34f translationMatrix;
+    translationMatrix.makeRT(sead::Vector3f::zero, trans);
+
+    sead::Matrix34f rotationMatrix;
+    rotationMatrix.makeRT(rotation, sead::Vector3f::zero);
+
+    sead::Matrix34f poseMatrix = rotationMatrix * translationMatrix;
+    sead::Matrix34f copy = *poseMtx;
+    al::normalize(&copy);
+
+    attachMtx->setMul(copy, poseMatrix);
+}

--- a/src/Enemy/Bros.h
+++ b/src/Enemy/Bros.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BrosWeaponBase : public al::LiveActor {
+public:
+    BrosWeaponBase(const char* name, const al::LiveActor* bros);
+
+    // TODO: Find what unknown does
+    virtual void shoot(const sead::Vector3f& trans, const sead::Quatf& quat,
+                       const sead::Vector3f& force, bool isHack, s32 unknown, bool isFast) = 0;
+    virtual void killCollide(al::HitSensor* sensor, const sead::Vector3f& trans, bool isHack) = 0;
+    virtual void killEnemy() = 0;
+
+    virtual void attach(const sead::Matrix34f* poseMtx, const sead::Vector3f& trans,
+                        const sead::Vector3f& rotation, const char* actionName);
+    void calcAttachMtx(sead::Matrix34f* attachMtx, const sead::Matrix34f* poseMtx,
+                       const sead::Vector3f& trans, const sead::Vector3f& rotation);
+
+    virtual u32 getBreakStep() const { return 0; }
+
+    virtual bool isBreak() const { return false; }
+
+    const sead::Matrix34f* getPoseMtx() const { return mPoseMtx; }
+
+    const sead::Vector3f& getTrans() const { return mTrans; }
+
+    const sead::Vector3f& getRotation() const { return mRotation; }
+
+    const LiveActor* getBrosActor() const { return mBros; }
+
+private:
+    const sead::Matrix34f* mPoseMtx = nullptr;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    sead::Vector3f mRotation = sead::Vector3f::zero;
+    const al::LiveActor* mBros;
+};
+
+static_assert(sizeof(BrosWeaponBase) == 0x130);


### PR DESCRIPTION
I love when math just works. This is a pre requisite for `FireBrosFireBall`. Header parameter names are obtained through the implementation of `FireBrosFireBall` and `HammerBrosHammer` I can link said implementations if needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1027)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b6f947c - 4f6c5d6)

📈 **Matched code**: 14.20% (+0.01%, +1048 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/Bros` | `BrosWeaponBase::calcAttachMtx(sead::Matrix34<float>*, sead::Matrix34<float> const*, sead::Vector3<float> const&, sead::Vector3<float> const&)` | +676 | 0.00% | 100.00% |
| `Enemy/Bros` | `BrosWeaponBase::BrosWeaponBase(char const*, al::LiveActor const*)` | +184 | 0.00% | 100.00% |
| `Enemy/Bros` | `BrosWeaponBase::attach(sead::Matrix34<float> const*, sead::Vector3<float> const&, sead::Vector3<float> const&, char const*)` | +172 | 0.00% | 100.00% |
| `Enemy/Bros` | `BrosWeaponBase::getBreakStep() const` | +8 | 0.00% | 100.00% |
| `Enemy/Bros` | `BrosWeaponBase::isBreak() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->