### PR TITLE
Boss/Koopa: Implement `KoopaHackStopCtrl`

### DIFF
--- a/src/Boss/Koopa/KoopaHackStopCtrl.cpp
+++ b/src/Boss/Koopa/KoopaHackStopCtrl.cpp
@@ -1,0 +1,66 @@
+#include "Boss/Koopa/KoopaHackStopCtrl.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+KoopaHackStopCtrl::KoopaHackStopCtrl() = default;
+
+void KoopaHackStopCtrl::startStop(const al::LiveActor* actor) {
+    mStopActor = actor;
+}
+
+void KoopaHackStopCtrl::endStop(const al::LiveActor* actor) {
+    mStopActor = nullptr;
+}
+
+void KoopaHackStopCtrl::resetPosture(const al::LiveActor* actor, const sead::Quatf& quat,
+                                     const sead::Vector3f& trans) {
+    mIsNeedResetPosture = true;
+    mResetQuat.set(quat);
+    mResetTrans.set(trans);
+}
+
+bool KoopaHackStopCtrl::tryResetPosture(al::LiveActor* actor) {
+    if (!mIsNeedResetPosture)
+        return false;
+
+    mIsNeedResetPosture = false;
+    al::resetQuatPosition(actor, mResetQuat, mResetTrans);
+    return true;
+}
+
+namespace KoopaHackFunction {
+
+void startStopKoopaHack(al::LiveActor* actor) {
+    al::getSceneObj<KoopaHackStopCtrl>(actor)->startStop(actor);
+}
+
+void endStopKoopaHack(al::LiveActor* actor) {
+    al::getSceneObj<KoopaHackStopCtrl>(actor)->endStop(actor);
+}
+
+void resetPostureKoopaHack(al::LiveActor* actor, const sead::Quatf& quat,
+                           const sead::Vector3f& trans) {
+    al::getSceneObj<KoopaHackStopCtrl>(actor)->resetPosture(actor, quat, trans);
+}
+
+bool isStopKoopaHack(const al::LiveActor* actor) {
+    return al::isExistSceneObj<KoopaHackStopCtrl>(actor) &&
+           al::getSceneObj<KoopaHackStopCtrl>(actor)->isStop();
+}
+
+bool isStatusDemoForSceneKoopaHack(const al::LiveActor* actor) {
+    return al::isExistSceneObj<KoopaHackStopCtrl>(actor) &&
+           al::getSceneObj<KoopaHackStopCtrl>(actor)->isStatusDemoForSceneKoopaHack();
+}
+
+void setStatusDemoForSceneKoopaHack(const al::LiveActor* actor) {
+    al::getSceneObj<KoopaHackStopCtrl>(actor)->setStatusDemoForSceneKoopaHack(true);
+}
+
+void resetStatusDemoForSceneKoopaHack(const al::LiveActor* actor) {
+    al::getSceneObj<KoopaHackStopCtrl>(actor)->setStatusDemoForSceneKoopaHack(false);
+}
+
+}  // namespace KoopaHackFunction

--- a/src/Boss/Koopa/KoopaHackStopCtrl.h
+++ b/src/Boss/Koopa/KoopaHackStopCtrl.h
@@ -14,11 +14,9 @@ class LiveActor;
 
 class KoopaHackStopCtrl : public al::ISceneObj {
 public:
-    static constexpr s32 sSceneObjId = SceneObjID_KoopaStopHackCtrl;
+    static constexpr s32 sSceneObjId = SceneObjID_KoopaHackStopCtrl;
 
     KoopaHackStopCtrl();
-
-    const char* getSceneObjName() const override { return "崩落クッパの停止制御"; }
 
     void startStop(const al::LiveActor* actor);
     void endStop(const al::LiveActor* actor);
@@ -26,15 +24,23 @@ public:
                       const sead::Vector3f& trans);
     bool tryResetPosture(al::LiveActor* actor);
 
+    const char* getSceneObjName() const override { return "崩落クッパの停止制御"; }
+
+    bool isStop() const { return mStopActor != nullptr; }
+
+    bool isStatusDemoForSceneKoopaHack() const { return mIsStatusDemoForSceneKoopaHack; }
+
+    void setStatusDemoForSceneKoopaHack(bool status) { mIsStatusDemoForSceneKoopaHack = status; }
+
 private:
     const al::LiveActor* mStopActor = nullptr;
     bool mIsNeedResetPosture = false;
     sead::Quatf mResetQuat = sead::Quatf::unit;
-    sead::Vector3f mResetTrans = sead::Vector3f::zero;
+    sead::Vector3f mResetTrans = {0.0f, 0.0f, 0.0f};
     bool mIsStatusDemoForSceneKoopaHack = false;
 };
 
-static_assert(sizeof(KoopaHackStopCtrl) == 0x38, "KoopaHackStopCtrl");
+static_assert(sizeof(KoopaHackStopCtrl) == 0x38);
 
 namespace KoopaHackFunction {
 void startStopKoopaHack(al::LiveActor* actor);

--- a/src/Scene/SceneObjFactory.h
+++ b/src/Scene/SceneObjFactory.h
@@ -37,7 +37,7 @@ enum SceneObjID : s32 {
     SceneObjID_InformationWindowDirector,
     SceneObjID__1c,
     SceneObjID_KidsModeLayoutAccessor,
-    SceneObjID_KoopaStopHackCtrl,
+    SceneObjID_KoopaHackStopCtrl,
     SceneObjID_KoopaShipDemoRequester,
     SceneObjID_alLayoutTextureRenderer,
     SceneObjID_LifeUpItemGenerateWatcher,


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1040)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4706601 - d49a564)

📈 **Matched code**: 14.55% (+0.01%, +628 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::resetPostureKoopaHack(al::LiveActor*, sead::Quat<float> const&, sead::Vector3<float> const&)` | +92 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::isStopKoopaHack(al::LiveActor const*)` | +84 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::isStatusDemoForSceneKoopaHack(al::LiveActor const*)` | +84 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::tryResetPosture(al::LiveActor*)` | +60 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::KoopaHackStopCtrl()` | +56 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::startStopKoopaHack(al::LiveActor*)` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::resetPosture(al::LiveActor const*, sead::Quat<float> const&, sead::Vector3<float> const&)` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::setStatusDemoForSceneKoopaHack(al::LiveActor const*)` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::endStopKoopaHack(al::LiveActor*)` | +40 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackFunction::resetStatusDemoForSceneKoopaHack(al::LiveActor const*)` | +40 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::startStop(al::LiveActor const*)` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::endStop(al::LiveActor const*)` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHackStopCtrl` | `KoopaHackStopCtrl::~KoopaHackStopCtrl()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->