### PR TITLE
MapObj: Implement `SnowVolumeEraser`

### DIFF
--- a/src/MapObj/SnowVolumeEraser.cpp
+++ b/src/MapObj/SnowVolumeEraser.cpp
@@ -1,0 +1,48 @@
+#include "MapObj/SnowVolumeEraser.h"
+
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+NERVE_IMPL(SnowVolumeEraser, Appear)
+
+NERVES_MAKE_NOSTRUCT(SnowVolumeEraser, Appear)
+}  // namespace
+
+SnowVolumeEraser::SnowVolumeEraser(const char* actorName) : al::LiveActor(actorName) {}
+
+void SnowVolumeEraser::init(const al::ActorInitInfo& info) {
+    using SnowVolumeEraserFunctor = al::FunctorV0M<SnowVolumeEraser*, void (SnowVolumeEraser::*)()>;
+
+    al::initActor(this, info);
+    al::initNerve(this, &Appear, 0);
+
+    if (al::listenStageSwitchOnStart(this, SnowVolumeEraserFunctor(this, &SnowVolumeEraser::start)))
+        makeActorDead();
+    else
+        makeActorAlive();
+
+    al::setSensorRadius(this, al::getScaleX(this) * 100.0f);
+}
+
+void SnowVolumeEraser::start() {
+    makeActorAlive();
+    al::setNerve(this, &Appear);
+}
+
+bool SnowVolumeEraser::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    return false;
+}
+
+void SnowVolumeEraser::exeAppear() {
+    if (al::isGreaterEqualStep(this, 2))
+        makeActorDead();
+}

--- a/src/MapObj/SnowVolumeEraser.h
+++ b/src/MapObj/SnowVolumeEraser.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SnowVolumeEraser : public al::LiveActor {
+public:
+    SnowVolumeEraser(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void start();
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeAppear();
+};
+
+static_assert(sizeof(SnowVolumeEraser) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -96,6 +96,7 @@
 #include "MapObj/SaveFlagCheckObj.h"
 #include "MapObj/ShineTowerRocket.h"
 #include "MapObj/SignBoardDanger.h"
+#include "MapObj/SnowVolumeEraser.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
 #include "MapObj/TrampleBush.h"
@@ -553,7 +554,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"SneakingMan", nullptr},
     {"SnowManRaceNpc", nullptr},
     {"SnowVolume", nullptr},
-    {"SnowVolumeEraser", nullptr},
+    {"SnowVolumeEraser", al::createActorFunction<SnowVolumeEraser>},
     {"Souvenir", al::createActorFunction<Souvenir>},
     {"SouvenirDirector", nullptr},
     {"Special2KeyMoveLift", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1055)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f34fe8b)

📈 **Matched code**: 14.67% (+0.01%, +764 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::init(al::ActorInitInfo const&)` | +160 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::SnowVolumeEraser(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::SnowVolumeEraser(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `al::FunctorV0M<SnowVolumeEraser*, void (SnowVolumeEraser::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `(anonymous namespace)::SnowVolumeEraserNrvAppear::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::exeAppear()` | +64 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::start()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SnowVolumeEraser>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `al::FunctorV0M<SnowVolumeEraser*, void (SnowVolumeEraser::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `SnowVolumeEraser::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `MapObj/SnowVolumeEraser` | `al::FunctorV0M<SnowVolumeEraser*, void (SnowVolumeEraser::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->