### PR TITLE
MapObj: Implement `CameraSub`

### DIFF
--- a/lib/al/Library/Draw/GraphicsSystemInfo.h
+++ b/lib/al/Library/Draw/GraphicsSystemInfo.h
@@ -207,6 +207,8 @@ public:
 
     RadialBlurDirector* getRadialBlurDirector() const { return mRadialBlurDirector; }
 
+    SubCameraRenderer* getSubCameraRenderer() const { return mSubCameraRenderer; }
+
 private:
     sead::StrTreeMap<128, const sead::PtrArray<UniformBlock>*> mViewIndexedUboArrayTree;
     GraphicsInitArg mInitArg;

--- a/lib/al/Library/Draw/SubCameraRenderer.h
+++ b/lib/al/Library/Draw/SubCameraRenderer.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
 #include <math/seadVector.h>
 
 #include "Library/Nerve/NerveExecutor.h"
@@ -8,12 +10,28 @@ namespace agl {
 class DrawContext;
 class RenderTargetDepth;
 class TextureData;
+
+namespace pfx {
+class ColorCorrection;
+}
 }  // namespace agl
 
 namespace al {
+class AreaObj;
 class ExecuteDirector;
 class GraphicsSystemInfo;
 class SceneCameraInfo;
+
+struct CameraSubAreaScreenInfo {
+    CameraSubAreaScreenInfo(const sead::Vector3f& scale, const sead::Matrix34f& mtx, AreaObj* obj)
+        : screenScale(scale), screenMatrix(mtx), areaObj(obj) {}
+
+    sead::Vector3f screenScale;
+    sead::Matrix34f screenMatrix;
+    AreaObj* areaObj;
+};
+
+static_assert(sizeof(CameraSubAreaScreenInfo) == 0x48);
 
 class SubCameraRenderer : public NerveExecutor {
 public:
@@ -30,11 +48,23 @@ public:
     void exeCapture();
     void exeCaptureFinish();
     bool isCaptureFinish() const;
-    void* findCameraSubAreaScreenInfo(const sead::Vector3f&) const;  // TODO unknown return type
+    CameraSubAreaScreenInfo* findCameraSubAreaScreenInfo(const sead::Vector3f&) const;
     void calcOnScreenPos(sead::Vector3f*, const sead::Vector3f&) const;
 
+    void addCameraSub() { mNumCameraSub++; }
+
+    void addCameraSubAreaScreenInfo(CameraSubAreaScreenInfo* screenInfo) {
+        mCameraSubAreaScreenInfos.pushBack(screenInfo);
+    }
+
 private:
-    void* _10[0x4a];
+    char _10[0x220];
+    SceneCameraInfo* mSceneCameraInfo;
+    s32 mNumCameraSub;
+    s32 _23c;
+    GraphicsSystemInfo* mGraphicsSystemInfo;
+    agl::pfx::ColorCorrection* mColorCorrection;
+    sead::PtrArray<CameraSubAreaScreenInfo> mCameraSubAreaScreenInfos;
 };
 
 static_assert(sizeof(SubCameraRenderer) == 0x260);

--- a/src/MapObj/CameraSub.cpp
+++ b/src/MapObj/CameraSub.cpp
@@ -1,0 +1,98 @@
+#include "MapObj/CameraSub.h"
+
+#include "Library/Area/AreaInitInfo.h"
+#include "Library/Area/AreaObj.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Draw/GraphicsSystemInfo.h"
+#include "Library/Draw/SubCameraRenderer.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(CameraSub, Wait);
+NERVE_IMPL(CameraSub, Active);
+
+NERVES_MAKE_NOSTRUCT(CameraSub, Wait, Active);
+}  // namespace
+
+CameraSub::CameraSub(const char* name) : al::LiveActor(name) {}
+
+void CameraSub::init(const al::ActorInitInfo& info) {
+    using CameraSubFunctor = al::FunctorV0M<CameraSub*, void (CameraSub::*)()>;
+
+    al::initActorSceneInfo(this, info);
+    al::initActorPoseTRSV(this);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");
+    al::initStageSwitch(this, info);
+
+    mCameraTicket = al::initObjectCamera(this, info, nullptr, nullptr);
+    mSubCameraRenderer = info.actorSceneInfo.graphicsSystemInfo->getSubCameraRenderer();
+    mSubCameraRenderer->addCameraSub();
+
+    al::initNerve(this, &Wait, 0);
+
+    mAreaObj = new al::AreaObj("カメラエリア[DRC]");
+
+    al::AreaInitInfo areaInitInfo(*info.placementInfo, info.stageSwitchDirector,
+                                  info.actorSceneInfo.sceneObjHolder);
+    mAreaObj->init(areaInitInfo);
+
+    al::invalidateClipping(this);
+
+    al::PlacementInfo screenInfo;
+    if (al::tryGetLinksInfo(&screenInfo, info, "Screen")) {
+        mHasScreenInfo = true;
+        al::tryGetMatrixTR(&mScreenMatrix, screenInfo);
+        al::tryGetScale(&mScreenScale, screenInfo);
+    }
+
+    makeActorAlive();
+
+    if (al::listenStageSwitchOnAppear(this, CameraSubFunctor(this, &CameraSub::onAppear)))
+        makeActorDead();
+}
+
+void CameraSub::onAppear() {
+    al::LiveActor::appear();
+}
+
+void CameraSub::initAfterPlacement() {
+    if (mHasScreenInfo) {
+        al::CameraSubAreaScreenInfo* screenInfo =
+            new al::CameraSubAreaScreenInfo(mScreenScale, mScreenMatrix, mAreaObj);
+        mSubCameraRenderer->addCameraSubAreaScreenInfo(screenInfo);
+    }
+}
+
+void CameraSub::exeWait() {
+    if (al::isActiveCamera(mCameraTicket))
+        return;
+
+    const sead::Vector3f& playerPos = rs::getPlayerPos(this);
+    if (mAreaObj->isInVolume(playerPos)) {
+        al::startCameraSub(this, mCameraTicket, -1);
+        al::setNerve(this, &Active);
+    }
+}
+
+void CameraSub::exeActive() {
+    if (!al::isActiveCamera(mCameraTicket))
+        return;
+
+    const sead::Vector3f& playerPos = rs::getPlayerPos(this);
+    if (!mAreaObj->isInVolume(playerPos)) {
+        al::endCameraSub(this, mCameraTicket, -1);
+        al::setNerve(this, &Wait);
+    }
+}

--- a/src/MapObj/CameraSub.h
+++ b/src/MapObj/CameraSub.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class AreaObj;
+class CameraTicket;
+class SubCameraRenderer;
+}  // namespace al
+
+class CameraSub : public al::LiveActor {
+public:
+    CameraSub(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void onAppear();
+    void initAfterPlacement() override;
+    void exeWait();
+    void exeActive();
+
+private:
+    al::CameraTicket* mCameraTicket = nullptr;
+    al::AreaObj* mAreaObj = nullptr;
+    al::SubCameraRenderer* mSubCameraRenderer = nullptr;
+    sead::Vector3f mScreenScale = sead::Vector3f::zero;
+    sead::Matrix34f mScreenMatrix = sead::Matrix34f::ident;
+    bool mHasScreenInfo = false;
+};
+
+static_assert(sizeof(CameraSub) == 0x160);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -73,6 +73,7 @@
 #include "MapObj/BlockQuestion2D.h"
 #include "MapObj/BossKnuckleFix.h"
 #include "MapObj/BreakablePole.h"
+#include "MapObj/CameraSub.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -204,7 +205,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"CameraDemoGateMapParts", nullptr},
     {"CameraDemoKeyMoveMapParts", nullptr},
     {"CameraRailHolder", al::createActorFunction<al::CameraRailHolder>},
-    {"CameraSub", nullptr},
+    {"CameraSub", al::createActorFunction<CameraSub>},
     {"CameraWatchPoint", al::createActorFunction<al::CameraWatchPoint>},
     {"Candlestand", nullptr},
     {"CandlestandFire", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1038)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - fc3c8d8)

📈 **Matched code**: 14.67% (+0.01%, +1524 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CameraSub` | `CameraSub::init(al::ActorInitInfo const&)` | +408 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::CameraSub(char const*)` | +188 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::CameraSub(char const*)` | +176 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::initAfterPlacement()` | +140 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::exeWait()` | +112 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::exeActive()` | +112 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `(anonymous namespace)::CameraSubNrvWait::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `(anonymous namespace)::CameraSubNrvActive::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `al::FunctorV0M<CameraSub*, void (CameraSub::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<CameraSub>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `al::FunctorV0M<CameraSub*, void (CameraSub::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `CameraSub::onAppear()` | +4 | 0.00% | 100.00% |
| `MapObj/CameraSub` | `al::FunctorV0M<CameraSub*, void (CameraSub::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->