### PR TITLE
MapObj: Implement `AppearSwitchFixMapParts`

### DIFF
--- a/src/MapObj/AppearSwitchFixMapParts.cpp
+++ b/src/MapObj/AppearSwitchFixMapParts.cpp
@@ -1,0 +1,58 @@
+#include "MapObj/AppearSwitchFixMapParts.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+AppearSwitchFixMapParts::AppearSwitchFixMapParts(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void AppearSwitchFixMapParts::init(const al::ActorInitInfo& info) {
+    const char* suffix = nullptr;
+
+    al::tryGetStringArg(&suffix, info, "Suffix");
+    al::initMapPartsActor(this, info, suffix);
+    al::trySyncStageSwitchAppearAndKill(this);
+    al::registActorToDemoInfo(this, info);
+
+    if (getModelKeeper() != nullptr && !al::isExistAction(this) && !al::isViewDependentModel(this))
+        mIsStatic = true;
+}
+
+void AppearSwitchFixMapParts::appear() {
+    al::LiveActor::appear();
+    al::tryStartAction(this, "Appear");
+}
+
+void AppearSwitchFixMapParts::movement() {
+    if (!mIsStatic)
+        al::LiveActor::movement();
+}
+
+void AppearSwitchFixMapParts::calcAnim() {
+    if (mIsStatic)
+        al::calcViewModel(this);
+    else
+        al::LiveActor::calcAnim();
+}
+
+bool AppearSwitchFixMapParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                         al::HitSensor* self) {
+    if (al::isMsgAskSafetyPoint(message))
+        return false;
+
+    if (al::isMsgShowModel(message)) {
+        al::showModelIfHide(this);
+        return true;
+    }
+
+    if (al::isMsgHideModel(message)) {
+        al::hideModelIfShow(this);
+        return true;
+    }
+
+    return false;
+}

--- a/src/MapObj/AppearSwitchFixMapParts.h
+++ b/src/MapObj/AppearSwitchFixMapParts.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class AppearSwitchFixMapParts : public al::LiveActor {
+public:
+    AppearSwitchFixMapParts(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void movement() override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+private:
+    bool mIsStatic = false;
+};
+
+static_assert(sizeof(AppearSwitchFixMapParts) == 0x110);

--- a/src/Scene/ProjectAppearSwitchFactory.cpp
+++ b/src/Scene/ProjectAppearSwitchFactory.cpp
@@ -2,16 +2,17 @@
 
 #include "Library/LiveActor/CreateActorFunction.h"
 #include "Library/MapObj/FallMapParts.h"
-#include "Library/MapObj/FixMapParts.h"
 #include "Library/MapObj/FloaterMapParts.h"
 #include "Library/MapObj/KeyMoveMapParts.h"
 #include "Library/MapObj/RotateMapParts.h"
 #include "Library/MapObj/SeesawMapParts.h"
 #include "Library/MapObj/WobbleMapParts.h"
 
+#include "MapObj/AppearSwitchFixMapParts.h"
+
 // FIXME fill in method references: (1.0) off_7101D89F18
 const al::NameToCreator<al::ActorCreatorFunction> sProjectAppearSwitchFactoryEntries[] = {
-    {"FixMapParts", al::createActorFunction<al::FixMapParts>},
+    {"FixMapParts", al::createActorFunction<AppearSwitchFixMapParts>},
     {"FallMapParts", al::createActorFunction<al::FallMapParts>},
     {"CapHanger", nullptr},
     {"Coin", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1030)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3f414ea - 4dda475)

📈 **Matched code**: 14.49% (+0.00%, +624 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::AppearSwitchFixMapParts(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::init(al::ActorInitInfo const&)` | +136 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::AppearSwitchFixMapParts(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +100 | 0.00% | 100.00% |
| `Scene/ProjectAppearSwitchFactory` | `al::LiveActor* al::createActorFunction<AppearSwitchFixMapParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::appear()` | +44 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::movement()` | +16 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFixMapParts` | `AppearSwitchFixMapParts::calcAnim()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->