### PR TITLE
MapObj: Implement `TrexScrollBreakMapParts`

### DIFF
--- a/src/Enemy/TRex.h
+++ b/src/Enemy/TRex.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Player/IUsePlayerCollision.h"
+
+namespace al {
+struct ActorInitInfo;
+class ActorCameraSubTarget;
+class ActorCameraTarget;
+class AreaObjGroup;
+class CameraTicket;
+class HitSensor;
+class IBgmParamsChanger;
+class IUseNerve;
+class JointSpringControllerHolder;
+class LiveActorGroup;
+class Nerve;
+class SensorMsg;
+}  // namespace al
+
+class CapTargetInfo;
+class CollisionShapeInfoSphere;
+class EnemyCap;
+class EnemyStateHackStart;
+class IUsePlayerHack;
+class PlayerCollider;
+class TRex;
+class TRexCollisionAnalyzer;
+class TRexFootIK;
+class TRexGroundHeightCtrl;
+class TRexNeckAnimInterpoleCtrl;
+class TRexNeckDynamicsCtrl;
+class TRexNeckRumbleCtrl;
+class TRexNeckSwingWatchCtrl;
+class TRexNeckUpswingCtrl;
+class TRexPartialAnimCtrl;
+class TRexPatrolRouteRider;
+class TRexSmallGroundJointAnimator;
+class TRexStatePatrolChase;
+class TRexStateSleep;
+
+class TRexHackTurnInfo {
+public:
+    TRexHackTurnInfo();
+
+    void resetSpeed();
+    void updateWithInput();
+    void updateNoInput();
+    void setReverseInput();
+    bool isExistPreInput() const;
+    bool isInvalidUpdateTurnSpeed() const;
+    f32 calcInputScale() const;
+
+private:
+    s32 mTurnSpeed = 0;  // TODO: verify
+    s32 _4 = 0;
+    s32 mPreInputCount = 0;
+    s32 mReverseInputTimer = 0;
+    s32 _10 = 0;
+    s32 _14 = 0;
+    s32 mSpeed = 0;  // TODO: verify
+    s32 _1c = 0;
+};
+
+static_assert(sizeof(TRexHackTurnInfo) == 0x20);
+
+struct TRexHackTimeUpInfo {
+    al::LiveActor* actor = nullptr;
+    s32 timer = 0;
+    const char* currentSeName = nullptr;
+};
+
+static_assert(sizeof(TRexHackTimeUpInfo) == 0x18);
+
+struct TRexCollidedShapeInfo {
+    const TRex* tRex = nullptr;
+    sead::PtrArrayImpl* collidedShapes = nullptr;
+    s32 _10 = 0;
+};
+
+static_assert(sizeof(TRexCollidedShapeInfo) == 0x18);
+
+class TRex : public al::LiveActor, public IUsePlayerCollision {
+public:
+    TRex(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    const TRexFootIK* getLeftFootIK() const;
+    const TRexFootIK* getRightFootIK() const;
+    void initAfterPlacement() override;
+    void appear() override;
+    void kill() override;
+    void movement() override;
+    void control() override;
+    void updateCollider() override;
+    void calcAnim() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeSleep();
+    void endSleep();
+    void exeSwoonStart();
+    void exeSwoonStartLand();
+    void exeSwoon();
+    void exeFall();
+    void exeLand();
+    void exeHackStart();
+    void exeHackWait();
+    void exeHackAttackWait();
+    void endHackAttackWait();
+    void exeHackMove();
+    void exeHackMoveAfter();
+    void exeHackMoveGround();
+    void exeHackMoveJump();
+    void exeHackMoveEnd();
+    void exeHackHoldJump();
+    void exeHackFall();
+    void exeHackJumpStart();
+    void exeHackJump();
+    void exeHackTurn();
+    void exeHackTurnEnd();
+    void exeHackLand();
+    void endHackLand();
+    void exeReset();
+    void resetAllJointController();
+    void exePatrolWalkStart();
+    void exePatrolWalk();
+    void exePatrolWalkAfter();
+    void exePatrolWalkGround();
+    void exePatrolWalkEndL();
+    void exePatrolWaitSniff();
+    void exePatrolNoticeSniff();
+    void exePatrolTurnMario();
+    void exePatrolTurnBack();
+    void exePatrolDash();
+    void exePatrolHoldJump();
+    void exePatrolFall();
+    void exePatrolLand();
+    void exePatrolSwoonStartDashClash();
+    void exePatrolSwoonStart();
+    void exePatrolSwoon();
+    void exePatrolSwoonEnd();
+    void exePatrolReset();
+    bool isEnableBreakPartsForceScroll() const;
+    f32 getMaxSinkGroundHeight();
+    f32 getHoldJumpStartUpSpeed();
+    f32 getHoldJumpMoveAccel();
+    f32 getPatrolGravityAccel();
+    f32 getPatrolGroundFriction();
+    f32 getMaxPatrolFallSpeedOnGround();
+    const char* getHeadColliderShapeName();
+    void exeForceScrollStartFall();
+    void exeForceScrollStartLand();
+    void exeForceScrollRunStart();
+    void exeForceScrollRun();
+    void exeForceScrollAttackSign();
+    void exeForceScrollAttackStart();
+    void exeForceScrollAttack();
+    void endForceScrollAttack();
+    void exeForceScrollAttackEnd();
+    void exeForceScrollEndFallStart();
+    void exeForceScrollEndFall();
+
+    PlayerCollider* getPlayerCollider() const override { return mPlayerCollider; }
+
+    bool isForceScrollEndFallStart() const { return mIsForceScrollEndFallStart; }
+
+private:
+    s32 mParamType = 0;
+    s32 mTRexType = 1;
+    TRexFootIK** mFootIKs = nullptr;
+    TRexHackTimeUpInfo* mHackTimeUpInfo = nullptr;
+    TRexGroundHeightCtrl* mGroundHeightCtrl = nullptr;
+    TRexNeckDynamicsCtrl* mNeckDynamicsCtrl = nullptr;
+    TRexNeckUpswingCtrl* mNeckUpswingCtrl = nullptr;
+    TRexNeckSwingWatchCtrl* mNeckSwingWatchCtrl = nullptr;
+    TRexNeckRumbleCtrl* mNeckRumbleCtrl = nullptr;
+    TRexNeckAnimInterpoleCtrl* mNeckAnimInterpoleCtrl = nullptr;
+    TRexSmallGroundJointAnimator* mSmallGroundJointAnimator = nullptr;
+    TRexPartialAnimCtrl* mPartialAnimCtrl = nullptr;
+    al::LiveActorGroup* mFootPrintGroup = nullptr;
+    al::JointSpringControllerHolder* mJointSpringControllerHolder = nullptr;
+    IUsePlayerHack* mPlayerHack = nullptr;
+    TRexHackTurnInfo* mHackTurnInfo = nullptr;
+    CapTargetInfo* mCapTargetInfo = nullptr;
+    EnemyCap* mEnemyCap = nullptr;
+    EnemyStateHackStart* mStateHackStart = nullptr;
+    TRexStateSleep* mStateSleep = nullptr;
+    TRexStatePatrolChase* mStatePatrolChase = nullptr;
+    TRexCollidedShapeInfo* mCollidedShapeInfo = nullptr;
+    TRexCollisionAnalyzer* mCollisionAnalyzer = nullptr;
+    PlayerCollider* mPlayerCollider = nullptr;
+    CollisionShapeInfoSphere* mHeadShapeInfo = nullptr;
+    CollisionShapeInfoSphere* mBodyShapeInfo = nullptr;
+    al::LiveActor* mHeadCollisionObj = nullptr;
+    al::CameraTicket* mHackStartCameraTicket = nullptr;
+    al::CameraTicket* mFollowLimitCameraTicket = nullptr;
+    al::ActorCameraTarget* mCameraTarget = nullptr;
+    al::ActorCameraSubTarget* mCameraSubTarget = nullptr;
+    sead::Vector3f mCameraSubTargetTrans = sead::Vector3f::zero;
+    sead::Matrix34f mWaterSurfaceBodyMtx = sead::Matrix34f::ident;
+    sead::Matrix34f mWaterSurfaceLMtx = sead::Matrix34f::ident;
+    sead::Matrix34f mWaterSurfaceRMtx = sead::Matrix34f::ident;
+    u8 _29c[4] = {};
+    al::AreaObjGroup* mWaterfallArea = nullptr;
+    bool mIsHackStartCameraActive = true;
+    sead::Vector3f mInitFront = sead::Vector3f::zero;
+    sead::Vector3f* mHackStartAfterPostureFront = nullptr;
+    sead::Vector3f mGroundNormal = sead::Vector3f::ey;
+    sead::Vector3f mCollisionPushOffset = sead::Vector3f::zero;
+    sead::Vector3f mTailSensorPos = sead::Vector3f::zero;
+    sead::Vector3f mRouteHeadGuidePos = sead::Vector3f::zero;
+    s32 mHackMoveCounter = 0;
+    sead::Vector3f mHackTurnPrevDir = sead::Vector3f::zero;
+    sead::Vector3f mHackTurnTargetDir = sead::Vector3f::zero;
+    f32 mPatrolTurnAngle = 0.0f;
+    f32 mJumpStartY = 0.0f;
+    f32 mAllRootLocalZRot = 0.0f;
+    bool mIsInWater = false;
+    sead::Vector3f mForceScrollMoveOffset = sead::Vector3f::zero;
+    f32 mMaxSideOffset = 1000.0f;
+    bool mIsForceScrollEndFallStart = false;
+    sead::PtrArray<al::IBgmParamsChanger>* mBgmParamsChangers = nullptr;
+    al::LiveActorGroup* mBirdGroup = nullptr;
+    TRexPatrolRouteRider* mPatrolRouteRider = nullptr;
+    s32 mNearPlayerCount = 0;
+    s32 mPatrolTurnRetryCount = 0;
+    void* _350 = nullptr;
+    s32 _358 = 0;
+    s32 mGamaneBulletHitCount = 0;
+};
+
+static_assert(sizeof(TRex) == 0x360);
+
+namespace TRexFunction {
+void sendMsgTRexAttackToAllCollidedCollision(const TRex* rex);
+void updateMaterialCodeByFootCollide(TRex* rex, const TRexFootIK* footIK);
+void appearFootPrint(al::LiveActorGroup* group, const TRex* rex, bool isLeft);
+void updatePatrolRouteRider(TRexPatrolRouteRider* rider, const TRex* rex);
+bool executePatrolTurn(al::IUseNerve* nerveKeeper, TRex* rex, sead::Vector3f* prevDir,
+                       sead::Vector3f* targetDir);
+f32 calcBlendAnimFrameRateByIndex(const TRex* rex, s32 index);
+bool tryStartPatrolTurnPoint(al::IUseNerve* nerveKeeper, const TRex* rex, const al::Nerve* nerve,
+                             sead::Vector3f* turnDir, sead::Vector3f* prevDir,
+                             const sead::Vector3f& target, f32 angleDegree);
+void updatePatrolRunSpeed(TRex* rex, sead::Vector3f* moveVec);
+void updatePatrolDashSpeed(TRex* rex, sead::Vector3f* moveVec, f32 speedScale);
+void updatePatrolFindTurn(TRexHackTurnInfo* turnInfo, TRex* rex, const sead::Vector3f& dir,
+                          f32 turnSpeed, const TRexCollisionAnalyzer* collisionAnalyzer);
+void updateFallPoseAndVelocity(TRex* rex, f32 gravityScale);
+}  // namespace TRexFunction

--- a/src/MapObj/TRexScrollBreakMapParts.cpp
+++ b/src/MapObj/TRexScrollBreakMapParts.cpp
@@ -1,0 +1,197 @@
+#include "MapObj/TRexScrollBreakMapParts.h"
+
+#include <cmath>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/BreakModel.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Enemy/TRex.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+// breakCount % 9 -> A, B, C, B, C, A, B, A, C
+constexpr u64 sBreakModelCycleMaskA = 0xA1uLL;
+constexpr u64 sBreakModelCycleMaskB = 0x4AuLL;
+
+NERVE_IMPL(TRexScrollBreakMapParts, Wait)
+NERVE_IMPL(TRexScrollBreakMapParts, Break)
+
+NERVES_MAKE_NOSTRUCT(TRexScrollBreakMapParts, Wait, Break)
+}  // namespace
+
+TRexScrollBreakMapParts::TRexScrollBreakMapParts(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void TRexScrollBreakMapParts::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+    al::initNerve(this, &Wait, 0);
+
+    if (al::isExistCollisionParts(this))
+        mBreakSensors.allocBuffer(64, nullptr, 8);
+
+    makeActorAlive();
+}
+
+bool TRexScrollBreakMapParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                         al::HitSensor* self) {
+    if (!rs::isMsgConfirmFrailBox(message))
+        return false;
+
+    mBreakSensors.pushBack(other);
+
+    return true;
+}
+
+void TRexScrollBreakMapParts::exeWait() {
+    if (!al::isExistSceneObj<TRexScrollBreakMapPartsBreakJudge>(this))
+        return;
+
+    TRexScrollBreakMapPartsBreakJudge* breakJudge =
+        al::getSceneObj<TRexScrollBreakMapPartsBreakJudge>(this);
+    if (!breakJudge->judgeBreak(this))
+        return;
+
+    al::startHitReaction(this, "破壊");
+    breakJudge->addBreakCountAndAppearBreakModel(this);
+
+    if (al::isExistCollisionParts(this)) {
+        s32 breakSensorCount = mBreakSensors.size();
+        al::HitSensor* collisionSensor = al::getHitSensor(this, "Collision");
+
+        for (s32 i = 0; i < breakSensorCount; i++)
+            rs::sendMsgTRexScrollPartsBreakWith(mBreakSensors[i], collisionSensor);
+    }
+
+    al::setNerve(this, &Break);
+}
+
+void TRexScrollBreakMapParts::exeBreak() {
+    kill();
+}
+
+bool TRexScrollBreakMapPartsBreakJudge::judgeBreak(const TRexScrollBreakMapParts* mapParts) const {
+    if (!mTRex->isEnableBreakPartsForceScroll())
+        return false;
+
+    if (mTRex->isForceScrollEndFallStart())
+        return true;
+
+    sead::Vector3f distance = al::getTrans(mTRex) - al::getTrans(mapParts);
+    sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+
+    al::calcFrontDir(&front, mapParts);
+    al::parallelizeVec(&distance, front, distance);
+
+    if (al::isNearZero(distance) || front.dot(distance) < 0.0f)
+        return false;
+
+    return distance.length() > 500.0f;
+}
+
+void TRexScrollBreakMapPartsBreakJudge::addBreakCountAndAppearBreakModel(
+    const TRexScrollBreakMapParts* mapParts) {
+    s64 breakModelCycleIndex = al::modi(mBreakCount++ + 9, 9);
+
+    if (((sBreakModelCycleMaskA >> breakModelCycleIndex) & 1) != 0) {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupA;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesA[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    } else if (((sBreakModelCycleMaskB >> breakModelCycleIndex) & 1) == 0) {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupC;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesC[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    } else {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupB;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesB[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    }
+}
+
+TRexScrollBreakMapPartsBreakJudge::TRexScrollBreakMapPartsBreakJudge(const TRex* tRex,
+                                                                     const al::ActorInitInfo& info)
+    : mTRex(tRex) {
+    sead::Matrix34f identity;
+    identity.makeIdentity();
+
+    mBreakModelGroupA = new al::LiveActorGroup("壊れモデルテーブルA", 16);
+    mBreakModelMatricesA = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesA[i] = identity;
+        mBreakModelGroupA->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルA", "TrexBikeExScrollBreakStep000BreakA",
+                                 nullptr, &mBreakModelMatricesA[i], "Break"));
+    }
+
+    mBreakModelGroupB = new al::LiveActorGroup("壊れモデルテーブルB", 16);
+    mBreakModelMatricesB = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesB[i] = identity;
+        mBreakModelGroupB->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルB", "TrexBikeExScrollBreakStep000BreakB",
+                                 nullptr, &mBreakModelMatricesB[i], "Break"));
+    }
+
+    mBreakModelGroupC = new al::LiveActorGroup("壊れモデルテーブルC", 16);
+    mBreakModelMatricesC = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesC[i] = identity;
+        mBreakModelGroupC->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルC", "TrexBikeExScrollBreakStep000BreakC",
+                                 nullptr, &mBreakModelMatricesC[i], "Break"));
+    }
+}
+
+void TRexFunction::createTRexScrollBreakMapPartsBreakJudge(const TRex* tRex,
+                                                           const al::ActorInitInfo& info) {
+    TRexScrollBreakMapPartsBreakJudge* breakJudge =
+        new TRexScrollBreakMapPartsBreakJudge(tRex, info);
+
+    return al::setSceneObj(tRex, breakJudge, TRexScrollBreakMapPartsBreakJudge::sSceneObjId);
+}

--- a/src/MapObj/TRexScrollBreakMapParts.cpp
+++ b/src/MapObj/TRexScrollBreakMapParts.cpp
@@ -1,0 +1,197 @@
+#include "MapObj/TRexScrollBreakMapParts.h"
+
+#include <cmath>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/BreakModel.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Enemy/TRex.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+// breakCount % 9 -> A, B, C, B, C, A, B, A, C
+constexpr u64 sBreakModelCycleMaskA = 0xA1uLL;
+constexpr u64 sBreakModelCycleMaskB = 0x4AuLL;
+
+NERVE_IMPL(TRexScrollBreakMapParts, Wait)
+NERVE_IMPL(TRexScrollBreakMapParts, Break)
+
+NERVES_MAKE_NOSTRUCT(TRexScrollBreakMapParts, Wait, Break)
+}  // namespace
+
+TRexScrollBreakMapParts::TRexScrollBreakMapParts(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void TRexScrollBreakMapParts::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+    al::initNerve(this, &Wait, 0);
+
+    if (al::isExistCollisionParts(this))
+        mBreakSensors.allocBuffer(64, nullptr, 8);
+
+    makeActorAlive();
+}
+
+bool TRexScrollBreakMapParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                         al::HitSensor* self) {
+    if (!rs::isMsgConfirmFrailBox(message))
+        return false;
+
+    mBreakSensors.pushBack(other);
+
+    return true;
+}
+
+void TRexScrollBreakMapParts::exeWait() {
+    if (!al::isExistSceneObj<TRexScrollBreakMapPartsBreakJudge>(this))
+        return;
+
+    TRexScrollBreakMapPartsBreakJudge* breakJudge =
+        al::getSceneObj<TRexScrollBreakMapPartsBreakJudge>(this);
+    if (!breakJudge->judgeBreak(this))
+        return;
+
+    al::startHitReaction(this, "破壊");
+    breakJudge->addBreakCountAndAppearBreakModel(this);
+
+    if (al::isExistCollisionParts(this)) {
+        s32 breakSensorCount = mBreakSensors.size();
+        al::HitSensor* collisionSensor = al::getHitSensor(this, "Collision");
+
+        for (s32 i = 0; i < breakSensorCount; i++)
+            rs::sendMsgTRexScrollPartsBreakWith(mBreakSensors[i], collisionSensor);
+    }
+
+    al::setNerve(this, &Break);
+}
+
+void TRexScrollBreakMapParts::exeBreak() {
+    kill();
+}
+
+bool TRexScrollBreakMapPartsBreakJudge::judgeBreak(const TRexScrollBreakMapParts* mapParts) const {
+    if (!mTRex->isEnableBreakPartsForceScroll())
+        return false;
+
+    if (mTRex->isForceScrollEndFallStart())
+        return true;
+
+    sead::Vector3f distance = al::getTrans(mTRex) - al::getTrans(mapParts);
+    sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+
+    al::calcFrontDir(&front, mapParts);
+    al::parallelizeVec(&distance, front, distance);
+
+    if (al::isNearZero(distance) || front.dot(distance) < 0.0f)
+        return false;
+
+    return distance.length() > 500.0f;
+}
+
+void TRexScrollBreakMapPartsBreakJudge::addBreakCountAndAppearBreakModel(
+    const TRexScrollBreakMapParts* mapParts) {
+    u64 breakModelCycleIndex = al::wrapValue(mBreakCount++, 9);
+
+    if (((sBreakModelCycleMaskA >> breakModelCycleIndex) & 1) != 0) {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupA;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesA[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    } else if (((sBreakModelCycleMaskB >> breakModelCycleIndex) & 1) == 0) {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupC;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesC[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    } else {
+        al::LiveActorGroup* breakModelGroup = mBreakModelGroupB;
+        s32 breakModelCount = breakModelGroup->getActorCount();
+
+        al::LiveActor* breakModel = nullptr;
+        s32 breakModelIndex = -1;
+        for (s32 i = 0; i < breakModelCount; i++) {
+            if (al::isDead(breakModelGroup->getActor(i))) {
+                breakModel = breakModelGroup->getActor(i);
+                breakModelIndex = i;
+                break;
+            }
+        }
+
+        mBreakModelMatricesB[breakModelIndex] = *mapParts->getBaseMtx();
+        return breakModel->appear();
+    }
+}
+
+TRexScrollBreakMapPartsBreakJudge::TRexScrollBreakMapPartsBreakJudge(const TRex* tRex,
+                                                                     const al::ActorInitInfo& info)
+    : mTRex(tRex) {
+    sead::Matrix34f identity;
+    identity.makeIdentity();
+
+    mBreakModelGroupA = new al::LiveActorGroup("壊れモデルテーブルA", 16);
+    mBreakModelMatricesA = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesA[i] = identity;
+        mBreakModelGroupA->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルA", "TrexBikeExScrollBreakStep000BreakA",
+                                 nullptr, &mBreakModelMatricesA[i], "Break"));
+    }
+
+    mBreakModelGroupB = new al::LiveActorGroup("壊れモデルテーブルB", 16);
+    mBreakModelMatricesB = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesB[i] = identity;
+        mBreakModelGroupB->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルB", "TrexBikeExScrollBreakStep000BreakB",
+                                 nullptr, &mBreakModelMatricesB[i], "Break"));
+    }
+
+    mBreakModelGroupC = new al::LiveActorGroup("壊れモデルテーブルC", 16);
+    mBreakModelMatricesC = new sead::Matrix34f[16];
+    for (s32 i = 0; i < 16; i++) {
+        mBreakModelMatricesC[i] = identity;
+        mBreakModelGroupC->registerActor(
+            al::createBreakModel(tRex, info, "壊れモデルC", "TrexBikeExScrollBreakStep000BreakC",
+                                 nullptr, &mBreakModelMatricesC[i], "Break"));
+    }
+}
+
+void TRexFunction::createTRexScrollBreakMapPartsBreakJudge(const TRex* tRex,
+                                                           const al::ActorInitInfo& info) {
+    TRexScrollBreakMapPartsBreakJudge* breakJudge =
+        new TRexScrollBreakMapPartsBreakJudge(tRex, info);
+
+    return al::setSceneObj(tRex, breakJudge, TRexScrollBreakMapPartsBreakJudge::sSceneObjId);
+}

--- a/src/MapObj/TRexScrollBreakMapParts.h
+++ b/src/MapObj/TRexScrollBreakMapParts.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActorGroup;
+}  // namespace al
+
+class TRex;
+
+class TRexScrollBreakMapParts : public al::LiveActor {
+public:
+    TRexScrollBreakMapParts(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeBreak();
+
+private:
+    sead::PtrArray<al::HitSensor> mBreakSensors;
+};
+
+static_assert(sizeof(TRexScrollBreakMapParts) == 0x118);
+
+class TRexScrollBreakMapPartsBreakJudge : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_TRexScrollBreakMapPartsBreakJudge;
+
+    TRexScrollBreakMapPartsBreakJudge(const TRex* tRex, const al::ActorInitInfo& info);
+
+    const char* getSceneObjName() const override {
+        return "Tレックススクロール破壊マップパーツの破壊判定";
+    }
+
+    bool judgeBreak(const TRexScrollBreakMapParts* mapParts) const;
+    void addBreakCountAndAppearBreakModel(const TRexScrollBreakMapParts* mapParts);
+
+private:
+    const TRex* mTRex = nullptr;
+    s32 mBreakCount = 0;
+    al::LiveActorGroup* mBreakModelGroupA = nullptr;
+    al::LiveActorGroup* mBreakModelGroupB = nullptr;
+    al::LiveActorGroup* mBreakModelGroupC = nullptr;
+    sead::Matrix34f* mBreakModelMatricesA = nullptr;
+    sead::Matrix34f* mBreakModelMatricesB = nullptr;
+    sead::Matrix34f* mBreakModelMatricesC = nullptr;
+};
+
+static_assert(sizeof(TRexScrollBreakMapPartsBreakJudge) == 0x48);
+
+namespace TRexFunction {
+void createTRexScrollBreakMapPartsBreakJudge(const TRex* tRex, const al::ActorInitInfo& info);
+}  // namespace TRexFunction


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1052)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0524374 - 1dce865)

📈 **Matched code**: 14.88% (+0.02%, +2244 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapPartsBreakJudge::TRexScrollBreakMapPartsBreakJudge(TRex const*, al::ActorInitInfo const&)` | +684 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapPartsBreakJudge::addBreakCountAndAppearBreakModel(TRexScrollBreakMapParts const*)` | +432 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapPartsBreakJudge::judgeBreak(TRexScrollBreakMapParts const*) const` | +300 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::exeWait()` | +236 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::TRexScrollBreakMapParts(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::TRexScrollBreakMapParts(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::init(al::ActorInitInfo const&)` | +100 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +96 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexFunction::createTRexScrollBreakMapPartsBreakJudge(TRex const*, al::ActorInitInfo const&)` | +84 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `(anonymous namespace)::TRexScrollBreakMapPartsNrvBreak::execute(al::NerveKeeper*) const` | +16 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapParts::exeBreak()` | +12 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapPartsBreakJudge::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `(anonymous namespace)::TRexScrollBreakMapPartsNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/TRexScrollBreakMapParts` | `TRexScrollBreakMapPartsBreakJudge::~TRexScrollBreakMapPartsBreakJudge()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->