### PR TITLE
MapObj: Implement `PoleClimbParts`

### DIFF
--- a/src/MapObj/PoleClimbParts.cpp
+++ b/src/MapObj/PoleClimbParts.cpp
@@ -1,0 +1,114 @@
+#include "MapObj/PoleClimbParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/PlayerUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(PoleClimbParts, Wait);
+NERVE_IMPL(PoleClimbParts, Break);
+NERVE_IMPL(PoleClimbParts, Reaction);
+
+NERVES_MAKE_STRUCT(PoleClimbParts, Wait, Break, Reaction);
+}  // namespace
+
+PoleClimbParts::PoleClimbParts(const char* name) : al::LiveActor(name) {}
+
+void PoleClimbParts::init(const al::ActorInitInfo& info) {
+    const char* suffix = nullptr;
+    al::tryGetStringArg(&suffix, info, "Suffix");
+    al::initMapPartsActor(this, info, suffix);
+
+    if (!al::isExistAction(this, "Reaction")) {
+        makeActorDead();
+        return;
+    }
+
+    mIsBreak = al::isClassName(info, "PoleClimbPartsBreak");
+    al::initNerve(this, &NrvPoleClimbParts.Wait, 0);
+
+    if (mIsBreak) {
+        if (!al::isExistAction(this, "Break"))
+            makeActorDead();
+
+        mBreakJudgeFunction = rs::getBreakJudgeFunction("標準攻撃");
+    }
+
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+bool PoleClimbParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isNerve(this, &NrvPoleClimbParts.Break))
+        return false;
+
+    if (rs::isMsgPlayerPoleClimbReaction(message)) {
+        if (al::isNerve(this, &NrvPoleClimbParts.Wait))
+            al::setNerve(this, &NrvPoleClimbParts.Reaction);
+        return true;
+    }
+
+    if (mIsBreak && mBreakJudgeFunction(message, other, self)) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        rs::sendMsgBreakFloorToPlayer(this);
+        al::invalidateCollisionParts(this);
+        al::setNerve(this, &NrvPoleClimbParts.Break);
+        return true;
+    }
+
+    return false;
+}
+
+void PoleClimbParts::movement() {
+    if (al::isNerve(this, &NrvPoleClimbParts.Wait))
+        return;
+
+    al::LiveActor::movement();
+}
+
+void PoleClimbParts::calcAnim() {
+    if (al::isNerve(this, &NrvPoleClimbParts.Wait))
+        return;
+
+    al::LiveActor::calcAnim();
+}
+
+void PoleClimbParts::exeWait() {}
+
+void PoleClimbParts::exeBreak() {
+    if (al::isFirstStep(this)) {
+        al::LiveActor* brokenModel = al::tryGetSubActor(this, "壊れモデル");
+        if (brokenModel)
+            brokenModel->appear();
+
+        al::LiveActor* remainsModel = al::tryGetSubActor(this, "残留モデル");
+        if (remainsModel)
+            remainsModel->appear();
+
+        if (al::isExistAction(this, "Break")) {
+            al::startAction(this, "Break");
+            return;
+        }
+    }
+
+    kill();
+}
+
+void PoleClimbParts::exeReaction() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Reaction");
+        return;
+    }
+
+    if (al::isIntervalStep(this, al::getActionFrameMax(this, "Reaction"), 0)) {
+        al::stopAction(this);
+        al::setNerve(this, &NrvPoleClimbParts.Wait);
+    }
+}

--- a/src/MapObj/PoleClimbParts.h
+++ b/src/MapObj/PoleClimbParts.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/MapObj/BreakMapPartsBase.h"
+
+#include "Util/BreakJudgeUtil.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class PoleClimbParts : public al::LiveActor {
+public:
+    PoleClimbParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void movement() override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeBreak();
+    void exeReaction();
+
+private:
+    bool mIsBreak = false;
+    al::JudgeFuncPtr mBreakJudgeFunction = nullptr;
+};
+
+static_assert(sizeof(PoleClimbParts) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -104,6 +104,7 @@
 #include "MapObj/MoviePlayerMapParts.h"
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PlayerMotionObserver.h"
+#include "MapObj/PoleClimbParts.h"
 #include "MapObj/PoleGrabCeil.h"
 #include "MapObj/QuestObj.h"
 #include "MapObj/ReactionMapParts.h"
@@ -484,7 +485,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"PlayerStartObjNoLink", nullptr},
     {"PochiHintPhoto", nullptr},
     {"Poetter", nullptr},
-    {"PoleClimbParts", nullptr},
+    {"PoleClimbParts", al::createActorFunction<PoleClimbParts>},
     {"PoleClimbPartsBreak", nullptr},
     {"PoleGrabCeil", al::createActorFunction<PoleGrabCeil>},
     {"PoleGrabCeilKeyMoveParts", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1035)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - e9b6fde)

📈 **Matched code**: 14.67% (+0.01%, +1292 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PoleClimbParts` | `PoleClimbParts::init(al::ActorInitInfo const&)` | +228 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +208 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::exeBreak()` | +156 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::PoleClimbParts(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::PoleClimbParts(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `(anonymous namespace)::PoleClimbPartsNrvReaction::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::exeReaction()` | +120 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::movement()` | +60 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::calcAnim()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<PoleClimbParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `(anonymous namespace)::PoleClimbPartsNrvBreak::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `PoleClimbParts::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/PoleClimbParts` | `(anonymous namespace)::PoleClimbPartsNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->