### PR TITLE
MapObj: Implement `PadRumblePoint`

### DIFF
--- a/src/MapObj/PadRumblePoint.cpp
+++ b/src/MapObj/PadRumblePoint.cpp
@@ -1,0 +1,34 @@
+#include "MapObj/PadRumblePoint.h"
+
+#include "Library/Controller/PadRumbleFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+namespace {
+NERVE_ACTION_IMPL(PadRumblePoint, Wait)
+
+NERVE_ACTIONS_MAKE_STRUCT(PadRumblePoint, Wait)
+}  // namespace
+
+PadRumblePoint::PadRumblePoint(const char* actorName) : al::LiveActor(actorName) {}
+
+void PadRumblePoint::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Wait", &NrvPadRumblePoint.collector, 0);
+    al::initActor(this, info);
+    al::tryGetStringArg(&mRumbleName, info, "RumbleName");
+    al::tryGetArg(&mRumbleNear, info, "RumbleNear");
+    al::tryGetArg(&mRumbleFar, info, "RumbleFar");
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+void PadRumblePoint::exeWait() {
+    if (alPadRumbleFunction::checkIsAlivePadRumbleLoop(this, mRumbleName, al::getTransPtr(this),
+                                                       -1)) {
+        return;
+    }
+
+    alPadRumbleFunction::startPadRumbleLoop(this, mRumbleName, al::getTransPtr(this), mRumbleNear,
+                                            mRumbleFar, -1);
+}

--- a/src/MapObj/PadRumblePoint.h
+++ b/src/MapObj/PadRumblePoint.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class PadRumblePoint : public al::LiveActor {
+public:
+    PadRumblePoint(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+
+private:
+    const char* mRumbleName = nullptr;
+    f32 mRumbleNear = 500.0f;
+    f32 mRumbleFar = 2000.0f;
+};
+
+static_assert(sizeof(PadRumblePoint) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1054)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - a94a12a)

📈 **Matched code**: 14.20% (+0.01%, +708 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PadRumblePoint` | `PadRumblePoint::PadRumblePoint(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `PadRumblePoint::init(al::ActorInitInfo const&)` | +136 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `PadRumblePoint::PadRumblePoint(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `(anonymous namespace)::PadRumblePointNrvWait::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `PadRumblePoint::exeWait()` | +108 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `_GLOBAL__sub_I_PadRumblePoint.cpp` | +64 | 0.00% | 100.00% |
| `MapObj/PadRumblePoint` | `(anonymous namespace)::PadRumblePointNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->