### PR TITLE
Camera: Add `CameraPoser` headers and factory entries

### DIFF
--- a/lib/al/Library/Camera/CameraPoserFixPoint.h
+++ b/lib/al/Library/Camera/CameraPoserFixPoint.h
@@ -4,17 +4,15 @@
 
 namespace al {
 
-class LiveActor;
-
 class CameraPoserFixPoint : public CameraPoser {
 public:
-    CameraPoserFixPoint(const LiveActor* actor);
+    CameraPoserFixPoint(const char* name);
 
     void init() override;
     void loadParam(const ByamlIter& iter) override;
-    void start(const CameraStartInfo& startInfo) override;
+    void start(const CameraStartInfo& info) override;
     void update() override;
-    void makeLookAtCamera(sead::LookAtCamera* lookAtCam) const override;
+    void makeLookAtCamera(sead::LookAtCamera* cam) const override;
 
 private:
     char _140[24];

--- a/lib/al/Library/Play/Camera/CameraPoserBossBattle.h
+++ b/lib/al/Library/Play/Camera/CameraPoserBossBattle.h
@@ -19,7 +19,7 @@ public:
     bool tryChangeFollowCamera();
     bool isCameraTargetOutOfRangeY() const;
     bool tryChangeTowerCamera();
-    sead::Vector3f calcOutOfRangeDistance() const;
+    f32 calcOutOfRangeDistance() const;
 
     void exeTower();
     void exeFollow();

--- a/lib/al/Library/Play/Camera/CameraPoserBossBattle.h
+++ b/lib/al/Library/Play/Camera/CameraPoserBossBattle.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserBossBattle : public CameraPoser {
+public:
+    CameraPoserBossBattle(const char* name, const sead::Vector3f* posPtr = nullptr);
+
+    void init() override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void makeLookAtCamera(sead::LookAtCamera* cam) const override;
+    void update() override;
+    bool isEnableRotateByPad() const override;
+
+    void setPosPtr(const sead::Vector3f* posPtr);
+    bool tryChangeFollowCamera();
+    bool isCameraTargetOutOfRangeY() const;
+    bool tryChangeTowerCamera();
+    sead::Vector3f calcOutOfRangeDistance() const;
+
+    void exeTower();
+    void exeFollow();
+    void endFollow();
+    void exeFollowNear();
+
+private:
+    s8 filler[0x1B8 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserBossBattle) == 0x1B8, "al::CameraPoserBossBattle size");

--- a/lib/al/Library/Play/Camera/CameraPoserEntrance.h
+++ b/lib/al/Library/Play/Camera/CameraPoserEntrance.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserEntrance : public CameraPoser {
+public:
+    CameraPoserEntrance(const char* name);
+
+    void initParam(f32, f32, f32, const sead::Vector3f&);
+    void initParam(f32, const sead::Vector3f&, const sead::Vector3f&);
+    void initLookAtPosDirect(const sead::Vector3f&);
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void movement() override;
+    void update() override;
+
+    void exeKeepByFlag();
+    void exeKeepInAir();
+    void exeWait();
+
+    bool isEnableRotateByPad() const override { return true; }
+
+private:
+    s8 filler[0x178 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserEntrance) == 0x178, "al::CameraPoserEntrance size");

--- a/lib/al/Library/Play/Camera/CameraPoserKinopioBrigade.h
+++ b/lib/al/Library/Play/Camera/CameraPoserKinopioBrigade.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserKinopioBrigade : public CameraPoser {
+public:
+    class V3bool;
+
+    CameraPoserKinopioBrigade(const char* name);
+
+    void start(const CameraStartInfo& info) override;
+    void resetValues(f32, f32);
+    void update() override;
+    void calcDrcAngle();
+    void calcBaseAngle();
+    void convergeBaseAngle();
+    void commitCamera();
+    void followLookAt(f32, const sead::Vector3f&, const sead::Vector3f&, const V3bool&);
+    void loadParam(const ByamlIter& iter) override;
+    void transferParam(const CameraPoserKinopioBrigade*);
+    bool isEnableRotateByPad() const override;
+
+private:
+    s8 filler[0x1F8 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserKinopioBrigade) == 0x1F8, "al::CameraPoserKinopioBrigade size");

--- a/lib/al/Library/Play/Camera/CameraPoserLookBoard.h
+++ b/lib/al/Library/Play/Camera/CameraPoserLookBoard.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserLookBoard : public CameraPoser {
+public:
+    CameraPoserLookBoard(const char* name);
+
+    void init() override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+
+private:
+    s8 filler[0x150 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserLookBoard) == 0x150, "al::CameraPoserLookBoard size");

--- a/lib/al/Library/Play/Camera/CameraPoserLookDown.h
+++ b/lib/al/Library/Play/Camera/CameraPoserLookDown.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserLookDown : public CameraPoser {
+public:
+    CameraPoserLookDown(const char* name);
+
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void update() override;
+    void makeLookAtCamera(sead::LookAtCamera* cam) const override;
+
+private:
+    s8 filler[0x150 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserLookDown) == 0x150, "al::CameraPoserLookDown size");

--- a/lib/al/Library/Play/Camera/CameraPoserRace.h
+++ b/lib/al/Library/Play/Camera/CameraPoserRace.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserRace : public CameraPoser {
+public:
+    CameraPoserRace(const char* name);
+
+    void init() override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void calcTargetFrontLocal(sead::Vector3f*, bool) const;
+    void update() override;
+
+private:
+    s8 filler[0x170 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserRace) == 0x170, "al::CameraPoserRace size");

--- a/lib/al/Library/Play/Camera/CameraPoserRailMoveLookAt.h
+++ b/lib/al/Library/Play/Camera/CameraPoserRailMoveLookAt.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserRailMoveLookAt : public CameraPoser {
+public:
+    CameraPoserRailMoveLookAt(const char* name);
+
+    void init() override;
+    void initByPlacementObj(const PlacementInfo& info) override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void update() override;
+
+private:
+    s8 filler[0x180 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserRailMoveLookAt) == 0x180, "al::CameraPoserRailMoveLookAt size");

--- a/lib/al/Library/Play/Camera/CameraPoserRailMoveMovie.h
+++ b/lib/al/Library/Play/Camera/CameraPoserRailMoveMovie.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserRailMoveMovie : public CameraPoser {
+public:
+    CameraPoserRailMoveMovie(const char* name);
+
+    void initByPlacementObj(const PlacementInfo& info) override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void exeMove();
+
+private:
+    s8 filler[0x148 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserRailMoveMovie) == 0x148, "al::CameraPoserRailMoveMovie size");

--- a/lib/al/Library/Play/Camera/CameraPoserTalk.h
+++ b/lib/al/Library/Play/Camera/CameraPoserTalk.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserTalk : public CameraPoser {
+public:
+    CameraPoserTalk(const char* name);
+
+    void init() override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void setMinDistance(f32);
+
+private:
+    s8 filler[0x148 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserTalk) == 0x148, "al::CameraPoserTalk size");

--- a/lib/al/Library/Play/Camera/CameraPoserTower.h
+++ b/lib/al/Library/Play/Camera/CameraPoserTower.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+class CameraPoserTower : public CameraPoser {
+public:
+    CameraPoserTower(const char* name, const sead::Vector3f* posPtr = nullptr);
+
+    void init() override;
+    void initByPlacementObj(const PlacementInfo& info) override;
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo& info) override;
+    void movement() override;
+    void update() override;
+    void resetInputRotate(f32, s32);
+    void makeLookAtCamera(sead::LookAtCamera* cam) const override;
+
+    void exeTower();
+    void exeTowerInput();
+    void exeFollow();
+
+private:
+    s8 filler[0x1F8 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::CameraPoserTower) == 0x1F8, "al::CameraPoserTower size");

--- a/lib/al/Library/Play/Camera/KeyMoveCameraFix.h
+++ b/lib/al/Library/Play/Camera/KeyMoveCameraFix.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Project/Poser/KeyMoveCameraBase.h"
+
+namespace al {
+
+class KeyMoveCameraFix : public KeyMoveCameraBase {
+public:
+    KeyMoveCameraFix(const char* name);
+
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo&) override;
+    void update() override;
+
+private:
+    s8 filler[0x180 - sizeof(KeyMoveCameraBase)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::KeyMoveCameraFix) == 0x180, "al::KeyMoveCameraFix size");

--- a/lib/al/Library/Play/Camera/KeyMoveCameraRailMove.h
+++ b/lib/al/Library/Play/Camera/KeyMoveCameraRailMove.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Project/Poser/KeyMoveCameraBase.h"
+
+namespace al {
+
+class KeyMoveCameraRailMove : public KeyMoveCameraBase {
+public:
+    KeyMoveCameraRailMove(const char* name);
+
+    void initByPlacementObj(const PlacementInfo& info) override;
+    void initPointInfoTable(s32);
+    void loadParam(const ByamlIter& iter) override;
+    void start(const CameraStartInfo&) override;
+    void calcPoseInfoDirect(f32*, f32*, f32*) const;
+    void updatePose();
+    void update() override;
+
+private:
+    s8 filler[0x198 - sizeof(KeyMoveCameraBase)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::KeyMoveCameraRailMove) == 0x198, "al::KeyMoveCameraRailMove size");

--- a/lib/al/Library/Play/Camera/KeyMoveCameraZoom.h
+++ b/lib/al/Library/Play/Camera/KeyMoveCameraZoom.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Project/Poser/KeyMoveCameraBase.h"
+
+namespace al {
+
+class KeyMoveCameraZoom : public KeyMoveCameraBase {
+public:
+    KeyMoveCameraZoom(const char* name);
+
+    void initByPlacementObj(const PlacementInfo& info) override;
+    void loadParam(const ByamlIter& iter) override;
+    void update() override;
+
+private:
+    s8 filler[0x180 - sizeof(KeyMoveCameraBase)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::KeyMoveCameraZoom) == 0x180, "al::KeyMoveCameraZoom size");

--- a/lib/al/Project/Poser/KeyMoveCameraBase.h
+++ b/lib/al/Project/Poser/KeyMoveCameraBase.h
@@ -16,12 +16,10 @@ public:
     void start(const CameraStartInfo&) override;
     void movement() override;
     virtual bool isEndKeyMoveCamera() const;
-    void calcRate() const;
+    f32 calcRate() const;
 
 private:
-    s8 filler[0x160 - sizeof(CameraPoser)];
+    s8 filler[0x168 - sizeof(CameraPoser)];
 };
 
 }  // namespace al
-
-static_assert(sizeof(al::KeyMoveCameraBase) == 0x160, "al::KeyMoveCameraBase size");

--- a/lib/al/Project/Poser/KeyMoveCameraBase.h
+++ b/lib/al/Project/Poser/KeyMoveCameraBase.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+namespace al {
+
+struct KeyMoveCameraInfo {
+    KeyMoveCameraInfo();
+};
+
+class KeyMoveCameraBase : public CameraPoser {
+public:
+    KeyMoveCameraBase(const char* name);
+
+    void load(const ByamlIter&) override;
+    void start(const CameraStartInfo&) override;
+    void movement() override;
+    virtual bool isEndKeyMoveCamera() const;
+    void calcRate() const;
+
+private:
+    s8 filler[0x160 - sizeof(CameraPoser)];
+};
+
+}  // namespace al
+
+static_assert(sizeof(al::KeyMoveCameraBase) == 0x160, "al::KeyMoveCameraBase size");

--- a/src/Camera/CameraPoserFollowLimit.h
+++ b/src/Camera/CameraPoserFollowLimit.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "Library/Camera/CameraPoser.h"
+
+class CameraPoserFollowLimit : public al::CameraPoser {
+public:
+    CameraPoserFollowLimit(const char* name);
+
+    void init() override;
+    bool isUseDistanceCurve() const;
+    void initByPlacementObj(const al::PlacementInfo& info) override;
+    void loadParam(const al::ByamlIter& iter) override;
+    void start(const al::CameraStartInfo& info) override;
+    f32 getAngleDegreeV() const;
+    bool isInvalidCollider() const;
+    f32 calcDistanceRaw() const;
+    f32 calcDistance() const;
+    bool tryStartWater(bool);
+    void movement() override;
+    void update() override;
+    void calcCameraPose(sead::LookAtCamera* cam) const override;
+    bool receiveRequestFromObject(const al::CameraObjectRequestInfo& info) override;
+    void startSnapShotMode() override;
+    void endSnapShotMode() override;
+    bool isEnableRotateByPad() const override;
+    void exeFollow();
+    bool trySwitchLimitObj();
+    void updateInputOrSubTargetTurnH();
+    void exeResetAngle();
+    void endWater();
+    void exeFollowRail();
+    void exeFollowRailUserCtrl();
+    void updateRotateSpeedInputH();
+    void exeWater();
+    void exeWaterRadicon();
+    void startTurnBrake(s32);
+    bool requestTurnToDirection(const al::CameraTurnInfo* info) override;
+    void invalidateAutoResetLowAngleV();
+
+private:
+    s8 filler[0x2A0 - sizeof(al::CameraPoser)];
+};
+
+static_assert(sizeof(CameraPoserFollowLimit) == 0x2A0, "CameraPoserFollowLimit size");

--- a/src/Camera/ScenarioStartCamera.h
+++ b/src/Camera/ScenarioStartCamera.h
@@ -27,7 +27,7 @@ public:
     s32 getMaxPlayStep();
 
 private:
-    void* _padding[0x8];
+    void* _110[0x8];
 };
 
 static_assert(sizeof(ScenarioStartCamera) == 0x150);

--- a/src/Scene/ProjectCameraPoserFactory.cpp
+++ b/src/Scene/ProjectCameraPoserFactory.cpp
@@ -1,33 +1,51 @@
 #include "Scene/ProjectCameraPoserFactory.h"
 
+#include "Library/Camera/CameraPoserFix.h"
+#include "Library/Camera/CameraPoserFixPoint.h"
 #include "Library/Camera/CreateCameraPoserFunction.h"
+#include "Library/Play/Camera/CameraPoserBossBattle.h"
+#include "Library/Play/Camera/CameraPoserEntrance.h"
+#include "Library/Play/Camera/CameraPoserKinopioBrigade.h"
+#include "Library/Play/Camera/CameraPoserLookBoard.h"
+#include "Library/Play/Camera/CameraPoserLookDown.h"
+#include "Library/Play/Camera/CameraPoserRace.h"
+#include "Library/Play/Camera/CameraPoserRailMoveLookAt.h"
+#include "Library/Play/Camera/CameraPoserRailMoveMovie.h"
+#include "Library/Play/Camera/CameraPoserSubjective.h"
+#include "Library/Play/Camera/CameraPoserTalk.h"
+#include "Library/Play/Camera/CameraPoserTower.h"
+#include "Library/Play/Camera/KeyMoveCameraFix.h"
+#include "Library/Play/Camera/KeyMoveCameraRailMove.h"
+#include "Library/Play/Camera/KeyMoveCameraZoom.h"
+
+#include "Camera/CameraPoserFollowLimit.h"
 
 const al::NameToCreator<al::CameraPoserCreatorFunction> sProjectCameraPoserFactoryEntries1[] = {
-    /* CameraPoserFollowLimit */ {"制限付きフォロー", nullptr},
-    /* CameraPoserFollowLimit */ {"制限付き平行", nullptr},
-    /* CameraPoserFollowLimit */ {"2D平行", nullptr},
-    /* al::CameraPoserFix */ {"固定", nullptr},
-    /* al::CameraPoserFix */ {"完全固定", nullptr},
-    /* al::CameraPoserFix */ {"出入口専用固定", nullptr},
-    /* al::CameraPoserFixPoint */ {"定点", nullptr},
-    /* al::CameraPoserFixPoint */ {"その場定点", nullptr},
-    /* al::CameraPoserFixPoint */ {"完全追従定点", nullptr},
-    /* al::CameraPoserRace */ {"レース", nullptr},
-    /* al::CameraPoserRailMoveLookAt */ {"レール移動", nullptr},
-    /* al::CameraPoserKinopioBrigade */ {"キノピオ探検隊", nullptr},
-    /* al::CameraPoserTalk */ {"会話用2点間", nullptr},
-    /* al::CameraPoserRailMoveMovie */ {"映像撮影レール", nullptr}};
+    {"制限付きフォロー", al::createCameraPoserFunction<CameraPoserFollowLimit>},
+    {"制限付き平行", al::createCameraPoserFunction<CameraPoserFollowLimit>},
+    {"2D平行", al::createCameraPoserFunction<CameraPoserFollowLimit>},
+    {"固定", al::createCameraPoserFunction<al::CameraPoserFix>},
+    {"完全固定", al::createCameraPoserFunction<al::CameraPoserFix>},
+    {"出入口専用固定", al::createCameraPoserFunction<al::CameraPoserFix>},
+    {"定点", al::createCameraPoserFunction<al::CameraPoserFixPoint>},
+    {"その場定点", al::createCameraPoserFunction<al::CameraPoserFixPoint>},
+    {"完全追従定点", al::createCameraPoserFunction<al::CameraPoserFixPoint>},
+    {"レース", al::createCameraPoserFunction<al::CameraPoserRace>},
+    {"レール移動", al::createCameraPoserFunction<al::CameraPoserRailMoveLookAt>},
+    {"キノピオ探検隊", al::createCameraPoserFunction<al::CameraPoserKinopioBrigade>},
+    {"会話用2点間", al::createCameraPoserFunction<al::CameraPoserTalk>},
+    {"映像撮影レール", al::createCameraPoserFunction<al::CameraPoserRailMoveMovie>}};
 
 const al::NameToCreator<al::CameraPoserCreatorFunction> sProjectCameraPoserFactoryEntries2[] = {
-    /* al::CameraPoserBossBattle */ {"ボス戦カメラ", nullptr},
-    /* al::CameraPoserEntrance */ {"スタート", nullptr},
-    /* al::CameraPoserLookBoard */ {"看板用2点間", nullptr},
-    /* al::CameraPoserLookDown */ {"見下ろし", nullptr},
-    /* al::CameraPoserSubjective */ {"主観", nullptr},
-    /* al::CameraPoserTower */ {"塔", nullptr},
-    /* al::KeyMoveCameraFix */ {"キー移動固定", nullptr},
-    /* al::KeyMoveCameraRailMove */ {"キー移動レール移動", nullptr},
-    /* al::KeyMoveCameraZoom */ {"キー移動ズーム", nullptr},
+    {"ボス戦カメラ", al::createCameraPoserFunction<al::CameraPoserBossBattle>},
+    {"スタート", al::createCameraPoserFunction<al::CameraPoserEntrance>},
+    {"看板用2点間", al::createCameraPoserFunction<al::CameraPoserLookBoard>},
+    {"見下ろし", al::createCameraPoserFunction<al::CameraPoserLookDown>},
+    {"主観", al::createCameraPoserFunction<al::CameraPoserSubjective>},
+    {"塔", al::createCameraPoserFunction<al::CameraPoserTower>},
+    {"キー移動固定", al::createCameraPoserFunction<al::KeyMoveCameraFix>},
+    {"キー移動レール移動", al::createCameraPoserFunction<al::KeyMoveCameraRailMove>},
+    {"キー移動ズーム", al::createCameraPoserFunction<al::KeyMoveCameraZoom>},
     /* ScenarioStartCameraPoserSimpleZoom */ {"シナリオ紹介シンプルズームカメラ", nullptr},
     /* ScenarioStartCameraPoserRailMove */ {"シナリオ紹介レール移動カメラ", nullptr}};
 


### PR DESCRIPTION
This PR adds some `CameraPoser` headers and fills in the camera poser factory.

The `ScenarioStartCameraPoser` stuff will be added in a separate PR as I decided to also implement those classes

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1073)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (dc5c854 - db60b68)

📈 **Matched code**: 14.42% (+0.01%, +892 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserBossBattle>(char const*)` | +56 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserTower>(char const*)` | +56 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<CameraPoserFollowLimit>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserFix>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserFixPoint>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserRace>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserRailMoveLookAt>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserKinopioBrigade>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserTalk>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserRailMoveMovie>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserEntrance>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserLookBoard>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserLookDown>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::CameraPoserSubjective>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::KeyMoveCameraFix>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::KeyMoveCameraRailMove>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectCameraPoserFactory` | `al::CameraPoser* al::createCameraPoserFunction<al::KeyMoveCameraZoom>(char const*)` | +52 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->