### PR TITLE
MapObj: Implement `StatueSnapMark`

### DIFF
--- a/src/MapObj/StatueSnapMark.cpp
+++ b/src/MapObj/StatueSnapMark.cpp
@@ -1,0 +1,58 @@
+#include "MapObj/StatueSnapMark.h"
+
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Enemy/DisregardReceiver.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(StatueSnapMark, Wait);
+NERVE_IMPL(StatueSnapMark, AppearShine);
+NERVE_IMPL(StatueSnapMark, Done);
+
+NERVES_MAKE_NOSTRUCT(StatueSnapMark, Wait, AppearShine, Done);
+}  // namespace
+
+StatueSnapMark::StatueSnapMark(const char* name) : al::LiveActor(name) {}
+
+void StatueSnapMark::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &Wait, 0);
+    mShineActor = rs::initLinkShine(info, "ShineActor", 0);
+    mDisregardReceiver = new DisregardReceiver(this, nullptr);
+    makeActorAlive();
+}
+
+bool StatueSnapMark::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (mDisregardReceiver->receiveMsg(message, other, self))
+        return true;
+
+    if (rs::isMsgStatueSnap(message) && al::isNerve(this, &Wait)) {
+        mSnapTarget = al::getSensorHost(other);
+        al::setNerve(this, &AppearShine);
+        return true;
+    }
+    return false;
+}
+
+void StatueSnapMark::exeWait() {}
+
+void StatueSnapMark::exeAppearShine() {
+    if (al::isFirstStep(this))
+        rs::appearPopupShine(mShineActor);
+
+    if (rs::isEndAppearShine(mShineActor))
+        al::setNerve(this, &Done);
+}
+
+void StatueSnapMark::exeDone() {
+    if (al::isFirstStep(this) && mSnapTarget) {
+        al::HitSensor* self = al::getHitSensor(this, nullptr);
+        rs::sendMsgCancelHack(al::getHitSensor(mSnapTarget, "Body"), self);
+    }
+}

--- a/src/MapObj/StatueSnapMark.h
+++ b/src/MapObj/StatueSnapMark.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class DisregardReceiver;
+class Shine;
+
+class StatueSnapMark : public al::LiveActor {
+public:
+    StatueSnapMark(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeAppearShine();
+    void exeDone();
+
+private:
+    Shine* mShineActor = nullptr;
+    al::LiveActor* mSnapTarget = nullptr;
+    DisregardReceiver* mDisregardReceiver = nullptr;
+};
+
+static_assert(sizeof(StatueSnapMark) == 0x120);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -117,6 +117,7 @@
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
+#include "MapObj/StatueSnapMark.h"
 #include "MapObj/TalkPoint.h"
 #include "MapObj/TrampleBush.h"
 #include "MapObj/TrampleSwitch.h"
@@ -590,7 +591,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"StageTalkDemoNpcCapMoonRock", nullptr},
     {"Stake", nullptr},
     {"Statue", nullptr},
-    {"StatueSnapMark", nullptr},
+    {"StatueSnapMark", al::createActorFunction<StatueSnapMark>},
     {"SubActorLodFixPartsScenarioAction", nullptr},
     {"SwitchAnd", nullptr},
     {"SwitchKeyMoveMapParts", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1042)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - 9b48ece)

📈 **Matched code**: 14.66% (+0.01%, +928 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/StatueSnapMark` | `StatueSnapMark::StatueSnapMark(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::StatueSnapMark(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +128 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::init(al::ActorInitInfo const&)` | +120 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `(anonymous namespace)::StatueSnapMarkNrvDone::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::exeDone()` | +92 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `(anonymous namespace)::StatueSnapMarkNrvAppearShine::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::exeAppearShine()` | +80 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<StatueSnapMark>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `StatueSnapMark::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/StatueSnapMark` | `(anonymous namespace)::StatueSnapMarkNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->