### PR TITLE
MapObj: Implement `FukankunZoomObj`

### DIFF
--- a/src/MapObj/FukankunZoomObj.cpp
+++ b/src/MapObj/FukankunZoomObj.cpp
@@ -1,0 +1,78 @@
+#include "MapObj/FukankunZoomObj.h"
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Rail/RailUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+NERVE_IMPL(FukankunZoomObj, Wait);
+
+NERVES_MAKE_STRUCT(FukankunZoomObj, Wait);
+}  // namespace
+
+FukankunZoomObj::FukankunZoomObj(const char* name) : al::LiveActor(name) {}
+
+void FukankunZoomObj::init(const al::ActorInitInfo& info) {
+    using FukankunZoomObjFunctor = al::FunctorV0M<FukankunZoomObj*, void (FukankunZoomObj::*)()>;
+
+    al::initActorSceneInfo(this, info);
+    al::initActorPoseTRSV(this);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::initExecutorUpdate(this, info, "地形オブジェ[Movement]");
+    al::initStageSwitch(this, info);
+    al::initNerve(this, &NrvFukankunZoomObj.Wait, 0);
+    al::initGroupClipping(this, info);
+
+    if (al::isExistRail(info, "Rail")) {
+        initRailKeeper(info, "Rail");
+        al::setSyncRailToNearestPos(this);
+    }
+
+    al::tryGetArg(&mRailMoveSpeed, info, "RailMoveSpeed");
+    al::tryGetArg((s32*)&mMoveType, info, "MoveType");
+
+    makeActorAlive();
+    if (al::listenStageSwitchOnAppear(this,
+                                      FukankunZoomObjFunctor(this, &FukankunZoomObj::onAppear)))
+        makeActorDead();
+
+    al::listenStageSwitchOnKill(this, FukankunZoomObjFunctor(this, &FukankunZoomObj::onKill));
+}
+
+void FukankunZoomObj::onAppear() {
+    al::LiveActor::appear();
+}
+
+void FukankunZoomObj::onKill() {
+    al::LiveActor::kill();
+}
+
+void FukankunZoomObj::attackSensor(al::HitSensor* self, al::HitSensor* other) {}
+
+bool FukankunZoomObj::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    return false;
+}
+
+void FukankunZoomObj::exeWait() {
+    if (!al::isExistRail(this))
+        return;
+
+    if (mMoveType == al::MoveType::Loop) {
+        al::moveSyncRailLoop(this, mRailMoveSpeed);
+        return;
+    }
+
+    if (mMoveType == al::MoveType::Turn) {
+        al::moveSyncRailTurn(this, mRailMoveSpeed);
+        return;
+    }
+
+    al::moveSyncRail(this, mRailMoveSpeed);
+}

--- a/src/MapObj/FukankunZoomObj.h
+++ b/src/MapObj/FukankunZoomObj.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Movement/MoveType.h"
+
+class FukankunZoomObj : public al::LiveActor {
+public:
+    FukankunZoomObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void onAppear();
+    void onKill();
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void exeWait();
+
+private:
+    f32 mRailMoveSpeed = 20.0f;
+    al::MoveType mMoveType = al::MoveType::Loop;
+};
+
+static_assert(sizeof(FukankunZoomObj) == 0x110);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1039)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3f414ea - 20afb74)

📈 **Matched code**: 14.50% (+0.01%, +964 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::init(al::ActorInitInfo const&)` | +352 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::FukankunZoomObj(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::FukankunZoomObj(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::exeWait()` | +108 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `(anonymous namespace)::FukankunZoomObjNrvWait::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `al::FunctorV0M<FukankunZoomObj*, void (FukankunZoomObj::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `al::FunctorV0M<FukankunZoomObj*, void (FukankunZoomObj::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::onAppear()` | +4 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::onKill()` | +4 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `FukankunZoomObj::attackSensor(al::HitSensor*, al::HitSensor*)` | +4 | 0.00% | 100.00% |
| `MapObj/FukankunZoomObj` | `al::FunctorV0M<FukankunZoomObj*, void (FukankunZoomObj::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->