### PR TITLE
MapObj: Implement `ShopMark`

### DIFF
--- a/src/Layout/BalloonIcon.h
+++ b/src/Layout/BalloonIcon.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class BalloonIcon : public al::LayoutActor {
+public:
+    BalloonIcon(const char*, const al::LayoutInitInfo&, const sead::Matrix34f*,
+                const sead::Vector3f&, const char*, bool, bool, bool);
+
+    void onSnapShotMode();
+    void offSnapShotMode();
+    void startUpdateDraw();
+    void hideAndStopUpdate();
+    void exeSleep();
+    void exeHide();
+    bool updateTransAndCheckShow();
+    void exeShowAppear();
+    void exeShowWait();
+    void exeShowEnd();
+    void exeEnd();
+
+private:
+    u8 _130[0x40];
+};
+
+static_assert(sizeof(BalloonIcon) == 0x170);
+
+namespace rs {
+BalloonIcon* createShopBalloon(const al::LayoutInitInfo&, const sead::Matrix34f*,
+                               const sead::Vector3f&);
+void setMainScenarioText(BalloonIcon*, const char16*);
+}  // namespace rs

--- a/src/MapObj/ShopMark.cpp
+++ b/src/MapObj/ShopMark.cpp
@@ -1,0 +1,53 @@
+#include "MapObj/ShopMark.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Matrix/MatrixUtil.h"
+
+#include "Layout/BalloonIcon.h"
+#include "Util/DemoUtil.h"
+
+ShopMark::ShopMark(const char* name) : al::LiveActor(name) {}
+
+void ShopMark::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "ShopMark", nullptr);
+    mBalloonIcon =
+        rs::createShopBalloon(al::getLayoutInitInfo(info), &mBalloonMtx, sead::Vector3f::zero);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    rs::addDemoActor(this, false);
+    makeActorAlive();
+}
+
+void ShopMark::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+
+    mBalloonIcon->startUpdateDraw();
+}
+
+void ShopMark::startClipped() {
+    al::LiveActor::startClipped();
+    mBalloonIcon->hideAndStopUpdate();
+}
+
+void ShopMark::endClipped() {
+    al::LiveActor::endClipped();
+    mBalloonIcon->startUpdateDraw();
+}
+
+void ShopMark::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+
+    al::makeMtxQuatPos(&mBalloonMtx, al::getQuat(this), al::getTrans(this));
+}
+
+bool ShopMark::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    return false;
+}

--- a/src/MapObj/ShopMark.h
+++ b/src/MapObj/ShopMark.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class BalloonIcon;
+
+class ShopMark : public al::LiveActor {
+public:
+    ShopMark(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void startClipped() override;
+    void endClipped() override;
+    void control() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+private:
+    BalloonIcon* mBalloonIcon = nullptr;
+    al::MtxConnector* mMtxConnector = nullptr;
+    sead::Matrix34f mBalloonMtx = sead::Matrix34f::ident;
+};
+
+static_assert(sizeof(ShopMark) == 0x148);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -101,6 +101,7 @@
 #include "MapObj/RouletteSwitch.h"
 #include "MapObj/SaveFlagCheckObj.h"
 #include "MapObj/ShineTowerRocket.h"
+#include "MapObj/ShopMark.h"
 #include "MapObj/SignBoard.h"
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
@@ -544,7 +545,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"ShineFukankunWatchObj", nullptr},
     {"ShineTowerRocket", al::createActorFunction<ShineTowerRocket>},
     {"ShopBgmPlayer", nullptr},
-    {"ShopMark", nullptr},
+    {"ShopMark", al::createActorFunction<ShopMark>},
     {"ShoppingWatcher", nullptr},
     {"SignBoardDanger", al::createActorFunction<SignBoardDanger>},
     {"SignBoardLayoutTexture", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1043)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (dc5c854 - ed6fae0)

📈 **Matched code**: 14.42% (+0.01%, +716 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ShopMark` | `ShopMark::ShopMark(char const*)` | +152 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::init(al::ActorInitInfo const&)` | +152 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::ShopMark(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::control()` | +88 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::initAfterPlacement()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<ShopMark>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::startClipped()` | +36 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::endClipped()` | +36 | 0.00% | 100.00% |
| `MapObj/ShopMark` | `ShopMark::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->