### PR TITLE
Item: Implement `ShineChipWatcherHolder`

### DIFF
--- a/src/Item/ShineChipWatcher.h
+++ b/src/Item/ShineChipWatcher.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class AreaObjGroup;
+struct ActorInitInfo;
+}  // namespace al
+
+class RouteGuidePointActor;
+class Shine;
+class ShineChip;
+
+class ShineChipWatcher : public al::LiveActor {
+public:
+    static s32 getCompleteNum();
+    void init(const al::ActorInitInfo& info) override;
+    void createShineChips(const al::ActorInitInfo& info, const char* shineName,
+                          const char* linkName);
+    void initAfterPlacement() override;
+    void updateHints();
+    bool isInArea() const;
+    void appear() override;
+    void kill() override;
+    s32 getCount() const;
+    bool isWatch(const al::LiveActor* actor) const;
+    bool updateCount();
+    bool tryStartAppearShine();
+    bool isAppearedShine() const;
+    void addDemoActorWithChips();
+    void exeWait();
+    void exeStartAppearShine();
+    void exeWaitAppearShine();
+    void exeComplete();
+    void exeDone();
+
+    const Shine* getShine() const { return mShine; }
+
+private:
+    u8 _108[0x10];
+    sead::PtrArray<ShineChip> mShineChips;
+    Shine* mShine = nullptr;
+    sead::Vector3f mAreaCenter = sead::Vector3f::zero;
+    f32 mAreaRadius = 0.0f;
+    RouteGuidePointActor* mRouteGuidePointActor = nullptr;
+    al::AreaObjGroup* mCounterAreaGroup = nullptr;
+};

--- a/src/Item/ShineChipWatcher.h
+++ b/src/Item/ShineChipWatcher.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class AreaObjGroup;
+struct ActorInitInfo;
+}  // namespace al
+
+class RouteGuidePointActor;
+class Shine;
+class ShineChip;
+
+class ShineChipWatcher : public al::LiveActor {
+public:
+    static s32 getCompleteNum();
+
+    ShineChipWatcher(const char* name) : al::LiveActor(name) {}
+
+    void init(const al::ActorInitInfo& info) override;
+    void createShineChips(const al::ActorInitInfo& info, const char* linkName,
+                          const char* chipActorName);
+    void initAfterPlacement() override;
+    void updateHints();
+    bool isInArea() const;
+    void appear() override;
+    void kill() override;
+    s32 getCount() const;
+    bool isWatch(const al::LiveActor* shineChip) const;
+    bool updateCount();
+    bool tryStartAppearShine();
+    bool isAppearedShine() const;
+    void addDemoActorWithChips();
+    void exeWait();
+    void exeStartAppearShine();
+    void exeWaitAppearShine();
+    void exeComplete();
+    void exeDone();
+
+    const Shine* getShine() const { return mShine; }
+
+private:
+    u8 _108[0x10];
+    sead::PtrArray<ShineChip> mShineChips;
+    Shine* mShine = nullptr;
+    sead::Vector3f mAreaCenter = sead::Vector3f::zero;
+    f32 mAreaRadius = 0.0f;
+    RouteGuidePointActor* mRouteGuidePointActor = nullptr;
+    al::AreaObjGroup* mCounterAreaGroup = nullptr;
+};

--- a/src/Item/ShineChipWatcherHolder.cpp
+++ b/src/Item/ShineChipWatcherHolder.cpp
@@ -1,0 +1,120 @@
+#include "Item/ShineChipWatcherHolder.h"
+
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Item/Shine.h"
+#include "Item/ShineChipWatcher.h"
+
+ShineChipWatcherHolder::ShineChipWatcherHolder() {
+    mWatchers.allocBuffer(8, nullptr);
+}
+
+void ShineChipWatcherHolder::entry(ShineChipWatcher* watcher) {
+    mWatchers.pushBack(watcher);
+}
+
+void ShineChipWatcherHolder::notify(ShineChipWatcher* watcher) {
+    mCurrentWatcherIndex = mWatchers.indexOf(watcher);
+}
+
+bool ShineChipWatcherHolder::tryStartAppearShine() {
+    return getCurrentWatcher()->tryStartAppearShine();
+}
+
+ShineChipWatcher* ShineChipWatcherHolder::getCurrentWatcher() const {
+    return mWatchers[mCurrentWatcherIndex];
+}
+
+bool ShineChipWatcherHolder::tryUpdateCurrentWatcher(const al::LiveActor* shineChip) {
+    s32 watcherCountMax = mWatchers.size();
+
+    for (s32 i = 0; i < watcherCountMax; i++) {
+        ShineChipWatcher* watcher = mWatchers[i];
+        if (watcher->isWatch(shineChip)) {
+            watcher->updateCount();
+            mCurrentWatcherIndex = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+namespace ShineChipLocalFunction {
+
+bool tryCreateShineChipWatcherHolder(const al::IUseSceneObjHolder* objHolder) {
+    if (al::isExistSceneObj<ShineChipWatcherHolder>(objHolder))
+        return false;
+
+    al::setSceneObj(objHolder, new ShineChipWatcherHolder());
+    return true;
+}
+
+void entryShineChipWatcher(ShineChipWatcher* watcher) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(watcher)->entry(watcher);
+}
+
+void notifyShineChipGet(ShineChipWatcher* watcher) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(watcher)->notify(watcher);
+}
+
+void notifyShineChipGet(const al::LiveActor* shineChip) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(shineChip)->tryUpdateCurrentWatcher(shineChip);
+}
+
+}  // namespace ShineChipLocalFunction
+
+namespace rs {
+
+bool isExistShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder) != nullptr;
+}
+
+bool isCompleteShineChip(const al::IUseSceneObjHolder* objHolder) {
+    return ShineChipWatcher::getCompleteNum() <= getShineChipCount(objHolder);
+}
+
+s32 getShineChipCount(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcher()->getCount();
+}
+
+s32 getCurrentShineChipWatcherIndex(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcherIndex();
+}
+
+bool isCurrentShineChipWatcherTypeEmpty(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->getShine()
+        ->isGot();
+}
+
+bool isAppearedShineChipShine(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->isAppearedShine();
+}
+
+void addDemoActorShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->addDemoActorWithChips();
+}
+
+bool isEnableStartShineChipCompleteDemo(const al::IUseSceneObjHolder* objHolder) {
+    if (!isExistShineChipWatcher(objHolder))
+        return false;
+
+    return isCompleteShineChip(objHolder) && !isAppearedShineChipShine(objHolder);
+}
+
+bool tryStartAppearShineChipShine(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->tryStartAppearShine();
+}
+
+bool isInAreaCurrentShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcher()->isInArea();
+}
+
+}  // namespace rs

--- a/src/Item/ShineChipWatcherHolder.cpp
+++ b/src/Item/ShineChipWatcherHolder.cpp
@@ -1,0 +1,127 @@
+#include "Item/ShineChipWatcherHolder.h"
+
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Item/Shine.h"
+#include "Item/ShineChipWatcher.h"
+
+ShineChipWatcherHolder::ShineChipWatcherHolder() {
+    mCurrentWatcherIndex = 0;
+    mWatchers.allocBuffer(8, nullptr);
+}
+
+void ShineChipWatcherHolder::entry(ShineChipWatcher* watcher) {
+    mWatchers.pushBack(watcher);
+}
+
+void ShineChipWatcherHolder::notify(ShineChipWatcher* watcher) {
+    mCurrentWatcherIndex = mWatchers.indexOf(watcher);
+}
+
+bool ShineChipWatcherHolder::tryStartAppearShine() {
+    return getCurrentWatcher()->tryStartAppearShine();
+}
+
+ShineChipWatcher* ShineChipWatcherHolder::getCurrentWatcher() const {
+    return mWatchers[mCurrentWatcherIndex];
+}
+
+bool ShineChipWatcherHolder::tryUpdateCurrentWatcher(const al::LiveActor* actor) {
+    s32 watcherCountMax = mWatchers.size();
+
+    for (s32 i = 0; i < watcherCountMax; i++) {
+        ShineChipWatcher* watcher = mWatchers[i];
+        if (watcher->isWatch(actor)) {
+            watcher->updateCount();
+            mCurrentWatcherIndex = i;
+            return true;
+        }
+    }
+    return false;
+}
+
+namespace ShineChipLocalFunction {
+
+bool tryCreateShineChipWatcherHolder(const al::IUseSceneObjHolder* objHolder) {
+    if (al::isExistSceneObj<ShineChipWatcherHolder>(objHolder))
+        return false;
+
+    al::setSceneObj(objHolder, new ShineChipWatcherHolder());
+    return true;
+}
+
+void entryShineChipWatcher(ShineChipWatcher* watcher) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(watcher)->entry(watcher);
+}
+
+void notifyShineChipGet(ShineChipWatcher* watcher) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(watcher)->notify(watcher);
+}
+
+void notifyShineChipGet(const al::LiveActor* actor) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(actor)->tryUpdateCurrentWatcher(actor);
+}
+
+}  // namespace ShineChipLocalFunction
+
+namespace rs {
+
+bool isExistShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder) != nullptr;
+}
+
+bool isCompleteShineChip(const al::IUseSceneObjHolder* objHolder) {
+    return ShineChipWatcher::getCompleteNum() <=
+           al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcher()->getCount();
+}
+
+s32 getShineChipCount(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcher()->getCount();
+}
+
+s32 getCurrentShineChipWatcherIndex(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcherIndex();
+}
+
+bool isCurrentShineChipWatcherTypeEmpty(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->getShine()
+        ->isGot();
+}
+
+bool isAppearedShineChipShine(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->isAppearedShine();
+}
+
+void addDemoActorShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->addDemoActorWithChips();
+}
+
+bool isEnableStartShineChipCompleteDemo(const al::IUseSceneObjHolder* objHolder) {
+    if (al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder) == nullptr)
+        return false;
+
+    if (isCompleteShineChip(objHolder))
+        return !al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+                    ->getCurrentWatcher()
+                    ->isAppearedShine();
+
+    return false;
+}
+
+bool tryStartAppearShineChipShine(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)
+        ->getCurrentWatcher()
+        ->tryStartAppearShine();
+}
+
+bool isInAreaCurrentShineChipWatcher(const al::IUseSceneObjHolder* objHolder) {
+    return al::tryGetSceneObj<ShineChipWatcherHolder>(objHolder)->getCurrentWatcher()->isInArea();
+}
+
+}  // namespace rs

--- a/src/Item/ShineChipWatcherHolder.h
+++ b/src/Item/ShineChipWatcherHolder.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class IUseSceneObjHolder;
+class LiveActor;
+}  // namespace al
+
+class ShineChipWatcher;
+
+class ShineChipWatcherHolder : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_ShineChipWatcherHolder;
+
+    ShineChipWatcherHolder();
+
+    const char* getSceneObjName() const override { return "シャインチップ全取得監視者 保持"; }
+
+    void entry(ShineChipWatcher* watcher);
+    void notify(ShineChipWatcher* watcher);
+    bool tryStartAppearShine();
+    ShineChipWatcher* getCurrentWatcher() const;
+    bool tryUpdateCurrentWatcher(const al::LiveActor* shineChip);
+
+    s32 getCurrentWatcherIndex() const { return mCurrentWatcherIndex; }
+
+private:
+    sead::PtrArray<ShineChipWatcher> mWatchers;
+    s32 mCurrentWatcherIndex = 0;
+};
+
+static_assert(sizeof(ShineChipWatcherHolder) == 0x20);
+
+namespace ShineChipLocalFunction {
+
+bool tryCreateShineChipWatcherHolder(const al::IUseSceneObjHolder* objHolder);
+void entryShineChipWatcher(ShineChipWatcher* watcher);
+void notifyShineChipGet(ShineChipWatcher* watcher);
+void notifyShineChipGet(const al::LiveActor* actor);
+
+}  // namespace ShineChipLocalFunction
+
+namespace rs {
+
+bool isExistShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+bool isCompleteShineChip(const al::IUseSceneObjHolder* objHolder);
+s32 getShineChipCount(const al::IUseSceneObjHolder* objHolder);
+s32 getCurrentShineChipWatcherIndex(const al::IUseSceneObjHolder* objHolder);
+bool isCurrentShineChipWatcherTypeEmpty(const al::IUseSceneObjHolder* objHolder);
+bool isAppearedShineChipShine(const al::IUseSceneObjHolder* objHolder);
+void addDemoActorShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+bool isEnableStartShineChipCompleteDemo(const al::IUseSceneObjHolder* objHolder);
+bool tryStartAppearShineChipShine(const al::IUseSceneObjHolder* objHolder);
+bool isInAreaCurrentShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+
+}  // namespace rs

--- a/src/Item/ShineChipWatcherHolder.h
+++ b/src/Item/ShineChipWatcherHolder.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class IUseSceneObjHolder;
+class LiveActor;
+}  // namespace al
+
+class ShineChipWatcher;
+
+class ShineChipWatcherHolder : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_ShineChipWatcherHolder;
+
+    ShineChipWatcherHolder();
+
+    const char* getSceneObjName() const override { return "シャインチップ全取得監視者 保持"; }
+
+    void entry(ShineChipWatcher* watcher);
+    void notify(ShineChipWatcher* watcher);
+    bool tryStartAppearShine();
+    ShineChipWatcher* getCurrentWatcher() const;
+
+    s32 getCurrentWatcherIndex() const { return mCurrentWatcherIndex; }
+
+    bool tryUpdateCurrentWatcher(const al::LiveActor* actor);
+
+private:
+    sead::PtrArray<ShineChipWatcher> mWatchers;
+    s32 mCurrentWatcherIndex;
+};
+
+static_assert(sizeof(ShineChipWatcherHolder) == 0x20);
+
+namespace ShineChipLocalFunction {
+
+bool tryCreateShineChipWatcherHolder(const al::IUseSceneObjHolder* objHolder);
+void entryShineChipWatcher(ShineChipWatcher* watcher);
+void notifyShineChipGet(ShineChipWatcher* watcher);
+void notifyShineChipGet(const al::LiveActor* actor);
+
+}  // namespace ShineChipLocalFunction
+
+namespace rs {
+
+bool isExistShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+bool isCompleteShineChip(const al::IUseSceneObjHolder* objHolder);
+s32 getShineChipCount(const al::IUseSceneObjHolder* objHolder);
+s32 getCurrentShineChipWatcherIndex(const al::IUseSceneObjHolder* objHolder);
+bool isCurrentShineChipWatcherTypeEmpty(const al::IUseSceneObjHolder* objHolder);
+bool isAppearedShineChipShine(const al::IUseSceneObjHolder* objHolder);
+void addDemoActorShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+bool isEnableStartShineChipCompleteDemo(const al::IUseSceneObjHolder* objHolder);
+bool tryStartAppearShineChipShine(const al::IUseSceneObjHolder* objHolder);
+bool isInAreaCurrentShineChipWatcher(const al::IUseSceneObjHolder* objHolder);
+
+}  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1071)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (997cd2c - 432bd2a)

📈 **Matched code**: 14.87% (+0.01%, +1572 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/ShineChipWatcherHolder` | `rs::isEnableStartShineChipCompleteDemo(al::IUseSceneObjHolder const*)` | +176 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipLocalFunction::notifyShineChipGet(al::LiveActor const*)` | +168 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::tryUpdateCurrentWatcher(al::LiveActor const*)` | +156 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipLocalFunction::tryCreateShineChipWatcherHolder(al::IUseSceneObjHolder const*)` | +124 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipLocalFunction::notifyShineChipGet(ShineChipWatcher*)` | +116 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::isCompleteShineChip(al::IUseSceneObjHolder const*)` | +92 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipLocalFunction::entryShineChipWatcher(ShineChipWatcher*)` | +88 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::notify(ShineChipWatcher*)` | +76 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::getShineChipCount(al::IUseSceneObjHolder const*)` | +60 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::isAppearedShineChipShine(al::IUseSceneObjHolder const*)` | +60 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::addDemoActorShineChipWatcher(al::IUseSceneObjHolder const*)` | +60 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::tryStartAppearShineChipShine(al::IUseSceneObjHolder const*)` | +60 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::isInAreaCurrentShineChipWatcher(al::IUseSceneObjHolder const*)` | +60 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::ShineChipWatcherHolder()` | +44 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::entry(ShineChipWatcher*)` | +44 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::isCurrentShineChipWatcherTypeEmpty(al::IUseSceneObjHolder const*)` | +40 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::tryStartAppearShine()` | +36 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::getCurrentWatcher() const` | +36 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::isExistShineChipWatcher(al::IUseSceneObjHolder const*)` | +32 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `rs::getCurrentShineChipWatcherIndex(al::IUseSceneObjHolder const*)` | +28 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Item/ShineChipWatcherHolder` | `ShineChipWatcherHolder::~ShineChipWatcherHolder()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->