### PR TITLE
MapObj: Implement `HipDropMoveLift`

### DIFF
--- a/src/MapObj/HipDropMoveLift.cpp
+++ b/src/MapObj/HipDropMoveLift.cpp
@@ -1,0 +1,102 @@
+#include "MapObj/HipDropMoveLift.h"
+
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_ACTION_IMPL(HipDropMoveLift, StandBy)
+NERVE_ACTION_IMPL(HipDropMoveLift, Wait)
+NERVE_ACTION_IMPL(HipDropMoveLift, Move)
+
+NERVE_ACTIONS_MAKE_STRUCT(HipDropMoveLift, StandBy, Wait, Move)
+}  // namespace
+
+HipDropMoveLift::HipDropMoveLift(const char* name) : al::LiveActor(name) {}
+
+void HipDropMoveLift::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Wait", &NrvHipDropMoveLift.collector, 0);
+    al::initMapPartsActor(this, info, nullptr);
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    mKeyPoseKeeper->setMoveTypeTurn();
+    al::registerAreaHostMtx(this, info);
+    al::startNerveAction(this, "StandBy");
+    makeActorAlive();
+}
+
+bool HipDropMoveLift::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    if (al::isMsgPlayerHipDropAll(message) &&
+        al::isNerve(this, NrvHipDropMoveLift.StandBy.data())) {
+        start();
+        return true;
+    }
+
+    return false;
+}
+
+void HipDropMoveLift::start() {
+    if (!al::isNerve(this, NrvHipDropMoveLift.StandBy.data()) ||
+        al::getKeyPoseCount(mKeyPoseKeeper) < 2)
+        return;
+
+    if (al::isExistAction(this, "Start"))
+        al::startAction(this, "Start");
+    al::startNerveAction(this, "Wait");
+    al::invalidateClipping(this);
+}
+
+void HipDropMoveLift::exeStandBy() {
+    if (al::isFirstStep(this))
+        al::validateClipping(this);
+}
+
+void HipDropMoveLift::exeWait() {
+    if (al::isFirstStep(this)) {
+        s32 waitTime = al::calcKeyMoveWaitTime(mKeyPoseKeeper);
+        if (waitTime >= 0)
+            mWaitTime = waitTime;
+    }
+
+    if (al::isGreaterEqualStep(this, mWaitTime))
+        setWaitEndNerve();
+}
+
+void HipDropMoveLift::setWaitEndNerve() {
+    if (!al::isRestart(mKeyPoseKeeper)) {
+        al::startNerveAction(this, "Move");
+        return;
+    }
+
+    al::restartKeyPose(mKeyPoseKeeper, al::getTransPtr(this), al::getQuatPtr(this));
+    al::resetPosition(this);
+    al::startNerveAction(this, "Wait");
+}
+
+void HipDropMoveLift::exeMove() {
+    if (al::isFirstStep(this))
+        mMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+
+    f32 rate = al::calcNerveRate(this, mMoveTime);
+    al::calcLerpKeyTrans(al::getTransPtr(this), mKeyPoseKeeper, rate);
+    al::calcSlerpKeyQuat(al::getQuatPtr(this), mKeyPoseKeeper, rate);
+
+    if (al::isGreaterEqualStep(this, mMoveTime)) {
+        al::nextKeyPose(mKeyPoseKeeper);
+
+        if (al::isFirstKey(mKeyPoseKeeper))
+            al::startNerveAction(this, "StandBy");
+        else if (al::calcKeyMoveWaitTime(mKeyPoseKeeper) != 0)
+            al::startNerveAction(this, "Wait");
+        else
+            setWaitEndNerve();
+    }
+}

--- a/src/MapObj/HipDropMoveLift.h
+++ b/src/MapObj/HipDropMoveLift.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class KeyPoseKeeper;
+}
+
+class HipDropMoveLift : public al::LiveActor {
+public:
+    HipDropMoveLift(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void start();
+    void exeStandBy();
+    void exeWait();
+    void setWaitEndNerve();
+    void exeMove();
+
+private:
+    al::KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    s32 mMoveTime = 0;
+    s32 mWaitTime = 30;
+};
+
+static_assert(sizeof(HipDropMoveLift) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -80,6 +80,7 @@
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
+#include "MapObj/HipDropMoveLift.h"
 #include "MapObj/HipDropSwitch.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
@@ -349,7 +350,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HipDropSwitchSave", nullptr},
     {"HipDropSwitchTimer", nullptr},
     {"HipDropTile", nullptr},
-    {"HipDropMoveLift", nullptr},
+    {"HipDropMoveLift", al::createActorFunction<HipDropMoveLift>},
     {"HipDropRepairParts", nullptr},
     {"HipDropTransformPartsWatcher", nullptr},
     {"HomeBed", nullptr},


### PR DESCRIPTION
<!-- decomp.dev report start -->
### Report for 1.0 (3f414ea - 6bbbc59)

📈 **Matched code**: 14.50% (+0.01%, +1544 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::exeMove()` | +236 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +168 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::HipDropMoveLift(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::init(al::ActorInitInfo const&)` | +132 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::HipDropMoveLift(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::start()` | +128 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::setWaitEndNerve()` | +120 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `_GLOBAL__sub_I_HipDropMoveLift.cpp` | +116 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvWait::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::exeWait()` | +84 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvStandBy::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `HipDropMoveLift::exeStandBy()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HipDropMoveLift>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvStandBy::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/HipDropMoveLift` | `(anonymous namespace)::HipDropMoveLiftNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1029)
<!-- Reviewable:end -->
