### PR TITLE
MapObj: Implement `PlayerMotionObserver`

### DIFF
--- a/src/MapObj/PlayerMotionObserver.cpp
+++ b/src/MapObj/PlayerMotionObserver.cpp
@@ -1,0 +1,89 @@
+#include "MapObj/PlayerMotionObserver.h"
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "System/GameDataUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerMotionObserver, Wait)
+NERVE_IMPL(PlayerMotionObserver, CheckLand)
+NERVE_IMPL(PlayerMotionObserver, WaitForSwitchOn)
+
+NERVES_MAKE_NOSTRUCT(PlayerMotionObserver, Wait, CheckLand, WaitForSwitchOn)
+}  // namespace
+
+PlayerMotionObserver::PlayerMotionObserver(const char* name) : al::LiveActor(name) {}
+
+void PlayerMotionObserver::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorUpdate(this, info, "監視オブジェ");
+    al::initStageSwitch(this, info);
+    al::initActorPoseTRSV(this);
+    al::initActorClipping(this, info);
+    al::invalidateClipping(this);
+
+    mPlayerHolder = info.actorSceneInfo.playerHolder;
+
+    const char* observationTargetMotion = nullptr;
+    al::tryGetStringArg(&observationTargetMotion, info, "ObservationTargetMotion");
+    if (!observationTargetMotion) {
+        kill();
+        return;
+    }
+
+    // NOTE: `initNerve` never called when this is not true
+    if (al::isEqualString(observationTargetMotion, "Land")) {
+        if (al::isValidStageSwitch(this, "SwitchStart")) {
+            al::initNerve(this, &Wait, 0);
+            mIsUseSwitchStart = true;
+        } else {
+            al::initNerve(this, &CheckLand, 0);
+        }
+    }
+
+    al::tryGetArg(&mSwitchOnDelayFrameNum, info, "SwitchOnDelayFrameNum");
+    mSaveObjInfo = rs::createSaveObjInfoNoWriteSaveDataInSameScenario(info);
+    if (rs::isOnSaveObjInfo(mSaveObjInfo)) {
+        al::onStageSwitch(this, "SwitchSpecifiedPlayerMotionOn");
+        makeActorDead();
+        return;
+    }
+
+    makeActorAlive();
+}
+
+void PlayerMotionObserver::exeWait() {
+    if (al::isOnStageSwitch(this, "SwitchStart"))
+        al::setNerve(this, &CheckLand);
+}
+
+void PlayerMotionObserver::exeCheckLand() {
+    if (mIsUseSwitchStart && !al::isOnStageSwitch(this, "SwitchStart")) {
+        al::setNerve(this, &Wait);
+        return;
+    }
+
+    if (rs::isPlayerOnGround(al::getPlayerActor(this, 0)))
+        al::setNerve(this, &WaitForSwitchOn);
+}
+
+void PlayerMotionObserver::exeWaitForSwitchOn() {
+    if (al::isFirstStep(this))
+        mSwitchOnDelayFrame = mSwitchOnDelayFrameNum;
+
+    mSwitchOnDelayFrame--;
+    if (mSwitchOnDelayFrame == -1) {
+        al::onStageSwitch(this, "SwitchSpecifiedPlayerMotionOn");
+        rs::onSaveObjInfo(mSaveObjInfo);
+        makeActorDead();
+    }
+}

--- a/src/MapObj/PlayerMotionObserver.h
+++ b/src/MapObj/PlayerMotionObserver.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class PlayerHolder;
+}  // namespace al
+
+class SaveObjInfo;
+
+class PlayerMotionObserver : public al::LiveActor {
+public:
+    PlayerMotionObserver(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    void exeCheckLand();
+    void exeWaitForSwitchOn();
+
+private:
+    al::PlayerHolder* mPlayerHolder = nullptr;
+    s32 mSwitchOnDelayFrameNum = 0;
+    s32 mSwitchOnDelayFrame = 0;
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    bool mIsUseSwitchStart = false;
+};
+
+static_assert(sizeof(PlayerMotionObserver) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -87,6 +87,7 @@
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/PeachWorldTree.h"
+#include "MapObj/PlayerMotionObserver.h"
 #include "MapObj/PoleGrabCeil.h"
 #include "MapObj/RiseMapPartsHolder.h"
 #include "MapObj/RouletteSwitch.h"
@@ -453,7 +454,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"PictureStageChange", nullptr},
     {"PillarKeyMoveParts", nullptr},
     {"PillarSwitchOpenMapParts", nullptr},
-    {"PlayerMotionObserver", nullptr},
+    {"PlayerMotionObserver", al::createActorFunction<PlayerMotionObserver>},
     {"PlayerStartObj", nullptr},
     {"PlayerSubjectiveWatchCheckObj", nullptr},
     {"PlayGuideBoard", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1032)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (dc5c854 - b371370)

📈 **Matched code**: 14.42% (+0.01%, +1288 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::init(al::ActorInitInfo const&)` | +332 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::PlayerMotionObserver(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::PlayerMotionObserver(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `(anonymous namespace)::PlayerMotionObserverNrvWaitForSwitchOn::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::exeWaitForSwitchOn()` | +120 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::exeCheckLand()` | +116 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `(anonymous namespace)::PlayerMotionObserverNrvCheckLand::execute(al::NerveKeeper*) const` | +116 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `PlayerMotionObserver::exeWait()` | +76 | 0.00% | 100.00% |
| `MapObj/PlayerMotionObserver` | `(anonymous namespace)::PlayerMotionObserverNrvWait::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<PlayerMotionObserver>(char const*)` | +52 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->