### PR TITLE
Library/Clipping: Implement `FrustumRadar`

### DIFF
--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -143,45 +143,113 @@ bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 f) const {
 }
 
 bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3) const {
-    f32 dot = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot;
+    f32 f4;
+    f32 fVar2;
 
-    if (!(dot < f2 - f1)) {
-        if (0.0 < f3 && f1 + f3 < dot)
+    dot = mOrthoFront.dot(pos - mOrthoTrans);
+    if (dot < f2 - f1)
+        return false;
+
+    if (0.0 < f3 && f1 + f3 < dot)
+        return false;
+
+    f4 = sead::Mathf::abs(mOrthoUp.dot(pos - mOrthoTrans));
+    if (dot * _38 + _3c * f1 < f4)
+        return false;
+
+    fVar2 = mOrthoSide.dot(pos - mOrthoTrans);
+    if (isNearZero(_40, 0.001)) {
+        if (dot * _30 + _34 * f1 < sead::Mathf::abs(fVar2)) {
             return false;
-
-        f32 f4 = mOrthoUp.dot(pos - mOrthoTrans);
-
-        if (f4 > 0.0) {
-            f4 = -f4;
-        }
-
-        if (!(dot * _38 + _3c * f1 < f4)) {
-
-            f32 fVar2 = mOrthoSide.dot(pos - mOrthoTrans);
-            if (isNearZero(_40,0.001)) {
-
-                if (fVar2 <= 0.0)
-                    fVar2 = -fVar2;
-
-                if (fVar2 <= dot * _30 + _34 * f1)
-                    return true;
-
-            }
-            else {
-                f32 fVar3 = dot * _4c + _50 * f1;
-                dot = dot * _44 + _48 * f1;
-                f32 fVar4 = fVar2 - _40;
-                fVar2 = fVar2 + _40;
-
-                if (!(fVar4 <= dot || fVar2 > fVar3 || dot < fVar4 && fVar2 < fVar3)) {
-                    return true;
-                }
-
-            }
         }
     }
-    return false;
+    else {
+        f32 fVar3 = dot * _4c + _50 * f1;
+        dot = dot * _44 + _48 * f1;
+        f32 fVar4 = fVar2 - _40;
+        fVar2 = fVar2 + _40;
+
+        if (fVar4 > dot && fVar2 > fVar3)
+            return false;
+
+        f32 neg_fVar3 = -fVar3;
+        f32 neg_dot = -dot;
+
+        if (fVar4 < neg_fVar3 && fVar2 < neg_dot) {
+            return false;
+        }
+    }
+    return true;
 }
+
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2) const {
+    return judgeInArea(pos, f1, f2, _58);
+}
+
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1) const {
+    return judgeInArea(pos, f1, _54, _58);
+}
+
+bool FrustumRadar::judgeInAreaNoFar(const sead::Vector3f& pos, f32 f1) const {
+    return judgeInArea(pos, f1, _54, -1.0f);
+}
+
+bool FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 f1, f32 f2) const {
+    bool bVar4;
+    bool bVar3;
+
+    sead::Vector3f transDotVec = pos - (mOrthoTrans);
+
+
+    float transDot = transDotVec.dot(mOrthoFront);
+
+    bool bVar1 = transDot < f1 | 2;
+    if (transDot <= f2 || f2 == 0.0 || (f2 < transDot && f2 < 0.0)) {
+        bVar1 = transDot < f1;
+    }
+
+    float dotUp = transDotVec.dot(mOrthoUp);
+
+    bool bVar2 = bVar1 | 4;
+    if (-(transDot * _38) <= dotUp) {
+        bVar2 = bVar1;
+    }
+    bool bVar5 = bVar2 | 8;
+    if (dotUp <= transDot * _38) {
+        bVar5 = bVar2;
+    }
+    transDotVec.x = transDotVec.x * mOrthoSide.x + transDotVec.y * mOrthoSide.y +
+                transDotVec.z * mOrthoSide.z;
+    bool bVar6 = isNearZero(_40, 0.001);
+    if (bVar6) {
+        bVar4 = bVar5 | 0x10;
+        if (-(transDot * _30) <= transDotVec.x) {
+            bVar4 = bVar5;
+        }
+        bVar6 = transDot * _30 < transDotVec.x;
+        bVar3 = bVar4 | 0x20;
+    }
+    else {
+        transDotVec.y = transDot * _44;
+        transDot = transDot * _4c;
+        transDotVec.z = transDotVec.x - _40;
+        transDotVec.x = transDotVec.x + _40;
+        bVar4 = bVar5 | 0x20;
+        if (transDotVec.x <= transDot || transDotVec.z == transDotVec.y ||
+            (transDot < transDotVec.x && transDotVec.z < transDotVec.y)) {
+            bVar4 = bVar5;
+        }
+
+        bVar3 = bVar4 | 0x10;
+        bVar6 = false;
+    }
+    if (!bVar6) {
+        bVar3 = bVar4;
+    }
+    return bVar3;
+}
+
 
 
 } // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -1,7 +1,5 @@
 #include "Library/Clipping/FrustumRadar.h"
 
-#include <algorithm>
-
 #include <math/seadMathCalcCommon.h>
 
 #include "Library/Math/MathUtil.h"
@@ -9,12 +7,10 @@
 
 namespace al {
 
-FrustumRadar::FrustumRadar() {
+FrustumRadar::FrustumRadar() {}
 
-
-}
-
-void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 f1, f32 f2, f32 f3, f32 f4) {
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 f1, f32 f2, f32 f3,
+                                   f32 f4) {
     setLocalAxis(orthoMtx);
 
     setFactor(f1, f2);
@@ -22,7 +18,6 @@ void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 f1, f32 
     _54 = f3;
     _58 = f4;
 }
-
 
 void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
     sead::Matrix34f mtxInvertOrtho;
@@ -34,7 +29,7 @@ void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
     mOrthoUp.x = mtxInvertOrtho.m[0][1];
     mOrthoUp.y = mtxInvertOrtho.m[1][1];
     mOrthoUp.z = mtxInvertOrtho.m[2][1];
-    const sead::Vector3f& base2=mtxInvertOrtho.getBase(2);
+    const sead::Vector3f& base2 = mtxInvertOrtho.getBase(2);
     mOrthoFront.x = -base2.x;
     mOrthoFront.y = -base2.y;
     mOrthoFront.z = -base2.z;
@@ -42,18 +37,18 @@ void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
     mOrthoTrans.y = mtxInvertOrtho.m[1][3];
     mOrthoTrans.z = mtxInvertOrtho.m[2][3];
     _40 = 0.0f;
-
 }
 
 void FrustumRadar::setFactor(f32 f1, f32 f2) {
     _38 = sead::Mathf::tan(sead::Mathf::deg2rad(f1 * 0.5f));
-    _3c = sead::Mathf::sqrt(_38*_38+1.0f);
+    _3c = sead::Mathf::sqrt(_38 * _38 + 1.0f);
 
     _30 = _38 * f2;
-    _34 = sead::Mathf::sqrt(_30*_30+1.0f);
+    _34 = sead::Mathf::sqrt(_30 * _30 + 1.0f);
 }
 
-void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, const sead::Matrix44f& factorMtx, f32 f1, f32 f2) {
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx,
+                                   const sead::Matrix44f& factorMtx, f32 f1, f32 f2) {
     setLocalAxis(orthoMtx);
     setFactor(factorMtx);
     _54 = f1;
@@ -62,23 +57,23 @@ void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, const sead::
 
 void FrustumRadar::setFactor(const sead::Matrix44f& mtx) {
     _38 = 1.0 / mtx(1, 1);
-    _3c = sead::Mathf::sqrt(_38*_38+1);
+    _3c = sead::Mathf::sqrt(_38 * _38 + 1);
 
-    _30 = 1.0 / mtx(0,0);
-    _34 = sead::Mathf::sqrt(_30*_30+1);
+    _30 = 1.0 / mtx(0, 0);
+    _34 = sead::Mathf::sqrt(_30 * _30 + 1);
 }
 
-void FrustumRadar::calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft, const sead::Matrix34f& OrthoMtxRight,
+void FrustumRadar::calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft,
+                                         const sead::Matrix34f& OrthoMtxRight,
                                          const sead::Matrix44f& mtx, f32 f1, f32 f2) {
     setLocalAxisStereo(orthoMtxLeft, OrthoMtxRight);
     setFactorStereo(mtx);
     _54 = f1;
     _58 = f2;
-
-
 }
 
-void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft, const sead::Matrix34f& orthoMtxRight) {
+void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft,
+                                      const sead::Matrix34f& orthoMtxRight) {
     sead::Matrix34f mtxInvertOrthoLeft;
     sead::Matrix34f mtxInvertRight;
 
@@ -102,14 +97,12 @@ void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft, const
 }
 
 void FrustumRadar::setFactorStereo(const sead::Matrix44f& mtx) {
-
     setFactor(mtx);
-    f32 f2 = mtx(0,2);
-
+    f32 f2 = mtx(0, 2);
 
     _44 = _30 * (1.0f - f2);
     _48 = sead::Mathf::sqrt(_44 * _44 + 1.0f);
-    _4c = _30 * (f2 + 1.0f) ;
+    _4c = _30 * (f2 + 1.0f);
     _50 = sead::Mathf::sqrt(_4c * _4c + 1.0f);
 }
 
@@ -139,7 +132,6 @@ bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 f) const {
     f32 dot2 = mOrthoUp.dot(pos - mOrthoTrans);
 
     return !(-(dot1 * _38 + _3c * f) > dot2);
-
 }
 
 bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3) const {
@@ -160,11 +152,9 @@ bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3
 
     fVar2 = mOrthoSide.dot(pos - mOrthoTrans);
     if (isNearZero(_40, 0.001)) {
-        if (dot * _30 + _34 * f1 < sead::Mathf::abs(fVar2)) {
+        if (dot * _30 + _34 * f1 < sead::Mathf::abs(fVar2))
             return false;
-        }
-    }
-    else {
+    } else {
         f32 fVar3 = dot * _4c + _50 * f1;
         dot = dot * _44 + _48 * f1;
         f32 fVar4 = fVar2 - _40;
@@ -176,9 +166,8 @@ bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3
         f32 neg_fVar3 = -fVar3;
         f32 neg_dot = -dot;
 
-        if (fVar4 < neg_fVar3 && fVar2 < neg_dot) {
+        if (fVar4 < neg_fVar3 && fVar2 < neg_dot)
             return false;
-        }
     }
     return true;
 }
@@ -195,61 +184,23 @@ bool FrustumRadar::judgeInAreaNoFar(const sead::Vector3f& pos, f32 f1) const {
     return judgeInArea(pos, f1, _54, -1.0f);
 }
 
-bool FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 f1, f32 f2) const {
-    bool bVar4;
-    bool bVar3;
+bool FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 f1, f32 f2) const {}
 
-    sead::Vector3f transDotVec = pos - (mOrthoTrans);
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound, f32 f1,
+                                  f32 f2) const {}
 
-
-    float transDot = transDotVec.dot(mOrthoFront);
-
-    bool bVar1 = transDot < f1 | 2;
-    if (transDot <= f2 || f2 == 0.0 || (f2 < transDot && f2 < 0.0)) {
-        bVar1 = transDot < f1;
-    }
-
-    float dotUp = transDotVec.dot(mOrthoUp);
-
-    bool bVar2 = bVar1 | 4;
-    if (-(transDot * _38) <= dotUp) {
-        bVar2 = bVar1;
-    }
-    bool bVar5 = bVar2 | 8;
-    if (dotUp <= transDot * _38) {
-        bVar5 = bVar2;
-    }
-    transDotVec.x = transDotVec.x * mOrthoSide.x + transDotVec.y * mOrthoSide.y +
-                transDotVec.z * mOrthoSide.z;
-    bool bVar6 = isNearZero(_40, 0.001);
-    if (bVar6) {
-        bVar4 = bVar5 | 0x10;
-        if (-(transDot * _30) <= transDotVec.x) {
-            bVar4 = bVar5;
-        }
-        bVar6 = transDot * _30 < transDotVec.x;
-        bVar3 = bVar4 | 0x20;
-    }
-    else {
-        transDotVec.y = transDot * _44;
-        transDot = transDot * _4c;
-        transDotVec.z = transDotVec.x - _40;
-        transDotVec.x = transDotVec.x + _40;
-        bVar4 = bVar5 | 0x20;
-        if (transDotVec.x <= transDot || transDotVec.z == transDotVec.y ||
-            (transDot < transDotVec.x && transDotVec.z < transDotVec.y)) {
-            bVar4 = bVar5;
-        }
-
-        bVar3 = bVar4 | 0x10;
-        bVar6 = false;
-    }
-    if (!bVar6) {
-        bVar3 = bVar4;
-    }
-    return bVar3;
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound,
+                                  f32 f1) const {
+    return judgeInAreaObb(mtx, bound, f1, _58);
 }
 
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound) {
+    return judgeInAreaObb(mtx, bound, _54, _58);
+}
 
+bool FrustumRadar::judgeInAreaObbNoFar(const sead::Matrix34f* mtx,
+                                       const sead::BoundBox3f& bound) const {
+    return judgeInAreaObb(mtx, bound, _54, -0.0);
+}
 
-} // namespace al
+}  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -1,0 +1,194 @@
+#include "Library/Clipping/FrustumRadar.h"
+
+#include <algorithm>
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/Math/MathUtil.h"
+#include "Library/Matrix/MatrixUtil.h"
+
+namespace al {
+
+FrustumRadar::FrustumRadar() {
+
+
+}
+
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 f1, f32 f2, f32 f3, f32 f4) {
+    setLocalAxis(orthoMtx);
+
+    setFactor(f1, f2);
+
+    _54 = f3;
+    _58 = f4;
+}
+
+
+void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
+    sead::Matrix34f mtxInvertOrtho;
+    calcMxtInvertOrtho(&mtxInvertOrtho, orthoMtx);
+
+    mOrthoSide.x = mtxInvertOrtho.m[0][0];
+    mOrthoSide.y = mtxInvertOrtho.m[1][0];
+    mOrthoSide.z = mtxInvertOrtho.m[2][0];
+    mOrthoUp.x = mtxInvertOrtho.m[0][1];
+    mOrthoUp.y = mtxInvertOrtho.m[1][1];
+    mOrthoUp.z = mtxInvertOrtho.m[2][1];
+    const sead::Vector3f& base2=mtxInvertOrtho.getBase(2);
+    mOrthoFront.x = -base2.x;
+    mOrthoFront.y = -base2.y;
+    mOrthoFront.z = -base2.z;
+    mOrthoTrans.x = mtxInvertOrtho.m[0][3];
+    mOrthoTrans.y = mtxInvertOrtho.m[1][3];
+    mOrthoTrans.z = mtxInvertOrtho.m[2][3];
+    _40 = 0.0f;
+
+}
+
+void FrustumRadar::setFactor(f32 f1, f32 f2) {
+    _38 = sead::Mathf::tan(sead::Mathf::deg2rad(f1 * 0.5f));
+    _3c = sead::Mathf::sqrt(_38*_38+1.0f);
+
+    _30 = _38 * f2;
+    _34 = sead::Mathf::sqrt(_30*_30+1.0f);
+}
+
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, const sead::Matrix44f& factorMtx, f32 f1, f32 f2) {
+    setLocalAxis(orthoMtx);
+    setFactor(factorMtx);
+    _54 = f1;
+    _58 = f2;
+}
+
+void FrustumRadar::setFactor(const sead::Matrix44f& mtx) {
+    _38 = 1.0 / mtx(1, 1);
+    _3c = sead::Mathf::sqrt(_38*_38+1);
+
+    _30 = 1.0 / mtx(0,0);
+    _34 = sead::Mathf::sqrt(_30*_30+1);
+}
+
+void FrustumRadar::calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft, const sead::Matrix34f& OrthoMtxRight,
+                                         const sead::Matrix44f& mtx, f32 f1, f32 f2) {
+    setLocalAxisStereo(orthoMtxLeft, OrthoMtxRight);
+    setFactorStereo(mtx);
+    _54 = f1;
+    _58 = f2;
+
+
+}
+
+void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft, const sead::Matrix34f& orthoMtxRight) {
+    sead::Matrix34f mtxInvertOrthoLeft;
+    sead::Matrix34f mtxInvertRight;
+
+    calcMxtInvertOrtho(&mtxInvertOrthoLeft, orthoMtxLeft);
+
+    mOrthoSide.x = mtxInvertOrthoLeft.m[0][0];
+    mOrthoSide.y = mtxInvertOrthoLeft.m[1][0];
+    mOrthoSide.z = mtxInvertOrthoLeft.m[2][0];
+    mOrthoUp.x = mtxInvertOrthoLeft.m[0][1];
+    mOrthoUp.y = mtxInvertOrthoLeft.m[1][1];
+    mOrthoUp.z = mtxInvertOrthoLeft.m[2][1];
+    const sead::Vector3f& base2 = mtxInvertOrthoLeft.getBase(2);
+    mOrthoFront.x = -base2.x;
+    mOrthoFront.y = -base2.y;
+    mOrthoFront.z = -base2.z;
+
+    calcMxtInvertOrtho(&mtxInvertRight, orthoMtxRight);
+    mOrthoTrans = (mtxInvertOrthoLeft.getTranslation() + mtxInvertRight.getTranslation()) * 0.5f;
+
+    _40 = mOrthoSide.dot(mOrthoTrans - mtxInvertOrthoLeft.getTranslation());
+}
+
+void FrustumRadar::setFactorStereo(const sead::Matrix44f& mtx) {
+
+    setFactor(mtx);
+    f32 f2 = mtx(0,2);
+
+
+    _44 = _30 * (1.0f - f2);
+    _48 = sead::Mathf::sqrt(_44 * _44 + 1.0f);
+    _4c = _30 * (f2 + 1.0f) ;
+    _50 = sead::Mathf::sqrt(_4c * _4c + 1.0f);
+}
+
+bool FrustumRadar::judgeInLeft(const sead::Vector3f& pos, f32 f) const {
+    f32 dot1 =mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot2 =mOrthoSide.dot(pos - mOrthoTrans);
+
+    return !(dot2 < -(dot1 * _30 + _34 * f));
+}
+
+bool FrustumRadar::judgeInRight(const sead::Vector3f& pos, f32 f) const {
+    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot2 = mOrthoSide.dot(pos - mOrthoTrans);
+
+    return !(dot1 * _30 + _34 * f < dot2);
+}
+
+bool FrustumRadar::judgeInTop(const sead::Vector3f& pos, f32 f) const {
+    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot2 = mOrthoUp.dot(pos - mOrthoTrans);
+
+    return !(dot1 * _38 + _3c * f < dot2);
+}
+
+bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 f) const {
+    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot2 = mOrthoUp.dot(pos - mOrthoTrans);
+
+    return !(-(dot1 * _38 + _3c * f) > dot2);
+
+}
+
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3) const {
+
+    float fVar2;
+    float f4;
+    float dot;
+
+    sead::Vector3f posMinTrans = pos - mOrthoTrans;
+
+    dot = posMinTrans.dot(mOrthoFront);
+
+
+    if (!(dot < f2 - f1)) {
+
+        if (0.0 < f3 && f1 + f3 < dot) {
+            return false;
+        }
+        f4 = posMinTrans.dot(mOrthoUp);
+        if (f4 > 0.0) {
+            f4 = -f4;
+        }
+
+        if (!(dot * _38 + _3c * f1 < f4)) {
+
+            fVar2 = posMinTrans.dot(mOrthoSide);
+            if (isNearZero(_40,0.001)) {
+
+                if (fVar2 <= 0.0)
+                    fVar2 = -fVar2;
+
+                if (fVar2 <= dot * _30 + _34 * f1)
+                    return true;
+
+            }
+            else {
+                f32 fVar3 = dot * _4c + _50 * f1;
+                dot = dot * _44 + _48 * f1;
+                f32 fVar4 = fVar2 - _40;
+                fVar2 = fVar2 + _40;
+                if (fVar4 <= dot || fVar2 == fVar3 || dot < fVar4 && fVar2 < fVar3) {
+                    return true;
+                }
+
+            }
+        }
+    }
+    return false;
+}
+
+
+} // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -114,8 +114,8 @@ void FrustumRadar::setFactorStereo(const sead::Matrix44f& mtx) {
 }
 
 bool FrustumRadar::judgeInLeft(const sead::Vector3f& pos, f32 f) const {
-    f32 dot1 =mOrthoFront.dot(pos - mOrthoTrans);
-    f32 dot2 =mOrthoSide.dot(pos - mOrthoTrans);
+    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dot2 = mOrthoSide.dot(pos - mOrthoTrans);
 
     return !(dot2 < -(dot1 * _30 + _34 * f));
 }
@@ -143,29 +143,21 @@ bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 f) const {
 }
 
 bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3) const {
-
-    float fVar2;
-    float f4;
-    float dot;
-
-    sead::Vector3f posMinTrans = pos - mOrthoTrans;
-
-    dot = posMinTrans.dot(mOrthoFront);
-
+    f32 dot = mOrthoFront.dot(pos - mOrthoTrans);
 
     if (!(dot < f2 - f1)) {
-
-        if (0.0 < f3 && f1 + f3 < dot) {
+        if (0.0 < f3 && f1 + f3 < dot)
             return false;
-        }
-        f4 = posMinTrans.dot(mOrthoUp);
+
+        f32 f4 = mOrthoUp.dot(pos - mOrthoTrans);
+
         if (f4 > 0.0) {
             f4 = -f4;
         }
 
         if (!(dot * _38 + _3c * f1 < f4)) {
 
-            fVar2 = posMinTrans.dot(mOrthoSide);
+            f32 fVar2 = mOrthoSide.dot(pos - mOrthoTrans);
             if (isNearZero(_40,0.001)) {
 
                 if (fVar2 <= 0.0)
@@ -180,7 +172,8 @@ bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3
                 dot = dot * _44 + _48 * f1;
                 f32 fVar4 = fVar2 - _40;
                 fVar2 = fVar2 + _40;
-                if (fVar4 <= dot || fVar2 == fVar3 || dot < fVar4 && fVar2 < fVar3) {
+
+                if (!(fVar4 <= dot || fVar2 > fVar3 || dot < fVar4 && fVar2 < fVar3)) {
                     return true;
                 }
 

--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -9,14 +9,14 @@ namespace al {
 
 FrustumRadar::FrustumRadar() = default;
 
-void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 vFovAngle, f32 aspectRatio,
-                                   f32 areaMin, f32 areaMax) {
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 fovyAngle, f32 aspectRatio,
+                                   f32 near, f32 far) {
     setLocalAxis(orthoMtx);
 
-    setFactor(vFovAngle, aspectRatio);
+    setFactor(fovyAngle, aspectRatio);
 
-    mAreaMin = areaMin;
-    mAreaMax = areaMax;
+    mNear = near;
+    mFar = far;
 }
 
 void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
@@ -32,8 +32,8 @@ void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
     mStereoEyeOffset = 0.0f;
 }
 
-void FrustumRadar::setFactor(f32 vFovAngle, f32 aspectRatio) {
-    mVerticalSlope = sead::Mathf::tan(sead::Mathf::deg2rad(vFovAngle * 0.5f));
+void FrustumRadar::setFactor(f32 fovyAngle, f32 aspectRatio) {
+    mVerticalSlope = sead::Mathf::tan(sead::Mathf::deg2rad(fovyAngle * 0.5f));
     mVerticalNormFactor = sead::Mathf::sqrt(mVerticalSlope * mVerticalSlope + 1.0f);
 
     mHorizontalSlope = mVerticalSlope * aspectRatio;
@@ -41,11 +41,11 @@ void FrustumRadar::setFactor(f32 vFovAngle, f32 aspectRatio) {
 }
 
 void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx,
-                                   const sead::Matrix44f& projectionMtx, f32 areaMin, f32 areaMax) {
+                                   const sead::Matrix44f& projectionMtx, f32 near, f32 far) {
     setLocalAxis(orthoMtx);
     setFactor(projectionMtx);
-    mAreaMin = areaMin;
-    mAreaMax = areaMax;
+    mNear = near;
+    mFar = far;
 }
 
 void FrustumRadar::setFactor(const sead::Matrix44f& projectionMtx) {
@@ -57,13 +57,12 @@ void FrustumRadar::setFactor(const sead::Matrix44f& projectionMtx) {
 }
 
 void FrustumRadar::calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft,
-                                         const sead::Matrix34f& OrthoMtxRight,
-                                         const sead::Matrix44f& projectionMtx, f32 areaMin,
-                                         f32 areaMax) {
-    setLocalAxisStereo(orthoMtxLeft, OrthoMtxRight);
+                                         const sead::Matrix34f& orthoMtxRight,
+                                         const sead::Matrix44f& projectionMtx, f32 near, f32 far) {
+    setLocalAxisStereo(orthoMtxLeft, orthoMtxRight);
     setFactorStereo(projectionMtx);
-    mAreaMin = areaMin;
-    mAreaMax = areaMax;
+    mNear = near;
+    mFar = far;
 }
 
 void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft,
@@ -90,7 +89,7 @@ void FrustumRadar::setFactorStereo(const sead::Matrix44f& projectionMtx) {
     mStereoSlopeLeft = mHorizontalSlope * (1.0f - centerOffset);
     mStereoNormFactorLeft = sead::Mathf::sqrt(mStereoSlopeLeft * mStereoSlopeLeft + 1.0f);
 
-    mStereoSlopeRight = mHorizontalSlope * (centerOffset + 1.0f);
+    mStereoSlopeRight = mHorizontalSlope * (1.0f + centerOffset);
     mStereoNormFactorRight = sead::Mathf::sqrt(mStereoSlopeRight * mStereoSlopeRight + 1.0f);
 }
 
@@ -119,17 +118,16 @@ bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 radius) const {
     f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
     f32 dotUp = mOrthoUp.dot(pos - mOrthoTrans);
 
-    return !(-(dotFront * mVerticalSlope + mVerticalNormFactor * radius) > dotUp);
+    return !(dotUp < -(dotFront * mVerticalSlope + mVerticalNormFactor * radius));
 }
 
-bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin,
-                               f32 areaMax) const {
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 near, f32 far) const {
     f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
 
-    if (dotFront < areaMin - radius)
+    if (dotFront < near - radius)
         return false;
 
-    if (0.0f < areaMax && radius + areaMax < dotFront)
+    if (far > 0.0f && radius + far < dotFront)
         return false;
 
     f32 dotUpAbs = sead::Mathf::abs(mOrthoUp.dot(pos - mOrthoTrans));
@@ -157,25 +155,29 @@ bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMi
     return true;
 }
 
-bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin) const {
-    return judgeInArea(pos, radius, areaMin, mAreaMax);
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 near) const {
+    return judgeInArea(pos, radius, near, mFar);
 }
 
 bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius) const {
-    return judgeInArea(pos, radius, mAreaMin, mAreaMax);
+    return judgeInArea(pos, radius, mNear, mFar);
 }
 
 bool FrustumRadar::judgeInAreaNoFar(const sead::Vector3f& pos, f32 radius) const {
-    return judgeInArea(pos, radius, mAreaMin, -1.0f);
+    return judgeInArea(pos, radius, mNear, -1.0f);
 }
 
-FrustumRadar::PointFlag FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 areaMin,
-                                                     f32 areaMax) const {
+FrustumRadar::PointFlag FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 near,
+                                                     f32 far) const {
+    u32 flag = PointFlag::None;
+
     sead::Vector3f relPos = pos - mOrthoTrans;
     f32 dotFront = mOrthoFront.dot(relPos);
 
-    u32 flag = (dotFront < areaMin) ? PointFlag::Near : PointFlag::None;
-    if (areaMax > 0.0f && dotFront > areaMax)
+    if (dotFront < near)
+        flag |= PointFlag::Near;
+
+    if (far > 0.0f && dotFront > far)
         flag |= PointFlag::Far;
 
     f32 dotUp = mOrthoUp.dot(relPos);
@@ -209,35 +211,35 @@ FrustumRadar::PointFlag FrustumRadar::judgePointFlag(const sead::Vector3f& pos, 
 }
 
 bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
-                                  f32 areaMin, f32 areaMax) const {
+                                  f32 near, f32 far) const {
     sead::Vector3f corners[8];
     calcObbCorners(corners, *mtx, boundBox);
 
-    s32 flags = PointFlag::Invalid;
+    s32 mask = ~PointFlag::None;
     for (s32 i = 0; i < 8; ++i) {
-        s32 pointFlags = judgePointFlag(corners[i], areaMin, areaMax);
+        s32 pointFlags = judgePointFlag(corners[i], near, far);
         if (pointFlags == PointFlag::None)
             return true;
 
-        flags &= pointFlags;
+        mask &= pointFlags;
     }
 
-    return flags == PointFlag::None;
+    return mask == PointFlag::None;
 }
 
 bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
-                                  f32 areaMin) const {
-    return judgeInAreaObb(mtx, boundBox, areaMin, mAreaMax);
+                                  f32 near) const {
+    return judgeInAreaObb(mtx, boundBox, near, mFar);
 }
 
 bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx,
                                   const sead::BoundBox3f& boundBox) const {
-    return judgeInAreaObb(mtx, boundBox, mAreaMin, mAreaMax);
+    return judgeInAreaObb(mtx, boundBox, mNear, mFar);
 }
 
 bool FrustumRadar::judgeInAreaObbNoFar(const sead::Matrix34f* mtx,
                                        const sead::BoundBox3f& boundBox) const {
-    return judgeInAreaObb(mtx, boundBox, mAreaMin, -1.0f);
+    return judgeInAreaObb(mtx, boundBox, mNear, -1.0f);
 }
 
 }  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.cpp
+++ b/lib/al/Library/Clipping/FrustumRadar.cpp
@@ -7,200 +7,237 @@
 
 namespace al {
 
-FrustumRadar::FrustumRadar() {}
+FrustumRadar::FrustumRadar() = default;
 
-void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 f1, f32 f2, f32 f3,
-                                   f32 f4) {
+void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 vFovAngle, f32 aspectRatio,
+                                   f32 areaMin, f32 areaMax) {
     setLocalAxis(orthoMtx);
 
-    setFactor(f1, f2);
+    setFactor(vFovAngle, aspectRatio);
 
-    _54 = f3;
-    _58 = f4;
+    mAreaMin = areaMin;
+    mAreaMax = areaMax;
 }
 
 void FrustumRadar::setLocalAxis(const sead::Matrix34f& orthoMtx) {
     sead::Matrix34f mtxInvertOrtho;
     calcMxtInvertOrtho(&mtxInvertOrtho, orthoMtx);
 
-    mOrthoSide.x = mtxInvertOrtho.m[0][0];
-    mOrthoSide.y = mtxInvertOrtho.m[1][0];
-    mOrthoSide.z = mtxInvertOrtho.m[2][0];
-    mOrthoUp.x = mtxInvertOrtho.m[0][1];
-    mOrthoUp.y = mtxInvertOrtho.m[1][1];
-    mOrthoUp.z = mtxInvertOrtho.m[2][1];
-    const sead::Vector3f& base2 = mtxInvertOrtho.getBase(2);
-    mOrthoFront.x = -base2.x;
-    mOrthoFront.y = -base2.y;
-    mOrthoFront.z = -base2.z;
-    mOrthoTrans.x = mtxInvertOrtho.m[0][3];
-    mOrthoTrans.y = mtxInvertOrtho.m[1][3];
-    mOrthoTrans.z = mtxInvertOrtho.m[2][3];
-    _40 = 0.0f;
+    mtxInvertOrtho.getBase(mOrthoSide, 0);
+    mtxInvertOrtho.getBase(mOrthoUp, 1);
+    mtxInvertOrtho.getBase(mOrthoFront, 2);
+    mOrthoFront.negate();
+    mtxInvertOrtho.getTranslation(mOrthoTrans);
+
+    mStereoEyeOffset = 0.0f;
 }
 
-void FrustumRadar::setFactor(f32 f1, f32 f2) {
-    _38 = sead::Mathf::tan(sead::Mathf::deg2rad(f1 * 0.5f));
-    _3c = sead::Mathf::sqrt(_38 * _38 + 1.0f);
+void FrustumRadar::setFactor(f32 vFovAngle, f32 aspectRatio) {
+    mVerticalSlope = sead::Mathf::tan(sead::Mathf::deg2rad(vFovAngle * 0.5f));
+    mVerticalNormFactor = sead::Mathf::sqrt(mVerticalSlope * mVerticalSlope + 1.0f);
 
-    _30 = _38 * f2;
-    _34 = sead::Mathf::sqrt(_30 * _30 + 1.0f);
+    mHorizontalSlope = mVerticalSlope * aspectRatio;
+    mHorizontalNormFactor = sead::Mathf::sqrt(mHorizontalSlope * mHorizontalSlope + 1.0f);
 }
 
 void FrustumRadar::calcFrustumArea(const sead::Matrix34f& orthoMtx,
-                                   const sead::Matrix44f& factorMtx, f32 f1, f32 f2) {
+                                   const sead::Matrix44f& projectionMtx, f32 areaMin, f32 areaMax) {
     setLocalAxis(orthoMtx);
-    setFactor(factorMtx);
-    _54 = f1;
-    _58 = f2;
+    setFactor(projectionMtx);
+    mAreaMin = areaMin;
+    mAreaMax = areaMax;
 }
 
-void FrustumRadar::setFactor(const sead::Matrix44f& mtx) {
-    _38 = 1.0 / mtx(1, 1);
-    _3c = sead::Mathf::sqrt(_38 * _38 + 1);
+void FrustumRadar::setFactor(const sead::Matrix44f& projectionMtx) {
+    mVerticalSlope = 1.0f / projectionMtx(1, 1);
+    mVerticalNormFactor = sead::Mathf::sqrt(mVerticalSlope * mVerticalSlope + 1.0f);
 
-    _30 = 1.0 / mtx(0, 0);
-    _34 = sead::Mathf::sqrt(_30 * _30 + 1);
+    mHorizontalSlope = 1.0f / projectionMtx(0, 0);
+    mHorizontalNormFactor = sead::Mathf::sqrt(mHorizontalSlope * mHorizontalSlope + 1.0f);
 }
 
 void FrustumRadar::calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft,
                                          const sead::Matrix34f& OrthoMtxRight,
-                                         const sead::Matrix44f& mtx, f32 f1, f32 f2) {
+                                         const sead::Matrix44f& projectionMtx, f32 areaMin,
+                                         f32 areaMax) {
     setLocalAxisStereo(orthoMtxLeft, OrthoMtxRight);
-    setFactorStereo(mtx);
-    _54 = f1;
-    _58 = f2;
+    setFactorStereo(projectionMtx);
+    mAreaMin = areaMin;
+    mAreaMax = areaMax;
 }
 
 void FrustumRadar::setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft,
                                       const sead::Matrix34f& orthoMtxRight) {
     sead::Matrix34f mtxInvertOrthoLeft;
     sead::Matrix34f mtxInvertRight;
-
     calcMxtInvertOrtho(&mtxInvertOrthoLeft, orthoMtxLeft);
 
-    mOrthoSide.x = mtxInvertOrthoLeft.m[0][0];
-    mOrthoSide.y = mtxInvertOrthoLeft.m[1][0];
-    mOrthoSide.z = mtxInvertOrthoLeft.m[2][0];
-    mOrthoUp.x = mtxInvertOrthoLeft.m[0][1];
-    mOrthoUp.y = mtxInvertOrthoLeft.m[1][1];
-    mOrthoUp.z = mtxInvertOrthoLeft.m[2][1];
-    const sead::Vector3f& base2 = mtxInvertOrthoLeft.getBase(2);
-    mOrthoFront.x = -base2.x;
-    mOrthoFront.y = -base2.y;
-    mOrthoFront.z = -base2.z;
+    mtxInvertOrthoLeft.getBase(mOrthoSide, 0);
+    mtxInvertOrthoLeft.getBase(mOrthoUp, 1);
+    mtxInvertOrthoLeft.getBase(mOrthoFront, 2);
+    mOrthoFront.negate();
 
     calcMxtInvertOrtho(&mtxInvertRight, orthoMtxRight);
     mOrthoTrans = (mtxInvertOrthoLeft.getTranslation() + mtxInvertRight.getTranslation()) * 0.5f;
 
-    _40 = mOrthoSide.dot(mOrthoTrans - mtxInvertOrthoLeft.getTranslation());
+    mStereoEyeOffset = mOrthoSide.dot(mOrthoTrans - mtxInvertOrthoLeft.getTranslation());
 }
 
-void FrustumRadar::setFactorStereo(const sead::Matrix44f& mtx) {
-    setFactor(mtx);
-    f32 f2 = mtx(0, 2);
+void FrustumRadar::setFactorStereo(const sead::Matrix44f& projectionMtx) {
+    setFactor(projectionMtx);
+    f32 centerOffset = projectionMtx(0, 2);
 
-    _44 = _30 * (1.0f - f2);
-    _48 = sead::Mathf::sqrt(_44 * _44 + 1.0f);
-    _4c = _30 * (f2 + 1.0f);
-    _50 = sead::Mathf::sqrt(_4c * _4c + 1.0f);
+    mStereoSlopeLeft = mHorizontalSlope * (1.0f - centerOffset);
+    mStereoNormFactorLeft = sead::Mathf::sqrt(mStereoSlopeLeft * mStereoSlopeLeft + 1.0f);
+
+    mStereoSlopeRight = mHorizontalSlope * (centerOffset + 1.0f);
+    mStereoNormFactorRight = sead::Mathf::sqrt(mStereoSlopeRight * mStereoSlopeRight + 1.0f);
 }
 
-bool FrustumRadar::judgeInLeft(const sead::Vector3f& pos, f32 f) const {
-    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
-    f32 dot2 = mOrthoSide.dot(pos - mOrthoTrans);
+bool FrustumRadar::judgeInLeft(const sead::Vector3f& pos, f32 radius) const {
+    f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dotSide = mOrthoSide.dot(pos - mOrthoTrans);
 
-    return !(dot2 < -(dot1 * _30 + _34 * f));
+    return !(dotSide < -(dotFront * mHorizontalSlope + mHorizontalNormFactor * radius));
 }
 
-bool FrustumRadar::judgeInRight(const sead::Vector3f& pos, f32 f) const {
-    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
-    f32 dot2 = mOrthoSide.dot(pos - mOrthoTrans);
+bool FrustumRadar::judgeInRight(const sead::Vector3f& pos, f32 radius) const {
+    f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dotSide = mOrthoSide.dot(pos - mOrthoTrans);
 
-    return !(dot1 * _30 + _34 * f < dot2);
+    return !(dotFront * mHorizontalSlope + mHorizontalNormFactor * radius < dotSide);
 }
 
-bool FrustumRadar::judgeInTop(const sead::Vector3f& pos, f32 f) const {
-    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
-    f32 dot2 = mOrthoUp.dot(pos - mOrthoTrans);
+bool FrustumRadar::judgeInTop(const sead::Vector3f& pos, f32 radius) const {
+    f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dotUp = mOrthoUp.dot(pos - mOrthoTrans);
 
-    return !(dot1 * _38 + _3c * f < dot2);
+    return !(dotFront * mVerticalSlope + mVerticalNormFactor * radius < dotUp);
 }
 
-bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 f) const {
-    f32 dot1 = mOrthoFront.dot(pos - mOrthoTrans);
-    f32 dot2 = mOrthoUp.dot(pos - mOrthoTrans);
+bool FrustumRadar::judgeInBottom(const sead::Vector3f& pos, f32 radius) const {
+    f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
+    f32 dotUp = mOrthoUp.dot(pos - mOrthoTrans);
 
-    return !(-(dot1 * _38 + _3c * f) > dot2);
+    return !(-(dotFront * mVerticalSlope + mVerticalNormFactor * radius) > dotUp);
 }
 
-bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2, f32 f3) const {
-    f32 dot;
-    f32 f4;
-    f32 fVar2;
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin,
+                               f32 areaMax) const {
+    f32 dotFront = mOrthoFront.dot(pos - mOrthoTrans);
 
-    dot = mOrthoFront.dot(pos - mOrthoTrans);
-    if (dot < f2 - f1)
+    if (dotFront < areaMin - radius)
         return false;
 
-    if (0.0 < f3 && f1 + f3 < dot)
+    if (0.0f < areaMax && radius + areaMax < dotFront)
         return false;
 
-    f4 = sead::Mathf::abs(mOrthoUp.dot(pos - mOrthoTrans));
-    if (dot * _38 + _3c * f1 < f4)
+    f32 dotUpAbs = sead::Mathf::abs(mOrthoUp.dot(pos - mOrthoTrans));
+    if (dotFront * mVerticalSlope + mVerticalNormFactor * radius < dotUpAbs)
         return false;
 
-    fVar2 = mOrthoSide.dot(pos - mOrthoTrans);
-    if (isNearZero(_40, 0.001)) {
-        if (dot * _30 + _34 * f1 < sead::Mathf::abs(fVar2))
+    f32 dotSide = mOrthoSide.dot(pos - mOrthoTrans);
+    if (isNearZero(mStereoEyeOffset)) {
+        if (dotFront * mHorizontalSlope + mHorizontalNormFactor * radius <
+            sead::Mathf::abs(dotSide))
             return false;
     } else {
-        f32 fVar3 = dot * _4c + _50 * f1;
-        dot = dot * _44 + _48 * f1;
-        f32 fVar4 = fVar2 - _40;
-        fVar2 = fVar2 + _40;
+        f32 limitRight = dotFront * mStereoSlopeRight + mStereoNormFactorRight * radius;
+        f32 limitLeft = dotFront * mStereoSlopeLeft + mStereoNormFactorLeft * radius;
 
-        if (fVar4 > dot && fVar2 > fVar3)
+        f32 relSideLeft = dotSide - mStereoEyeOffset;
+        f32 relSideRight = dotSide + mStereoEyeOffset;
+
+        if (relSideLeft > limitLeft && relSideRight > limitRight)
             return false;
 
-        f32 neg_fVar3 = -fVar3;
-        f32 neg_dot = -dot;
-
-        if (fVar4 < neg_fVar3 && fVar2 < neg_dot)
+        if (relSideLeft < -limitRight && relSideRight < -limitLeft)
             return false;
     }
     return true;
 }
 
-bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1, f32 f2) const {
-    return judgeInArea(pos, f1, f2, _58);
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin) const {
+    return judgeInArea(pos, radius, areaMin, mAreaMax);
 }
 
-bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 f1) const {
-    return judgeInArea(pos, f1, _54, _58);
+bool FrustumRadar::judgeInArea(const sead::Vector3f& pos, f32 radius) const {
+    return judgeInArea(pos, radius, mAreaMin, mAreaMax);
 }
 
-bool FrustumRadar::judgeInAreaNoFar(const sead::Vector3f& pos, f32 f1) const {
-    return judgeInArea(pos, f1, _54, -1.0f);
+bool FrustumRadar::judgeInAreaNoFar(const sead::Vector3f& pos, f32 radius) const {
+    return judgeInArea(pos, radius, mAreaMin, -1.0f);
 }
 
-bool FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 f1, f32 f2) const {}
+FrustumRadar::PointFlag FrustumRadar::judgePointFlag(const sead::Vector3f& pos, f32 areaMin,
+                                                     f32 areaMax) const {
+    sead::Vector3f relPos = pos - mOrthoTrans;
+    f32 dotFront = mOrthoFront.dot(relPos);
 
-bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound, f32 f1,
-                                  f32 f2) const {}
+    u32 flag = (dotFront < areaMin) ? PointFlag::Near : PointFlag::None;
+    if (areaMax > 0.0f && dotFront > areaMax)
+        flag |= PointFlag::Far;
 
-bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound,
-                                  f32 f1) const {
-    return judgeInAreaObb(mtx, bound, f1, _58);
+    f32 dotUp = mOrthoUp.dot(relPos);
+    if (dotUp < -(dotFront * mVerticalSlope))
+        flag |= PointFlag::Bottom;
+
+    if (dotFront * mVerticalSlope < dotUp)
+        flag |= PointFlag::Top;
+
+    f32 dotSide = mOrthoSide.dot(relPos);
+    if (isNearZero(mStereoEyeOffset)) {
+        if (dotSide < -(dotFront * mHorizontalSlope))
+            flag |= PointFlag::Left;
+        if (dotFront * mHorizontalSlope < dotSide)
+            flag |= PointFlag::Right;
+        return (PointFlag)flag;
+    }
+
+    f32 limitRight = dotFront * mStereoSlopeRight;
+    f32 limitLeft = dotFront * mStereoSlopeLeft;
+    f32 distSideLeftEye = dotSide - mStereoEyeOffset;
+    f32 distSideRightEye = dotSide + mStereoEyeOffset;
+
+    if (distSideLeftEye > limitLeft && distSideRightEye > limitRight)
+        flag |= PointFlag::Right;
+
+    if (distSideLeftEye < -limitRight && distSideRightEye < -limitLeft)
+        flag |= PointFlag::Left;
+
+    return (PointFlag)flag;
 }
 
-bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& bound) {
-    return judgeInAreaObb(mtx, bound, _54, _58);
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
+                                  f32 areaMin, f32 areaMax) const {
+    sead::Vector3f corners[8];
+    calcObbCorners(corners, *mtx, boundBox);
+
+    s32 flags = PointFlag::Invalid;
+    for (s32 i = 0; i < 8; ++i) {
+        s32 pointFlags = judgePointFlag(corners[i], areaMin, areaMax);
+        if (pointFlags == PointFlag::None)
+            return true;
+
+        flags &= pointFlags;
+    }
+
+    return flags == PointFlag::None;
+}
+
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
+                                  f32 areaMin) const {
+    return judgeInAreaObb(mtx, boundBox, areaMin, mAreaMax);
+}
+
+bool FrustumRadar::judgeInAreaObb(const sead::Matrix34f* mtx,
+                                  const sead::BoundBox3f& boundBox) const {
+    return judgeInAreaObb(mtx, boundBox, mAreaMin, mAreaMax);
 }
 
 bool FrustumRadar::judgeInAreaObbNoFar(const sead::Matrix34f* mtx,
-                                       const sead::BoundBox3f& bound) const {
-    return judgeInAreaObb(mtx, bound, _54, -0.0);
+                                       const sead::BoundBox3f& boundBox) const {
+    return judgeInAreaObb(mtx, boundBox, mAreaMin, -1.0f);
 }
 
 }  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -25,7 +25,7 @@ public:
     bool judgeInBottom(const sead::Vector3f&, f32) const;
     bool judgeInArea(const sead::Vector3f&, f32, f32, f32) const;
     bool judgeInArea(const sead::Vector3f&, f32, f32) const;
-    bool judgeInArea(const sead::Vector3f&, f32);
+    bool judgeInArea(const sead::Vector3f&, f32) const;
     bool judgeInAreaNoFar(const sead::Vector3f&, f32) const;
     bool judgePointFlag(const sead::Vector3f&, f32, f32) const;
     bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&, f32, f32) const;

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -3,6 +3,8 @@
 #include <math/seadBoundBox.h>
 #include <math/seadMatrix.h>
 
+#include "Library/Matrix/MatrixUtil.h"
+
 namespace al {
 
 class FrustumRadar {
@@ -12,7 +14,7 @@ public:
     void setLocalAxis(const sead::Matrix34f&);
     void setFactor(f32, f32);
     void calcFrustumArea(const sead::Matrix34f&, const sead::Matrix44f&, f32, f32);
-    void setFactor(sead::Matrix44f);
+    void setFactor(const sead::Matrix44f&);
     void calcFrustumAreaStereo(const sead::Matrix34f&, const sead::Matrix34f&,
                                const sead::Matrix44f&, f32, f32);
     void setLocalAxisStereo(const sead::Matrix34f&, const sead::Matrix34f&);
@@ -30,7 +32,22 @@ public:
     bool judgeInAreaObbNoFar(const sead::Matrix34f*, const sead::BoundBox3f&) const;
 
 private:
-    unsigned char filler[0x5c];
+    sead::Vector3f mOrthoSide;
+    sead::Vector3f mOrthoUp;
+    sead::Vector3f mOrthoFront;
+    sead::Vector3f mOrthoTrans;
+    f32 _30;
+    f32 _34;
+    f32 _38;
+    f32 _3c;
+    f32 _40;
+    f32 _44;
+    f32 _48;
+    f32 _4c;
+    f32 _50;
+    f32 _54;
+    f32 _58;
+
 };
 
 }  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -25,10 +25,12 @@ public:
     bool judgeInBottom(const sead::Vector3f&, f32) const;
     bool judgeInArea(const sead::Vector3f&, f32, f32, f32) const;
     bool judgeInArea(const sead::Vector3f&, f32, f32) const;
+    bool judgeInArea(const sead::Vector3f&, f32);
     bool judgeInAreaNoFar(const sead::Vector3f&, f32) const;
     bool judgePointFlag(const sead::Vector3f&, f32, f32) const;
     bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&, f32, f32) const;
     bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&, f32) const;
+    bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&);
     bool judgeInAreaObbNoFar(const sead::Matrix34f*, const sead::BoundBox3f&) const;
 
 private:

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -49,7 +49,6 @@ private:
     f32 _50;
     f32 _54;
     f32 _58;
-
 };
 
 }  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -9,8 +9,7 @@ namespace al {
 
 class FrustumRadar {
 public:
-    enum PointFlag : s32 {
-        Invalid = -1,
+    enum PointFlag : u32 {
         None = 0,
         Near = 1,
         Far = 2,
@@ -21,16 +20,16 @@ public:
     };
 
     FrustumRadar();
-    void calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 vFovAngle, f32 aspectRatio,
-                         f32 areaMin, f32 areaMax);
+    void calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 fovyAngle, f32 aspectRatio, f32 near,
+                         f32 far);
     void setLocalAxis(const sead::Matrix34f& orthoMtx);
-    void setFactor(f32 vFovAngle, f32 aspectRatio);
+    void setFactor(f32 fovyAngle, f32 aspectRatio);
     void calcFrustumArea(const sead::Matrix34f& orthoMtx, const sead::Matrix44f& projectionMtx,
-                         f32 areaMin, f32 areaMax);
+                         f32 near, f32 far);
     void setFactor(const sead::Matrix44f& projectionMtx);
     void calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft,
-                               const sead::Matrix34f& OrthoMtxRight,
-                               const sead::Matrix44f& projectionMtx, f32 areaMin, f32 areaMax);
+                               const sead::Matrix34f& orthoMtxRight,
+                               const sead::Matrix44f& projectionMtx, f32 near, f32 far);
     void setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft,
                             const sead::Matrix34f& orthoMtxRight);
     void setFactorStereo(const sead::Matrix44f& projectionMtx);
@@ -38,15 +37,15 @@ public:
     bool judgeInRight(const sead::Vector3f& pos, f32 radius) const;
     bool judgeInTop(const sead::Vector3f& pos, f32 radius) const;
     bool judgeInBottom(const sead::Vector3f& pos, f32 radius) const;
-    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin, f32 areaMax) const;
-    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin) const;
+    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 near, f32 far) const;
+    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 near) const;
     bool judgeInArea(const sead::Vector3f& pos, f32 radius) const;
     bool judgeInAreaNoFar(const sead::Vector3f& pos, f32 radius) const;
-    PointFlag judgePointFlag(const sead::Vector3f& pos, f32 areaMin, f32 areaMax) const;
-    bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox, f32 areaMin,
-                        f32 areaMax) const;
+    PointFlag judgePointFlag(const sead::Vector3f& pos, f32 near, f32 far) const;
+    bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox, f32 near,
+                        f32 far) const;
     bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
-                        f32 areaMin) const;
+                        f32 near) const;
     bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox) const;
     bool judgeInAreaObbNoFar(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox) const;
 
@@ -64,8 +63,8 @@ private:
     f32 mStereoNormFactorLeft = 1.04403f;
     f32 mStereoSlopeRight = 0.3f;
     f32 mStereoNormFactorRight = 1.04403f;
-    f32 mAreaMin = 100.0f;
-    f32 mAreaMax = 10000.0f;
+    f32 mNear = 100.0f;
+    f32 mFar = 10000.0f;
 };
 
 }  // namespace al

--- a/lib/al/Library/Clipping/FrustumRadar.h
+++ b/lib/al/Library/Clipping/FrustumRadar.h
@@ -9,46 +9,63 @@ namespace al {
 
 class FrustumRadar {
 public:
+    enum PointFlag : s32 {
+        Invalid = -1,
+        None = 0,
+        Near = 1,
+        Far = 2,
+        Bottom = 4,
+        Top = 8,
+        Left = 16,
+        Right = 32,
+    };
+
     FrustumRadar();
-    void calcFrustumArea(const sead::Matrix34f&, f32, f32, f32, f32);
-    void setLocalAxis(const sead::Matrix34f&);
-    void setFactor(f32, f32);
-    void calcFrustumArea(const sead::Matrix34f&, const sead::Matrix44f&, f32, f32);
-    void setFactor(const sead::Matrix44f&);
-    void calcFrustumAreaStereo(const sead::Matrix34f&, const sead::Matrix34f&,
-                               const sead::Matrix44f&, f32, f32);
-    void setLocalAxisStereo(const sead::Matrix34f&, const sead::Matrix34f&);
-    void setFactorStereo(const sead::Matrix44f&);
-    bool judgeInLeft(const sead::Vector3f&, f32) const;
-    bool judgeInRight(const sead::Vector3f&, f32) const;
-    bool judgeInTop(const sead::Vector3f&, f32) const;
-    bool judgeInBottom(const sead::Vector3f&, f32) const;
-    bool judgeInArea(const sead::Vector3f&, f32, f32, f32) const;
-    bool judgeInArea(const sead::Vector3f&, f32, f32) const;
-    bool judgeInArea(const sead::Vector3f&, f32) const;
-    bool judgeInAreaNoFar(const sead::Vector3f&, f32) const;
-    bool judgePointFlag(const sead::Vector3f&, f32, f32) const;
-    bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&, f32, f32) const;
-    bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&, f32) const;
-    bool judgeInAreaObb(const sead::Matrix34f*, const sead::BoundBox3f&);
-    bool judgeInAreaObbNoFar(const sead::Matrix34f*, const sead::BoundBox3f&) const;
+    void calcFrustumArea(const sead::Matrix34f& orthoMtx, f32 vFovAngle, f32 aspectRatio,
+                         f32 areaMin, f32 areaMax);
+    void setLocalAxis(const sead::Matrix34f& orthoMtx);
+    void setFactor(f32 vFovAngle, f32 aspectRatio);
+    void calcFrustumArea(const sead::Matrix34f& orthoMtx, const sead::Matrix44f& projectionMtx,
+                         f32 areaMin, f32 areaMax);
+    void setFactor(const sead::Matrix44f& projectionMtx);
+    void calcFrustumAreaStereo(const sead::Matrix34f& orthoMtxLeft,
+                               const sead::Matrix34f& OrthoMtxRight,
+                               const sead::Matrix44f& projectionMtx, f32 areaMin, f32 areaMax);
+    void setLocalAxisStereo(const sead::Matrix34f& orthoMtxLeft,
+                            const sead::Matrix34f& orthoMtxRight);
+    void setFactorStereo(const sead::Matrix44f& projectionMtx);
+    bool judgeInLeft(const sead::Vector3f& pos, f32 radius) const;
+    bool judgeInRight(const sead::Vector3f& pos, f32 radius) const;
+    bool judgeInTop(const sead::Vector3f& pos, f32 radius) const;
+    bool judgeInBottom(const sead::Vector3f& pos, f32 radius) const;
+    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin, f32 areaMax) const;
+    bool judgeInArea(const sead::Vector3f& pos, f32 radius, f32 areaMin) const;
+    bool judgeInArea(const sead::Vector3f& pos, f32 radius) const;
+    bool judgeInAreaNoFar(const sead::Vector3f& pos, f32 radius) const;
+    PointFlag judgePointFlag(const sead::Vector3f& pos, f32 areaMin, f32 areaMax) const;
+    bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox, f32 areaMin,
+                        f32 areaMax) const;
+    bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox,
+                        f32 areaMin) const;
+    bool judgeInAreaObb(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox) const;
+    bool judgeInAreaObbNoFar(const sead::Matrix34f* mtx, const sead::BoundBox3f& boundBox) const;
 
 private:
-    sead::Vector3f mOrthoSide;
-    sead::Vector3f mOrthoUp;
-    sead::Vector3f mOrthoFront;
-    sead::Vector3f mOrthoTrans;
-    f32 _30;
-    f32 _34;
-    f32 _38;
-    f32 _3c;
-    f32 _40;
-    f32 _44;
-    f32 _48;
-    f32 _4c;
-    f32 _50;
-    f32 _54;
-    f32 _58;
+    sead::Vector3f mOrthoSide = sead::Vector3f::ex;
+    sead::Vector3f mOrthoUp = sead::Vector3f::ey;
+    sead::Vector3f mOrthoFront = sead::Vector3f::ez;
+    sead::Vector3f mOrthoTrans = sead::Vector3f::zero;
+    f32 mHorizontalSlope = 0.3f;
+    f32 mHorizontalNormFactor = 1.04403f;
+    f32 mVerticalSlope = 0.2f;
+    f32 mVerticalNormFactor = 1.0098f;
+    f32 mStereoEyeOffset = 0.0f;
+    f32 mStereoSlopeLeft = 0.3f;
+    f32 mStereoNormFactorLeft = 1.04403f;
+    f32 mStereoSlopeRight = 0.3f;
+    f32 mStereoNormFactorRight = 1.04403f;
+    f32 mAreaMin = 100.0f;
+    f32 mAreaMax = 10000.0f;
 };
 
 }  // namespace al


### PR DESCRIPTION
Supersedes #713. Muz left that PR asking for help. It took several attempts and almost a year to get it right. There are some parts that I consider cursed. But that's better than no matching or having hacks.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1049)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 9011b64)

📈 **Matched code**: 14.22% (+0.03%, +3736 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::calcFrustumAreaStereo(sead::Matrix34<float> const&, sead::Matrix34<float> const&, sead::Matrix44<float> const&, float, float)` | +472 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInAreaObb(sead::Matrix34<float> const*, sead::BoundBox3<float> const&, float, float) const` | +396 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInArea(sead::Vector3<float> const&, float, float, float) const` | +376 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgePointFlag(sead::Vector3<float> const&, float, float) const` | +324 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::calcFrustumArea(sead::Matrix34<float> const&, float, float, float, float)` | +296 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::calcFrustumArea(sead::Matrix34<float> const&, sead::Matrix44<float> const&, float, float)` | +276 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::setLocalAxisStereo(sead::Matrix34<float> const&, sead::Matrix34<float> const&)` | +244 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::setFactorStereo(sead::Matrix44<float> const&)` | +228 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::FrustumRadar()` | +192 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::setLocalAxis(sead::Matrix34<float> const&)` | +156 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::setFactor(float, float)` | +148 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::setFactor(sead::Matrix44<float> const&)` | +132 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInLeft(sead::Vector3<float> const&, float) const` | +112 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInBottom(sead::Vector3<float> const&, float) const` | +112 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInRight(sead::Vector3<float> const&, float) const` | +108 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInTop(sead::Vector3<float> const&, float) const` | +108 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInAreaNoFar(sead::Vector3<float> const&, float) const` | +12 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInAreaObbNoFar(sead::Matrix34<float> const*, sead::BoundBox3<float> const&) const` | +12 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInArea(sead::Vector3<float> const&, float, float) const` | +8 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInArea(sead::Vector3<float> const&, float) const` | +8 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInAreaObb(sead::Matrix34<float> const*, sead::BoundBox3<float> const&, float) const` | +8 | 0.00% | 100.00% |
| `Library/Clipping/FrustumRadar` | `al::FrustumRadar::judgeInAreaObb(sead::Matrix34<float> const*, sead::BoundBox3<float> const&) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->