### PR TITLE
Boss/Koopa: Implement `KoopaStateDemoBattleStart`

### DIFF
--- a/src/Boss/Koopa/KoopaDemoExecutor.h
+++ b/src/Boss/Koopa/KoopaDemoExecutor.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class AddDemoInfo;
+struct ActorInitInfo;
+class EventFlowExecutor;
+class LiveActor;
+}  // namespace al
+
+class ChurchDoor;
+class IUseDemoSkip;
+class KoopaCameraCtrl;
+class KoopaCap;
+class KoopaShip;
+class Peach;
+
+class KoopaDemoExecutor {
+public:
+    KoopaDemoExecutor();
+
+    void init(al::LiveActor* actor, const al::ActorInitInfo& info,
+              al::EventFlowExecutor* flowExecutor, KoopaCameraCtrl* cameraCtrl, Peach* peach);
+    void initLv1(const al::ActorInitInfo& info, al::LiveActor* demoModel, KoopaCap* cap,
+                 KoopaShip* ship);
+    void registerDemoModel(al::LiveActor* actor);
+    void initMoonChurch(const al::ActorInitInfo& info, ChurchDoor* churchDoor,
+                        al::LiveActor* actor);
+    void initLv2(const al::ActorInitInfo& info, al::LiveActor* demoModel, KoopaCap* cap,
+                 al::LiveActor* ship);
+    bool update();
+    bool startDemoAction(const char* actionName, bool isResetEventDemoPlayerDynamics);
+    void skip();
+    void killAll();
+    bool tryStartChurchEnterDemo(IUseDemoSkip* demoSkip, al::AddDemoInfo* demoInfo);
+    void start(const char* eventName);
+    bool tryStartChurchStartDemo(IUseDemoSkip* demoSkip, al::AddDemoInfo* demoInfo);
+    bool tryStartBattleStartDemo(IUseDemoSkip* demoSkip);
+    bool tryStartBattleEndDemo(IUseDemoSkip* demoSkip);
+    bool tryStartClashBasementDemo(IUseDemoSkip* demoSkip);
+
+    bool isRunningDemo() const { return mDemoState != 0; }
+
+private:
+    u8 _0[0x18];
+    void* _18 = nullptr;
+    u8 _20[0xb0];
+    void* _d0 = nullptr;
+    s64 _d8 = 0;
+    u8 _e0[0x30];
+    u8 mDemoState = 0;
+    u8 _111 = 0;
+    u8 _112 = 0;
+    u8 _113 = 0;
+    u8 _114 = 0;
+    bool mIsStartEventFlow = false;
+    u8 _116[2];
+    s64 _118 = 0;
+};
+
+static_assert(sizeof(KoopaDemoExecutor) == 0x120);

--- a/src/Boss/Koopa/KoopaStateDemoBattleStart.cpp
+++ b/src/Boss/Koopa/KoopaStateDemoBattleStart.cpp
@@ -1,0 +1,110 @@
+#include "Boss/Koopa/KoopaStateDemoBattleStart.h"
+
+#include "Library/Area/AreaObjUtil.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/BossUtil/BossUtil.h"
+#include "Boss/Koopa/KoopaDemoExecutor.h"
+#include "MapObj/CapAppearMapParts.h"
+#include "Util/DemoUtil.h"
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+IUseDemoSkip* getDemoSkip(KoopaStateDemoBattleStart* state) {
+    return state;
+}
+
+NERVE_IMPL(KoopaStateDemoBattleStart, Prepare);
+NERVE_IMPL(KoopaStateDemoBattleStart, Demo);
+NERVE_IMPL(KoopaStateDemoBattleStart, Start);
+NERVE_IMPL(KoopaStateDemoBattleStart, Skip);
+NERVES_MAKE_NOSTRUCT(KoopaStateDemoBattleStart, Prepare, Demo, Start, Skip);
+}  // namespace
+
+KoopaStateDemoBattleStart::KoopaStateDemoBattleStart(al::LiveActor* actor,
+                                                     KoopaDemoExecutor* demoExecutor, s32 level)
+    : al::ActorStateBase("戦闘開始デモ", actor), mDemoExecutor(demoExecutor),
+      mBattleLevel(level + 1) {
+    initNerve(&Prepare, 0);
+}
+
+void KoopaStateDemoBattleStart::initDemoStartAreaGroup(const al::ActorInitInfo& info) {
+    mDemoStartAreaGroup =
+        al::createLinkAreaGroup(mActor, info, "DemoStartArea", "クッパ開始デモ起動エリアグループ",
+                                "クッパ開始デモ起動エリア");
+}
+
+void KoopaStateDemoBattleStart::setCapAppearMapPartsGroup(
+    al::DeriveActorGroup<CapAppearMapParts>* group) {
+    mCapAppearMapPartsGroup = group;
+}
+
+void KoopaStateDemoBattleStart::appear() {
+    NerveStateBase::appear();
+    al::invalidateShadow(mActor);
+    mIsSkipped = false;
+    if (mDemoExecutor->isRunningDemo())
+        al::setNerve(this, &Demo);
+    else if (mDemoStartAreaGroup)
+        al::setNerve(this, &Prepare);
+    else
+        al::setNerve(this, &Start);
+}
+
+void KoopaStateDemoBattleStart::kill() {
+    NerveStateBase::kill();
+    al::validateShadow(mActor);
+    rs::saveShowDemoBossBattleStart(mActor, 6, mBattleLevel);
+    if (mCapAppearMapPartsGroup)
+        for (s32 i = 0; i < mCapAppearMapPartsGroup->getActorCount(); i++)
+            mCapAppearMapPartsGroup->getDeriveActor(i)->killAll();
+}
+
+bool KoopaStateDemoBattleStart::isFirstDemo() const {
+    return (rs::isAlreadyShowDemoBossBattleStart(mActor, 6, mBattleLevel) & 1) == 0;
+}
+
+bool KoopaStateDemoBattleStart::isEnableSkipDemo() const {
+    return true;
+}
+
+void KoopaStateDemoBattleStart::skipDemo() {
+    mIsSkipped = true;
+    mDemoExecutor->skip();
+    rs::endEventCutSceneDemoBySkip(mActor);
+    al::setNerve(this, &Skip);
+    kill();
+}
+
+void KoopaStateDemoBattleStart::exePrepare() {
+    if (!al::isInAreaObj(mDemoStartAreaGroup, rs::getPlayerPos(mActor)) ||
+        !rs::isPlayerOnGround(mActor))
+        return;
+    if (mDemoExecutor->tryStartBattleStartDemo(this))
+        al::setNerve(this, &Demo);
+    else
+        al::setNerve(this, &Start);
+}
+
+void KoopaStateDemoBattleStart::exeStart() {
+    if (mDemoExecutor->tryStartBattleStartDemo(getDemoSkip(this)))
+        al::setNerve(this, &Demo);
+}
+
+void KoopaStateDemoBattleStart::exeDemo() {
+    if (al::isFirstStep(this) && mCapAppearMapPartsGroup) {
+        for (s32 i = 0; i < mCapAppearMapPartsGroup->getActorCount(); i++) {
+            rs::addDemoActor(mCapAppearMapPartsGroup->getDeriveActor(i), false);
+            mCapAppearMapPartsGroup->getDeriveActor(i)->startWait();
+        }
+    }
+    if (mDemoExecutor->update())
+        kill();
+}
+
+void KoopaStateDemoBattleStart::exeSkip() {}

--- a/src/Boss/Koopa/KoopaStateDemoBattleStart.h
+++ b/src/Boss/Koopa/KoopaStateDemoBattleStart.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+struct ActorInitInfo;
+class AreaObjGroup;
+template <class T>
+class DeriveActorGroup;
+}  // namespace al
+
+class CapAppearMapParts;
+class KoopaDemoExecutor;
+
+class KoopaStateDemoBattleStart : public al::ActorStateBase, public IUseDemoSkip {
+public:
+    KoopaStateDemoBattleStart(al::LiveActor* actor, KoopaDemoExecutor* demoExecutor, s32 level);
+
+    void initDemoStartAreaGroup(const al::ActorInitInfo& info);
+    void setCapAppearMapPartsGroup(al::DeriveActorGroup<CapAppearMapParts>* group);
+    void appear() override;
+    void kill() override;
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+
+    void exePrepare();
+    void exeStart();
+    void exeDemo();
+    void exeSkip();
+
+private:
+    KoopaDemoExecutor* mDemoExecutor = nullptr;
+    s32 mBattleLevel = 0;
+    al::AreaObjGroup* mDemoStartAreaGroup = nullptr;
+    al::DeriveActorGroup<CapAppearMapParts>* mCapAppearMapPartsGroup = nullptr;
+    bool mIsSkipped = false;
+};
+
+static_assert(sizeof(KoopaStateDemoBattleStart) == 0x50);

--- a/src/MapObj/CapAppearMapParts.h
+++ b/src/MapObj/CapAppearMapParts.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class CapAppearMapParts : public al::LiveActor {
+public:
+    CapAppearMapParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void listenAppear();
+    void startWait();
+    void killAll();
+    void control() override;
+    void appear() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeAppear();
+    void exeAppearEnd();
+    void exeWait();
+    void exeReaction();
+    void exeWaitForever();
+    void exeDisappear();
+
+private:
+    void* _108 = nullptr;
+    s32 _110 = 0;
+    sead::Vector3f _114 = sead::Vector3f::zero;
+    s32 _120 = 0;
+    bool mIs124 = false;
+    sead::Vector3f _128 = sead::Vector3f::zero;
+    bool mIs134 = false;
+};
+
+static_assert(sizeof(CapAppearMapParts) == 0x138);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -16,11 +16,13 @@ al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitIn
                                            const char*, const char*);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
+void endEventCutSceneDemoBySkip(al::LiveActor*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);
 void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
                            const char* name);
 void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
+bool isSuccessNpcEventBalloonMessage(const al::LiveActor*);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1075)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d3bab22 - c9dc52b)

📈 **Matched code**: 14.35% (+0.01%, +1464 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `(anonymous namespace)::KoopaStateDemoBattleStartNrvDemo::execute(al::NerveKeeper*) const` | +168 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::exeDemo()` | +164 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::KoopaStateDemoBattleStart(al::LiveActor*, KoopaDemoExecutor*, int)` | +120 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::exePrepare()` | +120 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `(anonymous namespace)::KoopaStateDemoBattleStartNrvPrepare::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::kill()` | +116 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::appear()` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `non-virtual thunk to KoopaStateDemoBattleStart::skipDemo()` | +84 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::skipDemo()` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::exeStart()` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `(anonymous namespace)::KoopaStateDemoBattleStartNrvStart::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::initDemoStartAreaGroup(al::ActorInitInfo const&)` | +64 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::isFirstDemo() const` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `non-virtual thunk to KoopaStateDemoBattleStart::isFirstDemo() const` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::~KoopaStateDemoBattleStart()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::setCapAppearMapPartsGroup(al::DeriveActorGroup<CapAppearMapParts>*)` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `non-virtual thunk to KoopaStateDemoBattleStart::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `IUseDemoSkip::updateOnlyDemoGraphics()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `KoopaStateDemoBattleStart::exeSkip()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoBattleStart` | `(anonymous namespace)::KoopaStateDemoBattleStartNrvSkip::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->