### PR TITLE
MapObj: Implement `BlockBrickBig2D`

### DIFF
--- a/src/MapObj/BlockBrickBig2D.cpp
+++ b/src/MapObj/BlockBrickBig2D.cpp
@@ -1,0 +1,65 @@
+#include "MapObj/BlockBrickBig2D.h"
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/ActorDimensionUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BlockBrickBig2D, Wait)
+
+NERVES_MAKE_STRUCT(BlockBrickBig2D, Wait)
+}  // namespace
+
+BlockBrickBig2D::BlockBrickBig2D(const char* name) : al::LiveActor(name) {}
+
+void BlockBrickBig2D::init(const al::ActorInitInfo& info) {
+    using BlockBrickBig2DFunctor = al::FunctorV0M<BlockBrickBig2D*, void (BlockBrickBig2D::*)()>;
+
+    al::initActor(this, info);
+    al::initNerve(this, &NrvBlockBrickBig2D.Wait, 0);
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    rs::snap2DParallelizeFront(this, this, 500.0f);
+    al::listenStageSwitchOn(this, "SwitchBreak",
+                            BlockBrickBig2DFunctor(this, &BlockBrickBig2D::startBreak));
+    al::trySyncStageSwitchAppear(this);
+}
+
+void BlockBrickBig2D::startBreak() {
+    if (al::isAlive(this))
+        kill();
+}
+
+void BlockBrickBig2D::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+void BlockBrickBig2D::kill() {
+    al::getSubActor(this, "壊れモデル")->appear();
+    al::LiveActor::kill();
+}
+
+bool BlockBrickBig2D::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    if (rs::isMsgBlockReaction2D(msg)) {
+        kill();
+        return true;
+    }
+
+    return false;
+}
+
+void BlockBrickBig2D::exeWait() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}

--- a/src/MapObj/BlockBrickBig2D.h
+++ b/src/MapObj/BlockBrickBig2D.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/IUseDimension.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class ActorDimensionKeeper;
+
+class BlockBrickBig2D : public al::LiveActor, public IUseDimension {
+public:
+    BlockBrickBig2D(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void startBreak();
+    void initAfterPlacement() override;
+    void kill() override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void exeWait();
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override { return mDimensionKeeper; }
+
+private:
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    al::MtxConnector* mMtxConnector = nullptr;
+};
+
+static_assert(sizeof(BlockBrickBig2D) == 0x120);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -68,6 +68,7 @@
 #include "Item/LifeUpItem2D.h"
 #include "MapObj/AllDeadWatcherWithShine.h"
 #include "MapObj/AnagramAlphabet.h"
+#include "MapObj/BlockBrickBig2D.h"
 #include "MapObj/BlockEmpty2D.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
@@ -142,7 +143,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BirdPlayerGlideCtrl", al::createActorFunction<BirdPlayerGlideCtrl>},
     {"BlockBrick", nullptr},
     {"BlockBrick2D", nullptr},
-    {"BlockBrickBig2D", nullptr},
+    {"BlockBrickBig2D", al::createActorFunction<BlockBrickBig2D>},
     {"BlockEmpty", nullptr},
     {"BlockEmpty2D", al::createActorFunction<BlockEmpty2D>},
     {"BlockHard", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1061)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 536e7f9)

📈 **Matched code**: 14.20% (+0.01%, +892 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::init(al::ActorInitInfo const&)` | +176 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::BlockBrickBig2D(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::BlockBrickBig2D(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `al::FunctorV0M<BlockBrickBig2D*, void (BlockBrickBig2D::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +68 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::startBreak()` | +60 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::kill()` | +56 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BlockBrickBig2D>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::initAfterPlacement()` | +28 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `al::FunctorV0M<BlockBrickBig2D*, void (BlockBrickBig2D::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `(anonymous namespace)::BlockBrickBig2DNrvWait::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::exeWait()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `BlockBrickBig2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `non-virtual thunk to BlockBrickBig2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/BlockBrickBig2D` | `al::FunctorV0M<BlockBrickBig2D*, void (BlockBrickBig2D::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->