### PR TITLE
MapObj: Implement `WorldMapKoopaShip`

### DIFF
--- a/src/MapObj/PropellerRotateCtrl.h
+++ b/src/MapObj/PropellerRotateCtrl.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Joint/JointControllerBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class PropellerRotateInfo;
+
+class PropellerRotateCtrl : public al::JointControllerBase {
+public:
+    PropellerRotateCtrl(al::LiveActor* actor, const PropellerRotateInfo& info);
+
+    void update();
+    void calcJointCallback(s32 jointIndex, sead::Matrix34f* mtx) override;
+    const char* getCtrlTypeName() const override;
+
+private:
+    const PropellerRotateInfo* mRotateInfo = nullptr;
+    s32 mRotateFrame = 0;
+};
+
+static_assert(sizeof(PropellerRotateCtrl) == 0x38);

--- a/src/MapObj/WorldMapKoopaShip.cpp
+++ b/src/MapObj/WorldMapKoopaShip.cpp
@@ -1,0 +1,40 @@
+#include "MapObj/WorldMapKoopaShip.h"
+
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+
+#include "MapObj/KoopaShip.h"
+#include "MapObj/PropellerRotateCtrl.h"
+
+static const sead::Vector3f sFloatOffset = {0.0f, 110.0f, 0.0f};
+
+WorldMapKoopaShip* WorldMapKoopaShip::create(const char* name, const al::ActorInitInfo& initInfo,
+                                             const sead::Matrix34f* worldMtx) {
+    WorldMapKoopaShip* koopaShip = new WorldMapKoopaShip(name);
+
+    al::initActorSceneInfo(koopaShip, initInfo);
+    initParts(koopaShip, "KoopaShip", initInfo, worldMtx, sead::Matrix34f::ident, "WorldMap");
+
+    s32 propellerRotateInfoNum = KoopaShipFunction::getPropellerRotateInfoNum();
+    koopaShip->mPropellerRotateCtrlNum = propellerRotateInfoNum;
+    al::initJointControllerKeeper(koopaShip, propellerRotateInfoNum);
+
+    koopaShip->mPropellerRotateCtrls = new PropellerRotateCtrl*[koopaShip->mPropellerRotateCtrlNum];
+
+    for (s32 i = 0; i < koopaShip->mPropellerRotateCtrlNum; i++) {
+        koopaShip->mPropellerRotateCtrls[i] =
+            new PropellerRotateCtrl(koopaShip, *KoopaShipFunction::getPropellerRotateInfo(i));
+    }
+
+    return koopaShip;
+}
+
+WorldMapKoopaShip::WorldMapKoopaShip(const char* name)
+    : WorldMapPartsFloat(name, sFloatOffset, 540, 10.0f) {}
+
+void WorldMapKoopaShip::control() {
+    WorldMapPartsFloat::control();
+
+    for (s32 i = 0; i < mPropellerRotateCtrlNum; i++)
+        mPropellerRotateCtrls[i]->update();
+}

--- a/src/MapObj/WorldMapKoopaShip.h
+++ b/src/MapObj/WorldMapKoopaShip.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "MapObj/WorldMapParts.h"
+
+namespace al {
+struct ActorInitInfo;
+}
+
+class PropellerRotateCtrl;
+
+class WorldMapKoopaShip : public WorldMapPartsFloat {
+public:
+    static WorldMapKoopaShip* create(const char* name, const al::ActorInitInfo& initInfo,
+                                     const sead::Matrix34f* worldMtx);
+
+    WorldMapKoopaShip(const char* name);
+
+    void control() override;
+
+private:
+    PropellerRotateCtrl** mPropellerRotateCtrls = nullptr;
+    s32 mPropellerRotateCtrlNum = 0;
+};
+
+static_assert(sizeof(WorldMapKoopaShip) == 0x180);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1051)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 9944587)

📈 **Matched code**: 14.67% (+0.01%, +740 bytes)

<details>
<summary>✅ 4 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/WorldMapKoopaShip` | `WorldMapKoopaShip::create(char const*, al::ActorInitInfo const&, sead::Matrix34<float> const*)` | +364 | 0.00% | 100.00% |
| `MapObj/WorldMapKoopaShip` | `WorldMapKoopaShip::WorldMapKoopaShip(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/WorldMapKoopaShip` | `WorldMapKoopaShip::WorldMapKoopaShip(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/WorldMapKoopaShip` | `WorldMapKoopaShip::control()` | +76 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->