### PR TITLE
Player: Implement `PlayerStateBind`

### DIFF
--- a/src/Player/PlayerPuppet.h
+++ b/src/Player/PlayerPuppet.h
@@ -25,6 +25,14 @@ class PlayerEffect;
 class PlayerInput;
 class WorldEndBorderKeeper;
 
+struct PlayerBindEndJumpInfo {
+    sead::Vector3f _0;
+    s32 _c;
+    f32 gravity;
+};
+
+static_assert(sizeof(PlayerBindEndJumpInfo) == 0x14);
+
 class PlayerPuppet : public IUsePlayerPuppet {
 public:
     PlayerPuppet(al::LiveActor*, HackCap*, PlayerAnimator*, IUsePlayerCollision*,
@@ -80,6 +88,11 @@ public:
                                    const al::AreaObj*);
     bool tryUpdateRecoveryInfo(bool*, bool*, sead::Vector3f*, sead::Vector3f*, const al::AreaObj**);
     bool isBinding() const;
+
+    bool isBindEndCapThrow() const { return mIsBindEndCapThrow; }
+
+    const PlayerBindEndJumpInfo* getBindEndJumpInfo() const { return mBindEndJumpInfo; }
+
     bool isNoCollide() const;
 
 private:
@@ -106,7 +119,7 @@ private:
     al::AreaObj* mAreaObj;
     bool mIsBindEndOnGround;
     bool mIsBindEndJump;
-    bool _aa;
+    bool mIsBindEndCapThrow;
     bool mIsValidCollisionCheck;
     bool _ac;
     bool mIsRequestDamage;
@@ -120,9 +133,8 @@ private:
     bool _b5;
     bool _b6;
 
-    char filler[0x8];
-
-    sead::Vector3f _c8;
+    char filler[0x10];
+    PlayerBindEndJumpInfo* mBindEndJumpInfo;
 };
 
 static_assert(sizeof(PlayerPuppet) == 0xd0);

--- a/src/Player/PlayerPuppet.h
+++ b/src/Player/PlayerPuppet.h
@@ -25,6 +25,12 @@ class PlayerEffect;
 class PlayerInput;
 class WorldEndBorderKeeper;
 
+struct PlayerBindEndJumpInfo {
+    sead::Vector3f endTrans;
+    s32 endFrame;
+    f32 gravity;
+};
+
 class PlayerPuppet : public IUsePlayerPuppet {
 public:
     PlayerPuppet(al::LiveActor*, HackCap*, PlayerAnimator*, IUsePlayerCollision*,
@@ -80,6 +86,11 @@ public:
                                    const al::AreaObj*);
     bool tryUpdateRecoveryInfo(bool*, bool*, sead::Vector3f*, sead::Vector3f*, const al::AreaObj**);
     bool isBinding() const;
+
+    bool isBindEndCapThrow() const { return mIsBindEndCapThrow; }
+
+    const PlayerBindEndJumpInfo* getBindEndJumpInfo() const { return mBindEndJumpInfo; }
+
     bool isNoCollide() const;
 
 private:
@@ -106,7 +117,7 @@ private:
     al::AreaObj* mAreaObj;
     bool mIsBindEndOnGround;
     bool mIsBindEndJump;
-    bool _aa;
+    bool mIsBindEndCapThrow;
     bool mIsValidCollisionCheck;
     bool _ac;
     bool mIsRequestDamage;
@@ -120,9 +131,9 @@ private:
     bool _b5;
     bool _b6;
 
-    char filler[0x8];
-
-    sead::Vector3f _c8;
+    char filler[0x10];
+    PlayerBindEndJumpInfo* mBindEndJumpInfo;
 };
 
+static_assert(sizeof(PlayerBindEndJumpInfo) == 0x14);
 static_assert(sizeof(PlayerPuppet) == 0xd0);

--- a/src/Player/PlayerStateBind.cpp
+++ b/src/Player/PlayerStateBind.cpp
@@ -1,0 +1,122 @@
+#include "Player/PlayerStateBind.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionAirMoveControl.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerPuppet.h"
+#include "Player/PlayerTrigger.h"
+
+namespace {
+NERVE_IMPL(PlayerStateBind, Bind)
+NERVE_IMPL(PlayerStateBind, EndOnGround)
+NERVE_IMPL(PlayerStateBind, EndJump)
+NERVE_IMPL(PlayerStateBind, EndCapThrow)
+NERVE_IMPL(PlayerStateBind, EndFall)
+
+NERVES_MAKE_NOSTRUCT(PlayerStateBind, Bind, EndOnGround, EndJump, EndCapThrow, EndFall)
+}  // namespace
+
+PlayerStateBind::PlayerStateBind(al::LiveActor* player, const PlayerConst* playerConst,
+                                 const PlayerInput* input, const PlayerPuppet* playerPuppet,
+                                 const IUsePlayerCollision* collision, PlayerTrigger* trigger)
+    : al::ActorStateBase("バインド", player), mConst(playerConst), mPuppet(playerPuppet),
+      mTrigger(trigger) {
+    mAirMoveControl = new PlayerActionAirMoveControl(player, playerConst, input, collision, false);
+    initNerve(&Bind, 0);
+}
+
+void PlayerStateBind::appear() {
+    al::setVelocityZero(mActor);
+
+    if (mPuppet->isBinding())
+        al::setNerve(this, &Bind);
+    else
+        endBind();
+
+    al::NerveStateBase::appear();
+}
+
+void PlayerStateBind::endBind() {
+    if (mPuppet->isBindEndOnGround())
+        al::setNerve(this, &EndOnGround);
+    else if (mPuppet->isBindEndJump())
+        al::setNerve(this, &EndJump);
+    else if (mPuppet->isBindEndCapThrow())
+        al::setNerve(this, &EndCapThrow);
+    else
+        al::setNerve(this, &EndFall);
+}
+
+void PlayerStateBind::exeBind() {}
+
+void PlayerStateBind::exeEndOnGround() {
+    if (al::isFirstStep(this))
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+    al::tryAddVelocityLimit(mActor, al::getGravity(mActor) * mConst->getGravityAir(),
+                            mConst->getFallSpeedMax());
+}
+
+void PlayerStateBind::exeEndJump() {
+    if (al::isFirstStep(this)) {
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+        const PlayerBindEndJumpInfo* bindEndJumpInfo = mPuppet->getBindEndJumpInfo();
+        al::setVelocity(mActor, bindEndJumpInfo->_0);
+
+        mAirMoveControl->setup(10000.0f, mConst->getJumpMoveSpeedMin(), 0, al::calcSpeedV(mActor),
+                               bindEndJumpInfo->gravity, bindEndJumpInfo->_c, 0.0f);
+    }
+
+    mAirMoveControl->update();
+}
+
+void PlayerStateBind::exeEndCapThrow() {
+    if (al::isFirstStep(this))
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+    al::tryAddVelocityLimit(mActor, al::getGravity(mActor) * mConst->getGravityAir(),
+                            mConst->getFallSpeedMax());
+}
+
+void PlayerStateBind::exeEndFall() {
+    if (al::isFirstStep(this)) {
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+        mAirMoveControl->setup(10000.0f, mConst->getJumpMoveSpeedMin(), 0, al::calcSpeedV(mActor),
+                               mConst->getJumpGravity(), 0, 0.0f);
+    }
+
+    mAirMoveControl->update();
+}
+
+bool PlayerStateBind::isEndOnGround() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    return al::isNerve(this, &EndOnGround);
+}
+
+bool PlayerStateBind::isEndAir() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    return al::isNerve(this, &EndJump) || al::isNerve(this, &EndFall);
+}
+
+bool PlayerStateBind::isEndCapThrow() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    return al::isNerve(this, &EndCapThrow);
+}
+
+bool PlayerStateBind::isInvalidInput() const {
+    return al::isNerve(this, &EndJump) &&
+           al::isLessEqualStep(this, mPuppet->getBindEndJumpInfo()->_c);
+}

--- a/src/Player/PlayerStateBind.cpp
+++ b/src/Player/PlayerStateBind.cpp
@@ -1,0 +1,127 @@
+#include "Player/PlayerStateBind.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionAirMoveControl.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerPuppet.h"
+#include "Player/PlayerTrigger.h"
+
+namespace {
+NERVE_IMPL(PlayerStateBind, Bind)
+NERVE_IMPL(PlayerStateBind, EndOnGround)
+NERVE_IMPL(PlayerStateBind, EndJump)
+NERVE_IMPL(PlayerStateBind, EndCapThrow)
+NERVE_IMPL(PlayerStateBind, EndFall)
+
+NERVES_MAKE_NOSTRUCT(PlayerStateBind, Bind, EndOnGround, EndJump, EndCapThrow, EndFall)
+}  // namespace
+
+PlayerStateBind::PlayerStateBind(al::LiveActor* player, const PlayerConst* playerConst,
+                                 const PlayerInput* input, const PlayerPuppet* playerPuppet,
+                                 const IUsePlayerCollision* collision, PlayerTrigger* trigger)
+    : al::ActorStateBase("バインド", player), mConst(playerConst), mPuppet(playerPuppet),
+      mTrigger(trigger) {
+    mAirMoveControl = new PlayerActionAirMoveControl(player, playerConst, input, collision, false);
+    initNerve(&Bind, 0);
+}
+
+void PlayerStateBind::appear() {
+    al::setVelocityZero(mActor);
+
+    if (mPuppet->isBinding())
+        al::setNerve(this, &Bind);
+    else
+        endBind();
+
+    al::NerveStateBase::appear();
+}
+
+void PlayerStateBind::endBind() {
+    if (mPuppet->isBindEndOnGround())
+        al::setNerve(this, &EndOnGround);
+    else if (mPuppet->isBindEndJump())
+        al::setNerve(this, &EndJump);
+    else if (mPuppet->isBindEndCapThrow())
+        al::setNerve(this, &EndCapThrow);
+    else
+        al::setNerve(this, &EndFall);
+}
+
+void PlayerStateBind::exeBind() {}
+
+void PlayerStateBind::exeEndOnGround() {
+    if (al::isFirstStep(this))
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+    al::tryAddVelocityLimit(mActor, al::getGravity(mActor) * mConst->getGravityAir(),
+                            mConst->getFallSpeedMax());
+}
+
+void PlayerStateBind::exeEndJump() {
+    if (al::isFirstStep(this)) {
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+        const PlayerBindEndJumpInfo* bindEndJumpInfo = mPuppet->getBindEndJumpInfo();
+        al::setVelocity(mActor, bindEndJumpInfo->endTrans);
+
+        mAirMoveControl->setup(10000.0f, mConst->getJumpMoveSpeedMin(), 0, al::calcSpeedV(mActor),
+                               bindEndJumpInfo->gravity, bindEndJumpInfo->endFrame, 0.0f);
+    }
+
+    mAirMoveControl->update();
+}
+
+void PlayerStateBind::exeEndCapThrow() {
+    if (al::isFirstStep(this))
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+    al::tryAddVelocityLimit(mActor, al::getGravity(mActor) * mConst->getGravityAir(),
+                            mConst->getFallSpeedMax());
+}
+
+void PlayerStateBind::exeEndFall() {
+    if (al::isFirstStep(this)) {
+        mTrigger->set(PlayerTrigger::EActionTrigger_val3);
+
+        mAirMoveControl->setup(10000.0f, mConst->getJumpMoveSpeedMin(), 0, al::calcSpeedV(mActor),
+                               mConst->getJumpGravity(), 0, 0.0f);
+    }
+
+    mAirMoveControl->update();
+}
+
+bool PlayerStateBind::isEndOnGround() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    return al::isNerve(this, &EndOnGround);
+}
+
+bool PlayerStateBind::isEndAir() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    if (al::isNerve(this, &EndJump))
+        return true;
+
+    return al::isNerve(this, &EndFall);
+}
+
+bool PlayerStateBind::isEndCapThrow() const {
+    if (al::isNerve(this, &Bind))
+        return false;
+
+    return al::isNerve(this, &EndCapThrow);
+}
+
+bool PlayerStateBind::isInvalidInput() const {
+    if (!al::isNerve(this, &EndJump))
+        return false;
+
+    return al::isLessEqualStep(this, mPuppet->getBindEndJumpInfo()->endFrame);
+}

--- a/src/Player/PlayerStateBind.h
+++ b/src/Player/PlayerStateBind.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class IUsePlayerCollision;
+class PlayerActionAirMoveControl;
+class PlayerConst;
+class PlayerInput;
+class PlayerPuppet;
+class PlayerTrigger;
+
+class PlayerStateBind : public al::ActorStateBase {
+public:
+    PlayerStateBind(al::LiveActor* player, const PlayerConst* playerConst, const PlayerInput* input,
+                    const PlayerPuppet* playerPuppet, const IUsePlayerCollision* collision,
+                    PlayerTrigger* trigger);
+
+    void appear() override;
+
+    void endBind();
+    void exeBind();
+    void exeEndOnGround();
+    void exeEndJump();
+    void exeEndCapThrow();
+    void exeEndFall();
+    bool isEndOnGround() const;
+    bool isEndAir() const;
+    bool isEndCapThrow() const;
+    bool isInvalidInput() const;
+
+private:
+    const PlayerConst* mConst = nullptr;
+    const PlayerPuppet* mPuppet = nullptr;
+    PlayerTrigger* mTrigger = nullptr;
+    PlayerActionAirMoveControl* mAirMoveControl = nullptr;
+};
+
+static_assert(sizeof(PlayerStateBind) == 0x40);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1067)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 43f4ffd)

📈 **Matched code**: 14.68% (+0.01%, +1828 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerStateBind` | `PlayerStateBind::appear()` | +184 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::PlayerStateBind(al::LiveActor*, PlayerConst const*, PlayerInput const*, PlayerPuppet const*, IUsePlayerCollision const*, PlayerTrigger*)` | +172 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::exeEndJump()` | +172 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::exeEndFall()` | +160 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `(anonymous namespace)::PlayerStateBindNrvEndOnGround::execute(al::NerveKeeper*) const` | +156 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `(anonymous namespace)::PlayerStateBindNrvEndCapThrow::execute(al::NerveKeeper*) const` | +156 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::exeEndOnGround()` | +152 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::exeEndCapThrow()` | +152 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::endBind()` | +144 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::isEndAir() const` | +96 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::isInvalidInput() const` | +80 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::isEndOnGround() const` | +72 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::isEndCapThrow() const` | +72 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::~PlayerStateBind()` | +36 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `(anonymous namespace)::PlayerStateBindNrvEndJump::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `(anonymous namespace)::PlayerStateBindNrvEndFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `PlayerStateBind::exeBind()` | +4 | 0.00% | 100.00% |
| `Player/PlayerStateBind` | `(anonymous namespace)::PlayerStateBindNrvBind::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->