### PR TITLE
MapObj: Implement `MeganePartsState`

### DIFF
--- a/src/MapObj/MeganePartsState.cpp
+++ b/src/MapObj/MeganePartsState.cpp
@@ -1,0 +1,91 @@
+#include "MapObj/MeganePartsState.h"
+
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(MeganePartsState, Hide);
+NERVE_IMPL(MeganePartsState, On);
+NERVE_IMPL(MeganePartsState, Off);
+NERVE_IMPL(MeganePartsState, Show);
+
+NERVES_MAKE_STRUCT(MeganePartsState, Hide, On, Off, Show);
+}  // namespace
+
+MeganePartsState::MeganePartsState(al::LiveActor* actor)
+    : al::ActorStateBase("メガネーパーツ状態", actor) {
+    initNerve(&NrvMeganePartsState.Hide, 0);
+}
+
+void MeganePartsState::appear() {
+    al::setMaterialProgrammable(mActor);
+    al::hideModelIfShow(mActor);
+    al::NerveStateBase::appear();
+    al::setNerve(this, &NrvMeganePartsState.Hide);
+}
+
+bool MeganePartsState::update() {
+    s32 subActorNum = al::getSubActorNum(mActor);
+    for (s32 i = 0; i < subActorNum; i++)
+        al::setTrans(al::getSubActor(mActor, i), al::getTrans(mActor));
+
+    al::setModelMaterialParameterF32(mActor, al::getMaterialName(mActor, 0), "const_single0",
+                                     mAlpha);
+
+    return al::NerveStateBase::update();
+}
+
+void MeganePartsState::exeHide() {
+    if (al::isFirstStep(this))
+        al::hideModelIfShow(mActor);
+
+    if (rs::isPlayerEnableToSeeOddSpace(mActor))
+        al::setNerve(this, &NrvMeganePartsState.On);
+}
+
+void MeganePartsState::exeOn() {
+    if (al::isFirstStep(this))
+        al::showModelIfHide(mActor);
+
+    mAlpha = sead::Mathf::min(mAlpha + (1.0f / 15.0f), 1.0f);
+    if (!rs::isPlayerEnableToSeeOddSpace(mActor)) {
+        al::setNerve(this, &NrvMeganePartsState.Off);
+        return;
+    }
+
+    updateAlpha();
+    if (mAlpha == 1.0f)
+        al::setNerve(this, &NrvMeganePartsState.Show);
+}
+
+void MeganePartsState::updateAlpha() {
+    if (!al::isExistSubActorKeeper(mActor))
+        return;
+
+    f32 alpha = sead::Mathf::clamp((mAlpha - (7.0f / 15.0f)) / (8.0f / 15.0f), 0.0f, 1.0f);
+    s32 subActorNum = al::getSubActorNum(mActor);
+    for (s32 i = 0; i < subActorNum; i++)
+        al::setModelAlphaMask(al::getSubActor(mActor, i), alpha);
+}
+
+void MeganePartsState::exeShow() {
+    if (!rs::isPlayerEnableToSeeOddSpace(mActor))
+        al::setNerve(this, &NrvMeganePartsState.Off);
+}
+
+void MeganePartsState::exeOff() {
+    mAlpha = sead::Mathf::clampMin(mAlpha - (1.0f / 15.0f), 0.0f);
+    if (rs::isPlayerEnableToSeeOddSpace(mActor)) {
+        al::setNerve(this, &NrvMeganePartsState.On);
+        return;
+    }
+
+    updateAlpha();
+    if (mAlpha == 0.0f)
+        al::setNerve(this, &NrvMeganePartsState.Hide);
+}

--- a/src/MapObj/MeganePartsState.h
+++ b/src/MapObj/MeganePartsState.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class MeganePartsState : public al::ActorStateBase {
+public:
+    MeganePartsState(al::LiveActor* actor);
+
+    void appear() override;
+    bool update() override;
+
+    void exeHide();
+    void exeOn();
+    void updateAlpha();
+    void exeShow();
+    void exeOff();
+
+private:
+    f32 mAlpha = 0.0f;
+};
+
+static_assert(sizeof(MeganePartsState) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1047)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - 92e33f9)

📈 **Matched code**: 14.24% (+0.01%, +1388 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MeganePartsState` | `MeganePartsState::exeOn()` | +288 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::exeOff()` | +268 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::updateAlpha()` | +172 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::update()` | +156 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `(anonymous namespace)::MeganePartsStateNrvHide::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::MeganePartsState(al::LiveActor*)` | +84 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::exeHide()` | +84 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::exeShow()` | +68 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `(anonymous namespace)::MeganePartsStateNrvShow::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::appear()` | +60 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `MeganePartsState::~MeganePartsState()` | +36 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `(anonymous namespace)::MeganePartsStateNrvOn::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/MeganePartsState` | `(anonymous namespace)::MeganePartsStateNrvOff::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->