### PR TITLE
MapObj: Implement `MoviePlayerMapParts`

### DIFF
--- a/src/Library/Shader/ForwardRendering/ShaderSamplerSetter.h
+++ b/src/Library/Shader/ForwardRendering/ShaderSamplerSetter.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace agl {
+class TextureData;
+}  // namespace agl
+
+namespace al {
+const agl::TextureData* getWhite2DTexture();
+}  // namespace al

--- a/src/Library/Texture/TextureUtil.h
+++ b/src/Library/Texture/TextureUtil.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace agl {
+class TextureData;
+}  // namespace agl
+
+namespace al {
+class LiveActor;
+
+class TextureReplacer {
+public:
+    TextureReplacer();
+    TextureReplacer(const agl::TextureData* textureData);
+
+    void setup(const agl::TextureData* textureData);
+    void replace(LiveActor* actor, const char* sourceTextureName, const char* replaceTextureName);
+    void update();
+
+private:
+    u8 _0[0x20];
+};
+
+static_assert(sizeof(TextureReplacer) == 0x20);
+
+}  // namespace al

--- a/src/MapObj/MoviePlayerMapParts.cpp
+++ b/src/MapObj/MoviePlayerMapParts.cpp
@@ -1,0 +1,100 @@
+#include "MapObj/MoviePlayerMapParts.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Library/Shader/ForwardRendering/ShaderSamplerSetter.h"
+#include "Library/Texture/TextureUtil.h"
+#include "Util/MoviePlayer.h"
+
+MoviePlayerMapParts::MoviePlayerMapParts(const char* name) : al::LiveActor(name) {}
+
+void MoviePlayerMapParts::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+    mMoviePlayer = al::createSceneObj<MoviePlayer>(this);
+    mMovieTextureReplacer = new al::TextureReplacer(mMoviePlayer->getTexture());
+    mWhiteTextureReplacer = new al::TextureReplacer(al::getWhite2DTexture());
+    mWhiteTextureReplacer->replace(this, "Snow_Cake-Snow_Cake.png", "Snow_Cake");
+
+    mMoviePath.format("content:/MovieData/SnowWithShip.mp4");
+    mSwitchMoviePath.format("content:/MovieData/SnowWithShip.mp4");
+
+    const char* movieName = nullptr;
+    if (al::tryGetStringArg(&movieName, info, "MovieName"))
+        mMoviePath.format("content:/MovieData/%s.mp4", movieName);
+
+    const char* switchMovieName = nullptr;
+    if (al::tryGetStringArg(&switchMovieName, info, "SwitchMovieName"))
+        mSwitchMoviePath.format("content:/MovieData/%s.mp4", switchMovieName);
+
+    al::registActorToDemoInfo(this, info);
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+bool MoviePlayerMapParts::tryPlayMovie() {
+    if (mMoviePlayer->isPlay() && !mMoviePlayer->isLooped())
+        return false;
+
+    const char* moviePath = nullptr;
+    if (al::isValidStageSwitch(this, "SwitchMovieChange") &&
+        al::isOnStageSwitch(this, "SwitchMovieChange")) {
+        moviePath = mSwitchMoviePath.cstr();
+    } else {
+        moviePath = mMoviePath.cstr();
+    }
+
+    if (mCurrentMoviePath == moviePath)
+        return false;
+
+    mIsNeedTextureUpdate = true;
+    mCurrentMoviePath = moviePath;
+    mMoviePlayer->play(moviePath);
+    mWhiteTextureReplacer->replace(this, "Snow_Cake-Snow_Cake.png", "Snow_Cake");
+    mWhiteTextureReplacer->update();
+    al::recreateModelDisplayList(this);
+    return true;
+}
+
+void MoviePlayerMapParts::appear() {
+    mCurrentMoviePath = nullptr;
+    tryPlayMovie();
+    al::LiveActor::appear();
+}
+
+void MoviePlayerMapParts::kill() {
+    mIsNeedTextureUpdate = false;
+    mMoviePlayer->stop();
+    al::LiveActor::kill();
+}
+
+void MoviePlayerMapParts::startClipped() {
+    mIsNeedTextureUpdate = false;
+    mMoviePlayer->stop();
+    al::LiveActor::startClipped();
+}
+
+void MoviePlayerMapParts::endClipped() {
+    mCurrentMoviePath = nullptr;
+    tryPlayMovie();
+    al::LiveActor::endClipped();
+}
+
+void MoviePlayerMapParts::control() {
+    tryPlayMovie();
+    mMoviePlayer->update();
+
+    if (!mMoviePlayer->isDecode())
+        return;
+
+    if (mIsNeedTextureUpdate) {
+        mMovieTextureReplacer->replace(this, "Snow_Cake-Snow_Cake.png", "Snow_Cake");
+        al::recreateModelDisplayList(this);
+        mIsNeedTextureUpdate = false;
+    }
+
+    mMovieTextureReplacer->update();
+}

--- a/src/MapObj/MoviePlayerMapParts.h
+++ b/src/MapObj/MoviePlayerMapParts.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class TextureReplacer;
+}  // namespace al
+
+class MoviePlayer;
+
+class MoviePlayerMapParts : public al::LiveActor {
+public:
+    MoviePlayerMapParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+    void startClipped() override;
+    void endClipped() override;
+    void control() override;
+
+    bool tryPlayMovie();
+
+private:
+    MoviePlayer* mMoviePlayer = nullptr;
+    al::TextureReplacer* mMovieTextureReplacer = nullptr;
+    al::TextureReplacer* mWhiteTextureReplacer = nullptr;
+    sead::FixedSafeString<128> mMoviePath;
+    sead::FixedSafeString<128> mSwitchMoviePath;
+    const char* mCurrentMoviePath = nullptr;
+    bool mIsNeedTextureUpdate = false;
+};
+
+static_assert(sizeof(MoviePlayerMapParts) == 0x260);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -96,6 +96,7 @@
 #include "MapObj/MoonBasementFloor.h"
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
+#include "MapObj/MoviePlayerMapParts.h"
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PoleGrabCeil.h"
 #include "MapObj/ReactionMapParts.h"
@@ -436,7 +437,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"Motorcycle", nullptr},
     {"MotorcycleParkingLot", nullptr},
     {"MoveHomeNpc", nullptr},
-    {"MoviePlayerMapParts", nullptr},
+    {"MoviePlayerMapParts", al::createActorFunction<MoviePlayerMapParts>},
     {"MultiGateKeeperBonfire", nullptr},
     {"MultiGateKeeperWatcher", nullptr},
     {"Mummy", al::createActorFunction<Mummy>},

--- a/src/Util/MoviePlayer.h
+++ b/src/Util/MoviePlayer.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <heap/seadDisposer.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace agl {
+class DrawContext;
+class TextureData;
+
+template <typename T>
+class GPUMemBlock;
+
+}  // namespace agl
+
+class MovieDecoderPlayer;
+
+class MoviePlayer : public al::ISceneObj, public sead::IDisposer {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_MoviePlayer;
+
+    MoviePlayer();
+
+    void update();
+    void draw(agl::DrawContext* drawContext) const;
+    const agl::TextureData* getTexture() const;
+    void play(const char* moviePath);
+    void stop();
+    bool isPlay() const;
+    bool isDecode() const;
+    bool isLooped() const;
+
+private:
+    MovieDecoderPlayer* mDecoderPlayer = nullptr;
+    agl::TextureData* mTextureData = nullptr;
+    agl::GPUMemBlock<u8>* mGpuMemBlock = nullptr;
+    bool mIsDecode = false;
+    s32 mFrame = 0;
+};
+
+static_assert(sizeof(MoviePlayer) == 0x48);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1036)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4706601 - 191b02b)

📈 **Matched code**: 14.56% (+0.01%, +1428 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::init(al::ActorInitInfo const&)` | +336 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::MoviePlayerMapParts(char const*)` | +268 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::MoviePlayerMapParts(char const*)` | +256 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::tryPlayMovie()` | +232 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::control()` | +116 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<MoviePlayerMapParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::kill()` | +44 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::startClipped()` | +44 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::appear()` | +40 | 0.00% | 100.00% |
| `MapObj/MoviePlayerMapParts` | `MoviePlayerMapParts::endClipped()` | +40 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->