### PR TITLE
MapObj: Implement `LinkTargetPoint`

### DIFF
--- a/src/MapObj/LinkTargetPoint.cpp
+++ b/src/MapObj/LinkTargetPoint.cpp
@@ -1,0 +1,70 @@
+#include "MapObj/LinkTargetPoint.h"
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/Collision/PartsMtxConnector.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "MapObj/TouchTargetInfo.h"
+#include "Util/SensorMsgFunction.h"
+
+LinkTargetPoint::LinkTargetPoint() : al::LiveActor("リンク対象位置") {}
+
+void LinkTargetPoint::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorMapObjMovement(this, info);
+    al::initActorPoseTQSV(this);
+    al::initActorSRT(this, info);
+    al::initActorClipping(this, info);
+    al::invalidateClipping(this);
+    al::calcUpDir(&mNormal, this);
+
+    bool isConnect = false;
+    al::tryGetArg(&isConnect, info, "IsConnectToCollision");
+    if (isConnect)
+        mMtxConnector = al::createMtxConnector(this);
+
+    makeActorAlive();
+}
+
+void LinkTargetPoint::initAfterPlacement() {
+    if (!mMtxConnector)
+        return;
+
+    al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 100.0f);
+    if (alCollisionUtil::getStrikeArrowInfoNum(this) >= 1)
+        mNormal = (*alCollisionUtil::getStrikeArrowInfo(this, 0))->triangle.getFaceNormal();
+}
+
+void LinkTargetPoint::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void LinkTargetPoint::calcTargetCenterPos(sead::Vector3f* pos) const {
+    al::MtxConnector* connector = mMtxConnector;
+    if (connector) {
+        const sead::Vector3f& baseTrans = al::getConnectBaseTrans(connector);
+        connector->multTrans(pos, baseTrans);
+    } else {
+        *pos = al::getTrans(this);
+    }
+}
+
+bool LinkTargetPoint::receiveMsgInitTouchTargetInfo(const al::SensorMsg* msg) {
+    TouchTargetInfo* info;
+    if (!rs::tryGetTouchTargetInfo(&info, msg))
+        return false;
+
+    if (mMtxConnector) {
+        info->setInfoByConnector(mMtxConnector, al::getConnectBaseTrans(mMtxConnector), mNormal,
+                                 true);
+    } else {
+        info->setInfoByPosAndNrm(al::getTrans(this), mNormal);
+    }
+
+    return true;
+}

--- a/src/MapObj/LinkTargetPoint.h
+++ b/src/MapObj/LinkTargetPoint.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class LinkTargetPoint : public al::LiveActor {
+public:
+    LinkTargetPoint();
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void control() override;
+    void calcTargetCenterPos(sead::Vector3f* pos) const;
+    bool receiveMsgInitTouchTargetInfo(const al::SensorMsg* msg);
+
+private:
+    al::MtxConnector* mMtxConnector = nullptr;
+    sead::Vector3f mNormal = sead::Vector3f::ey;
+};
+
+static_assert(sizeof(LinkTargetPoint) == 0x120);

--- a/src/MapObj/TouchTargetInfo.h
+++ b/src/MapObj/TouchTargetInfo.h
@@ -12,4 +12,5 @@ public:
     void setInfoBySensor(const al::HitSensor*, const sead::Vector3f&, const sead::Vector3f&);
     void setInfoByConnector(const al::MtxConnector*, const sead::Vector3f&, const sead::Vector3f&,
                             bool);
+    void setInfoByPosAndNrm(const sead::Vector3f&, const sead::Vector3f&);
 };


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1059)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4de3f22 - 9702b2f)

📈 **Matched code**: 14.55% (+0.01%, +856 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::init(al::ActorInitInfo const&)` | +168 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::LinkTargetPoint()` | +160 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::LinkTargetPoint()` | +156 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::receiveMsgInitTouchTargetInfo(al::SensorMsg const*)` | +140 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::initAfterPlacement()` | +120 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::calcTargetCenterPos(sead::Vector3<float>*) const` | +96 | 0.00% | 100.00% |
| `MapObj/LinkTargetPoint` | `LinkTargetPoint::control()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->