### PR TITLE
MapObj: Implement `MotorcyclePlayerAnimator`

### DIFF
--- a/src/MapObj/MotorcyclePlayerAnimator.cpp
+++ b/src/MapObj/MotorcyclePlayerAnimator.cpp
@@ -1,0 +1,159 @@
+#include "MapObj/MotorcyclePlayerAnimator.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerPuppetFunction.h"
+
+namespace {
+NERVE_IMPL(MotorcyclePlayerAnimator, None)
+NERVE_IMPL(MotorcyclePlayerAnimator, BindKeepDemo)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideStartL)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideStartR)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideOn)
+NERVE_IMPL(MotorcyclePlayerAnimator, Wait)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideRunStart)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideClash)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideJump)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideRun)
+NERVE_IMPL(MotorcyclePlayerAnimator, RideLand)
+
+NERVES_MAKE_NOSTRUCT(MotorcyclePlayerAnimator, None, BindKeepDemo, RideStartL, RideStartR, RideOn,
+                     Wait, RideClash)
+NERVES_MAKE_STRUCT(MotorcyclePlayerAnimator, RideRunStart, RideJump, RideRun, RideLand)
+}  // namespace
+
+MotorcyclePlayerAnimator::MotorcyclePlayerAnimator()
+    : al::NerveExecutor("バイクに乗っているときのプレイヤーアニメ") {
+    initNerve(&None, 0);
+}
+
+void MotorcyclePlayerAnimator::update(f32 weightL, f32 weightC, f32 weightR) {
+    mWeightL = weightL;
+    mWeightC = weightC;
+    mWeightR = weightR;
+    updateNerve();
+}
+
+void MotorcyclePlayerAnimator::startBind(IUsePlayerPuppet* playerPuppet) {
+    mPlayerPuppet = playerPuppet;
+}
+
+void MotorcyclePlayerAnimator::startBindKeepDemo() {
+    al::setNerve(this, &BindKeepDemo);
+}
+
+void MotorcyclePlayerAnimator::endBind() {
+    rs::startPuppetAction(mPlayerPuppet, "Jump");
+    mPlayerPuppet = nullptr;
+    al::setNerve(this, &None);
+}
+
+void MotorcyclePlayerAnimator::startBindRideStartL() {
+    rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideStartL");
+    al::setNerve(this, &RideStartL);
+}
+
+void MotorcyclePlayerAnimator::startBindRideStartR() {
+    rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideStartR");
+    al::setNerve(this, &RideStartR);
+}
+
+void MotorcyclePlayerAnimator::startBindRideOn() {
+    rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideOn");
+    al::setNerve(this, &RideOn);
+}
+
+void MotorcyclePlayerAnimator::startBindWait() {
+    al::setNerve(this, &Wait);
+}
+
+void MotorcyclePlayerAnimator::startBindRideRunStart() {
+    al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideRunStart);
+}
+
+void MotorcyclePlayerAnimator::startBindRideClash() {
+    al::setNerve(this, &RideClash);
+}
+
+void MotorcyclePlayerAnimator::startBindRideJump() {
+    al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideJump);
+}
+
+bool MotorcyclePlayerAnimator::tryStartBindRideRunIfNotPlaying() {
+    if (al::isNerve(this, &NrvMotorcyclePlayerAnimator.RideRunStart))
+        return false;
+
+    if (al::isNerve(this, &NrvMotorcyclePlayerAnimator.RideRun))
+        return false;
+
+    al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideRun);
+    return true;
+}
+
+bool MotorcyclePlayerAnimator::tryStartBindRideLandIfJump() {
+    if (mPlayerPuppet == nullptr || !al::isNerve(this, &NrvMotorcyclePlayerAnimator.RideJump))
+        return false;
+
+    al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideLand);
+    return true;
+}
+
+void MotorcyclePlayerAnimator::exeNone() {}
+
+void MotorcyclePlayerAnimator::exeRideStartL() {}
+
+void MotorcyclePlayerAnimator::exeRideStartR() {}
+
+void MotorcyclePlayerAnimator::exeRideOn() {}
+
+void MotorcyclePlayerAnimator::exeWait() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleWait");
+}
+
+void MotorcyclePlayerAnimator::exeRideRunStart() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideRunStart");
+
+    rs::setPuppetAnimBlendWeight(mPlayerPuppet, mWeightL, mWeightC, mWeightR, 0.0f, 0.0f, 0.0f);
+
+    if (rs::isPuppetActionEnd(mPlayerPuppet))
+        al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideRun);
+}
+
+void MotorcyclePlayerAnimator::exeRideRun() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleRide");
+
+    rs::setPuppetAnimBlendWeight(mPlayerPuppet, mWeightL, mWeightC, mWeightR, 0.0f, 0.0f, 0.0f);
+}
+
+void MotorcyclePlayerAnimator::exeRideClash() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideClash");
+
+    rs::setPuppetAnimBlendWeight(mPlayerPuppet, mWeightL, mWeightC, mWeightR, 0.0f, 0.0f, 0.0f);
+
+    if (rs::isPuppetActionEnd(mPlayerPuppet))
+        al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideRun);
+}
+
+void MotorcyclePlayerAnimator::exeRideJump() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideJump");
+
+    rs::setPuppetAnimBlendWeight(mPlayerPuppet, mWeightL, mWeightC, mWeightR, 0.0f, 0.0f, 0.0f);
+}
+
+void MotorcyclePlayerAnimator::exeRideLand() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "MotorcycleRideLand");
+
+    rs::setPuppetAnimBlendWeight(mPlayerPuppet, mWeightL, mWeightC, mWeightR, 0.0f, 0.0f, 0.0f);
+
+    if (rs::isPuppetActionEnd(mPlayerPuppet))
+        al::setNerve(this, &NrvMotorcyclePlayerAnimator.RideRun);
+}
+
+void MotorcyclePlayerAnimator::exeBindKeepDemo() {}

--- a/src/MapObj/MotorcyclePlayerAnimator.h
+++ b/src/MapObj/MotorcyclePlayerAnimator.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+class IUsePlayerPuppet;
+
+class MotorcyclePlayerAnimator : public al::NerveExecutor {
+public:
+    MotorcyclePlayerAnimator();
+
+    void update(f32 weightL, f32 weightC, f32 weightR);
+    void startBind(IUsePlayerPuppet* playerPuppet);
+    void startBindKeepDemo();
+    void endBind();
+    void startBindRideStartL();
+    void startBindRideStartR();
+    void startBindRideOn();
+    void startBindWait();
+    void startBindRideRunStart();
+    void startBindRideClash();
+    void startBindRideJump();
+    bool tryStartBindRideRunIfNotPlaying();
+    bool tryStartBindRideLandIfJump();
+    void exeNone();
+    void exeRideStartL();
+    void exeRideStartR();
+    void exeRideOn();
+    void exeWait();
+    void exeRideRunStart();
+    void exeRideRun();
+    void exeRideClash();
+    void exeRideJump();
+    void exeRideLand();
+    void exeBindKeepDemo();
+
+private:
+    IUsePlayerPuppet* mPlayerPuppet = nullptr;
+    f32 mWeightL = 0.0f;
+    f32 mWeightC = 0.0f;
+    f32 mWeightR = 0.0f;
+};
+
+static_assert(sizeof(MotorcyclePlayerAnimator) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1063)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f71c198)

📈 **Matched code**: 14.68% (+0.01%, +1824 bytes)

<details>
<summary>✅ 37 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvRideRunStart::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvRideClash::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvRideLand::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideRunStart()` | +120 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideClash()` | +120 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideLand()` | +120 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::tryStartBindRideRunIfNotPlaying()` | +100 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::tryStartBindRideLandIfJump()` | +84 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::MotorcyclePlayerAnimator()` | +80 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvRideJump::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvRideRun::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideRun()` | +76 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideJump()` | +76 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `(anonymous namespace)::MotorcyclePlayerAnimatorNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::endBind()` | +60 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeWait()` | +60 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideStartL()` | +56 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideStartR()` | +56 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideOn()` | +56 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::~MotorcyclePlayerAnimator()` | +36 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::update(float, float, float)` | +16 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideJump()` | +16 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindKeepDemo()` | +12 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindWait()` | +12 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideRunStart()` | +12 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBindRideClash()` | +12 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::startBind(IUsePlayerPuppet*)` | +8 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeNone()` | +4 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideStartL()` | +4 | 0.00% | 100.00% |
| `MapObj/MotorcyclePlayerAnimator` | `MotorcyclePlayerAnimator::exeRideStartR()` | +4 | 0.00% | 100.00% |

...and 7 more new matches
</details>


<!-- decomp.dev report end -->