### PR TITLE
Layout: Implement MapSeaOfTreeIcon

### DIFF
--- a/src/Layout/MapSeaOfTreeIcon.cpp
+++ b/src/Layout/MapSeaOfTreeIcon.cpp
@@ -1,0 +1,117 @@
+#include "Layout/MapSeaOfTreeIcon.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(MapSeaOfTreeIcon, Wait);
+NERVE_IMPL(MapSeaOfTreeIcon, Appear);
+NERVE_IMPL(MapSeaOfTreeIcon, End);
+NERVE_IMPL(MapSeaOfTreeIcon, Dead);
+
+NERVES_MAKE_NOSTRUCT(MapSeaOfTreeIcon, Wait, Appear, End, Dead);
+
+inline void preserveIconTypeGuardOrder(s32& nextIconType, s32& iconTypeNext) {
+    asm("" : "+r"(nextIconType), "+r"(iconTypeNext));
+}
+}  // namespace
+
+MapSeaOfTreeIcon::MapSeaOfTreeIcon(const al::LayoutInitInfo& initInfo) : al::LayoutActor("[") {
+    initNerve(&Wait);
+    al::initLayoutActor(this, initInfo, "MapIconUnclear");
+    kill();
+}
+
+void MapSeaOfTreeIcon::appearHint0Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::appearHint1Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::appearHint2Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::end() {
+    al::setNerve(this, &End);
+}
+
+bool MapSeaOfTreeIcon::trySetIconType(SeaOfTreeIconType iconType) {
+    volatile s32 iconTypeLocal = iconType;
+    s32 currentIconType = mCurrentIconType;
+    s32 iconTypeCurrent = iconTypeLocal;
+
+    if (currentIconType == iconTypeCurrent)
+        return false;
+
+    if (currentIconType == Value_2) {
+        mCurrentIconType = iconTypeCurrent;
+        return true;
+    }
+
+    s32 nextIconType = mNextIconType;
+    s32 iconTypeNext = iconTypeLocal;
+
+    preserveIconTypeGuardOrder(nextIconType, iconTypeNext);
+
+    if (nextIconType == iconTypeNext)
+        return false;
+
+    if (nextIconType == Value_2) {
+        mCurrentIconType = iconTypeNext;
+        return true;
+    }
+
+    return false;
+}
+
+void MapSeaOfTreeIcon::resetIconType() {
+    mCurrentIconType = Value_2;
+    mNextIconType = Value_2;
+}
+
+void MapSeaOfTreeIcon::getHint1LayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Hint00");
+}
+
+void MapSeaOfTreeIcon::getHint2LayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Hint01");
+}
+
+void MapSeaOfTreeIcon::getPlayerLayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Player");
+}
+
+void MapSeaOfTreeIcon::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void MapSeaOfTreeIcon::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MapSeaOfTreeIcon::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Dead);
+}
+
+void MapSeaOfTreeIcon::exeDead() {
+    kill();
+}

--- a/src/Layout/MapSeaOfTreeIcon.cpp
+++ b/src/Layout/MapSeaOfTreeIcon.cpp
@@ -1,0 +1,109 @@
+#include "Layout/MapSeaOfTreeIcon.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(MapSeaOfTreeIcon, Wait);
+NERVE_IMPL(MapSeaOfTreeIcon, Appear);
+NERVE_IMPL(MapSeaOfTreeIcon, End);
+NERVE_IMPL(MapSeaOfTreeIcon, Dead);
+
+NERVES_MAKE_NOSTRUCT(MapSeaOfTreeIcon, Wait, Appear, End, Dead);
+}  // namespace
+
+MapSeaOfTreeIcon::MapSeaOfTreeIcon(const al::LayoutInitInfo& initInfo) : al::LayoutActor("[") {
+    initNerve(&Wait);
+    al::initLayoutActor(this, initInfo, "MapIconUnclear");
+    kill();
+}
+
+void MapSeaOfTreeIcon::appearHint0Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::appearHint1Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::appearHint2Mode() {
+    appear();
+    al::startAction(this, "Hint2", "State");
+    al::setNerve(this, &Appear);
+}
+
+void MapSeaOfTreeIcon::end() {
+    al::setNerve(this, &End);
+}
+
+// NONMATCHING: https://decomp.me/scratch/keMrY
+bool MapSeaOfTreeIcon::trySetIconType(SeaOfTreeIconType iconType) {
+    volatile s32 iconTypeLocal = iconType;
+    s32 currentIconType = mCurrentIconType;
+    s32 iconTypeCurrent = iconTypeLocal;
+
+    if (currentIconType == iconTypeCurrent)
+        return false;
+
+    if (currentIconType == Value_2) {
+        mCurrentIconType = iconTypeCurrent;
+        return true;
+    }
+
+    s32 nextIconType = mNextIconType;
+    s32 iconTypeNext = iconTypeLocal;
+
+    if (nextIconType == iconTypeNext || nextIconType == Value_2) {
+        mCurrentIconType = iconTypeNext;
+        return true;
+    }
+
+    return false;
+}
+
+void MapSeaOfTreeIcon::resetIconType() {
+    mCurrentIconType = Value_2;
+    mNextIconType = Value_2;
+}
+
+void MapSeaOfTreeIcon::getHint1LayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Hint00");
+}
+
+void MapSeaOfTreeIcon::getHint2LayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Hint01");
+}
+
+void MapSeaOfTreeIcon::getPlayerLayoutPos(sead::Vector3f* trans) const {
+    *trans = al::getPaneLocalTrans(this, "Player");
+}
+
+void MapSeaOfTreeIcon::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void MapSeaOfTreeIcon::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MapSeaOfTreeIcon::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Dead);
+}
+
+void MapSeaOfTreeIcon::exeDead() {
+    kill();
+}

--- a/src/Layout/MapSeaOfTreeIcon.h
+++ b/src/Layout/MapSeaOfTreeIcon.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class MapSeaOfTreeIcon : public al::LayoutActor {
+public:
+    enum SeaOfTreeIconType : s32 {
+        Value_0 = 0,
+        Value_1 = 1,
+        Value_2 = 2,
+    };
+
+    MapSeaOfTreeIcon(const al::LayoutInitInfo& initInfo);
+
+    void appearHint0Mode();
+    void appearHint1Mode();
+    void appearHint2Mode();
+    void end();
+    bool trySetIconType(SeaOfTreeIconType iconType);
+    void resetIconType();
+    void getHint1LayoutPos(sead::Vector3f* trans) const;
+    void getHint2LayoutPos(sead::Vector3f* trans) const;
+    void getPlayerLayoutPos(sead::Vector3f* trans) const;
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void exeDead();
+
+private:
+    s32 mCurrentIconType = Value_2;
+    s32 mNextIconType = Value_2;
+};
+
+static_assert(sizeof(MapSeaOfTreeIcon) == 0x138);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1079)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (774e056 - 17b0b21)

📈 **Matched code**: 14.87% (+0.01%, +1400 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::MapSeaOfTreeIcon(al::LayoutInitInfo const&)` | +200 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::MapSeaOfTreeIcon(al::LayoutInitInfo const&)` | +196 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `(anonymous namespace)::MapSeaOfTreeIconNrvAppear::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `(anonymous namespace)::MapSeaOfTreeIconNrvEnd::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::exeAppear()` | +100 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::exeEnd()` | +100 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::appearHint0Mode()` | +80 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::appearHint1Mode()` | +80 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::appearHint2Mode()` | +80 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `(anonymous namespace)::MapSeaOfTreeIconNrvWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::exeWait()` | +64 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::getHint1LayoutPos(sead::Vector3<float>*) const` | +56 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::getHint2LayoutPos(sead::Vector3<float>*) const` | +56 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::getPlayerLayoutPos(sead::Vector3<float>*) const` | +56 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::resetIconType()` | +16 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `(anonymous namespace)::MapSeaOfTreeIconNrvDead::execute(al::NerveKeeper*) const` | +16 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::end()` | +12 | 0.00% | 100.00% |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::exeDead()` | +12 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Layout/MapSeaOfTreeIcon` | `MapSeaOfTreeIcon::trySetIconType(MapSeaOfTreeIcon::SeaOfTreeIconType)` | +24 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->