### PR TITLE
Player: Implement `PlayerCapManHeroEyesControl`

### DIFF
--- a/src/Player/PlayerCapManHeroEyesControl.cpp
+++ b/src/Player/PlayerCapManHeroEyesControl.cpp
@@ -1,0 +1,144 @@
+#include "Player/PlayerCapManHeroEyesControl.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerCapManHeroEyesControl, Dead)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Appear)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Wait)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Disappear)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Demo)
+
+NERVES_MAKE_NOSTRUCT(PlayerCapManHeroEyesControl, Dead, Disappear, Demo, Appear, Wait)
+}  // namespace
+
+PlayerCapManHeroEyesControl::PlayerCapManHeroEyesControl(const char* name, al::LiveActor* puppetEye,
+                                                         al::LiveActor* normal2DEye)
+    : al::NerveExecutor(name), mPuppetEye(puppetEye), mNormal2DEye(normal2DEye) {
+    mPuppetEye->kill();
+    mNormal2DEye->kill();
+    initNerve(&Dead, 0);
+}
+
+void PlayerCapManHeroEyesControl::start() {
+    if (!mPuppetEye)
+        return;
+
+    if (al::isDead(mPuppetEye))
+        mPuppetEye->appear();
+
+    al::setNerve(this, &Appear);
+}
+
+void PlayerCapManHeroEyesControl::fastStart() {
+    if (!mPuppetEye)
+        return;
+
+    if (al::isDead(mPuppetEye))
+        mPuppetEye->appear();
+
+    al::startAction(mPuppetEye, "Appear");
+    al::setActionFrame(mPuppetEye, al::getActionFrameMax(mPuppetEye, "Appear"));
+    al::setNerve(this, &Wait);
+}
+
+void PlayerCapManHeroEyesControl::end() {
+    if (mPuppetEye)
+        al::setNerve(this, &Disappear);
+}
+
+void PlayerCapManHeroEyesControl::startPuppet() {
+    if (mPuppetEye)
+        mPuppetEye->kill();
+
+    if (mNormal2DEye)
+        mNormal2DEye->kill();
+
+    al::setNerve(this, &Demo);
+}
+
+void PlayerCapManHeroEyesControl::endPuppet() {
+    if (!mPuppetEye)
+        return;
+
+    mPuppetEye->kill();
+
+    if (mPuppetEye) {
+        mPuppetEye->kill();
+        al::setNerve(this, &Dead);
+    }
+}
+
+void PlayerCapManHeroEyesControl::kill() {
+    if (!mPuppetEye)
+        return;
+
+    mPuppetEye->kill();
+    al::setNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::update() {
+    updateNerve();
+}
+
+al::LiveActor* PlayerCapManHeroEyesControl::getPuppetEye() const {
+    return mPuppetEye;
+}
+
+bool PlayerCapManHeroEyesControl::isAppear() const {
+    return al::isNerve(this, &Appear) || al::isNerve(this, &Wait);
+}
+
+bool PlayerCapManHeroEyesControl::isDisappear() const {
+    if (al::isNerve(this, &Appear)) {
+    } else if (!al::isNerve(this, &Wait)) {
+        return true;
+    }
+
+    return false;
+}
+
+bool PlayerCapManHeroEyesControl::isDemo() const {
+    return al::isNerve(this, &Demo);
+}
+
+bool PlayerCapManHeroEyesControl::isDeadCap() const {
+    return al::isNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::requestWaitAnimChange(const char* actionName) {
+    if (al::isNerve(this, &Wait) && al::isAlive(mPuppetEye))
+        al::tryStartActionIfNotPlaying(mPuppetEye, actionName);
+}
+
+void PlayerCapManHeroEyesControl::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(mPuppetEye, "Appear");
+
+    if (al::isActionEnd(mPuppetEye))
+        al::setNerve(this, &Wait);
+}
+
+void PlayerCapManHeroEyesControl::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(mPuppetEye, "Wait");
+}
+
+void PlayerCapManHeroEyesControl::exeDisappear() {
+    if (al::isFirstStep(this))
+        al::startAction(mPuppetEye, "Disappear");
+
+    if (al::isActionEnd(mPuppetEye))
+        al::setNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::exeDead() {
+    if (mPuppetEye)
+        mPuppetEye->kill();
+}
+
+void PlayerCapManHeroEyesControl::exeDemo() {}

--- a/src/Player/PlayerCapManHeroEyesControl.cpp
+++ b/src/Player/PlayerCapManHeroEyesControl.cpp
@@ -1,0 +1,137 @@
+#include "Player/PlayerCapManHeroEyesControl.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerCapManHeroEyesControl, Dead)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Appear)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Wait)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Disappear)
+NERVE_IMPL(PlayerCapManHeroEyesControl, Demo)
+
+NERVES_MAKE_NOSTRUCT(PlayerCapManHeroEyesControl, Dead, Disappear, Demo, Appear, Wait)
+}  // namespace
+
+PlayerCapManHeroEyesControl::PlayerCapManHeroEyesControl(const char* name, al::LiveActor* capEye,
+                                                         al::LiveActor* capEye2D)
+    : al::NerveExecutor(name), mCapEye(capEye), mCapEye2D(capEye2D) {
+    mCapEye->kill();
+    mCapEye2D->kill();
+    initNerve(&Dead, 0);
+}
+
+void PlayerCapManHeroEyesControl::start() {
+    if (!mCapEye)
+        return;
+
+    if (al::isDead(mCapEye))
+        mCapEye->appear();
+
+    al::setNerve(this, &Appear);
+}
+
+void PlayerCapManHeroEyesControl::fastStart() {
+    if (!mCapEye)
+        return;
+
+    if (al::isDead(mCapEye))
+        mCapEye->appear();
+
+    al::startAction(mCapEye, "Appear");
+    al::setActionFrame(mCapEye, al::getActionFrameMax(mCapEye, "Appear"));
+    al::setNerve(this, &Wait);
+}
+
+void PlayerCapManHeroEyesControl::end() {
+    if (mCapEye)
+        al::setNerve(this, &Disappear);
+}
+
+void PlayerCapManHeroEyesControl::startPuppet() {
+    if (mCapEye)
+        mCapEye->kill();
+
+    if (mCapEye2D)
+        mCapEye2D->kill();
+
+    al::setNerve(this, &Demo);
+}
+
+void PlayerCapManHeroEyesControl::endPuppet() {
+    // BUG: does not kill `mCapEye2D`
+    if (mCapEye)
+        mCapEye->kill();
+
+    kill();
+}
+
+void PlayerCapManHeroEyesControl::kill() {
+    if (!mCapEye)
+        return;
+
+    mCapEye->kill();
+    al::setNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::update() {
+    updateNerve();
+}
+
+al::LiveActor* PlayerCapManHeroEyesControl::getPuppetEye() const {
+    return mCapEye;
+}
+
+bool PlayerCapManHeroEyesControl::isAppear() const {
+    return al::isNerve(this, &Appear) || al::isNerve(this, &Wait);
+}
+
+bool PlayerCapManHeroEyesControl::isDisappear() const {
+    if (isAppear())
+        return false;
+    return true;
+}
+
+bool PlayerCapManHeroEyesControl::isDemo() const {
+    return al::isNerve(this, &Demo);
+}
+
+bool PlayerCapManHeroEyesControl::isDeadCap() const {
+    return al::isNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::requestWaitAnimChange(const char* actionName) {
+    if (al::isNerve(this, &Wait) && al::isAlive(mCapEye))
+        al::tryStartActionIfNotPlaying(mCapEye, actionName);
+}
+
+void PlayerCapManHeroEyesControl::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(mCapEye, "Appear");
+
+    if (al::isActionEnd(mCapEye))
+        al::setNerve(this, &Wait);
+}
+
+void PlayerCapManHeroEyesControl::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(mCapEye, "Wait");
+}
+
+void PlayerCapManHeroEyesControl::exeDisappear() {
+    if (al::isFirstStep(this))
+        al::startAction(mCapEye, "Disappear");
+
+    if (al::isActionEnd(mCapEye))
+        al::setNerve(this, &Dead);
+}
+
+void PlayerCapManHeroEyesControl::exeDead() {
+    if (mCapEye)
+        mCapEye->kill();
+}
+
+void PlayerCapManHeroEyesControl::exeDemo() {}

--- a/src/Player/PlayerCapManHeroEyesControl.h
+++ b/src/Player/PlayerCapManHeroEyesControl.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerCapManHeroEyesControl : public al::NerveExecutor {
+public:
+    PlayerCapManHeroEyesControl(const char* name, al::LiveActor* puppetEye,
+                                al::LiveActor* normal2DEye);
+
+    void start();
+    void fastStart();
+    void end();
+    void startPuppet();
+    void endPuppet();
+    void kill();
+    void update();
+    al::LiveActor* getPuppetEye() const;
+    bool isAppear() const;
+    bool isDisappear() const;
+    bool isDemo() const;
+    bool isDeadCap() const;
+    void requestWaitAnimChange(const char* actionName);
+    void exeAppear();
+    void exeWait();
+    void exeDisappear();
+    void exeDead();
+    void exeDemo();
+
+private:
+    al::LiveActor* mPuppetEye;
+    al::LiveActor* mNormal2DEye;
+};
+
+static_assert(sizeof(PlayerCapManHeroEyesControl) == 0x20);

--- a/src/Player/PlayerCapManHeroEyesControl.h
+++ b/src/Player/PlayerCapManHeroEyesControl.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerCapManHeroEyesControl : public al::NerveExecutor {
+public:
+    PlayerCapManHeroEyesControl(const char* name, al::LiveActor* capEye, al::LiveActor* capEye2D);
+
+    void start();
+    void fastStart();
+    void end();
+    void startPuppet();
+    void endPuppet();
+    void kill();
+    void update();
+    al::LiveActor* getPuppetEye() const;
+    bool isAppear() const;
+    bool isDisappear() const;
+    bool isDemo() const;
+    bool isDeadCap() const;
+    void requestWaitAnimChange(const char* actionName);
+    void exeAppear();
+    void exeWait();
+    void exeDisappear();
+    void exeDead();
+    void exeDemo();
+
+private:
+    al::LiveActor* mCapEye;
+    al::LiveActor* mCapEye2D;
+};
+
+static_assert(sizeof(PlayerCapManHeroEyesControl) == 0x20);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1076)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (befc651 - 0002573)

📈 **Matched code**: 15.42% (+0.01%, +1468 bytes)

<details>
<summary>✅ 25 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::fastStart()` | +144 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::PlayerCapManHeroEyesControl(char const*, al::LiveActor*, al::LiveActor*)` | +116 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `(anonymous namespace)::PlayerCapManHeroEyesControlNrvAppear::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::endPuppet()` | +92 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::exeAppear()` | +92 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `(anonymous namespace)::PlayerCapManHeroEyesControlNrvDisappear::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::exeDisappear()` | +88 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::start()` | +84 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::requestWaitAnimChange(char const*)` | +84 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::startPuppet()` | +80 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::isDisappear() const` | +76 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::kill()` | +72 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::isAppear() const` | +72 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `(anonymous namespace)::PlayerCapManHeroEyesControlNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::exeWait()` | +60 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::~PlayerCapManHeroEyesControl()` | +36 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `(anonymous namespace)::PlayerCapManHeroEyesControlNrvDead::execute(al::NerveKeeper*) const` | +28 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::end()` | +24 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::exeDead()` | +24 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::isDemo() const` | +12 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::isDeadCap() const` | +12 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::getPuppetEye() const` | +8 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::update()` | +4 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `PlayerCapManHeroEyesControl::exeDemo()` | +4 | 0.00% | 100.00% |
| `Player/PlayerCapManHeroEyesControl` | `(anonymous namespace)::PlayerCapManHeroEyesControlNrvDemo::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->