### PR TITLE
Library/Effect: Implement `EffectSystemInfo`

### DIFF
--- a/lib/al/Library/Effect/EffectKeeper.h
+++ b/lib/al/Library/Effect/EffectKeeper.h
@@ -23,9 +23,9 @@ class MtxPtrHolder;
 class EffectSystemInfo;
 class EffectPrefixType;
 class EffectSystem;
-class EffectSystemInfo;
 class EffectResourceInfo;
 class IUseEffectKeeper;
+class IUseLayout;
 class ModelKeeper;
 class IUseCamera;
 
@@ -34,7 +34,7 @@ public:
     EffectKeeper(const EffectSystemInfo* systemInfo, const char*, const sead::Vector3f*,
                  const sead::Vector3f*, const sead::Matrix34f*);
     void update();
-    void tryUpdateMaterial(const char*);
+    bool tryUpdateMaterial(const char*);
     void updatePrefix(const EffectPrefixType&, bool);
     void emitEffectCurrentPos(const char*);
     Effect* findEffect(const char*) const;
@@ -61,6 +61,8 @@ public:
 
     bool get_21() const { return field_21; }
 
+    MtxPtrHolder* getMtxPtrHolder() const { return mMtxPtrHolder; }
+
 private:
     const char* mName;
     u32 mEffectCount;
@@ -84,7 +86,9 @@ void emitEffectIfExist(al::IUseEffectKeeper* effectKeeperHolder, const char* eff
 
 namespace alEffectKeeperInitFunction {
 void setupModelToEffectKeeper(al::EffectKeeper* effectKeeper, const al::ModelKeeper* modelKeeper);
+void setupLayoutToEffectKeeper(al::EffectKeeper* effectKeeper, const al::IUseLayout* iUseLayout);
 void setupCameraToEffectKeeper(al::EffectKeeper* effectKeeper, const al::IUseCamera* iUseCamera);
+bool updateNamedMtxPtr(al::EffectKeeper* effectKeeper, const char* mtxName);
 }  // namespace alEffectKeeperInitFunction
 
 namespace alEffectSystemFunction {

--- a/lib/al/Library/Effect/EffectSystemInfo.cpp
+++ b/lib/al/Library/Effect/EffectSystemInfo.cpp
@@ -1,0 +1,166 @@
+#include "Library/Effect/EffectSystemInfo.h"
+
+#include "Library/Effect/EffectKeeper.h"
+#include "Library/Effect/IUseEffectKeeper.h"
+#include "Library/Effect/PtclSystem.h"
+#include "Library/Matrix/MatrixPtrHolder.h"
+#include "Project/Effect/Effect.h"
+#include "Project/Effect/EffectPrefixType.h"
+
+namespace al {
+EffectSystemInfo::EffectSystemInfo() : _0(0), mPtclSystem(nullptr), _10(nullptr), _18(0) {}
+
+const EffectSystem& EffectSystemInfo::getEffectSystem() const {
+    return mPtclSystem->getEffectSystem();
+}
+
+void emitEffectCurrentPos(IUseEffectKeeper* iUseEffectKeeper, const char* effectName) {
+    iUseEffectKeeper->getEffectKeeper()->emitEffectCurrentPos(effectName);
+}
+
+void emitEffect(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                const sead::Vector3f* pos) {
+    iUseEffectKeeper->getEffectKeeper()->emitEffect(effectName, pos);
+}
+
+bool tryEmitEffect(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                   const sead::Vector3f* pos) {
+    return iUseEffectKeeper->getEffectKeeper()->tryEmitEffect(effectName, pos);
+}
+
+void deleteEffect(IUseEffectKeeper* iUseEffectKeeper, const char* effectName) {
+    iUseEffectKeeper->getEffectKeeper()->deleteEffect(effectName);
+}
+
+void tryDeleteEffect(IUseEffectKeeper* iUseEffectKeeper, const char* effectName) {
+    iUseEffectKeeper->getEffectKeeper()->tryDeleteEffect(effectName);
+}
+
+void deleteEffectAll(IUseEffectKeeper* iUseEffectKeeper) {
+    iUseEffectKeeper->getEffectKeeper()->deleteEffectAll();
+}
+
+void tryKillEmitterAndParticleAll(IUseEffectKeeper* iUseEffectKeeper) {
+    iUseEffectKeeper->getEffectKeeper()->tryKillEmitterAndParticleAll();
+}
+
+void onCalcAndDrawEffect(IUseEffectKeeper* iUseEffectKeeper) {
+    iUseEffectKeeper->getEffectKeeper()->onCalcAndDraw();
+}
+
+void offCalcAndDrawEffect(IUseEffectKeeper* iUseEffectKeeper) {
+    iUseEffectKeeper->getEffectKeeper()->offCalcAndDraw();
+}
+
+void forceSetStopCalcAndDraw(IUseEffectKeeper* iUseEffectKeeper, bool isStop) {
+    iUseEffectKeeper->getEffectKeeper()->forceSetStopCalcAndDraw(isStop);
+}
+
+bool isEffectEmitting(const IUseEffectKeeper* iUseEffectKeeper, const char* effectName) {
+    return iUseEffectKeeper->getEffectKeeper()->findEffect(effectName)->isEmitterActive();
+}
+
+void setEffectEmitRatio(IUseEffectKeeper* iUseEffectKeeper, const char* effectName, f32 emitRatio) {
+    iUseEffectKeeper->getEffectKeeper()->setEmitRatio(effectName, emitRatio);
+}
+
+void setEffectAllScale(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                       const sead::Vector3f& scale) {
+    iUseEffectKeeper->getEffectKeeper()->setEmitterAllScale(effectName, scale);
+}
+
+void setEffectEmitterVolumeScale(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                                 const sead::Vector3f& scale) {
+    iUseEffectKeeper->getEffectKeeper()->setEmitterVolumeScale(effectName, scale);
+}
+
+void setEffectParticleScale(IUseEffectKeeper* iUseEffectKeeper, const char* effectName, f32 scale) {
+    iUseEffectKeeper->getEffectKeeper()->setParticleScale(effectName, scale);
+}
+
+void setEffectParticleScale(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                            const sead::Vector3f& scale) {
+    iUseEffectKeeper->getEffectKeeper()->setParticleScale(effectName, scale);
+}
+
+void setEffectParticleAlpha(IUseEffectKeeper* iUseEffectKeeper, const char* effectName, f32 alpha) {
+    iUseEffectKeeper->getEffectKeeper()->setParticleAlpha(effectName, alpha);
+}
+
+void setEffectParticleColor(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                            const sead::Color4f& color) {
+    iUseEffectKeeper->getEffectKeeper()->setParticleColor(effectName, color);
+}
+
+void setParticleLifeScale(IUseEffectKeeper* iUseEffectKeeper, const char* effectName, f32 scale) {
+    iUseEffectKeeper->getEffectKeeper()->setParticleLifeScale(effectName, scale);
+}
+
+void setEffectParticleDirectionalVel(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                                     f32 directionalVel) {
+    Effect* effect = iUseEffectKeeper->getEffectKeeper()->findEffect(effectName);
+    s32 emitterCount = effect->getEmitterCount();
+
+    if (emitterCount >= 1) {
+        for (s32 i = 0; i < emitterCount; i++) {
+            nn::vfx::Handle* handle = effect->getEmitters()[i]->getHandle();
+
+            if (handle->isValid())
+                handle->GetEmitterSet()->directionalVel = directionalVel;
+        }
+    }
+}
+
+void setEffectFollowPosPtr(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                           const sead::Vector3f* pos) {
+    iUseEffectKeeper->getEffectKeeper()->findEffect(effectName)->setPosPtr(pos);
+}
+
+void setEffectFollowMtxPtr(IUseEffectKeeper* iUseEffectKeeper, const char* effectName,
+                           const sead::Matrix34f* mtx) {
+    iUseEffectKeeper->getEffectKeeper()->findEffect(effectName)->setMtxPtr(mtx);
+}
+
+void setEffectNamedMtxPtr(IUseEffectKeeper* iUseEffectKeeper, const char* mtxName,
+                          const sead::Matrix34f* mtx) {
+    iUseEffectKeeper->getEffectKeeper()->getMtxPtrHolder()->setMtxPtr(mtxName, mtx);
+    alEffectKeeperInitFunction::updateNamedMtxPtr(iUseEffectKeeper->getEffectKeeper(), mtxName);
+}
+
+bool trySetEffectNamedMtxPtr(IUseEffectKeeper* iUseEffectKeeper, const char* mtxName,
+                             const sead::Matrix34f* mtx) {
+    if (iUseEffectKeeper->getEffectKeeper()) {
+        iUseEffectKeeper->getEffectKeeper()->getMtxPtrHolder()->setMtxPtr(mtxName, mtx);
+        return alEffectKeeperInitFunction::updateNamedMtxPtr(iUseEffectKeeper->getEffectKeeper(),
+                                                             mtxName);
+    }
+
+    return false;
+}
+
+bool tryUpdateEffectMaterialCode(IUseEffectKeeper* iUseEffectKeeper, const char* materialCode) {
+    return iUseEffectKeeper->getEffectKeeper()->tryUpdateMaterial(materialCode);
+}
+
+void resetEffectMaterialCode(IUseEffectKeeper* iUseEffectKeeper) {
+    iUseEffectKeeper->getEffectKeeper()->tryUpdateMaterial("");
+}
+
+void updateEffectMaterialWater(IUseEffectKeeper* iUseEffectKeeper, bool isApply) {
+    EffectKeeper* effectKeeper = iUseEffectKeeper->getEffectKeeper();
+    EffectPrefixType prefixType(0);
+    effectKeeper->updatePrefix(prefixType, isApply);
+}
+
+void updateEffectMaterialWet(IUseEffectKeeper* iUseEffectKeeper, bool isApply) {
+    EffectKeeper* effectKeeper = iUseEffectKeeper->getEffectKeeper();
+    EffectPrefixType prefixType(1);
+    effectKeeper->updatePrefix(prefixType, isApply);
+}
+
+void updateEffectMaterialPuddle(IUseEffectKeeper* iUseEffectKeeper, bool isApply) {
+    EffectKeeper* effectKeeper = iUseEffectKeeper->getEffectKeeper();
+    EffectPrefixType prefixType(2);
+    effectKeeper->updatePrefix(prefixType, isApply);
+}
+}  // namespace al

--- a/lib/al/Library/Effect/EffectSystemInfo.h
+++ b/lib/al/Library/Effect/EffectSystemInfo.h
@@ -28,7 +28,7 @@ void emitEffectCurrentPos(IUseEffectKeeper*, const char*);
 void emitEffect(IUseEffectKeeper*, const char*, const sead::Vector3f*);
 bool tryEmitEffect(IUseEffectKeeper*, const char*, const sead::Vector3f*);
 void deleteEffect(IUseEffectKeeper*, const char*);
-bool tryDeleteEffect(IUseEffectKeeper*, const char*);
+void tryDeleteEffect(IUseEffectKeeper*, const char*);
 void deleteEffectAll(IUseEffectKeeper*);
 void tryKillEmitterAndParticleAll(IUseEffectKeeper*);
 void onCalcAndDrawEffect(IUseEffectKeeper*);

--- a/lib/al/Library/Effect/PtclSystem.h
+++ b/lib/al/Library/Effect/PtclSystem.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace sead::ptcl {
+class Config;
+}  // namespace sead::ptcl
+
+namespace al {
+class EffectSystem;
+
+class PtclSystem {
+public:
+    PtclSystem(const sead::ptcl::Config&, EffectSystem*);
+
+    s32 getNumResource() const;
+    void entryResourceEnd();
+    void* getEffectEnvParam();
+
+    const EffectSystem& getEffectSystem() const { return *mEffectSystem; }
+
+private:
+    u8 _0[0x2900];
+    EffectSystem* mEffectSystem = nullptr;
+    void* mEffectEnvParam = nullptr;
+};
+}  // namespace al

--- a/lib/al/Library/Model/JointMtxPtr.h
+++ b/lib/al/Library/Model/JointMtxPtr.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+template <typename T>
+class Matrix43;
+using Matrix43f = Matrix43<f32>;
+
+class JointMtxPtr {
+public:
+    JointMtxPtr();
+
+    void setNull();
+    void set(const sead::Matrix34f*);
+    void set(const Matrix43f*);
+    void getTranslation(sead::Vector3f*) const;
+    void calcMtxScale(sead::Vector3f*) const;
+    void copyTo(sead::Matrix34f*) const;
+
+private:
+    const void* mMtxPtr;
+    bool mIsMatrix43;
+};
+
+static_assert(sizeof(JointMtxPtr) == 0x10);
+}  // namespace al

--- a/lib/al/Project/Effect/Effect.h
+++ b/lib/al/Project/Effect/Effect.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <gfx/seadColor.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Model/JointMtxPtr.h"
+#include "Project/Effect/EffectEmitter.h"
+
+namespace al {
+class EffectCameraHolder;
+class EffectInfo;
+class EffectSystem;
+class EffectSystemInfo;
+
+class Effect {
+public:
+    Effect(const EffectSystemInfo*, const EffectInfo*, const sead::Vector3f*, const sead::Vector3f*,
+           const sead::Matrix34f*, u64);
+
+    void setCameraHolder(EffectCameraHolder*);
+    void setPosPtr(const sead::Vector3f*);
+    void setMtxPtr(const sead::Matrix34f*);
+    bool update();
+    void setFarClip(bool);
+    bool tryUpdateMaterial(const char*, const bool (&)[3]);
+    void emitEmitter(EffectEmitter*, const sead::Vector3f*);
+    void emitEmitters(const sead::Vector3f*, bool);
+    bool tryEmitEmitters(const sead::Vector3f*, bool);
+    bool tryEmitEmitter(EffectEmitter*, const sead::Vector3f*);
+    void tryDeleteEmitters();
+    void deleteAndClearEmitter();
+    bool isOneTimeFade() const;
+    void tryKillEmitterAndParticleAll();
+    void forceSetStopCalcAndDraw(bool);
+    void setStopCalcAndDraw(bool);
+    void setActorClip(bool);
+    void setEmitRatio(f32);
+    void setEmitterAllScale(const sead::Vector3f&);
+    void setEmitterVolumeScale(const sead::Vector3f&);
+    void setParticleScale(f32);
+    void setParticleScale(const sead::Vector3f&);
+    void setParticleAlpha(f32);
+    void setParticleColor(const sead::Color4f&);
+    void setParticleLifeScale(f32);
+    const sead::Matrix34f* getViewMtxPtr() const;
+    bool isLoopOrInfinity() const;
+    bool isEmitterActive() const;
+
+    EffectEmitter* const* getEmitters() const { return mEmitters; }
+
+    s32 getEmitterCount() const { return mEmitterCount; }
+
+private:
+    void* _0 = nullptr;
+    EffectEmitter** mEmitters = nullptr;
+    s32 mEmitterCount = 0;
+    const EffectSystem* mEffectSystem = nullptr;
+    const EffectInfo* mEffectInfo = nullptr;
+    const sead::Vector3f* mPosPtr = nullptr;
+    const sead::Vector3f* _30 = nullptr;
+    JointMtxPtr mJointMtxPtr;
+    const sead::Matrix34f* mViewMtxPtr = nullptr;
+    EffectCameraHolder* mCameraHolder = nullptr;
+    u8 _58[8] = {};
+    sead::FixedSafeString<64> _60;
+    u8 _b8[0x10] = {};
+};
+
+static_assert(sizeof(Effect) == 0xc8);
+}  // namespace al

--- a/lib/al/Project/Effect/EffectEmitter.h
+++ b/lib/al/Project/Effect/EffectEmitter.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Model/JointMtxPtr.h"
+
+namespace nn::vfx {
+struct EmitterHandleData {
+    u8 _0[0x2c];
+    s32 createId;
+};
+
+struct EmitterSet {
+    u8 _0[0x210];
+    f32 directionalVel;
+};
+
+class Handle {
+public:
+    EmitterSet* GetEmitterSet();
+
+    bool isValid() const { return mHandle != nullptr && mCreateId == mHandle->createId; }
+
+private:
+    EmitterHandleData* mHandle = nullptr;
+    s32 mCreateId = -1;
+    u32 _c = 0;
+};
+
+static_assert(sizeof(Handle) == 0x10);
+}  // namespace nn::vfx
+
+namespace sead::ptcl {
+using Handle = nn::vfx::Handle;
+}  // namespace sead::ptcl
+
+namespace al {
+class EffectResourceInfo;
+class EffectSystemInfo;
+
+class EffectEmitter {
+public:
+    EffectEmitter(const EffectSystemInfo*, EffectResourceInfo*, s32);
+
+    void initMtxPtr(JointMtxPtr);
+    void updateMtxPtr(JointMtxPtr);
+    nn::vfx::EmitterSet* createEmitter(const JointMtxPtr*, const sead::Vector3f*, s32, s32, u64);
+    void tryDeleteEmitter(bool);
+    void tryDeleteHandle(sead::ptcl::Handle*, bool);
+    void setStopCalcAndDraw(bool);
+    bool isActive() const;
+    bool isEnableEmit() const;
+    bool isFirstFrame() const;
+    void resetFirstFrame();
+
+    nn::vfx::Handle* getHandle() const { return mHandle; }
+
+private:
+    const EffectSystemInfo* mEffectSystemInfo = nullptr;
+    sead::ptcl::Handle* mHandle = nullptr;
+    sead::ptcl::Handle** mHandles = nullptr;
+    s32 mHandleCount = 0;
+    EffectResourceInfo* mResourceInfo = nullptr;
+    bool mIsFirstFrame = false;
+    u8 _29[3] = {};
+    s32 _2c = -1;
+    u8 _30[4] = {};
+    JointMtxPtr mJointMtxPtr;
+};
+
+static_assert(sizeof(EffectEmitter) == 0x48);
+}  // namespace al

--- a/lib/al/Project/Effect/EffectPrefixType.h
+++ b/lib/al/Project/Effect/EffectPrefixType.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class EffectPrefixType {
+public:
+    explicit constexpr EffectPrefixType(s32 type) : mType(type) {}
+
+private:
+    static const char* text_(s32);
+
+    s32 mType;
+};
+
+static_assert(sizeof(EffectPrefixType) == 0x4);
+}  // namespace al


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1069)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 5890522)

📈 **Matched code**: 14.21% (+0.01%, +1648 bytes)

<details>
<summary>✅ 31 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Effect/EffectSystemInfo` | `al::setEffectParticleDirectionalVel(al::IUseEffectKeeper*, char const*, float)` | +144 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::trySetEffectNamedMtxPtr(al::IUseEffectKeeper*, char const*, sead::Matrix34<float> const*)` | +128 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectNamedMtxPtr(al::IUseEffectKeeper*, char const*, sead::Matrix34<float> const*)` | +92 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectEmitRatio(al::IUseEffectKeeper*, char const*, float)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectParticleScale(al::IUseEffectKeeper*, char const*, float)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectParticleAlpha(al::IUseEffectKeeper*, char const*, float)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setParticleLifeScale(al::IUseEffectKeeper*, char const*, float)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::updateEffectMaterialWet(al::IUseEffectKeeper*, bool)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::updateEffectMaterialPuddle(al::IUseEffectKeeper*, bool)` | +60 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectFollowPosPtr(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const*)` | +56 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectFollowMtxPtr(al::IUseEffectKeeper*, char const*, sead::Matrix34<float> const*)` | +56 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::updateEffectMaterialWater(al::IUseEffectKeeper*, bool)` | +56 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::emitEffect(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const*)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::tryEmitEffect(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const*)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectAllScale(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const&)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectEmitterVolumeScale(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const&)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectParticleScale(al::IUseEffectKeeper*, char const*, sead::Vector3<float> const&)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::setEffectParticleColor(al::IUseEffectKeeper*, char const*, sead::Color4f const&)` | +52 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::isEffectEmitting(al::IUseEffectKeeper const*, char const*)` | +48 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::emitEffectCurrentPos(al::IUseEffectKeeper*, char const*)` | +44 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::deleteEffect(al::IUseEffectKeeper*, char const*)` | +44 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::tryDeleteEffect(al::IUseEffectKeeper*, char const*)` | +44 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::forceSetStopCalcAndDraw(al::IUseEffectKeeper*, bool)` | +44 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::tryUpdateEffectMaterialCode(al::IUseEffectKeeper*, char const*)` | +44 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::resetEffectMaterialCode(al::IUseEffectKeeper*)` | +36 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::deleteEffectAll(al::IUseEffectKeeper*)` | +28 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::tryKillEmitterAndParticleAll(al::IUseEffectKeeper*)` | +28 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::onCalcAndDrawEffect(al::IUseEffectKeeper*)` | +28 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::offCalcAndDrawEffect(al::IUseEffectKeeper*)` | +28 | 0.00% | 100.00% |
| `Library/Effect/EffectSystemInfo` | `al::EffectSystemInfo::EffectSystemInfo()` | +16 | 0.00% | 100.00% |

...and 1 more new matches
</details>


<!-- decomp.dev report end -->