### PR TITLE
MapObj: Implement `FixMapPartsAppearKillAsync`

### DIFF
--- a/src/MapObj/FixMapPartsAppearKillAsync.cpp
+++ b/src/MapObj/FixMapPartsAppearKillAsync.cpp
@@ -1,0 +1,59 @@
+#include "MapObj/FixMapPartsAppearKillAsync.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+FixMapPartsAppearKillAsync::FixMapPartsAppearKillAsync(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void FixMapPartsAppearKillAsync::init(const al::ActorInitInfo& info) {
+    const char* suffix = nullptr;
+
+    al::tryGetStringArg(&suffix, info, "Suffix");
+    al::initMapPartsActor(this, info, suffix);
+    al::tryListenStageSwitchKill(this);
+    al::tryListenStageSwitchAppear(this);
+}
+
+void FixMapPartsAppearKillAsync::appear() {
+    al::LiveActor::appear();
+    al::tryStartAction(this, "Appear");
+}
+
+void FixMapPartsAppearKillAsync::kill() {
+    al::LiveActor::kill();
+    al::tryStartAction(this, "Kill");
+}
+
+void FixMapPartsAppearKillAsync::movement() {
+    if (!mIsStatic)
+        al::LiveActor::movement();
+}
+
+void FixMapPartsAppearKillAsync::calcAnim() {
+    if (!mIsStatic)
+        al::LiveActor::calcAnim();
+    else
+        al::calcViewModel(this);
+}
+
+bool FixMapPartsAppearKillAsync::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                            al::HitSensor* self) {
+    if (al::isMsgAskSafetyPoint(message))
+        return true;
+
+    if (al::isMsgShowModel(message)) {
+        al::showModelIfHide(this);
+        return true;
+    }
+
+    if (al::isMsgHideModel(message)) {
+        al::hideModelIfShow(this);
+        return true;
+    }
+
+    return false;
+}

--- a/src/MapObj/FixMapPartsAppearKillAsync.h
+++ b/src/MapObj/FixMapPartsAppearKillAsync.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class FixMapPartsAppearKillAsync : public al::LiveActor {
+public:
+    FixMapPartsAppearKillAsync(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+    void movement() override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+private:
+    bool mIsStatic = false;
+};
+
+static_assert(sizeof(FixMapPartsAppearKillAsync) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -79,6 +79,7 @@
 #include "MapObj/Doshi.h"
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
+#include "MapObj/FixMapPartsAppearKillAsync.h"
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
 #include "MapObj/HipDropSwitch.h"
@@ -302,7 +303,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"FireDrum2D", al::createActorFunction<FireDrum2D>},
     {"FishingFish", nullptr},
     {"FixMapParts2D", nullptr},
-    {"FixMapPartsAppearKillAsync", nullptr},
+    {"FixMapPartsAppearKillAsync", al::createActorFunction<FixMapPartsAppearKillAsync>},
     {"FixMapPartsBgmChangeAction", al::createActorFunction<FixMapPartsBgmChangeAction>},
     {"FixMapPartsCapHanger", nullptr},
     {"FixMapPartsDitherAppear", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1065)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 0833770)

📈 **Matched code**: 14.67% (+0.00%, +532 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::FixMapPartsAppearKillAsync(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::FixMapPartsAppearKillAsync(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +100 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<FixMapPartsAppearKillAsync>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::appear()` | +44 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::kill()` | +44 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::movement()` | +16 | 0.00% | 100.00% |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::calcAnim()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->