### PR TITLE
MapObj: Implement `WaterfallWorldWaterfall`

### DIFF
--- a/src/MapObj/WaterfallWorldWaterfall.cpp
+++ b/src/MapObj/WaterfallWorldWaterfall.cpp
@@ -1,0 +1,74 @@
+#include "MapObj/WaterfallWorldWaterfall.h"
+
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/EffectObjFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+NERVE_IMPL(WaterfallWorldWaterfall, WaitMax)
+NERVE_IMPL(WaterfallWorldWaterfall, ChangeMaxToMin)
+NERVE_IMPL(WaterfallWorldWaterfall, ChangeMinToMax)
+NERVE_IMPL(WaterfallWorldWaterfall, WaitMin)
+
+NERVES_MAKE_NOSTRUCT(WaterfallWorldWaterfall, WaitMax, ChangeMaxToMin, ChangeMinToMax, WaitMin)
+}  // namespace
+
+WaterfallWorldWaterfall::WaterfallWorldWaterfall(const char* name) : al::LiveActor(name) {}
+
+void WaterfallWorldWaterfall::init(const al::ActorInitInfo& info) {
+    using WaterfallWorldWaterfallFunctor =
+        al::FunctorV0M<WaterfallWorldWaterfall*, void (WaterfallWorldWaterfall::*)()>;
+
+    al::EffectObjFunction::initActorEffectObj(this, info);
+    al::initNerve(this, &WaitMax, 0);
+
+    al::listenStageSwitchOnOff(
+        this, "OnChangeAlphaSwitch",
+        WaterfallWorldWaterfallFunctor(this, &WaterfallWorldWaterfall::changeToMin),
+        WaterfallWorldWaterfallFunctor(this, &WaterfallWorldWaterfall::changeToMax));
+
+    al::makeMtxRT(&mBaseMtx, this);
+    makeActorAlive();
+}
+
+void WaterfallWorldWaterfall::changeToMin() {
+    al::setNerve(this, &ChangeMaxToMin);
+}
+
+void WaterfallWorldWaterfall::changeToMax() {
+    al::setNerve(this, &ChangeMinToMax);
+}
+
+void WaterfallWorldWaterfall::exeWaitMax() {
+    if (al::isFirstStep(this)) {
+        al::emitEffect(this, "Wait", nullptr);
+        al::setEffectParticleAlpha(this, "Wait", 1.0f);
+    }
+}
+
+void WaterfallWorldWaterfall::exeChangeMaxToMin() {
+    al::setEffectParticleAlpha(this, "Wait",
+                               al::lerpValue(1.0f, 0.1f, al::calcNerveRate(this, 10)));
+
+    if (al::isGreaterEqualStep(this, 10))
+        al::setNerve(this, &WaitMin);
+}
+
+void WaterfallWorldWaterfall::exeWaitMin() {
+    if (al::isFirstStep(this))
+        al::setEffectParticleAlpha(this, "Wait", 0.1f);
+}
+
+void WaterfallWorldWaterfall::exeChangeMinToMax() {
+    al::setEffectParticleAlpha(this, "Wait",
+                               al::lerpValue(0.1f, 1.0f, al::calcNerveRate(this, 10)));
+
+    if (al::isGreaterEqualStep(this, 10))
+        al::setNerve(this, &WaitMax);
+}

--- a/src/MapObj/WaterfallWorldWaterfall.h
+++ b/src/MapObj/WaterfallWorldWaterfall.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class WaterfallWorldWaterfall : public al::LiveActor {
+public:
+    WaterfallWorldWaterfall(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    const sead::Matrix34f* getBaseMtx() const override { return &mBaseMtx; }
+
+    void changeToMin();
+    void changeToMax();
+    void exeWaitMax();
+    void exeChangeMaxToMin();
+    void exeWaitMin();
+    void exeChangeMinToMax();
+
+private:
+    sead::Matrix34f mBaseMtx = sead::Matrix34f::ident;
+};
+
+static_assert(sizeof(WaterfallWorldWaterfall) == 0x138);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -105,6 +105,7 @@
 #include "MapObj/TreasureBoxKey.h"
 #include "MapObj/VolleyballBase.h"
 #include "MapObj/VolleyballNet.h"
+#include "MapObj/WaterfallWorldWaterfall.h"
 #include "MapObj/WeightSwitch.h"
 #include "MapObj/WorldMapEarth.h"
 #include "MapObj/WorldWarpHole.h"
@@ -637,7 +638,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"WaterfallWorldBigBreakableWall", nullptr},
     {"WaterfallWorldFallDownBridge", nullptr},
     {"WaterfallWorldHomeCage", nullptr},
-    {"WaterfallWorldWaterfall", nullptr},
+    {"WaterfallWorldWaterfall", al::createActorFunction<WaterfallWorldWaterfall>},
     {"WaterRoad", nullptr},
     {"WeightSwitch", al::createActorFunction<WeightSwitch>},
     {"WheelWaveSurfParts", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1050)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - 5483feb)

📈 **Matched code**: 14.67% (+0.01%, +1492 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::init(al::ActorInitInfo const&)` | +160 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::WaterfallWorldWaterfall(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::WaterfallWorldWaterfall(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `(anonymous namespace)::WaterfallWorldWaterfallNrvChangeMaxToMin::execute(al::NerveKeeper*) const` | +136 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `(anonymous namespace)::WaterfallWorldWaterfallNrvChangeMinToMax::execute(al::NerveKeeper*) const` | +136 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::exeChangeMaxToMin()` | +132 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::exeChangeMinToMax()` | +132 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `(anonymous namespace)::WaterfallWorldWaterfallNrvWaitMax::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::exeWaitMax()` | +88 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `al::FunctorV0M<WaterfallWorldWaterfall*, void (WaterfallWorldWaterfall::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `(anonymous namespace)::WaterfallWorldWaterfallNrvWaitMin::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::exeWaitMin()` | +68 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<WaterfallWorldWaterfall>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `al::FunctorV0M<WaterfallWorldWaterfall*, void (WaterfallWorldWaterfall::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::changeToMin()` | +12 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::changeToMax()` | +12 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `WaterfallWorldWaterfall::getBaseMtx() const` | +8 | 0.00% | 100.00% |
| `MapObj/WaterfallWorldWaterfall` | `al::FunctorV0M<WaterfallWorldWaterfall*, void (WaterfallWorldWaterfall::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->