### PR TITLE
MapObj: Implement `RhyhtmInfoWatcher`

### DIFF
--- a/src/MapObj/RhyhtmInfoWatcher.cpp
+++ b/src/MapObj/RhyhtmInfoWatcher.cpp
@@ -1,0 +1,56 @@
+#include "MapObj/RhyhtmInfoWatcher.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+RhyhtmInfoWatcher::RhyhtmInfoWatcher(const char* name) : al::LiveActor(name) {}
+
+void RhyhtmInfoWatcher::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorWatchObj(this, info);
+    al::initActorBgmKeeper(this, info, nullptr);
+    getSceneObjName();
+    makeActorAlive();
+}
+
+void RhyhtmInfoWatcher::control() {
+    if (!al::isEnableRhythmAnim(this, nullptr))
+        return;
+
+    mPreviousBeat = mCurrentBeat;
+
+    mCurrentBeat = al::getCurBeat(this);
+    mIsLooping = loopCheck();
+}
+
+bool RhyhtmInfoWatcher::loopCheck() {
+    return !(mPreviousBeat <= mCurrentBeat);
+}
+
+namespace rs {
+
+RhyhtmInfoWatcher* getInstance(al::IUseSceneObjHolder* holder) {
+    return al::getSceneObj<RhyhtmInfoWatcher>(holder);
+}
+
+void registerRhyhtmInfoListener(al::IUseSceneObjHolder* holder) {
+    if (al::isExistSceneObj(holder, SceneObjID_RhyhtmInfoWatcher))
+        return;
+
+    al::createSceneObj(holder, SceneObjID_RhyhtmInfoWatcher);
+}
+
+f32 getCurrentBeat(al::IUseSceneObjHolder* holder) {
+    return al::getSceneObj<RhyhtmInfoWatcher>(holder)->getCurrentBeat();
+}
+
+f32 getBeatDelta(al::IUseSceneObjHolder* holder) {
+    return al::getSceneObj<RhyhtmInfoWatcher>(holder)->getBeatDelta();
+}
+
+bool isLooping(al::IUseSceneObjHolder* holder) {
+    return al::getSceneObj<RhyhtmInfoWatcher>(holder)->isLooping();
+}
+
+}  // namespace rs

--- a/src/MapObj/RhyhtmInfoWatcher.h
+++ b/src/MapObj/RhyhtmInfoWatcher.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class RhyhtmInfoWatcher : public al::LiveActor, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_RhyhtmInfoWatcher;
+
+    RhyhtmInfoWatcher(const char* name);
+
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+    void control() override;
+
+    virtual f32 getCurrentBeat() const { return mCurrentBeat; }
+
+    virtual f32 getBeatDelta() const { return mCurrentBeat - mPreviousBeat; }
+
+    virtual bool isLooping() const { return mIsLooping; }
+
+private:
+    bool loopCheck();
+
+    f32 mCurrentBeat = -1.0f;
+    f32 mPreviousBeat = -1.0f;
+    bool mIsLooping = false;
+};
+
+static_assert(sizeof(RhyhtmInfoWatcher) == 0x120);
+
+namespace rs {
+RhyhtmInfoWatcher* getInstance(al::IUseSceneObjHolder* holder);
+void registerRhyhtmInfoListener(al::IUseSceneObjHolder* holder);
+f32 getCurrentBeat(al::IUseSceneObjHolder* holder);
+f32 getBeatDelta(al::IUseSceneObjHolder* holder);
+bool isLooping(al::IUseSceneObjHolder* holder);
+}  // namespace rs

--- a/src/Scene/SceneObjFactory.cpp
+++ b/src/Scene/SceneObjFactory.cpp
@@ -9,6 +9,7 @@
 #include "Item/CoinCollectHolder.h"
 #include "Item/CoinCollectWatcher.h"
 #include "Layout/KidsModeLayoutAccessor.h"
+#include "MapObj/RhyhtmInfoWatcher.h"
 #include "MapObj/RouteGuideDirector.h"
 #include "Scene/HintPhotoLayoutHolder.h"
 
@@ -84,7 +85,7 @@ static al::ISceneObj* sceneObjCreator(s32 id) {
         return nullptr;
 
     case SceneObjID_RhyhtmInfoWatcher:
-        return nullptr;
+        return new RhyhtmInfoWatcher("");
 
     case SceneObjID_RouteGuideDirector:
         return new RouteGuideDirector();


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1062)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 0efff29)

📈 **Matched code**: 14.67% (+0.01%, +900 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::RhyhtmInfoWatcher(char const*)` | +160 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::RhyhtmInfoWatcher(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `non-virtual thunk to RhyhtmInfoWatcher::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +108 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +92 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::control()` | +84 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `rs::registerRhyhtmInfoListener(al::IUseSceneObjHolder*)` | +60 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `rs::getCurrentBeat(al::IUseSceneObjHolder*)` | +44 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `rs::getBeatDelta(al::IUseSceneObjHolder*)` | +44 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `rs::isLooping(al::IUseSceneObjHolder*)` | +44 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `rs::getInstance(al::IUseSceneObjHolder*)` | +36 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::loopCheck()` | +20 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::getBeatDelta() const` | +16 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::getCurrentBeat() const` | +8 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::isLooping() const` | +8 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `non-virtual thunk to RhyhtmInfoWatcher::~RhyhtmInfoWatcher()` | +8 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::~RhyhtmInfoWatcher()` | +4 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `RhyhtmInfoWatcher::~RhyhtmInfoWatcher()` | +4 | 0.00% | 100.00% |
| `MapObj/RhyhtmInfoWatcher` | `non-virtual thunk to RhyhtmInfoWatcher::~RhyhtmInfoWatcher()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->