### PR TITLE
Enemy: Implement `Bomb`

### DIFF
--- a/src/Enemy/Bomb.cpp
+++ b/src/Enemy/Bomb.cpp
@@ -1,0 +1,111 @@
+#include "Enemy/Bomb.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(Bomb, Wait);
+NERVE_IMPL(Bomb, Trampled);
+NERVE_IMPL(Bomb, WhipHold);
+NERVE_IMPL(Bomb, Explosion);
+NERVE_IMPL(Bomb, Throw);
+
+NERVES_MAKE_STRUCT(Bomb, Wait, Trampled, WhipHold, Explosion, Throw);
+}  // namespace
+
+Bomb::Bomb(const char* name) : al::LiveActor(name) {}
+
+void Bomb::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "Bomb", nullptr);
+    al::initNerve(this, &NrvBomb.Wait, 0);
+    makeActorAlive();
+}
+
+void Bomb::appearWithMsg(const al::LiveActor* actor, const al::SensorMsg* message) {
+    al::copyPose(this, actor);
+    al::resetPosition(this);
+    appear();
+
+    if (al::isMsgPlayerTrample(message)) {
+        al::setNerve(this, &NrvBomb.Trampled);
+        return;
+    }
+
+    if (rs::isMsgWhipHold(message)) {
+        rs::tryInitWhipTarget(message, al::getHitSensor(this, "Body"), nullptr);
+        al::setNerve(this, &NrvBomb.WhipHold);
+        return;
+    }
+
+    al::setNerve(this, &NrvBomb.Wait);
+}
+
+void Bomb::exeWait() {}
+
+void Bomb::exeTrampled() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "TrampledDefault");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvBomb.Wait);
+}
+
+void Bomb::exeWhipHold() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "TrampledDefault");
+}
+
+void Bomb::exeThrow() {
+    al::addVelocityToGravity(this, 1.5f);
+
+    if (!al::isLessStep(this, 5) && al::isCollided(this))
+        al::setNerve(this, &NrvBomb.Explosion);
+}
+
+void Bomb::exeExplosion() {
+    if (al::isFirstStep(this)) {
+        al::hideModelIfShow(this);
+        al::setVelocityZero(this);
+        al::offCollide(this);
+        al::startHitReaction(this, "爆発");
+        al::invalidateHitSensors(this);
+        al::validateHitSensor(this, "ExplosionPlayer");
+    }
+
+    kill();
+}
+
+void Bomb::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvBomb.Throw)) {
+        if (al::isSensorName(self, "Body") && al::sendMsgExplosion(other, self, nullptr))
+            al::setNerve(this, &NrvBomb.Explosion);
+    } else if (al::isNerve(this, &NrvBomb.Explosion) && al::isSensorName(self, "ExplosionPlayer")) {
+        al::sendMsgExplosion(other, self, nullptr);
+    }
+}
+
+bool Bomb::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    sead::Vector3f whipThrowDir;
+
+    if (!rs::isMsgWhipThrow(message) || !rs::tryGetWhipThrowDir(&whipThrowDir, message))
+        return false;
+
+    al::setVelocityToDirection(this, whipThrowDir, 40.0f);
+    al::addVelocityToGravity(this, -35.0f);
+    al::invalidateClipping(this);
+    al::setNerve(this, &NrvBomb.Throw);
+    return true;
+}

--- a/src/Enemy/Bomb.cpp
+++ b/src/Enemy/Bomb.cpp
@@ -1,0 +1,111 @@
+#include "Enemy/Bomb.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(Bomb, Wait);
+NERVE_IMPL(Bomb, Trampled);
+NERVE_IMPL(Bomb, WhipHold);
+NERVE_IMPL(Bomb, Explosion);
+NERVE_IMPL(Bomb, Throw);
+
+NERVES_MAKE_STRUCT(Bomb, Wait, Trampled, WhipHold, Explosion, Throw);
+}  // namespace
+
+Bomb::Bomb(const char* name) : al::LiveActor(name) {}
+
+void Bomb::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "Bomb", nullptr);
+    al::initNerve(this, &NrvBomb.Wait, 0);
+    makeActorAlive();
+}
+
+void Bomb::appearWithMsg(const al::LiveActor* actor, const al::SensorMsg* message) {
+    al::copyPose(this, actor);
+    al::resetPosition(this);
+    appear();
+
+    if (al::isMsgPlayerTrample(message)) {
+        al::setNerve(this, &NrvBomb.Trampled);
+        return;
+    }
+
+    if (rs::isMsgWhipHold(message)) {
+        rs::tryInitWhipTarget(message, al::getHitSensor(this, "Body"), nullptr);
+        al::setNerve(this, &NrvBomb.WhipHold);
+        return;
+    }
+
+    al::setNerve(this, &NrvBomb.Wait);
+}
+
+void Bomb::exeWait() {}
+
+void Bomb::exeTrampled() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "TrampledDefault");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvBomb.Wait);
+}
+
+void Bomb::exeWhipHold() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "TrampledDefault");
+}
+
+void Bomb::exeThrow() {
+    al::addVelocityToGravity(this, 1.5f);
+
+    if (!al::isLessStep(this, 5) && al::isCollided(this))
+        al::setNerve(this, &NrvBomb.Explosion);
+}
+
+void Bomb::exeExplosion() {
+    if (al::isFirstStep(this)) {
+        al::hideModelIfShow(this);
+        al::setVelocityZero(this);
+        al::offCollide(this);
+        al::startHitReaction(this, "爆発");
+        al::invalidateHitSensors(this);
+        al::validateHitSensor(this, "ExplosionPlayer");
+    }
+
+    kill();
+}
+
+void Bomb::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvBomb.Throw)) {
+        if (al::isSensorName(self, "Body") && al::sendMsgExplosion(other, self, nullptr))
+            al::setNerve(this, &NrvBomb.Explosion);
+    } else if (al::isNerve(this, &NrvBomb.Explosion) && al::isSensorName(self, "ExplosionPlayer")) {
+        al::sendMsgExplosion(other, self, nullptr);
+    }
+}
+
+bool Bomb::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    sead::Vector3f whipThrowDir;
+
+    if (rs::isMsgWhipThrow(message) && rs::tryGetWhipThrowDir(&whipThrowDir, message)) {
+        al::setVelocityToDirection(this, whipThrowDir, 40.0f);
+        al::addVelocityToGravity(this, -35.0f);
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvBomb.Throw);
+        return true;
+    }
+    return false;
+}

--- a/src/Enemy/Bomb.h
+++ b/src/Enemy/Bomb.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class Bomb : public al::LiveActor {
+public:
+    Bomb(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void appearWithMsg(const al::LiveActor* actor, const al::SensorMsg* message);
+    void exeWait();
+    void exeTrampled();
+    void exeWhipHold();
+    void exeThrow();
+    void exeExplosion();
+};
+
+static_assert(sizeof(Bomb) == 0x108);

--- a/src/Enemy/Bomb.h
+++ b/src/Enemy/Bomb.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class Bomb : public al::LiveActor {
+public:
+    Bomb(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void appearWithMsg(const al::LiveActor* actor, const al::SensorMsg* message);
+    void exeWait();
+    void exeTrampled();
+    void exeWhipHold();
+    void exeThrow();
+    void exeExplosion();
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1077)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0524374 - df9e585)

📈 **Matched code**: 14.87% (+0.01%, +1480 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/Bomb` | `Bomb::attackSensor(al::HitSensor*, al::HitSensor*)` | +192 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::appearWithMsg(al::LiveActor const*, al::SensorMsg const*)` | +160 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +144 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::Bomb(char const*)` | +132 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::Bomb(char const*)` | +120 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::exeExplosion()` | +112 | 0.00% | 100.00% |
| `Enemy/Bomb` | `(anonymous namespace)::BombNrvThrow::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::exeThrow()` | +92 | 0.00% | 100.00% |
| `Enemy/Bomb` | `(anonymous namespace)::BombNrvTrampled::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::exeTrampled()` | +88 | 0.00% | 100.00% |
| `Enemy/Bomb` | `(anonymous namespace)::BombNrvWhipHold::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::exeWhipHold()` | +60 | 0.00% | 100.00% |
| `Enemy/Bomb` | `(anonymous namespace)::BombNrvExplosion::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/Bomb` | `Bomb::exeWait()` | +4 | 0.00% | 100.00% |
| `Enemy/Bomb` | `(anonymous namespace)::BombNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->