### PR TITLE
MapObj: Implement `GrowSeedStateRevival`

### DIFF
--- a/src/MapObj/GrowSeedStateRevival.cpp
+++ b/src/MapObj/GrowSeedStateRevival.cpp
@@ -1,0 +1,63 @@
+#include "MapObj/GrowSeedStateRevival.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/GrowSeedUtil.h"
+
+namespace {
+NERVE_IMPL(GrowSeedStateRevival, RevivalWait);
+NERVE_IMPL(GrowSeedStateRevival, Revival);
+
+NERVES_MAKE_NOSTRUCT(GrowSeedStateRevival, RevivalWait, Revival);
+}  // namespace
+
+GrowSeedStateRevival::GrowSeedStateRevival(const char* name, al::LiveActor* actor,
+                                           sead::Quatf* quat)
+    : al::ActorStateBase(name, actor), mRevivalQuat(quat) {
+    mRevivalTrans.set(al::getTrans(mActor));
+
+    initNerve(&RevivalWait, 0);
+}
+
+void GrowSeedStateRevival::appear() {
+    al::NerveStateBase::appear();
+    al::invalidateClipping(mActor);
+    al::invalidateHitSensors(mActor);
+    al::setNerve(this, &RevivalWait);
+}
+
+void GrowSeedStateRevival::kill() {
+    al::NerveStateBase::kill();
+    al::validateHitSensors(mActor);
+}
+
+void GrowSeedStateRevival::exeRevivalWait() {
+    if (al::isFirstStep(mActor)) {
+        al::hideModelIfShow(mActor);
+        al::setVelocityZero(mActor);
+        al::offCollide(mActor);
+    }
+
+    if (al::isGreaterEqualStep(mActor, 300)) {
+        al::setTrans(mActor, mRevivalTrans);
+        mRevivalQuat->set(sead::Quatf::unit);
+        GrowSeedUtil::rotateRandom(mRevivalQuat);
+        al::setNerve(this, &Revival);
+    }
+}
+
+void GrowSeedStateRevival::exeRevival() {
+    al::showModelIfHide(mActor);
+    al::startHitReaction(mActor, "復活");
+    al::onCollide(mActor);
+    kill();
+}

--- a/src/MapObj/GrowSeedStateRevival.h
+++ b/src/MapObj/GrowSeedStateRevival.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class GrowSeedStateRevival : public al::ActorStateBase {
+public:
+    GrowSeedStateRevival(const char* name, al::LiveActor* actor, sead::Quatf* quat);
+
+    void appear() override;
+    void kill() override;
+
+    void exeRevivalWait();
+    void exeRevival();
+
+private:
+    sead::Vector3f mRevivalTrans = sead::Vector3f::zero;
+    sead::Quatf* mRevivalQuat;
+};
+
+static_assert(sizeof(GrowSeedStateRevival) == 0x38);

--- a/src/MapObj/GrowSeedUtil.h
+++ b/src/MapObj/GrowSeedUtil.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+class HitSensor;
+class LiveActor;
+}  // namespace al
+
+class GrowSeedStateWait;
+
+namespace GrowSeedUtil {
+
+const char* getGuideLabelName();
+bool isInDeathArea(const al::LiveActor*);
+void throwToDirection(al::LiveActor*, const sead::Vector3f&, f32);
+void throwFromPlayer(al::LiveActor*, f32, f32);
+f32 getPlantPartsAddRadius();
+void rotateRandom(sead::Quatf*);
+void rotateRandomY(sead::Quatf*);
+void setVelocityForBlow(al::LiveActor*, al::HitSensor*, al::HitSensor*, f32, f32, f32);
+void setVelocityForReflect(al::LiveActor*, f32, f32);
+bool checkStrikeArrowBetweenPlayer(al::LiveActor*);
+bool tryEmitEffectWaterSurface(bool, sead::Vector3f*, al::LiveActor*);
+void prepareKillByShineGet(al::LiveActor*, const sead::Vector3f&);
+bool isEnableSeedAttackSpeed(const al::LiveActor*, GrowSeedStateWait*, GrowSeedStateWait*, f32);
+
+}  // namespace GrowSeedUtil


### PR DESCRIPTION
<!-- decomp.dev report start -->
### Report for 1.0 (befc651 - 3e0aef8)

📈 **Matched code**: 15.41% (+0.00%, +536 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::exeRevivalWait()` | +152 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::GrowSeedStateRevival(char const*, al::LiveActor*, sead::Quat<float>*)` | +120 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::exeRevival()` | +72 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `(anonymous namespace)::GrowSeedStateRevivalNrvRevival::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::appear()` | +60 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::~GrowSeedStateRevival()` | +36 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `GrowSeedStateRevival::kill()` | +16 | 0.00% | 100.00% |
| `MapObj/GrowSeedStateRevival` | `(anonymous namespace)::GrowSeedStateRevivalNrvRevivalWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1081)
<!-- Reviewable:end -->
