### PR TITLE
MapObj: Implement `SignBoard`

### DIFF
--- a/src/MapObj/SignBoard.cpp
+++ b/src/MapObj/SignBoard.cpp
@@ -1,0 +1,77 @@
+#include "MapObj/SignBoard.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "MapObj/SimpleSignBoard.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(SignBoard, Wait);
+NERVE_IMPL(SignBoard, Reaction);
+
+NERVES_MAKE_NOSTRUCT(SignBoard, Wait, Reaction);
+}  // namespace
+
+SignBoard::SignBoard(const char* name) : al::LiveActor(name) {}
+
+void SignBoard::init(const al::ActorInitInfo& info) {
+    const char* objectName = nullptr;
+    al::getObjectName(&objectName, info);
+
+    bool isWall = al::isEqualString(objectName, "SignBoardNormalWall");
+    if (isWall)
+        al::initActorWithArchiveName(this, info, "SignBoardNormal", "Wall");
+    else
+        al::initActor(this, info);
+
+    al::initNerve(this, &Wait, 0);
+    SimpleSignBoardFunction::startSignAimVisAnimFromModelName(this, info);
+
+    if (isWall) {
+        al::startVisAnimForAction(this, "WallOn");
+
+        sead::Vector3f frontDir;
+        al::calcFrontDir(&frontDir, this);
+
+        al::setTrans(this, al::getTrans(this) - frontDir * 16.0f);
+    }
+
+    mIsWall = isWall;
+    makeActorAlive();
+}
+
+void SignBoard::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void SignBoard::exeReaction() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Reaction");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+bool SignBoard::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                           al::HitSensor* self) {
+    if (mIsWall)
+        return false;
+
+    if (rs::isMsgCapReflectCollide(message) || rs::isMsgPlayerRollingWallHitDown(message)) {
+        al::setNerve(this, &Reaction);
+        rs::requestHitReactionToAttacker(message, self, other);
+        return true;
+    }
+
+    return false;
+}

--- a/src/MapObj/SignBoard.h
+++ b/src/MapObj/SignBoard.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SignBoard : public al::LiveActor {
+public:
+    SignBoard(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void exeWait();
+    void exeReaction();
+
+private:
+    bool mIsWall = false;
+};
+
+static_assert(sizeof(SignBoard) == 0x110);

--- a/src/MapObj/SimpleSignBoard.h
+++ b/src/MapObj/SimpleSignBoard.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class SimpleSignBoard : public al::LiveActor {
+public:
+    SimpleSignBoard(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+};
+
+static_assert(sizeof(SimpleSignBoard) == 0x108);
+
+namespace SimpleSignBoardFunction {
+void startSignAimVisAnimFromModelName(al::LiveActor* actor, const al::ActorInitInfo& info);
+}  // namespace SimpleSignBoardFunction

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -95,6 +95,7 @@
 #include "MapObj/RouletteSwitch.h"
 #include "MapObj/SaveFlagCheckObj.h"
 #include "MapObj/ShineTowerRocket.h"
+#include "MapObj/SignBoard.h"
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
@@ -545,7 +546,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"SkyWorldKoopaFire", nullptr},
     {"SkyWorldKoopaFrame", nullptr},
     {"SkyWorldMiddleViewCloud", nullptr},
-    {"SignBoard", nullptr},
+    {"SignBoard", al::createActorFunction<SignBoard>},
     {"SnowWorldBigIcicle", nullptr},
     {"SnowWorldSequenceFlagCheckObj", nullptr},
     {"Sky", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1046)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - cceb226)

📈 **Matched code**: 14.24% (+0.01%, +1052 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SignBoard` | `SignBoard::init(al::ActorInitInfo const&)` | +312 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `SignBoard::SignBoard(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `SignBoard::SignBoard(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `SignBoard::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +124 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `(anonymous namespace)::SignBoardNrvReaction::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `SignBoard::exeReaction()` | +88 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `(anonymous namespace)::SignBoardNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/SignBoard` | `SignBoard::exeWait()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SignBoard>(char const*)` | +52 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->