### PR TITLE
MapObj: Implement `BlockStateNoItem`

### DIFF
--- a/src/MapObj/BlockStateNoItem.cpp
+++ b/src/MapObj/BlockStateNoItem.cpp
@@ -1,0 +1,74 @@
+#include "MapObj/BlockStateNoItem.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/PartsFunction.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BlockStateNoItem, Wait);
+NERVE_IMPL(BlockStateNoItem, Reaction);
+
+NERVES_MAKE_STRUCT(BlockStateNoItem, Wait, Reaction);
+}  // namespace
+
+BlockStateNoItem::BlockStateNoItem(al::LiveActor* actor)
+    : al::ActorStateBase("アイテムなし状態", actor) {}
+
+void BlockStateNoItem::init() {
+    // NOTE: initializes storage for one sub-state, but never adds it
+    initNerve(&NrvBlockStateNoItem.Wait, 1);
+}
+
+void BlockStateNoItem::appear() {
+    al::ActorStateBase::appear();
+    al::validateCollisionParts(mActor);
+    al::startAction(mActor, "Wait");
+    al::setNerve(this, &NrvBlockStateNoItem.Wait);
+}
+
+bool BlockStateNoItem::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self) {
+    if (al::isNerve(this, &NrvBlockStateNoItem.Wait) && rs::isMsgBlockReactionAll(message)) {
+        doReaction();
+        return true;
+    }
+    return false;
+}
+
+void BlockStateNoItem::doReaction() {
+    al::LiveActor* subActor = al::tryGetSubActor(mActor, "壊れモデル");
+    if (subActor) {
+        al::appearBreakModelRandomRotateY(subActor);
+        al::startHitReaction(mActor, "破壊");
+        al::hideModelIfShow(mActor);
+        al::invalidateCollisionParts(mActor);
+    }
+
+    al::setNerve(this, &NrvBlockStateNoItem.Reaction);
+}
+
+bool BlockStateNoItem::isReaction() const {
+    return al::isNerve(this, &NrvBlockStateNoItem.Reaction);
+}
+
+void BlockStateNoItem::exeWait() {}
+
+void BlockStateNoItem::exeReaction() {
+    if (!al::isExistAction(mActor, "Reaction")) {
+        if (al::isGreaterEqualStep(this, 5))
+            kill();
+        return;
+    }
+
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Reaction");
+
+    if (al::isActionEnd(mActor))
+        kill();
+}

--- a/src/MapObj/BlockStateNoItem.cpp
+++ b/src/MapObj/BlockStateNoItem.cpp
@@ -1,0 +1,74 @@
+#include "MapObj/BlockStateNoItem.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/PartsFunction.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_HOST_TYPE_IMPL(BlockStateNoItem, Wait);
+NERVE_HOST_TYPE_IMPL(BlockStateNoItem, Reaction);
+
+NERVES_MAKE_STRUCT(HostType, Wait, Reaction);
+}  // namespace
+
+BlockStateNoItem::BlockStateNoItem(al::LiveActor* actor)
+    : al::ActorStateBase("アイテムなし状態", actor) {}
+
+void BlockStateNoItem::init() {
+    // NOTE: initializes storage for one sub-state, but never adds it
+    initNerve(&NrvHostType.Wait, 1);
+}
+
+void BlockStateNoItem::appear() {
+    al::ActorStateBase::appear();
+    al::validateCollisionParts(mActor);
+    al::startAction(mActor, "Wait");
+    al::setNerve(this, &NrvHostType.Wait);
+}
+
+bool BlockStateNoItem::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self) {
+    if (al::isNerve(this, &NrvHostType.Wait) && rs::isMsgBlockReactionAll(message)) {
+        doReaction();
+        return true;
+    }
+    return false;
+}
+
+void BlockStateNoItem::doReaction() {
+    al::LiveActor* subActor = al::tryGetSubActor(mActor, "壊れモデル");
+    if (subActor) {
+        al::appearBreakModelRandomRotateY(subActor);
+        al::startHitReaction(mActor, "破壊");
+        al::hideModelIfShow(mActor);
+        al::invalidateCollisionParts(mActor);
+    }
+
+    al::setNerve(this, &NrvHostType.Reaction);
+}
+
+bool BlockStateNoItem::isReaction() const {
+    return al::isNerve(this, &NrvHostType.Reaction);
+}
+
+void BlockStateNoItem::exeWait() {}
+
+void BlockStateNoItem::exeReaction() {
+    if (!al::isExistAction(mActor, "Reaction")) {
+        if (al::isGreaterEqualStep(this, 5))
+            kill();
+        return;
+    }
+
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Reaction");
+
+    if (al::isActionEnd(mActor))
+        kill();
+}

--- a/src/MapObj/BlockStateNoItem.h
+++ b/src/MapObj/BlockStateNoItem.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class BlockStateNoItem : public al::ActorStateBase {
+public:
+    BlockStateNoItem(al::LiveActor* actor);
+
+    void init() override;
+    void appear() override;
+
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    void doReaction();
+    bool isReaction() const;
+    void exeWait();
+    void exeReaction();
+};
+
+static_assert(sizeof(BlockStateNoItem) == 0x20);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1056)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0524374 - 0e6a00f)

📈 **Matched code**: 14.87% (+0.00%, +588 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +152 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::exeReaction()` | +132 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::doReaction()` | +100 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::appear()` | +68 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::BlockStateNoItem(al::LiveActor*)` | +64 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::~BlockStateNoItem()` | +36 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::init()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::isReaction() const` | +16 | 0.00% | 100.00% |
| `MapObj/BlockStateNoItem` | `BlockStateNoItem::exeWait()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->