### PR TITLE
Event: Implement `EventDemoCtrl`

### DIFF
--- a/src/Event/EventDemoCtrl.cpp
+++ b/src/Event/EventDemoCtrl.cpp
@@ -1,0 +1,305 @@
+#include "Event/EventDemoCtrl.h"
+
+#include "Util/DemoUtil.h"
+#include "Util/NpcEventFlowUtil.h"
+
+void endEventDemo(EventDemoCtrlInfo* info) {
+    switch (info->demoType) {
+    case EventDemoType::TalkOnlyRequester:
+    case EventDemoType::CutSceneTalkOnlyRequester:
+        rs::requestEndDemoNormalTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::TalkKeepHack:
+    case EventDemoType::CutSceneKeepHack:
+        rs::requestEndDemoKeepHackTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::Normal:
+        rs::requestEndDemoNormal(info->demoStartActor);
+        break;
+
+    case EventDemoType::Talk:
+    default:
+        rs::requestEndDemoWithPlayerKeepCarryTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::TalkUseCoin:
+        rs::requestEndDemoWithPlayerUseCoinTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::KeepBind:
+        rs::requestEndDemoWithPlayerKeepBindTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::CutScene:
+        rs::requestEndDemoWithPlayerCinemaFrameTalk(info->demoStartActor);
+        break;
+    }
+
+    info->demoType = EventDemoType::None;
+    info->demoStartActor = nullptr;
+    info->isRequestEndDemo = false;
+}
+
+EventDemoCtrl::EventDemoCtrl() {
+    mEventDemoInfo = new EventDemoCtrlInfo;
+}
+
+bool EventDemoCtrl::isSuccessLockTalkDemo(const al::LiveActor* actor) {
+    return mEventDemoInfo->lockTalkActor == actor;
+}
+
+bool EventDemoCtrl::tryLockStartTalkDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::isSuccessNpcEventBalloonMessage(actor))
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    info->lockTalkActor = actor;
+    return true;
+}
+
+bool EventDemoCtrl::tryLockStartTalkDemoWithoutBalloon(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    info->lockTalkActor = actor;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoWithPlayerKeepCarryTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::Talk;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoNormalTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkOnlyRequester;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkKeepHackDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoKeepHackTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkKeepHack;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkUseCoinDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoWithPlayerUseCoinTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkUseCoin;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartNormalDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    bool isSuccess = true;
+    if (!rs::requestStartDemoNormal(actor, true)) {
+        isSuccess = false;
+    } else {
+        info->demoType = EventDemoType::Normal;
+        info->demoStartActor = actor;
+        info->lockTalkActor = nullptr;
+        info->isRequestEndDemo = false;
+        info->isDemoSkipStart = false;
+    }
+
+    return isSuccess;
+}
+
+bool EventDemoCtrl::tryStartKeepBindDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoWithPlayerKeepBindTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::KeepBind;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoWithPlayerCinemaFrameTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutScene;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneKeepHackDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoKeepHackTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutSceneKeepHack;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoNormalTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutSceneTalkOnlyRequester;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+void EventDemoCtrl::requestEndDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneDemoBySkip(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+    endEventDemo(info);
+    info->isDemoSkipStart = false;
+}
+
+bool EventDemoCtrl::isActiveDemo() const {
+    return mEventDemoInfo->demoType != EventDemoType::None;
+}
+
+bool EventDemoCtrl::isActiveDemoWithPlayer() const {
+    return mEventDemoInfo->demoType == EventDemoType::Talk;
+}
+
+bool EventDemoCtrl::isRequestEndDemo() const {
+    return mEventDemoInfo->isRequestEndDemo != 0;
+}
+
+al::LiveActor* EventDemoCtrl::getDemoStartActor() const {
+    return mEventDemoInfo->demoStartActor;
+}
+
+void EventDemoCtrl::endDemo() {
+    endEventDemo(mEventDemoInfo);
+}
+
+bool EventDemoCtrl::isDemoStartActor(const al::LiveActor* actor) const {
+    return mEventDemoInfo->demoStartActor == actor;
+}
+
+void EventDemoCtrl::notifyStartDemoSkipFromScene() {
+    if (mEventDemoInfo->demoStartActor != nullptr)
+        mEventDemoInfo->isDemoSkipStart = true;
+}
+
+bool EventDemoCtrl::isDemoSkipStart() const {
+    return mEventDemoInfo->isDemoSkipStart != 0;
+}

--- a/src/Event/EventDemoCtrl.cpp
+++ b/src/Event/EventDemoCtrl.cpp
@@ -1,0 +1,302 @@
+#include "Event/EventDemoCtrl.h"
+
+#include "Util/DemoUtil.h"
+#include "Util/NpcEventFlowUtil.h"
+
+void endEventDemo(EventDemoCtrlInfo* info) {
+    switch (info->demoType) {
+    case EventDemoType::TalkOnlyRequester:
+    case EventDemoType::CutSceneTalkOnlyRequester:
+        rs::requestEndDemoNormalTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::TalkKeepHack:
+    case EventDemoType::CutSceneKeepHack:
+        rs::requestEndDemoKeepHackTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::Normal:
+        rs::requestEndDemoNormal(info->demoStartActor);
+        break;
+
+    case EventDemoType::TalkUseCoin:
+        rs::requestEndDemoWithPlayerUseCoinTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::KeepBind:
+        rs::requestEndDemoWithPlayerKeepBindTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::CutScene:
+        rs::requestEndDemoWithPlayerCinemaFrameTalk(info->demoStartActor);
+        break;
+
+    case EventDemoType::Talk:
+    default:
+        rs::requestEndDemoWithPlayerKeepCarryTalk(info->demoStartActor);
+        break;
+    }
+
+    info->demoType = EventDemoType::None;
+    info->demoStartActor = nullptr;
+    info->isRequestEndDemo = false;
+}
+
+EventDemoCtrl::EventDemoCtrl() {
+    mEventDemoInfo = new EventDemoCtrlInfo;
+}
+
+bool EventDemoCtrl::isSuccessLockTalkDemo(const al::LiveActor* actor) {
+    return mEventDemoInfo->lockTalkActor == actor;
+}
+
+bool EventDemoCtrl::tryLockStartTalkDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::isSuccessNpcEventBalloonMessage(actor))
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    info->lockTalkActor = actor;
+    return true;
+}
+
+bool EventDemoCtrl::tryLockStartTalkDemoWithoutBalloon(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    info->lockTalkActor = actor;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoWithPlayerKeepCarryTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::Talk;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoNormalTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkOnlyRequester;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkKeepHackDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoKeepHackTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkKeepHack;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartTalkUseCoinDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (!rs::requestStartDemoWithPlayerUseCoinTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::TalkUseCoin;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartNormalDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoNormal(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::Normal;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartKeepBindDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoWithPlayerKeepBindTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::KeepBind;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoWithPlayerCinemaFrameTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutScene;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneKeepHackDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoKeepHackTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutSceneKeepHack;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+bool EventDemoCtrl::tryStartCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+
+    if (info->lockTalkActor != nullptr)
+        return false;
+
+    if (rs::isActiveDemo(actor))
+        return false;
+
+    if (info->demoType != EventDemoType::None)
+        return false;
+
+    if (!rs::requestStartDemoNormalTalk(actor, true))
+        return false;
+
+    info->demoType = EventDemoType::CutSceneTalkOnlyRequester;
+    info->demoStartActor = actor;
+    info->lockTalkActor = nullptr;
+    info->isRequestEndDemo = false;
+    info->isDemoSkipStart = false;
+    return true;
+}
+
+void EventDemoCtrl::requestEndDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    mEventDemoInfo->isRequestEndDemo = true;
+}
+
+void EventDemoCtrl::endCutSceneDemoBySkip(al::LiveActor* actor) {
+    EventDemoCtrlInfo* info = mEventDemoInfo;
+    endEventDemo(info);
+    info->isDemoSkipStart = false;
+}
+
+bool EventDemoCtrl::isActiveDemo() const {
+    return mEventDemoInfo->demoType != EventDemoType::None;
+}
+
+bool EventDemoCtrl::isActiveDemoWithPlayer() const {
+    return mEventDemoInfo->demoType == EventDemoType::Talk;
+}
+
+bool EventDemoCtrl::isRequestEndDemo() const {
+    return mEventDemoInfo->isRequestEndDemo;
+}
+
+al::LiveActor* EventDemoCtrl::getDemoStartActor() const {
+    return mEventDemoInfo->demoStartActor;
+}
+
+void EventDemoCtrl::endDemo() {
+    endEventDemo(mEventDemoInfo);
+}
+
+bool EventDemoCtrl::isDemoStartActor(const al::LiveActor* actor) const {
+    return mEventDemoInfo->demoStartActor == actor;
+}
+
+void EventDemoCtrl::notifyStartDemoSkipFromScene() {
+    if (mEventDemoInfo->demoStartActor != nullptr)
+        mEventDemoInfo->isDemoSkipStart = true;
+}
+
+bool EventDemoCtrl::isDemoSkipStart() const {
+    return mEventDemoInfo->isDemoSkipStart;
+}

--- a/src/Event/EventDemoCtrl.h
+++ b/src/Event/EventDemoCtrl.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class LiveActor;
+}
+
+enum class EventDemoType : s32 {
+    None = 0,
+    Normal = 1,
+    Talk = 2,
+    TalkOnlyRequester = 3,
+    TalkKeepHack = 4,
+    TalkUseCoin = 5,
+    KeepBind = 6,
+    CutScene = 7,
+    CutSceneKeepHack = 8,
+    CutSceneTalkOnlyRequester = 9,
+};
+
+struct EventDemoCtrlInfo {
+    EventDemoType demoType = EventDemoType::None;
+    al::LiveActor* demoStartActor = nullptr;
+    const al::LiveActor* lockTalkActor = nullptr;
+    u8 isRequestEndDemo = false;
+    u8 isDemoSkipStart = false;
+};
+
+static_assert(sizeof(EventDemoCtrlInfo) == 0x20);
+
+class EventDemoCtrl : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_EventDemoCtrl;
+
+    EventDemoCtrl();
+
+    const char* getSceneObjName() const override { return "イベントデモ操作"; }
+
+    bool isSuccessLockTalkDemo(const al::LiveActor* actor);
+    bool tryLockStartTalkDemo(al::LiveActor* actor);
+    bool tryLockStartTalkDemoWithoutBalloon(al::LiveActor* actor);
+    bool tryStartTalkDemo(al::LiveActor* actor);
+    bool tryStartTalkOnlyRequesterDemo(al::LiveActor* actor);
+    bool tryStartTalkKeepHackDemo(al::LiveActor* actor);
+    bool tryStartTalkUseCoinDemo(al::LiveActor* actor);
+    bool tryStartNormalDemo(al::LiveActor* actor);
+    bool tryStartKeepBindDemo(al::LiveActor* actor);
+    bool tryStartCutSceneDemo(al::LiveActor* actor);
+    bool tryStartCutSceneKeepHackDemo(al::LiveActor* actor);
+    bool tryStartCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor);
+    void requestEndDemo(al::LiveActor* actor);
+    void endCutSceneDemo(al::LiveActor* actor);
+    void endCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor);
+    void endCutSceneDemoBySkip(al::LiveActor* actor);
+    bool isActiveDemo() const;
+    bool isActiveDemoWithPlayer() const;
+    bool isRequestEndDemo() const;
+    al::LiveActor* getDemoStartActor() const;
+    void endDemo();
+    bool isDemoStartActor(const al::LiveActor* actor) const;
+    void notifyStartDemoSkipFromScene();
+    bool isDemoSkipStart() const;
+
+private:
+    EventDemoCtrlInfo* mEventDemoInfo = nullptr;
+};
+
+static_assert(sizeof(EventDemoCtrl) == 0x10, "EventDemoCtrl");

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -21,6 +21,7 @@ void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorI
                            const char* name);
 void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
+bool isSuccessNpcEventBalloonMessage(const al::LiveActor*);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1078)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c4d724d - defab2c)

📈 **Matched code**: 15.14% (+0.01%, +1488 bytes)

<details>
<summary>✅ 28 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventDemoCtrl` | `endEventDemo(EventDemoCtrlInfo*)` | +156 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartNormalDemo(al::LiveActor*)` | +112 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartKeepBindDemo(al::LiveActor*)` | +104 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartCutSceneDemo(al::LiveActor*)` | +104 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartCutSceneKeepHackDemo(al::LiveActor*)` | +104 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartCutSceneTalkOnlyRequesterDemo(al::LiveActor*)` | +104 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryLockStartTalkDemo(al::LiveActor*)` | +88 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryLockStartTalkDemoWithoutBalloon(al::LiveActor*)` | +76 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartTalkDemo(al::LiveActor*)` | +76 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartTalkOnlyRequesterDemo(al::LiveActor*)` | +76 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartTalkKeepHackDemo(al::LiveActor*)` | +76 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::tryStartTalkUseCoinDemo(al::LiveActor*)` | +76 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::EventDemoCtrl()` | +68 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::endCutSceneDemoBySkip(al::LiveActor*)` | +40 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::notifyStartDemoSkipFromScene()` | +24 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isSuccessLockTalkDemo(al::LiveActor const*)` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isActiveDemo() const` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isActiveDemoWithPlayer() const` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isRequestEndDemo() const` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isDemoStartActor(al::LiveActor const*) const` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::isDemoSkipStart() const` | +20 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::requestEndDemo(al::LiveActor*)` | +16 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::endCutSceneDemo(al::LiveActor*)` | +16 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::endCutSceneTalkOnlyRequesterDemo(al::LiveActor*)` | +16 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::getDemoStartActor() const` | +12 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::endDemo()` | +8 | 0.00% | 100.00% |
| `Event/EventDemoCtrl` | `EventDemoCtrl::~EventDemoCtrl()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->