### PR TITLE
Library/Movement: Implement `ClockMovement`

### DIFF
--- a/lib/al/Library/MapObj/ClockMapParts.cpp
+++ b/lib/al/Library/MapObj/ClockMapParts.cpp
@@ -250,7 +250,7 @@ void ClockMapParts::exeRotate() {
 
     mTimer++;
     if (mTimer >= mRotateTimer) {
-        mCurrentStep = modi(mCurrentStep + mTurnStepCount + 1, mTurnStepCount);
+        mCurrentStep = wrapValue(mCurrentStep + 1, mTurnStepCount);
         startNerveAction(this, "Wait");
         tryStartSe(this, "RotateEnd");
     }

--- a/lib/al/Library/Math/MathUtil.h
+++ b/lib/al/Library/Math/MathUtil.h
@@ -205,6 +205,10 @@ void makeBoxMullerRandomGauss(sead::Vector2f* outBox, f32 randA, f32 randB);
 f32 modf(f32 a, f32 b);
 s32 modi(s32 a, s32 b);
 
+inline s32 wrapValue(s32 value, s32 maxRange) {
+    return modi(value + maxRange, maxRange);
+}
+
 inline f32 wrapValue(f32 value, f32 maxRange) {
     return modf(value + maxRange, maxRange) + 0.0f;
 }

--- a/lib/al/Library/Movement/ClockMovement.cpp
+++ b/lib/al/Library/Movement/ClockMovement.cpp
@@ -1,0 +1,99 @@
+#include "Library/Movement/ClockMovement.h"
+
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+namespace al {
+namespace {
+NERVE_IMPL(ClockMovement, Delay);
+NERVE_IMPL(ClockMovement, RotateSign);
+NERVE_IMPL(ClockMovement, Rotate);
+NERVE_IMPL(ClockMovement, Wait);
+
+NERVES_MAKE_STRUCT(ClockMovement, Delay, RotateSign, Rotate);
+NERVES_MAKE_NOSTRUCT(ClockMovement, Wait);
+}  // namespace
+
+ClockMovement::ClockMovement(const ActorInitInfo& info) : NerveExecutor("クロックパーツ動作") {
+    getQuat(&mInitialActorQuat, info);
+    mActorQuat = mInitialActorQuat;
+    tryGetArg(&mClockAngleDegree, info, "ClockAngleDegree");
+    tryGetArg(&mRotateAxis, info, "RotateAxis");
+    tryGetArg(&mDelayTime, info, "DelayTime");
+    tryGetArg(&mRotateSignTime, info, "RotateSignTime");
+    tryGetArg(&mRotateTime, info, "RotateTime");
+    tryGetArg(&mWaitTime, info, "WaitTime");
+
+    if (mDelayTime == 0)
+        initNerve(&NrvClockMovement.RotateSign, 0);
+    else
+        initNerve(&NrvClockMovement.Delay, 0);
+
+    s32 stepsPerCycle = 1;
+    if (mClockAngleDegree != 0) {
+        stepsPerCycle = sead::Mathi::lcm(sead::Mathi::abs(mClockAngleDegree), 360) /
+                        sead::Mathi::abs(mClockAngleDegree);
+    }
+    mMaxStepCount = stepsPerCycle;
+}
+
+void ClockMovement::exeDelay() {
+    if (isGreaterEqualStep(this, mDelayTime - 1)) {
+        if (mRotateSignTime > 0)
+            setNerve(this, &NrvClockMovement.RotateSign);
+        else
+            setNerve(this, &NrvClockMovement.Rotate);
+    }
+}
+
+void ClockMovement::exeRotateSign() {
+    f32 rotateAngle = wrapValue(mCurrentStepIndex * mClockAngleDegree, 360.0f);
+
+    // NOTE: This rotation has and aditional wobble
+    rotateQuatLocalDirDegree(&mActorQuat, mInitialActorQuat, mRotateAxis,
+                             rotateAngle +
+                                 sead::Mathf::sin(getNerveStep(this) * sead::Mathf::pi2() / 18.0f));
+
+    if (isGreaterEqualStep(this, mRotateSignTime - 1))
+        setNerve(this, &NrvClockMovement.Rotate);
+}
+
+void ClockMovement::exeRotate() {
+    f32 rotateAngle = wrapValue(
+        (calcNerveRate(this, mRotateTime) + mCurrentStepIndex) * mClockAngleDegree, 360.0f);
+    rotateQuatLocalDirDegree(&mActorQuat, mInitialActorQuat, mRotateAxis, rotateAngle);
+
+    if (isGreaterEqualStep(this, mRotateTime)) {
+        mCurrentStepIndex = modi(mCurrentStepIndex + 1 + mMaxStepCount, mMaxStepCount);
+        setNerve(this, &Wait);
+    }
+}
+
+void ClockMovement::exeWait() {
+    if (isGreaterEqualStep(this, mWaitTime)) {
+        if (mRotateSignTime > 0)
+            setNerve(this, &NrvClockMovement.RotateSign);
+        else
+            setNerve(this, &NrvClockMovement.Rotate);
+    }
+}
+
+bool ClockMovement::isFirstStepDelay() const {
+    return isNerve(this, &NrvClockMovement.Delay) && isFirstStep(this);
+}
+
+bool ClockMovement::isFirstStepRotateSign() const {
+    return isNerve(this, &NrvClockMovement.RotateSign) && isFirstStep(this);
+}
+
+bool ClockMovement::isFirstStepRotate() const {
+    return isNerve(this, &NrvClockMovement.Rotate) && isFirstStep(this);
+}
+
+bool ClockMovement::isFirstStepWait() const {
+    return isNerve(this, &Wait) && isFirstStep(this);
+}
+
+}  // namespace al

--- a/lib/al/Library/Movement/ClockMovement.cpp
+++ b/lib/al/Library/Movement/ClockMovement.cpp
@@ -5,8 +5,9 @@
 #include "Library/Nerve/NerveUtil.h"
 #include "Library/Placement/PlacementFunction.h"
 
-namespace al {
 namespace {
+using namespace al;
+
 NERVE_IMPL(ClockMovement, Delay);
 NERVE_IMPL(ClockMovement, RotateSign);
 NERVE_IMPL(ClockMovement, Rotate);
@@ -16,9 +17,11 @@ NERVES_MAKE_STRUCT(ClockMovement, Delay, RotateSign, Rotate);
 NERVES_MAKE_NOSTRUCT(ClockMovement, Wait);
 }  // namespace
 
+namespace al {
+
 ClockMovement::ClockMovement(const ActorInitInfo& info) : NerveExecutor("クロックパーツ動作") {
-    getQuat(&mInitialActorQuat, info);
-    mActorQuat = mInitialActorQuat;
+    getQuat(&mInitialQuat, info);
+    mCurrentQuat = mInitialQuat;
     tryGetArg(&mClockAngleDegree, info, "ClockAngleDegree");
     tryGetArg(&mRotateAxis, info, "RotateAxis");
     tryGetArg(&mDelayTime, info, "DelayTime");
@@ -36,7 +39,7 @@ ClockMovement::ClockMovement(const ActorInitInfo& info) : NerveExecutor("クロ�
         stepsPerCycle = sead::Mathi::lcm(sead::Mathi::abs(mClockAngleDegree), 360) /
                         sead::Mathi::abs(mClockAngleDegree);
     }
-    mMaxStepCount = stepsPerCycle;
+    mMaxStepIndex = stepsPerCycle;
 }
 
 void ClockMovement::exeDelay() {
@@ -49,10 +52,9 @@ void ClockMovement::exeDelay() {
 }
 
 void ClockMovement::exeRotateSign() {
-    f32 rotateAngle = wrapValue(mCurrentStepIndex * mClockAngleDegree, 360.0f);
+    f32 rotateAngle = wrapValue(static_cast<f32>(mCurrentStepIndex * mClockAngleDegree), 360.0f);
 
-    // NOTE: This rotation has and aditional wobble
-    rotateQuatLocalDirDegree(&mActorQuat, mInitialActorQuat, mRotateAxis,
+    rotateQuatLocalDirDegree(&mCurrentQuat, mInitialQuat, mRotateAxis,
                              rotateAngle +
                                  sead::Mathf::sin(getNerveStep(this) * sead::Mathf::pi2() / 18.0f));
 
@@ -63,10 +65,10 @@ void ClockMovement::exeRotateSign() {
 void ClockMovement::exeRotate() {
     f32 rotateAngle = wrapValue(
         (calcNerveRate(this, mRotateTime) + mCurrentStepIndex) * mClockAngleDegree, 360.0f);
-    rotateQuatLocalDirDegree(&mActorQuat, mInitialActorQuat, mRotateAxis, rotateAngle);
+    rotateQuatLocalDirDegree(&mCurrentQuat, mInitialQuat, mRotateAxis, rotateAngle);
 
     if (isGreaterEqualStep(this, mRotateTime)) {
-        mCurrentStepIndex = modi(mCurrentStepIndex + 1 + mMaxStepCount, mMaxStepCount);
+        mCurrentStepIndex = wrapValue(mCurrentStepIndex + 1, mMaxStepIndex);
         setNerve(this, &Wait);
     }
 }

--- a/lib/al/Library/Movement/ClockMovement.h
+++ b/lib/al/Library/Movement/ClockMovement.h
@@ -20,12 +20,12 @@ public:
     bool isFirstStepWait() const;
 
 private:
-    sead::Quatf mActorQuat = sead::Quatf::unit;
-    sead::Quatf mInitialActorQuat = sead::Quatf::unit;
+    sead::Quatf mCurrentQuat = sead::Quatf::unit;
+    sead::Quatf mInitialQuat = sead::Quatf::unit;
     s32 mRotateAxis = 0;
     s32 mClockAngleDegree = 90;
     s32 mCurrentStepIndex = 0;
-    s32 mMaxStepCount = 4;
+    s32 mMaxStepIndex = 4;
     s32 mDelayTime = 0;
     s32 mRotateSignTime = 36;
     s32 mRotateTime = 60;

--- a/lib/al/Library/Movement/ClockMovement.h
+++ b/lib/al/Library/Movement/ClockMovement.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <math/seadQuat.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+struct ActorInitInfo;
+
+class ClockMovement : public NerveExecutor {
+public:
+    ClockMovement(const ActorInitInfo& info);
+    void exeDelay();
+    void exeRotateSign();
+    void exeRotate();
+    void exeWait();
+    bool isFirstStepDelay() const;
+    bool isFirstStepRotateSign() const;
+    bool isFirstStepRotate() const;
+    bool isFirstStepWait() const;
+
+private:
+    sead::Quatf mActorQuat = sead::Quatf::unit;
+    sead::Quatf mInitialActorQuat = sead::Quatf::unit;
+    s32 mRotateAxis = 0;
+    s32 mClockAngleDegree = 90;
+    s32 mCurrentStepIndex = 0;
+    s32 mMaxStepCount = 4;
+    s32 mDelayTime = 0;
+    s32 mRotateSignTime = 36;
+    s32 mRotateTime = 60;
+    s32 mWaitTime = 0;
+};
+
+static_assert(sizeof(ClockMovement) == 0x50);
+}  // namespace al

--- a/lib/al/Library/Movement/SwingMovement.cpp
+++ b/lib/al/Library/Movement/SwingMovement.cpp
@@ -59,7 +59,7 @@ void SwingMovement::exeMove() {
     if (updateRotate())
         setNerve(this, &Stop);
 
-    mFrameInCycle = modi((mFrameInCycle + 1) + mSwingCycle, mSwingCycle);
+    mFrameInCycle = wrapValue(mFrameInCycle + 1, mSwingCycle);
 }
 
 void SwingMovement::exeStop() {

--- a/lib/al/Library/Rail/RailUtil.cpp
+++ b/lib/al/Library/Rail/RailUtil.cpp
@@ -323,11 +323,8 @@ s32 getNextRailPointNo(const IUseRail* railHolder) {
     s32 newIndex = getRailPointNo(railHolder) + modifier;
     s32 railPointNum = getRailPointNum(railHolder);
 
-    if (isLoop) {
-        s32 sum = railPointNum + newIndex;
-        s32 railPointNumAgain = getRailPointNum(railHolder);
-        return modi(sum + railPointNumAgain, railPointNumAgain);
-    }
+    if (isLoop)
+        return wrapValue(railPointNum + newIndex, getRailPointNum(railHolder));
 
     return sead::Mathi::clamp2(0, newIndex, railPointNum - 1);
 }

--- a/lib/al/Project/Fluid/FlowMapCtrl.cpp
+++ b/lib/al/Project/Fluid/FlowMapCtrl.cpp
@@ -17,8 +17,7 @@ void FlowMapCtrl::update() {
     flowParameters.y =
         calcRate01(halfInterval - sead::Mathi::abs(halfInterval - mFlowStep), 0.0f, halfInterval);
     flowParameters.z = calcRate01(mFlowStep, 0.0f, mInterval);
-    flowParameters.w =
-        calcRate01(modi(mFlowStep + halfInterval + mInterval, mInterval), 0.0f, mInterval);
+    flowParameters.w = calcRate01(wrapValue(mFlowStep + halfInterval, mInterval), 0.0f, mInterval);
 
     s32 materialCount = getMaterialCount(mParent);
     for (s32 i = 0; i < materialCount; i++) {
@@ -27,7 +26,7 @@ void FlowMapCtrl::update() {
     }
 
     mFlowStep++;
-    mFlowStep = modi(mFlowStep + mInterval, mInterval);
+    mFlowStep = wrapValue(mFlowStep, mInterval);
 }
 
 }  // namespace al

--- a/src/Boss/Koopa/KoopaLandPointHolder.cpp
+++ b/src/Boss/Koopa/KoopaLandPointHolder.cpp
@@ -65,8 +65,8 @@ void KoopaLandPointHolder::decidePointEitherFarSide(const sead::Vector3f& pos) {
     }
 
     mInvalidPoints[mCurrentLandPoint] = false;
-    s32 prevPoint = al::modi(mCurrentLandPoint - 1 + mLandPoints, mLandPoints);
-    s32 nextPoint = al::modi(mCurrentLandPoint + 1 + mLandPoints, mLandPoints);
+    s32 prevPoint = al::wrapValue(mCurrentLandPoint - 1, mLandPoints);
+    s32 nextPoint = al::wrapValue(mCurrentLandPoint + 1, mLandPoints);
 
     f32 prevDist = getKoopaLandPointDistance(mPointsTrans[prevPoint], pos);
     f32 nextDist = getKoopaLandPointDistance(mPointsTrans[nextPoint], pos);

--- a/src/Enemy/Bubble.cpp
+++ b/src/Enemy/Bubble.cpp
@@ -638,7 +638,8 @@ void Bubble::control() {
     if (!al::isNerve(this, &NrvBubble.StandBy) && !al::isNerve(this, &NrvBubble.Delay) &&
         (!isHack() || !rs::isActiveHackStartDemo(mPlayerHack)) &&
         !al::isClipped(mClippingProbeActor) && !mIsClipped) {
-        mReviveDelayCount = al::modi(mReviveDelayCount + 1 + mReviveDelayTime, mReviveDelayTime);
+        mReviveDelayCount =
+            al::wrapValue(static_cast<s32>(mReviveDelayCount + 1), mReviveDelayTime);
     }
 
     mIsClipped = al::isClipped(mClippingProbeActor);

--- a/src/Enemy/Gamane.cpp
+++ b/src/Enemy/Gamane.cpp
@@ -505,7 +505,8 @@ void Gamane::exeHack() {
         mCoinsLeft--;
     }
 
-    mHackCoinAppearCounter = al::modi((mHackCoinAppearCounter++ + 1) + 6, 6);
+    // NOTE: this is only one increment, as post-incrementing is used
+    mHackCoinAppearCounter = al::wrapValue(mHackCoinAppearCounter++ + 1, 6);
 }
 
 void Gamane::exeTrampled() {

--- a/src/Enemy/HosuiTrailKeeper.cpp
+++ b/src/Enemy/HosuiTrailKeeper.cpp
@@ -25,7 +25,7 @@ HosuiTrailKeeper::HosuiTrailKeeper(const al::ActorInitInfo& initInfo) {
 void HosuiTrailKeeper::appearTrail(const sead::Vector3f& pos, const sead::Vector3f& dir) {
     s32 count = mTrails.size();
 
-    s32 prevIdx = al::modi(mIndex + count - 1 + count, count);
+    s32 prevIdx = al::wrapValue(mIndex + count - 1, count);
     HosuiTrail* prevTrail = mTrails[prevIdx];
 
     if (al::isAlive(prevTrail) && (pos - al::getTrans(prevTrail)).length() < 120.0f)
@@ -56,12 +56,12 @@ void HosuiTrailKeeper::appearTrail(const sead::Vector3f& pos, const sead::Vector
         trail->setFollowCollisionParts(triangle.getCollisionParts());
     }
 
-    s32 disappearIdx = al::modi(mIndex + 5 + count, count);
+    s32 disappearIdx = al::wrapValue(mIndex + 5, count);
     HosuiTrail* disappearTrail = mTrails[disappearIdx];
     if (al::isAlive(disappearTrail))
         disappearTrail->disappear();
 
-    mIndex = al::modi(mIndex + 1 + count, count);
+    mIndex = al::wrapValue(mIndex + 1, count);
 }
 
 void HosuiTrailKeeper::forceKillAll() {

--- a/src/Layout/MenuSelectParts.cpp
+++ b/src/Layout/MenuSelectParts.cpp
@@ -243,8 +243,7 @@ void MenuSelectParts::exeSelect() {
         s32 direction = mKeyRepeatCtrl->isUp() ? -1 : 1;
 
         al::startAction(mLayoutArray[calcPartsIndex(mCursorItemIndex)], "Wait");
-        mCursorItemIndex =
-            al::modi(mCursorItemIndex + direction + mMenuItemAmount, mMenuItemAmount);
+        mCursorItemIndex = al::wrapValue(mCursorItemIndex + direction, mMenuItemAmount);
 
         f32 pitch = ((1.0f - (f32)mCursorItemIndex / (mMenuItemAmount - 1)) * 0.375f) + 1.0f;
         al::PadRumbleParam param;

--- a/src/Layout/WindowConfirmData.cpp
+++ b/src/Layout/WindowConfirmData.cpp
@@ -161,15 +161,15 @@ void WindowConfirmData::exeWait() {
 
     if (rs::isRepeatUiDown(mWindowConfirmLayout)) {
         if (mSelectionCooldown == 0)
-            changeSelectingIdx(al::modi((mSelectionIndex + 1) + 2, 2));
-        mSelectionCooldown = al::modi((mSelectionCooldown + 1) + 10, 10);
+            changeSelectingIdx(al::wrapValue(mSelectionIndex + 1, 2));
+        mSelectionCooldown = al::wrapValue(mSelectionCooldown + 1, 10);
         return;
     }
 
     if (rs::isRepeatUiUp(mWindowConfirmLayout)) {
         if (mSelectionCooldown == 0)
-            changeSelectingIdx(al::modi((mSelectionIndex - 1) + 2, 2));
-        mSelectionCooldown = al::modi((mSelectionCooldown + 1) + 10, 10);
+            changeSelectingIdx(al::wrapValue(mSelectionIndex - 1, 2));
+        mSelectionCooldown = al::wrapValue(mSelectionCooldown + 1, 10);
         return;
     }
 

--- a/src/Npc/SmallBirdStateFlyAway.cpp
+++ b/src/Npc/SmallBirdStateFlyAway.cpp
@@ -82,18 +82,18 @@ void SmallBirdStateFlyAway::exeFlyAway() {
         mIsColliding = false;
         startActionAtRandomFrameIfNotPlaying(mActor, "Fly");
         if (rs::isModeE3MovieRom()) {
-            gVerticalAccelIndex = al::modi(gVerticalAccelIndex + 7, 6);
+            gVerticalAccelIndex = al::wrapValue(gVerticalAccelIndex + 1, 6);
             mVerticalAccel = gE3MovieVerticalAccel[gVerticalAccelIndex];
-            gHorizontalAccelIndex = al::modi(gHorizontalAccelIndex + 5, 4);
+            gHorizontalAccelIndex = al::wrapValue(gHorizontalAccelIndex + 1, 4);
             mHorizontalAccel = gE3MovieHorizontalAccel[gHorizontalAccelIndex];
         } else {
-            gVerticalAccelIndex = al::modi(gVerticalAccelIndex + 5, 4);
+            gVerticalAccelIndex = al::wrapValue(gVerticalAccelIndex + 1, 4);
             mVerticalAccel = gVerticalAccel[gVerticalAccelIndex];
             mHorizontalAccel = gHorizontalAccel;
         }
         mTargetAccelDir = {0, mVerticalAccel, mHorizontalAccel};
         al::normalize(&mTargetAccelDir);
-        gCollisionCheckOffsetStep = al::modi(gCollisionCheckOffsetStep + 11, 10);
+        gCollisionCheckOffsetStep = al::wrapValue(gCollisionCheckOffsetStep + 1, 10);
         mCollisionCheckOffsetStep = gCollisionCheckOffsetStep;
     }
 


### PR DESCRIPTION
Simple clock rotation. You have two modes, linear and with wobble.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1053)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 589e105)

📈 **Matched code**: 14.20% (+0.01%, +1524 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | +448 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | +204 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | +156 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `(anonymous namespace)::ClockMovementNrvDelay::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | +100 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `(anonymous namespace)::ClockMovementNrvWait::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | +96 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | +68 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | +68 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | +64 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | +64 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | +36 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `(anonymous namespace)::ClockMovementNrvRotateSign::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Library/Movement/ClockMovement` | `(anonymous namespace)::ClockMovementNrvRotate::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->