### PR TITLE
MapObj: Implement `CollectBgmSpeaker`

### DIFF
--- a/src/MapObj/CollectBgmSpeaker.cpp
+++ b/src/MapObj/CollectBgmSpeaker.cpp
@@ -1,0 +1,65 @@
+#include "MapObj/CollectBgmSpeaker.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Enemy/DisregardReceiver.h"
+#include "Util/NpcEventFlowUtil.h"
+
+namespace {
+NERVE_IMPL(CollectBgmSpeaker, Wait);
+NERVE_IMPL(CollectBgmSpeaker, Open);
+NERVE_IMPL(CollectBgmSpeaker, Close);
+NERVES_MAKE_NOSTRUCT(CollectBgmSpeaker, Wait, Open, Close);
+}  // namespace
+
+const sead::Vector3f sRequestIconOffset = {0.0f, 0.0f, 0.0f};
+
+CollectBgmSpeaker::CollectBgmSpeaker(const char* name) : al::LiveActor(name) {}
+
+void CollectBgmSpeaker::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "CollectBgmSpeaker", nullptr);
+    al::initNerve(this, &Wait, 0);
+    mDisregardReceiver = new DisregardReceiver(this, nullptr);
+    al::startAction(this, "Wait");
+    makeActorAlive();
+}
+
+void CollectBgmSpeaker::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorEye(self) && al::isSensorPlayer(other) &&
+        rs::checkTriggerDecideWithRequestIcon(this, sRequestIconOffset, -1.0f))
+        al::setNerve(this, &Open);
+}
+
+bool CollectBgmSpeaker::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    return mDisregardReceiver->receiveMsg(message, other, self);
+}
+
+void CollectBgmSpeaker::exeWait() {}
+
+void CollectBgmSpeaker::exeOpen() {
+    if (al::isFirstStep(this))
+        al::invalidateClipping(this);
+}
+
+void CollectBgmSpeaker::exeClose() {
+    if (al::isGreaterEqualStep(this, 30)) {
+        al::validateClipping(this);
+        al::setNerve(this, &Wait);
+    }
+}
+
+void CollectBgmSpeaker::exePlayBgm() {}
+
+bool CollectBgmSpeaker::isOpen() const {
+    return al::isNerve(this, &Open);
+}
+
+void CollectBgmSpeaker::close() {
+    al::setNerve(this, &Close);
+}

--- a/src/MapObj/CollectBgmSpeaker.h
+++ b/src/MapObj/CollectBgmSpeaker.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class DisregardReceiver;
+
+class CollectBgmSpeaker : public al::LiveActor {
+public:
+    CollectBgmSpeaker(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeOpen();
+    void exeClose();
+    void exePlayBgm();
+    bool isOpen() const;
+    void close();
+
+private:
+    DisregardReceiver* mDisregardReceiver = nullptr;
+};
+
+static_assert(sizeof(CollectBgmSpeaker) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -82,6 +82,7 @@
 #include "MapObj/ChurchDoor.h"
 #include "MapObj/CitySignal.h"
 #include "MapObj/CoinCollectHintObj.h"
+#include "MapObj/CollectBgmSpeaker.h"
 #include "MapObj/CollectionList.h"
 #include "MapObj/DoorCity.h"
 #include "MapObj/DoorSnow.h"
@@ -252,7 +253,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"CloudStep", nullptr},
     {"CollapseSandHill", nullptr},
     {"CollectAnimalWatcher", nullptr},
-    {"CollectBgmSpeaker", nullptr},
+    {"CollectBgmSpeaker", al::createActorFunction<CollectBgmSpeaker>},
     {"CollectionList", al::createActorFunction<CollectionList>},
     {"Coin", al::createActorFunction<Coin>},
     {"Coin2D", al::createActorFunction<Coin2D>},

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -28,4 +28,5 @@ void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
 void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
+bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
 }  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1058)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 58db8a8)

📈 **Matched code**: 14.67% (+0.01%, +872 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::init(al::ActorInitInfo const&)` | +156 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::CollectBgmSpeaker(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::CollectBgmSpeaker(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::attackSensor(al::HitSensor*, al::HitSensor*)` | +104 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `(anonymous namespace)::CollectBgmSpeakerNrvClose::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::exeClose()` | +72 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `(anonymous namespace)::CollectBgmSpeakerNrvOpen::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::exeOpen()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<CollectBgmSpeaker>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::isOpen() const` | +12 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::close()` | +12 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `CollectBgmSpeaker::exePlayBgm()` | +4 | 0.00% | 100.00% |
| `MapObj/CollectBgmSpeaker` | `(anonymous namespace)::CollectBgmSpeakerNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->