### PR TITLE
MapObj: Implement `HomeInside`

### DIFF
--- a/src/MapObj/HomeInside.cpp
+++ b/src/MapObj/HomeInside.cpp
@@ -1,0 +1,26 @@
+#include "MapObj/HomeInside.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "System/GameDataFunction.h"
+
+HomeInside::HomeInside(const char* name) : al::LiveActor(name) {}
+
+void HomeInside::init(const al::ActorInitInfo& info) {
+    auto* gameDataHolder = reinterpret_cast<GameDataHolder*>(info.actorSceneInfo.gameDataHolder);
+    const char* currentStageName = GameDataFunction::getCurrentStageName(gameDataHolder);
+
+    const char* suffix = nullptr;
+    if (al::isEqualString(currentStageName, "DemoChangeWorldStage") ||
+        al::isEqualString(currentStageName, "DemoChangeWorldBossRaidAttackStage") ||
+        al::isEqualString(currentStageName, "DemoChangeWorldFindKoopaShipStage")) {
+        suffix = "DemoChangeWorldScene";
+    }
+
+    al::initActorSuffix(this, info, suffix);
+    makeActorAlive();
+}

--- a/src/MapObj/HomeInside.h
+++ b/src/MapObj/HomeInside.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class HomeInside : public al::LiveActor {
+public:
+    HomeInside(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+};
+
+static_assert(sizeof(HomeInside) == 0x108);

--- a/src/MapObj/HomeShip.cpp
+++ b/src/MapObj/HomeShip.cpp
@@ -1,0 +1,33 @@
+#include "MapObj/HomeShip.h"
+
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+
+namespace {
+NERVE_IMPL(HomeShip, Wait);
+NERVES_MAKE_NOSTRUCT(HomeShip, Wait);
+}  // namespace
+
+HomeShip::HomeShip(const char* name) : al::LiveActor(name) {}
+
+void HomeShip::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "KoopaShip", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::setScaleAll(this, 0.25f);
+
+    al::PlacementInfo placementInfo;
+    al::getLinksInfo(&placementInfo, info, "GoalObj");
+
+    mGoalObj = al::createChildLinkSimpleActor("ゴールホーム", "GoalObj", info, true);
+    makeActorAlive();
+}
+
+bool HomeShip::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    return false;
+}
+
+void HomeShip::exeWait() {}

--- a/src/MapObj/HomeShip.h
+++ b/src/MapObj/HomeShip.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class HomeShip : public al::LiveActor {
+public:
+    HomeShip(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+
+private:
+    al::LiveActor* mGoalObj = nullptr;
+};
+
+static_assert(sizeof(HomeShip) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -82,6 +82,8 @@
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
 #include "MapObj/HipDropSwitch.h"
+#include "MapObj/HomeInside.h"
+#include "MapObj/HomeShip.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
@@ -357,8 +359,8 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HipDropTransformPartsWatcher", nullptr},
     {"HomeBed", nullptr},
     {"HomeChair", nullptr},
-    {"HomeInside", nullptr},
-    {"HomeShip", nullptr},
+    {"HomeInside", al::createActorFunction<HomeInside>},
+    {"HomeShip", al::createActorFunction<HomeShip>},
     {"Hosui", nullptr},
     {"IcicleFall", nullptr},
     {"Imomu", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1060)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 301b208)

📈 **Matched code**: 14.67% (+0.01%, +976 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/HomeShip` | `HomeShip::init(al::ActorInitInfo const&)` | +196 | 0.00% | 100.00% |
| `MapObj/HomeInside` | `HomeInside::init(al::ActorInitInfo const&)` | +148 | 0.00% | 100.00% |
| `MapObj/HomeShip` | `HomeShip::HomeShip(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/HomeInside` | `HomeInside::HomeInside(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/HomeShip` | `HomeShip::HomeShip(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/HomeInside` | `HomeInside::HomeInside(char const*)` | +120 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HomeInside>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HomeShip>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/HomeShip` | `HomeShip::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `MapObj/HomeShip` | `HomeShip::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/HomeShip` | `(anonymous namespace)::HomeShipNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->