### PR TITLE
Boss/BossMagma: Implement `BossMagmaStep` and `BossMagmaStepAnimControl`

### DIFF
--- a/src/Boss/BossMagma/BossMagmaStep.cpp
+++ b/src/Boss/BossMagma/BossMagmaStep.cpp
@@ -1,0 +1,43 @@
+#include "Boss/BossMagma/BossMagmaStep.h"
+
+#include "Library/LiveActor/ActorSensorUtil.h"
+
+#include "Boss/BossMagma/BossMagmaStepAnimControl.h"
+#include "Util/SensorMsgFunction.h"
+
+BossMagmaStep::BossMagmaStep() : WaveSurfMapParts("溶岩ボス足場") {}
+
+void BossMagmaStep::init(const al::ActorInitInfo& info) {
+    WaveSurfMapParts::init(info);
+    mAnimControl = new BossMagmaStepAnimControl(this);
+}
+
+bool BossMagmaStep::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                               al::HitSensor* self) {
+    if (al::isSensorName(self, "Collision")) {
+        if (rs::isMsgBubbleReflectV(message) || rs::isMsgBubbleWallTouch(message)) {
+            mAnimControl->requestDownImm();
+            return true;
+        }
+    }
+
+    if (al::isMsgExplosionCollide(message)) {
+        mAnimControl->requestDown();
+        return true;
+    }
+
+    return WaveSurfMapParts::receiveMsg(message, other, self);
+}
+
+void BossMagmaStep::rebirth() {
+    mAnimControl->requestUp();
+}
+
+void BossMagmaStep::down() {
+    mAnimControl->requestDown();
+}
+
+void BossMagmaStep::control() {
+    WaveSurfMapParts::control();
+    mAnimControl->updateNerve();
+}

--- a/src/Boss/BossMagma/BossMagmaStep.h
+++ b/src/Boss/BossMagma/BossMagmaStep.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "MapObj/WaveSurfMapParts.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BossMagmaStepAnimControl;
+
+class BossMagmaStep : public WaveSurfMapParts {
+public:
+    BossMagmaStep();
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void rebirth();
+    void down();
+    void control() override;
+
+private:
+    BossMagmaStepAnimControl* mAnimControl = nullptr;
+};
+
+static_assert(sizeof(BossMagmaStep) == 0x160);

--- a/src/Boss/BossMagma/BossMagmaStep.h
+++ b/src/Boss/BossMagma/BossMagmaStep.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "MapObj/WaveSurfMapParts.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BossMagmaStepAnimControl;
+
+class BossMagmaStep : public WaveSurfMapParts {
+public:
+    BossMagmaStep();
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void rebirth();
+    void down();
+    void control() override;
+
+private:
+    BossMagmaStepAnimControl* mAnimControl = nullptr;
+};

--- a/src/Boss/BossMagma/BossMagmaStepAnimControl.cpp
+++ b/src/Boss/BossMagma/BossMagmaStepAnimControl.cpp
@@ -1,0 +1,66 @@
+#include "Boss/BossMagma/BossMagmaStepAnimControl.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(BossMagmaStepAnimControl, Wait)
+NERVE_IMPL(BossMagmaStepAnimControl, Up)
+NERVE_IMPL(BossMagmaStepAnimControl, DownSign)
+NERVE_IMPL(BossMagmaStepAnimControl, Down)
+
+NERVES_MAKE_NOSTRUCT(BossMagmaStepAnimControl, Wait, Up, DownSign, Down)
+}  // namespace
+
+BossMagmaStepAnimControl::BossMagmaStepAnimControl(al::LiveActor* actor)
+    : al::NerveExecutor("溶岩ボス足場のアニメ制御"), mActor(actor) {
+    initNerve(&Wait, 0);
+}
+
+void BossMagmaStepAnimControl::requestUp() {
+    if (al::isNerve(this, &Wait) || al::isNerve(this, &Up))
+        return;
+
+    al::setNerve(this, &Up);
+}
+
+void BossMagmaStepAnimControl::requestDown() {
+    if (al::isNerve(this, &DownSign) || al::isNerve(this, &Down))
+        return;
+
+    al::setNerve(this, &DownSign);
+}
+
+void BossMagmaStepAnimControl::requestDownImm() {
+    if (al::isNerve(this, &Down))
+        return;
+
+    al::setNerve(this, &Down);
+}
+
+void BossMagmaStepAnimControl::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Wait");
+}
+
+void BossMagmaStepAnimControl::exeUp() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Up");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Wait);
+}
+
+void BossMagmaStepAnimControl::exeDownSign() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "DownSign");
+
+    if (al::isGreaterEqualStep(this, 180))
+        al::setNerve(this, &Down);
+}
+
+void BossMagmaStepAnimControl::exeDown() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Down");
+}

--- a/src/Boss/BossMagma/BossMagmaStepAnimControl.h
+++ b/src/Boss/BossMagma/BossMagmaStepAnimControl.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class BossMagmaStepAnimControl : public al::NerveExecutor {
+public:
+    BossMagmaStepAnimControl(al::LiveActor* actor);
+
+    void requestUp();
+    void requestDown();
+    void requestDownImm();
+    void exeWait();
+    void exeUp();
+    void exeDownSign();
+    void exeDown();
+
+private:
+    al::LiveActor* mActor;
+};
+
+static_assert(sizeof(BossMagmaStepAnimControl) == 0x18);

--- a/src/MapObj/WaveSurfMapParts.h
+++ b/src/MapObj/WaveSurfMapParts.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class WaveSurfMapParts : public al::LiveActor {
+public:
+    WaveSurfMapParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    bool isExistSurface() const;
+    void updateFinder();
+    void approachSurface();
+    void syncSurfaceUp();
+    void exeWait();
+    void exeSink();
+    void exeSinkDeep();
+    f32 getSurfaceHeight() const;
+
+private:
+    u8 _108[0x40];
+    bool _148;
+    u8 _149[3];
+    s32 _14c;
+    void* _150;
+};
+
+static_assert(sizeof(WaveSurfMapParts) == 0x158);


### PR DESCRIPTION
I split them in 2 files as it was doing noinline compiler instructions for it to match otherwise

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1072)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0524374 - 9f22142)

📈 **Matched code**: 14.87% (+0.01%, +1520 bytes)

<details>
<summary>✅ 20 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +160 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::BossMagmaStep()` | +136 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::BossMagmaStep()` | +132 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `(anonymous namespace)::BossMagmaStepAnimControlNrvDownSign::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::exeDownSign()` | +96 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `(anonymous namespace)::BossMagmaStepAnimControlNrvUp::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::requestUp()` | +88 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::exeUp()` | +88 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::requestDown()` | +84 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::BossMagmaStepAnimControl(al::LiveActor*)` | +80 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::requestDownImm()` | +72 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `(anonymous namespace)::BossMagmaStepAnimControlNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `(anonymous namespace)::BossMagmaStepAnimControlNrvDown::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::exeWait()` | +60 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::exeDown()` | +60 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::init(al::ActorInitInfo const&)` | +56 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::control()` | +36 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStepAnimControl` | `BossMagmaStepAnimControl::~BossMagmaStepAnimControl()` | +36 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::rebirth()` | +8 | 0.00% | 100.00% |
| `Boss/BossMagma/BossMagmaStep` | `BossMagmaStep::down()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->