### PR TITLE
Enemy: Implement `TRexStateSleep`

### DIFF
--- a/src/Enemy/TRexStateSleep.cpp
+++ b/src/Enemy/TRexStateSleep.cpp
@@ -1,0 +1,54 @@
+#include "Enemy/TRexStateSleep.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(TRexStateSleep, Sleep);
+NERVE_IMPL(TRexStateSleep, SleepReactionHipDrop);
+
+NERVES_MAKE_NOSTRUCT(TRexStateSleep, Sleep, SleepReactionHipDrop);
+}  // namespace
+
+TRexStateSleep::TRexStateSleep(const char* name, al::LiveActor* actor)
+    : al::ActorStateBase(name, actor) {
+    initNerve(&Sleep, 0);
+}
+
+void TRexStateSleep::appear() {
+    al::ActorStateBase::appear();
+    al::offCollide(mActor);
+    al::setNerve(this, &Sleep);
+}
+
+bool TRexStateSleep::receiveMsg(bool* outResult, const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isSensorCollision(self) && rs::isMsgPlayerAndCapHipDropAll(message)) {
+        *outResult = false;
+        al::setNerve(this, &SleepReactionHipDrop);
+        return true;
+    }
+
+    return false;
+}
+
+void TRexStateSleep::exeSleep() {
+    if (al::isFirstStep(this)) {
+        al::tryStartActionIfNotPlaying(mActor, "Sleep");
+        al::setVelocityZero(mActor);
+    }
+}
+
+void TRexStateSleep::exeSleepReactionHipDrop() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "SleepReactionHipDrop");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Sleep);
+}

--- a/src/Enemy/TRexStateSleep.cpp
+++ b/src/Enemy/TRexStateSleep.cpp
@@ -1,0 +1,54 @@
+#include "Enemy/TRexStateSleep.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(TRexStateSleep, Sleep);
+NERVE_IMPL(TRexStateSleep, SleepReactionHipDrop);
+
+NERVES_MAKE_NOSTRUCT(TRexStateSleep, Sleep, SleepReactionHipDrop);
+}  // namespace
+
+TRexStateSleep::TRexStateSleep(const char* name, al::LiveActor* actor)
+    : al::ActorStateBase(name, actor) {
+    initNerve(&Sleep, 0);
+}
+
+void TRexStateSleep::appear() {
+    al::NerveStateBase::appear();
+    al::offCollide(mActor);
+    al::setNerve(this, &Sleep);
+}
+
+bool TRexStateSleep::receiveMsg(bool* outResult, const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isSensorCollision(self) && rs::isMsgPlayerAndCapHipDropAll(message)) {
+        *outResult = false;
+        al::setNerve(this, &SleepReactionHipDrop);
+        return true;
+    }
+
+    return false;
+}
+
+void TRexStateSleep::exeSleep() {
+    if (al::isFirstStep(this)) {
+        al::tryStartActionIfNotPlaying(mActor, "Sleep");
+        al::setVelocityZero(mActor);
+    }
+}
+
+void TRexStateSleep::exeSleepReactionHipDrop() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "SleepReactionHipDrop");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Sleep);
+}

--- a/src/Enemy/TRexStateSleep.h
+++ b/src/Enemy/TRexStateSleep.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class TRexStateSleep : public al::ActorStateBase {
+public:
+    TRexStateSleep(const char* name, al::LiveActor* actor);
+
+    void appear() override;
+
+    bool receiveMsg(bool* outResult, const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self);
+
+    void exeSleep();
+    void exeSleepReactionHipDrop();
+};
+
+static_assert(sizeof(TRexStateSleep) == 0x20);

--- a/src/Enemy/TRexStateSleep.h
+++ b/src/Enemy/TRexStateSleep.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class TRexStateSleep : public al::ActorStateBase {
+public:
+    TRexStateSleep(const char* name, al::LiveActor* actor);
+
+    void appear() override;
+
+    bool receiveMsg(bool* outResult, const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self);
+
+    void exeSleep();
+    void exeSleepReactionHipDrop();
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1066)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 46587af)

📈 **Matched code**: 14.67% (+0.00%, +572 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/TRexStateSleep` | `TRexStateSleep::receiveMsg(bool*, al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +100 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `(anonymous namespace)::TRexStateSleepNrvSleepReactionHipDrop::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `TRexStateSleep::exeSleepReactionHipDrop()` | +88 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `(anonymous namespace)::TRexStateSleepNrvSleep::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `TRexStateSleep::exeSleep()` | +68 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `TRexStateSleep::TRexStateSleep(char const*, al::LiveActor*)` | +64 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `TRexStateSleep::appear()` | +52 | 0.00% | 100.00% |
| `Enemy/TRexStateSleep` | `TRexStateSleep::~TRexStateSleep()` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->