### PR TITLE
Scene: Implement StageSceneStateGetShineMainWaterfallWorld

### DIFF
--- a/src/MapObj/WaterfallWorldFallDownBridge.h
+++ b/src/MapObj/WaterfallWorldFallDownBridge.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class WaterfallWorldFallDownBridge : public al::LiveActor {
+public:
+    WaterfallWorldFallDownBridge(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+
+    void startDemo();
+    bool isEndDemo() const;
+    void fallDown();
+    void exeWait();
+    void exeWaitCameraInterpolate();
+    void exeDemo();
+    void exeDemoAfter();
+    void exeFallDown();
+};

--- a/src/Scene/StageSceneStateGetShineMain.h
+++ b/src/Scene/StageSceneStateGetShineMain.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class LayoutInitInfo;
+class LiveActor;
+class Scene;
+struct SceneInitInfo;
+class SimpleLayoutAppearWaitEnd;
+class WipeSimple;
+}  // namespace al
+
+class DoorSnow;
+class GameDataHolder;
+class QuestInfo;
+class ScenarioStartCameraHolder;
+class Shine;
+class StageSceneLayout;
+
+class StageSceneStateScenarioCamera;
+
+class StageSceneStateGetShineMain : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateGetShineMain(const char*, al::Scene*, StageSceneLayout*,
+                                const al::SceneInitInfo&, const al::ActorInitInfo&,
+                                const al::LayoutInitInfo&, al::LiveActor*,
+                                ScenarioStartCameraHolder*, GameDataHolder*);
+    ~StageSceneStateGetShineMain() override;
+
+    void appear() override;
+    void kill() override;
+
+    void setScenarioCameraState(StageSceneStateScenarioCamera*);
+
+    void exeWaitPlayerAnimFirst();
+    void exeDemoGetStart();
+    void exeDemoAppearShineGetLayout();
+    void exeDemoShineCount();
+    void exeDemoWipeClose();
+    void exeDemoWipeWait();
+    void exeDemoLand();
+    void exeDemoOpenDoorSnow();
+    void exeDemoRiseMapParts();
+    void exeDemoScenarioCamera();
+    void exeDemoLifeRecover();
+    void exeDemoEnd();
+    void exeDemoEndCity();
+
+    void startDemoEnd();
+    bool isDrawChromakey() const;
+    QuestInfo* getQuestInfo() const;
+
+    al::LiveActor* getCapManHero() const { return mCapManHero; }
+
+    void setIsEndAfterDemoLand(bool isEndAfterDemoLand) {
+        mIsEndAfterDemoLand = isEndAfterDemoLand;
+    }
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mMoonGetLayout = nullptr;
+    al::WipeSimple* mResultMainStartWipe = nullptr;
+    al::WipeSimple* mResultMainStartBackWipe = nullptr;
+    al::WipeSimple* mResultMainWipe = nullptr;
+    al::SimpleLayoutAppearWaitEnd* mResultMainLayout = nullptr;
+    al::CameraTicket* mDemoAnimCameraTicket = nullptr;
+    sead::Matrix34f mDemoAnimCameraMtx;
+    al::LiveActor* mCapManHero = nullptr;
+    al::LiveActor* mDemoShine = nullptr;
+    al::LiveActor* mDemoDepthMask = nullptr;
+    al::LiveActor* mShineReactionActor = nullptr;
+    StageSceneLayout* mStageSceneLayout = nullptr;
+    ScenarioStartCameraHolder* mScenarioStartCameraHolder = nullptr;
+    Shine* mShine = nullptr;
+    GameDataHolder* mGameDataHolder = nullptr;
+    DoorSnow* mDoorSnow = nullptr;
+    bool mIsEndAfterDemoLand = false;
+    void* _d0 = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMain) == 0xD8);

--- a/src/Scene/StageSceneStateGetShineMainLast.h
+++ b/src/Scene/StageSceneStateGetShineMainLast.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class CameraTicket;
+class LiveActor;
+class Scene;
+}  // namespace al
+
+class StageSceneStateGetShineMainLast : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateGetShineMainLast(const char*, al::Scene*, al::LiveActor*, al::CameraTicket*);
+
+    void appear() override;
+    void kill() override;
+
+    void exeWait();
+
+private:
+    al::LiveActor* mDemoShine = nullptr;
+    al::CameraTicket* mCameraTicket = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMainLast) == 0x30);

--- a/src/Scene/StageSceneStateGetShineMainWaterfallWorld.cpp
+++ b/src/Scene/StageSceneStateGetShineMainWaterfallWorld.cpp
@@ -1,0 +1,159 @@
+#include "Scene/StageSceneStateGetShineMainWaterfallWorld.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneUtil.h"
+
+#include "MapObj/WaterfallWorldFallDownBridge.h"
+#include "Scene/QuestInfoHolder.h"
+#include "Scene/StageScene.h"
+#include "Scene/StageSceneStateGetShineMain.h"
+#include "Scene/StageSceneStateGetShineMainLast.h"
+#include "Scene/StageSceneStateRecoverLife.h"
+#include "Scene/StageSceneStateScenarioCamera.h"
+#include "Util/CapManHeroDemoUtil.h"
+#include "Util/PlayerDemoUtil.h"
+
+namespace {
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoGetShine);
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoEnd);
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoDownBridge);
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoCapManHeroTalkFirstMoonGet);
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoScenarioCamera);
+NERVE_IMPL(StageSceneStateGetShineMainWaterfallWorld, DemoRecoverLife);
+NERVES_MAKE_NOSTRUCT(StageSceneStateGetShineMainWaterfallWorld, DemoGetShine, DemoEnd,
+                     DemoDownBridge, DemoCapManHeroTalkFirstMoonGet, DemoScenarioCamera,
+                     DemoRecoverLife);
+}  // namespace
+
+StageSceneStateGetShineMainWaterfallWorld*
+StageSceneStateGetShineMainWaterfallWorld::tryCreate(al::Scene* scene,
+                                                     const al::ActorInitInfo& info) {
+    auto* bridge = al::tryInitPlacementSingleObject(scene, info, 0, "SceneWatchObjList",
+                                                    "WaterfallWorldHomeStoneBridge");
+
+    if (bridge == nullptr)
+        return nullptr;
+
+    return new StageSceneStateGetShineMainWaterfallWorld(
+        "メインムーンゲットデモ[滝]", scene, static_cast<WaterfallWorldFallDownBridge*>(bridge));
+}
+
+StageSceneStateGetShineMainWaterfallWorld::StageSceneStateGetShineMainWaterfallWorld(
+    const char* name, al::Scene* scene, WaterfallWorldFallDownBridge* bridge)
+    : al::HostStateBase<al::Scene>(name, scene), mBridge(bridge) {
+    initNerve(&DemoGetShine, 5);
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::init() {
+    if (rs::getActiveQuestNum(getHost()) == 0) {
+        mBridge->fallDown();
+        return;
+    }
+
+    if (rs::getActiveQuestNo(getHost()) != 0)
+        mBridge->fallDown();
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &DemoGetShine);
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::kill() {
+    al::NerveStateBase::kill();
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::setStateGetShine(
+    StageSceneStateGetShineMain* stateGetShine) {
+    mStateGetShine = stateGetShine;
+    mStateGetShine->setIsEndAfterDemoLand(true);
+    al::addNerveState(this, stateGetShine, &DemoGetShine, "ムーンゲット");
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::setStateScenarioCamera(
+    StageSceneStateScenarioCamera* stateScenarioCamera) {
+    mStateScenarioCamera = stateScenarioCamera;
+    al::addNerveState(this, stateScenarioCamera, &DemoScenarioCamera, "シナリオ紹介カメラ");
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::setStateRecoverLife(
+    StageSceneStateRecoverLife* stateRecoverLife) {
+    mStateRecoverLife = stateRecoverLife;
+    al::addNerveState(this, stateRecoverLife, &DemoRecoverLife, "ライフ回復");
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::setStateGetShineLast(
+    StageSceneStateGetShineMainLast* stateGetShineLast) {
+    mStateGetShineLast = stateGetShineLast;
+    al::addNerveState(this, stateGetShineLast, &DemoEnd, "ムーンゲット最後");
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoGetShine() {
+    if (al::updateNerveState(this)) {
+        CapManHeroDemoUtil::getCapManHero(getHost())->appear();
+        al::setNerve(this, &DemoDownBridge);
+    }
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoDownBridge() {
+    if (al::isFirstStep(this)) {
+        mBridge->startDemo();
+        rs::forcePutOffMarioHeadCap(rs::getPlayerActor(getHost()));
+        rs::keepMarioCapVisibilityEndDemo(mBridge);
+    }
+
+    al::updateKitListPrev(getHost());
+    rs::updateKitListDemoNormalWithPauseEffect(getHost());
+    al::updateKitListPostDemoWithPauseNormalEffect(getHost());
+
+    if (mBridge->isEndDemo()) {
+        if (mStateScenarioCamera->tryStart()) {
+            rs::forcePutOffMarioHeadCap(rs::getPlayerActor(getHost()));
+            al::setNerve(this, &DemoScenarioCamera);
+            return;
+        }
+
+        al::setNerve(this, &DemoRecoverLife);
+    }
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoScenarioCamera() {
+    if (al::isFirstStep(this))
+        rs::keepMarioCapVisibilityEndDemo(mBridge);
+
+    if (al::updateNerveState(this)) {
+        CapManHeroDemoUtil::preEventFromSceneFirstMoonGet(getHost(), "PrepareShow");
+        al::setNerve(this, &DemoRecoverLife);
+    }
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoRecoverLife() {
+    if (al::isFirstStep(this)) {
+        mStateGetShine->getCapManHero()->kill();
+        CapManHeroDemoUtil::preEventFromSceneFirstMoonGet(getHost(), "ShowModel");
+    }
+
+    if (al::updateNerveState(this)) {
+        CapManHeroDemoUtil::startTalkDemoFirstMoonGet(getHost());
+        al::setNerve(this, &DemoCapManHeroTalkFirstMoonGet);
+    }
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoCapManHeroTalkFirstMoonGet() {
+    al::updateKitListPrev(getHost());
+    rs::updateKitListDemoPlayerWithPauseEffect(getHost());
+    al::updateKitListPostDemoWithPauseNormalEffect(getHost());
+
+    if (CapManHeroDemoUtil::isEndDemo(getHost())) {
+        al::updateKitList(getHost(), "Npc");
+        al::enableBgmLineChange(getHost());
+        kill();
+    }
+}
+
+void StageSceneStateGetShineMainWaterfallWorld::exeDemoEnd() {
+    if (al::updateNerveState(this))
+        kill();
+}

--- a/src/Scene/StageSceneStateGetShineMainWaterfallWorld.h
+++ b/src/Scene/StageSceneStateGetShineMainWaterfallWorld.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class Scene;
+}  // namespace al
+
+class StageSceneStateGetShineMain;
+class StageSceneStateGetShineMainLast;
+class StageSceneStateRecoverLife;
+class StageSceneStateScenarioCamera;
+class WaterfallWorldFallDownBridge;
+
+class StageSceneStateGetShineMainWaterfallWorld : public al::HostStateBase<al::Scene> {
+public:
+    static StageSceneStateGetShineMainWaterfallWorld* tryCreate(al::Scene* scene,
+                                                                const al::ActorInitInfo& info);
+
+    StageSceneStateGetShineMainWaterfallWorld(const char* name, al::Scene* scene,
+                                              WaterfallWorldFallDownBridge* bridge);
+
+    void init() override;
+    void appear() override;
+    void kill() override;
+
+    void setStateGetShine(StageSceneStateGetShineMain* stateGetShine);
+    void setStateScenarioCamera(StageSceneStateScenarioCamera* stateScenarioCamera);
+    void setStateRecoverLife(StageSceneStateRecoverLife* stateRecoverLife);
+    void setStateGetShineLast(StageSceneStateGetShineMainLast* stateGetShineLast);
+
+    void exeDemoGetShine();
+    void exeDemoDownBridge();
+    void exeDemoScenarioCamera();
+    void exeDemoRecoverLife();
+    void exeDemoCapManHeroTalkFirstMoonGet();
+    void exeDemoEnd();
+
+private:
+    StageSceneStateGetShineMain* mStateGetShine = nullptr;
+    StageSceneStateScenarioCamera* mStateScenarioCamera = nullptr;
+    StageSceneStateRecoverLife* mStateRecoverLife = nullptr;
+    StageSceneStateGetShineMainLast* mStateGetShineLast = nullptr;
+    WaterfallWorldFallDownBridge* mBridge = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMainWaterfallWorld) == 0x48);

--- a/src/Scene/StageSceneStateRecoverLife.h
+++ b/src/Scene/StageSceneStateRecoverLife.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class Scene;
+}  // namespace al
+
+class StageScene;
+class StageSceneLayout;
+
+class StageSceneStateRecoverLife : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateRecoverLife(const char*, StageScene*, StageSceneLayout*);
+
+    void appear() override;
+    void kill() override;
+
+    void exeDemoLifeRecover();
+
+private:
+    StageSceneLayout* mStageSceneLayout = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateRecoverLife) == 0x28);

--- a/src/Scene/StageSceneStateScenarioCamera.h
+++ b/src/Scene/StageSceneStateScenarioCamera.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class CameraTicket;
+class LiveActor;
+class Scene;
+}  // namespace al
+
+class ScenarioStartCameraHolder;
+class StageSceneStateSkipDemo;
+
+class StageSceneStateScenarioCamera : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateScenarioCamera(const char*, al::Scene*, const char*, s32, al::LiveActor*);
+    ~StageSceneStateScenarioCamera() override;
+
+    void setStateSkipDemo(StageSceneStateSkipDemo*);
+
+    void appear() override;
+    void kill() override;
+
+    bool tryStart();
+    bool isExistEnableCamera() const;
+    void exeCamera();
+    void exeSkip();
+
+private:
+    al::CameraTicket* mCameraTicket = nullptr;
+    ScenarioStartCameraHolder* mScenarioStartCameraHolder = nullptr;
+    const char* mStageName = nullptr;
+    s32 mScenarioNo = 0;
+    al::LiveActor* mDemoActor = nullptr;
+    StageSceneStateSkipDemo* mStateSkipDemo = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateScenarioCamera) == 0x50);

--- a/src/Util/CapManHeroDemoUtil.h
+++ b/src/Util/CapManHeroDemoUtil.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+class LiveActor;
+class Scene;
+}  // namespace al
+
+class StageTalkDemoNpcCap;
+
+namespace CapManHeroDemoUtil {
+void initCapManHeroDemoDirector(const al::Scene*, const al::ActorInitInfo&);
+void initCapManHeroTailJointController(al::LiveActor*);
+void startCapManHeroCommonSettingAfterShowModel(al::LiveActor*);
+al::LiveActor* createDemoCapManHero(const char*, const al::ActorInitInfo&, const char*);
+void capManHeroControl(al::LiveActor*);
+void stopTailScroll(al::LiveActor*);
+void restartTailScroll(al::LiveActor*);
+al::LiveActor* getCapManHero(const al::IUseSceneObjHolder*);
+void setTalkDemoFirstMoonGet(StageTalkDemoNpcCap*);
+void setTalkDemoStageStart(StageTalkDemoNpcCap*);
+void setTalkDemoMoonRock(StageTalkDemoNpcCap*);
+void preEventFromSceneFirstMoonGet(const al::Scene*, const char*);
+void startTalkDemoFirstMoonGet(const al::Scene*);
+void startTalkDemoStageStart(const al::Scene*);
+void startTalkDemoMoonRockFind(const al::Scene*);
+void startTalkDemoAfterMoonRockBreakDemo(const al::Scene*);
+bool isExistTalkDemoStageStart(const al::Scene*);
+bool isExistTalkDemoMoonRockFind(const al::Scene*);
+bool isExistTalkDemoAfterMoonRockBreakDemo(const al::Scene*);
+bool isEndDemo(const al::Scene*);
+bool tryCloseDemoFadeIfExistStageStartTalk(const al::LiveActor*);
+void startActionCapManHero(al::LiveActor*, const char*);
+f32 calcAngleDemoPlayerToTargetH(const al::LiveActor*, const sead::Vector3f&);
+void turnDemoPlayerToTargetH(const al::LiveActor*, const sead::Vector3f&, f32);
+bool isEnablePlayerTurnNeck(al::LiveActor*, f32);
+void tryPlayerTurnNeck(al::LiveActor*, const sead::Vector3f&);
+void invalidateDitherAnimIfExist(al::LiveActor*);
+}  // namespace CapManHeroDemoUtil


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1070)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - 880d19d)

📈 **Matched code**: 14.20% (+0.01%, +1596 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoDownBridge()` | +196 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::tryCreate(al::Scene*, al::ActorInitInfo const&)` | +152 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoCapManHeroTalkFirstMoonGet()` | +124 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoRecoverLife::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoRecoverLife()` | +116 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoScenarioCamera::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoScenarioCamera()` | +100 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoGetShine::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::StageSceneStateGetShineMainWaterfallWorld(char const*, al::Scene*, WaterfallWorldFallDownBridge*)` | +92 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::init()` | +92 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoGetShine()` | +92 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoEnd::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::exeDemoEnd()` | +60 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::~StageSceneStateGetShineMainWaterfallWorld()` | +36 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::setStateGetShine(StageSceneStateGetShineMain*)` | +32 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::setStateRecoverLife(StageSceneStateRecoverLife*)` | +28 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::setStateScenarioCamera(StageSceneStateScenarioCamera*)` | +24 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::setStateGetShineLast(StageSceneStateGetShineMainLast*)` | +24 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::appear()` | +16 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `StageSceneStateGetShineMainWaterfallWorld::kill()` | +12 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoDownBridge::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWaterfallWorld` | `(anonymous namespace)::StageSceneStateGetShineMainWaterfallWorldNrvDemoCapManHeroTalkFirstMoonGet::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->