### PR TITLE
MapObj: Implement `TalkPoint`

### DIFF
--- a/src/MapObj/TalkPoint.cpp
+++ b/src/MapObj/TalkPoint.cpp
@@ -1,0 +1,51 @@
+#include "MapObj/TalkPoint.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Event/EventFlowUtil.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/NpcEventFlowUtil.h"
+
+namespace {
+NERVE_IMPL(TalkPoint, Wait);
+
+NERVES_MAKE_NOSTRUCT(TalkPoint, Wait);
+}  // namespace
+
+TalkPoint::TalkPoint(const char* name) : al::LiveActor(name) {}
+
+void TalkPoint::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorPoseTRSV(this);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::initExecutorWatchObj(this, info);
+    al::initStageSwitch(this, info);
+    al::initNerve(this, &Wait, 0);
+    al::initActorSeKeeper(this, info, "TalkPoint");
+    al::setClippingInfo(this, 300.0f, nullptr);
+
+    const char* eventName = al::getStringArg(info, "EventName");
+    mEventFlowExecutor = rs::initEventFlow(this, info, "TalkPoint", eventName);
+    al::invalidateUiCollisionCheck(mEventFlowExecutor);
+
+    if (rs::isDefinedEventCamera(mEventFlowExecutor, "Default"))
+        rs::initEventCameraObject(mEventFlowExecutor, info, "Default");
+
+    sead::Vector3f balloonLocalOffset = {0.0f, 0.0f, 0.0f};
+    al::getArg(&balloonLocalOffset.y, info, "BalloonLocalOffsetY");
+    al::setBalloonLocalOffset(mEventFlowExecutor, balloonLocalOffset);
+    rs::startEventFlow(mEventFlowExecutor, "Init");
+
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+void TalkPoint::exeWait() {
+    rs::updateEventFlow(mEventFlowExecutor);
+}

--- a/src/MapObj/TalkPoint.h
+++ b/src/MapObj/TalkPoint.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowExecutor;
+}  // namespace al
+
+class TalkPoint : public al::LiveActor {
+public:
+    TalkPoint(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void exeWait();
+
+private:
+    al::EventFlowExecutor* mEventFlowExecutor = nullptr;
+};
+
+static_assert(sizeof(TalkPoint) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -95,6 +95,7 @@
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
+#include "MapObj/TalkPoint.h"
 #include "MapObj/TrampleBush.h"
 #include "MapObj/TrampleSwitch.h"
 #include "MapObj/TrampleSwitchTimer.h"
@@ -597,7 +598,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"TalkNpcSnowMan", nullptr},
     {"TalkNpcSnowManLeader", nullptr},
     {"TalkNpcSnowManRacer", nullptr},
-    {"TalkPoint", nullptr},
+    {"TalkPoint", al::createActorFunction<TalkPoint>},
     {"Tank", nullptr},
     {"TankReviveCtrl", nullptr},
     {"TaxiStop", nullptr},

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -14,6 +14,7 @@ al::EventFlowExecutor* initEventFlow(al::LiveActor*, const al::ActorInitInfo&, c
                                      const char*);
 al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                            const char*, const char*);
+bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);


### PR DESCRIPTION
<!-- decomp.dev report start -->
### Report for 1.0 (3528e9e - 3dbe13e)

📈 **Matched code**: 14.19% (+0.01%, +656 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TalkPoint` | `TalkPoint::init(al::ActorInitInfo const&)` | +324 | 0.00% | 100.00% |
| `MapObj/TalkPoint` | `TalkPoint::TalkPoint(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/TalkPoint` | `TalkPoint::TalkPoint(char const*)` | +124 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<TalkPoint>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/TalkPoint` | `(anonymous namespace)::TalkPointNrvWait::execute(al::NerveKeeper*) const` | +12 | 0.00% | 100.00% |
| `MapObj/TalkPoint` | `TalkPoint::exeWait()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1033)
<!-- Reviewable:end -->
