### PR TITLE
MapObj: Implement `DoorSnow`

### DIFF
--- a/src/MapObj/DoorSnow.cpp
+++ b/src/MapObj/DoorSnow.cpp
@@ -1,0 +1,82 @@
+#include "MapObj/DoorSnow.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/NpcEventFlowUtil.h"
+
+namespace {
+NERVE_IMPL(DoorSnow, Wait);
+NERVE_IMPL(DoorSnow, Open);
+
+NERVES_MAKE_NOSTRUCT(DoorSnow, Wait, Open);
+
+static const char* getIndexedAction(const char* actionNameFormat, u32 doorIndex) {
+    al::StringTmp<64> actionName(actionNameFormat, doorIndex);
+    return actionName.cstr();
+}
+}  // namespace
+
+DoorSnow::DoorSnow(const char* name) : al::LiveActor(name) {}
+
+void DoorSnow::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+
+    mCameraTicketOpen = al::initObjectCamera(this, info, "扉オープン1", nullptr);
+    return alCameraFunction::validateKeepPreSelfPoseNextCamera(mCameraTicketOpen);
+}
+
+void DoorSnow::exeWait() {}
+
+void DoorSnow::exeOpen() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, getIndexedAction("Open%d", mDoorIndex));
+        al::startCamera(this, mCameraTicketOpen);
+    }
+
+    if (al::isActionEnd(this) && al::isGreaterEqualStep(this, 120)) {
+        al::startAction(this, getIndexedAction("OpenWait%d", mDoorIndex));
+
+        al::setNerve(this, &Wait);
+        al::endCamera(this, mCameraTicketOpen, 0, false);
+        rs::requestSwitchTalkNpcEventAfterDoorSnow(this, mDoorIndex);
+
+        al::StringTmp<128> switchName("OutputSwitch%dOn", mDoorIndex);
+        al::tryOnStageSwitch(this, switchName.cstr());
+
+        al::validateClipping(this);
+    }
+}
+
+void DoorSnow::reset(u32 doorIndex) {
+    mDoorIndex = doorIndex;
+    if (doorIndex == 0)
+        return;
+
+    al::startAction(this, getIndexedAction("OpenWait%d", doorIndex));
+
+    al::setNerve(this, &Wait);
+
+    al::StringTmp<128> switchName("OutputSwitch%dOn", mDoorIndex);
+    al::tryOnStageSwitch(this, switchName.cstr());
+
+    rs::requestSwitchTalkNpcEventAfterDoorSnow(this, mDoorIndex);
+}
+
+void DoorSnow::startDemo(u32 doorIndex) {
+    mDoorIndex = doorIndex;
+    al::invalidateClipping(this);
+    return al::setNerve(this, &Open);
+}
+
+bool DoorSnow::isDemoEnd() const {
+    return al::isNerve(this, &Wait);
+}

--- a/src/MapObj/DoorSnow.h
+++ b/src/MapObj/DoorSnow.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CameraTicket;
+}  // namespace al
+
+class DoorSnow : public al::LiveActor {
+public:
+    DoorSnow(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    void exeOpen();
+    void reset(u32 doorIndex);
+    void startDemo(u32 doorIndex);
+    bool isDemoEnd() const;
+
+private:
+    u32 mDoorIndex = 0;
+    al::CameraTicket* mCameraTicketOpen = nullptr;
+};
+
+static_assert(sizeof(DoorSnow) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -75,6 +75,7 @@
 #include "MapObj/ChurchDoor.h"
 #include "MapObj/CitySignal.h"
 #include "MapObj/CoinCollectHintObj.h"
+#include "MapObj/DoorSnow.h"
 #include "MapObj/Doshi.h"
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
@@ -273,7 +274,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"DoorAreaChange", nullptr},
     {"DoorAreaChangeCap", nullptr},
     {"DoorCity", nullptr},
-    {"DoorSnow", nullptr},
+    {"DoorSnow", al::createActorFunction<DoorSnow>},
     {"DoorWarp", nullptr},
     {"DoorWarpStageChange", nullptr},
     {"EchoBlockMapParts", nullptr},

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -23,5 +23,6 @@ void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
+void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
 }  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1034)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9bd349a - 839826c)

📈 **Matched code**: 14.52% (+0.01%, +964 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/DoorSnow` | `DoorSnow::exeOpen()` | +292 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::reset(unsigned int)` | +176 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::DoorSnow(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::DoorSnow(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::init(al::ActorInitInfo const&)` | +100 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<DoorSnow>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::startDemo(unsigned int)` | +48 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::isDemoEnd() const` | +12 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `(anonymous namespace)::DoorSnowNrvOpen::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `DoorSnow::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/DoorSnow` | `(anonymous namespace)::DoorSnowNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->