### PR TITLE
MapObj: Implement `TalkMessageInfoDirectorStateAppearWaitEndMessage`

### DIFF
--- a/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.cpp
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.cpp
@@ -1,0 +1,59 @@
+#include "MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+
+namespace {
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearWaitEndMessage, Appear);
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearWaitEndMessage, Wait);
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearWaitEndMessage, End);
+
+NERVES_MAKE_NOSTRUCT(TalkMessageInfoDirectorStateAppearWaitEndMessage, Appear, Wait, End);
+}  // namespace
+
+TalkMessageInfoDirectorStateAppearWaitEndMessage::TalkMessageInfoDirectorStateAppearWaitEndMessage(
+    TalkMessageInfoDirector* director, al::SimpleLayoutAppearWaitEnd* layout)
+    : al::HostStateBase<TalkMessageInfoDirector>("メッセージ表示", director), mLayout(layout) {
+    initNerve(&Appear, 0);
+}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::appear() {
+    al::HostStateBase<TalkMessageInfoDirector>::appear();
+    al::setNerve(this, &Appear);
+}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::kill() {
+    al::HostStateBase<TalkMessageInfoDirector>::kill();
+    mLayout->kill();
+}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::exeAppear() {
+    if (al::isFirstStep(this)) {
+        mLayout->appear();
+        al::startAction(mLayout, "Appear");
+    }
+
+    if (al::isActionEnd(mLayout))
+        al::setNerve(this, &Wait);
+}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::exeWait() {}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mLayout, "End");
+
+    if (al::isActionEnd(mLayout))
+        kill();
+}
+
+void TalkMessageInfoDirectorStateAppearWaitEndMessage::end() {
+    al::setNerve(this, &End);
+}
+
+bool TalkMessageInfoDirectorStateAppearWaitEndMessage::isActiveCapMessage() const {
+    return !isDead() && mLayout->isAlive();
+}

--- a/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class SimpleLayoutAppearWaitEnd;
+}
+
+class TalkMessageInfoDirector;
+
+class TalkMessageInfoDirectorStateAppearWaitEndMessage
+    : public al::HostStateBase<TalkMessageInfoDirector> {
+public:
+    TalkMessageInfoDirectorStateAppearWaitEndMessage(TalkMessageInfoDirector* director,
+                                                     al::SimpleLayoutAppearWaitEnd* layout);
+
+    void appear() override;
+    void kill() override;
+
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void end();
+    bool isActiveCapMessage() const;
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mLayout = nullptr;
+};
+
+static_assert(sizeof(TalkMessageInfoDirectorStateAppearWaitEndMessage) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1057)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 672569e)

📈 **Matched code**: 14.67% (+0.01%, +744 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearWaitEndMessageNrvAppear::execute(al::NerveKeeper*) const` | +140 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::exeAppear()` | +136 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearWaitEndMessageNrvEnd::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::exeEnd()` | +120 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::TalkMessageInfoDirectorStateAppearWaitEndMessage(TalkMessageInfoDirector*, al::SimpleLayoutAppearWaitEnd*)` | +92 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::isActiveCapMessage() const` | +36 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::~TalkMessageInfoDirectorStateAppearWaitEndMessage()` | +36 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::kill()` | +24 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::appear()` | +16 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::end()` | +12 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `TalkMessageInfoDirectorStateAppearWaitEndMessage::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearWaitEndMessageNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->