### PR TITLE
MapObj: Implement `HipDropRepairParts`

### DIFF
--- a/src/MapObj/HipDropRepairParts.cpp
+++ b/src/MapObj/HipDropRepairParts.cpp
@@ -1,0 +1,101 @@
+#include "MapObj/HipDropRepairParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/ItemGenerator.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(HipDropRepairParts, Wait);
+NERVE_IMPL(HipDropRepairParts, On);
+NERVE_IMPL(HipDropRepairParts, OnWait);
+
+NERVES_MAKE_NOSTRUCT(HipDropRepairParts, OnWait);
+NERVES_MAKE_STRUCT(HipDropRepairParts, Wait, On);
+}  // namespace
+
+HipDropRepairParts::HipDropRepairParts(const char* name) : al::LiveActor(name) {}
+
+void HipDropRepairParts::init(const al::ActorInitInfo& info) {
+    using HipDropRepairPartsFunctor =
+        al::FunctorV0M<HipDropRepairParts*, void (HipDropRepairParts::*)()>;
+
+    const char* suffixName = nullptr;
+    al::tryGetStringArg(&suffixName, info, "SuffixName");
+    al::initMapPartsActor(this, info, suffixName);
+    al::initNerve(this, &NrvHipDropRepairParts.Wait, 0);
+
+    mInitTrans = al::getTrans(this);
+    al::calcTransLocalOffset(&mItemGeneratePos, this, sead::Vector3f::ey * 100.0f);
+
+    mItemGenerator = new ItemGenerator(this, info);
+    mTraceModel = al::tryGetSubActor(this, "跡モデル");
+    if (mTraceModel)
+        mTraceModel->makeActorDead();
+
+    if (al::isValidStageSwitch(this, "SwitchHide")) {
+        al::listenStageSwitchOnOff(this, "SwitchHide",
+                                   HipDropRepairPartsFunctor(this, &HipDropRepairParts::startHide),
+                                   HipDropRepairPartsFunctor(this, &HipDropRepairParts::startShow));
+    } else if (al::isValidStageSwitch(this, "SwitchShow")) {
+        al::listenStageSwitchOnOff(this, "SwitchShow",
+                                   HipDropRepairPartsFunctor(this, &HipDropRepairParts::startShow),
+                                   HipDropRepairPartsFunctor(this, &HipDropRepairParts::startHide));
+        al::hideModel(this);
+        if (mTraceModel)
+            al::hideModel(mTraceModel);
+    }
+
+    makeActorAlive();
+}
+
+void HipDropRepairParts::startHide() {
+    al::hideModelIfShow(this);
+    if (mTraceModel)
+        al::hideModelIfShow(mTraceModel);
+}
+
+void HipDropRepairParts::startShow() {
+    al::showModelIfHide(this);
+    if (mTraceModel)
+        al::showModelIfHide(mTraceModel);
+}
+
+bool HipDropRepairParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                    al::HitSensor* self) {
+    if (rs::isMsgPlayerAndCapHipDropAll(message) &&
+        al::isNerve(this, &NrvHipDropRepairParts.Wait)) {
+        al::startHitReaction(this, "ヒップドロップ開始");
+        al::setNerve(this, &NrvHipDropRepairParts.On);
+        if (mTraceModel)
+            mTraceModel->makeActorAlive();
+    }
+
+    return false;
+}
+
+void HipDropRepairParts::exeWait() {}
+
+void HipDropRepairParts::exeOn() {
+    f32 moveOffset = (al::getNerveStep(this) + 1) * -25.0f;
+    al::setTrans(this, mInitTrans + sead::Vector3f::ey * moveOffset);
+
+    if (al::isGreaterEqualStep(this, 4)) {
+        mItemGenerator->generate(mItemGeneratePos, al::getQuat(this));
+        al::startHitReaction(this, "ヒップドロップ完了");
+        al::tryOnStageSwitch(this, "SwitchHipDropOn");
+        al::setNerve(this, &OnWait);
+        kill();
+    }
+}
+
+void HipDropRepairParts::exeOnWait() {}

--- a/src/MapObj/HipDropRepairParts.h
+++ b/src/MapObj/HipDropRepairParts.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class ItemGenerator;
+
+class HipDropRepairParts : public al::LiveActor {
+public:
+    HipDropRepairParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void startHide();
+    void startShow();
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void exeWait();
+    void exeOn();
+    void exeOnWait();
+
+private:
+    al::LiveActor* mTraceModel = nullptr;
+    ItemGenerator* mItemGenerator = nullptr;
+    sead::Vector3f mInitTrans = sead::Vector3f::zero;
+    sead::Vector3f mItemGeneratePos = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(HipDropRepairParts) == 0x130);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -81,6 +81,7 @@
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
+#include "MapObj/HipDropRepairParts.h"
 #include "MapObj/HipDropSwitch.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
@@ -353,7 +354,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HipDropSwitchTimer", nullptr},
     {"HipDropTile", nullptr},
     {"HipDropMoveLift", nullptr},
-    {"HipDropRepairParts", nullptr},
+    {"HipDropRepairParts", al::createActorFunction<HipDropRepairParts>},
     {"HipDropTransformPartsWatcher", nullptr},
     {"HomeBed", nullptr},
     {"HomeChair", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1044)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 2baabcc)

📈 **Matched code**: 14.20% (+0.01%, +1492 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::init(al::ActorInitInfo const&)` | +492 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::exeOn()` | +248 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::HipDropRepairParts(char const*)` | +180 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::HipDropRepairParts(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +116 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `al::FunctorV0M<HipDropRepairParts*, void (HipDropRepairParts::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::startHide()` | +52 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::startShow()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HipDropRepairParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `al::FunctorV0M<HipDropRepairParts*, void (HipDropRepairParts::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `(anonymous namespace)::HipDropRepairPartsNrvOn::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `HipDropRepairParts::exeOnWait()` | +4 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `(anonymous namespace)::HipDropRepairPartsNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `(anonymous namespace)::HipDropRepairPartsNrvOnWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/HipDropRepairParts` | `al::FunctorV0M<HipDropRepairParts*, void (HipDropRepairParts::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->