### PR TITLE
Library/Event: Implement EventFlowUtil

### DIFF
--- a/lib/al/Library/Event/EventFlowActorParamHolder.h
+++ b/lib/al/Library/Event/EventFlowActorParamHolder.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ByamlIter;
+
+struct EventFlowActorParam {
+    const char* actionName = nullptr;
+    f32 moveSpeed = 2.0f;
+    f32 turnSpeedDegree = 3.5f;
+};
+
+class EventFlowActorParamHolder {
+public:
+    EventFlowActorParamHolder();
+
+    void load(const ByamlIter&);
+    const EventFlowActorParam* findSuffixParam(const char*) const;
+
+    const EventFlowActorParam* getDefaultParam() const { return mDefaultParam; }
+
+private:
+    EventFlowActorParam* mDefaultParam = nullptr;
+    EventFlowActorParam* mSubActorParams = nullptr;
+    s32 mSubActorParamCount = 0;
+};
+
+static_assert(sizeof(EventFlowActorParam) == 0x10);
+static_assert(sizeof(EventFlowActorParamHolder) == 0x18);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -6,9 +6,18 @@
 
 namespace al {
 class CameraTicket;
+class BalloonOrderGroup;
+class EventFlowActorTerritory;
+struct EventFlowActorParam;
 class LiveActor;
 class EventFlowEventData;
+class EventFlowMovement;
+class EventFlowRequestInfo;
+class EventFlowScareCtrlBase;
+class EventFlowWatchParam;
+class IEventFlowEventReceiver;
 class IUseCamera;
+struct EventFlowExecutorState;
 
 class EventFlowDataHolder {
 public:
@@ -37,6 +46,59 @@ public:
     void endAllEventCamera(IUseCamera*);
     bool isEndInterpoleCamera(const IUseCamera*, const char*) const;
     bool isPlayingEventAnimCamera(const char*) const;
+
+    EventFlowRequestInfo* getRequestInfo() { return mRequestInfo; }
+
+    const EventFlowRequestInfo* getRequestInfo() const { return mRequestInfo; }
+
+    EventFlowExecutorState* getExecutorState() { return mExecutorState; }
+
+    const EventFlowExecutorState* getExecutorState() const { return mExecutorState; }
+
+    const EventFlowActorParam* getDefaultActorParam() const { return mDefaultActorParam; }
+
+    EventFlowWatchParam* getWatchParam() const { return mWatchParam; }
+
+    const sead::Vector3f& getActorFront() const { return mActorFront; }
+
+    bool isStopMovementByNode() const { return mIsStopMovementByNode; }
+
+    EventFlowActorTerritory* getTerritory() { return mTerritory; }
+
+    const EventFlowActorTerritory* getTerritory() const { return mTerritory; }
+
+    BalloonOrderGroup* getBalloonOrderGroup() const { return mBalloonOrderGroup; }
+
+    EventFlowScareCtrlBase* getScareCtrl() const { return mScareCtrl; }
+
+    void clearTalkSubActorName() { mTalkSubActorName = nullptr; }
+
+private:
+    EventFlowRequestInfo* mRequestInfo = nullptr;
+    void* _08 = nullptr;
+    EventFlowExecutorState* mExecutorState = nullptr;
+    EventFlowActorParam* mDefaultActorParam = nullptr;
+    EventFlowWatchParam* mWatchParam = nullptr;
+    sead::Vector3f mActorFront = sead::Vector3f::ez;
+    bool mIsStopMovementByNode = false;
+    u16 _36 = 0;
+    s32 mItemType = 0;
+    void* _40 = nullptr;
+    void* _48 = nullptr;
+    EventFlowActorTerritory* mTerritory = nullptr;
+    IEventFlowEventReceiver* mEventReceiver = nullptr;
+    EventFlowMovement* mMovement = nullptr;
+    EventFlowScareCtrlBase* mScareCtrl = nullptr;
+    void* mQueryJudge = nullptr;
+    void* mActionNameConverter = nullptr;
+    void* _80 = nullptr;
+    BalloonOrderGroup* mBalloonOrderGroup = nullptr;
+    sead::WFixedSafeString<32> mCharacterName = {u""};
+    void* _e8 = nullptr;
+    const char* mTalkSubActorName = nullptr;
+    void* _f8 = nullptr;
+    void* _100 = nullptr;
 };
 
+static_assert(sizeof(EventFlowDataHolder) == 0x108);
 }  // namespace al

--- a/lib/al/Library/Event/EventFlowExecutor.h
+++ b/lib/al/Library/Event/EventFlowExecutor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+
 #include "Library/Event/IUseEventFlowData.h"
 #include "Library/HostIO/HioNode.h"
 
@@ -11,6 +13,12 @@ class EventFlowNode;
 class EventFlowScareCtrlBase;
 class HitSensor;
 class LiveActor;
+
+struct EventFlowExecutorState {
+    bool isStopMovement = false;
+    bool isInvalidUiCollisionCheck = false;
+    bool hasLookAtJointCtrl = false;
+};
 
 class EventFlowExecutor : public HioNode, public IUseEventFlowData {
 public:
@@ -31,14 +39,27 @@ public:
 
     LiveActor* getActor() const { return mActor; }
 
+    const char* getCurrentEntryName() const { return mCurrentEntryName; }
+
+    EventFlowNode* getCurrentNode() const { return mCurrentNode; }
+
+    EventFlowMovement* getMovement() const { return mMovement; }
+
+    EventFlowExecutorState* getState() const { return mState; }
+
+    EventFlowScareCtrlBase* getScareCtrl() const { return mScareCtrl; }
+
 private:
-    LiveActor* mActor;
-    EventFlowChart* mEventFlowChart;
-    const char* mName;
-    EventFlowDataHolder* mEventFlowDataHolder;
-    EventFlowNode* mEventFlowNode;
-    EventFlowMovement* mEventFlowMovement;
-    void* _38;
-    EventFlowScareCtrlBase* mEventFlowScareCtrlBase;
+    LiveActor* mActor = nullptr;
+    EventFlowChart* mEventFlowChart = nullptr;
+    const char* mCurrentEntryName = nullptr;
+    EventFlowDataHolder* mEventFlowDataHolder = nullptr;
+    EventFlowNode* mCurrentNode = nullptr;
+    EventFlowMovement* mMovement = nullptr;
+    EventFlowExecutorState* mState = nullptr;
+    EventFlowScareCtrlBase* mScareCtrl = nullptr;
 };
+
+static_assert(sizeof(EventFlowExecutorState) == 0x3);
+static_assert(sizeof(EventFlowExecutor) == 0x48);
 }  // namespace al

--- a/lib/al/Library/Event/EventFlowNode.h
+++ b/lib/al/Library/Event/EventFlowNode.h
@@ -40,6 +40,8 @@ public:
 
     virtual const char* getNextEntry() const { return nullptr; }
 
+    const char* getName() const { return mName; }
+
     const MessageSystem* getMessageSystem() const override { return mMessageSystem; }
 
     NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
@@ -50,6 +52,8 @@ public:
     void execute();
 
     LiveActor* getActor() const { return mActor; }
+
+    SceneEventFlowMsg* getSceneEventFlowMsg() const { return mSceneEventFlowMsg; }
 
 private:
     LiveActor* mActor = nullptr;

--- a/lib/al/Library/Event/EventFlowScareCtrlBase.h
+++ b/lib/al/Library/Event/EventFlowScareCtrlBase.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class HitSensor;
+
+class EventFlowScareCtrlBase {
+public:
+    virtual bool isScare() const = 0;
+    virtual bool tryGetScareEnemyPos(sead::Vector3f*) const = 0;
+    virtual const char16* getScareMessage() const = 0;
+    virtual void update() = 0;
+    virtual void attackSensor(HitSensor* self, HitSensor* other) = 0;
+};
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowUtil.cpp
+++ b/lib/al/Library/Event/EventFlowUtil.cpp
@@ -1,0 +1,492 @@
+#include "Library/Event/EventFlowUtil.h"
+
+#include <math/seadQuat.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Event/BalloonOrderGroup.h"
+#include "Library/Event/EventFlowActorParamHolder.h"
+#include "Library/Event/EventFlowDataHolder.h"
+#include "Library/Event/EventFlowExecutor.h"
+#include "Library/Event/EventFlowNode.h"
+#include "Library/Event/EventFlowScareCtrlBase.h"
+#include "Library/Event/EventFlowWatchParam.h"
+#include "Library/Event/SceneEventFlowMsg.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Yaml/ByamlUtil.h"
+#include "Project/Event/EventFlowActorTerritory.h"
+#include "Project/Event/EventFlowEventData.h"
+
+namespace {
+const char16 EmptyScareMessage[] = {0};
+}
+
+namespace al {
+EventFlowRequestInfo::EventFlowRequestInfo() {
+    mIsDemoActionStarted = false;
+    mIsResetDemoPlayerDynamics = false;
+    mIsDemoCameraStarted = false;
+    mDemoActionName = nullptr;
+    mIsRequestShowDemoPlayer = false;
+    mIsHideDemoPlayer = false;
+    mIsRequestHideDemoPlayer = false;
+    mDemoCameraAnimName = nullptr;
+    mDemoTalkActionName = nullptr;
+    mPlayerDemoActionName = nullptr;
+}
+
+void EventFlowRequestInfo::reset() {
+    mIsDemoActionStarted = false;
+    mIsResetDemoPlayerDynamics = false;
+    mIsDemoCameraStarted = false;
+    mIsHideDemoPlayer = false;
+    mIsRequestHideDemoPlayer = false;
+    mDemoCameraAnimName = nullptr;
+    mDemoActionName = nullptr;
+    mDemoTalkActionName = nullptr;
+}
+
+__attribute__((noinline)) void EventFlowRequestInfo::requestDemoAction(const char* actionName) {
+    mDemoActionName = actionName;
+}
+
+__attribute__((noinline)) void EventFlowRequestInfo::requestDemoCamera(const char* cameraName) {
+    mDemoCameraAnimName = cameraName;
+}
+
+bool isNodeName(const EventFlowNode* node, const char* nodeName) {
+    return isEqualString(node->getName(), nodeName);
+}
+
+const char16* getScareMessage(const EventFlowNode* node) {
+    const IUseEventFlowData* eventFlowUser = node;
+    if (eventFlowUser->getEventFlowDataHolder()->getScareCtrl() == nullptr)
+        return EmptyScareMessage;
+    return eventFlowUser->getEventFlowDataHolder()->getScareCtrl()->getScareMessage();
+}
+
+void startEventCamera(EventFlowNode* node, const char* cameraName, s32 priority) {
+    IUseEventFlowData* eventFlowUser = node;
+    EventFlowDataHolder* holder = eventFlowUser->getEventFlowDataHolder();
+    LiveActor* actor = node->getActor();
+    IUseCamera* cameraUser = actor != nullptr ? static_cast<IUseCamera*>(actor) : nullptr;
+    holder->startEventCamera(cameraUser, cameraName, priority);
+}
+
+void startEventAnimCamera(EventFlowNode* node, const char* cameraName, const char* animName,
+                          s32 priority) {
+    IUseEventFlowData* eventFlowUser = node;
+    EventFlowDataHolder* holder = eventFlowUser->getEventFlowDataHolder();
+    LiveActor* actor = node->getActor();
+    IUseCamera* cameraUser = actor != nullptr ? static_cast<IUseCamera*>(actor) : nullptr;
+    holder->startEventAnimCamera(cameraUser, cameraName, animName, priority);
+}
+
+void endEventCamera(EventFlowNode* node, const char* cameraName, s32 priority, bool isInterpole) {
+    IUseEventFlowData* eventFlowUser = node;
+    EventFlowDataHolder* holder = eventFlowUser->getEventFlowDataHolder();
+    LiveActor* actor = node->getActor();
+    IUseCamera* cameraUser = actor != nullptr ? static_cast<IUseCamera*>(actor) : nullptr;
+    holder->endEventCamera(cameraUser, cameraName, priority, isInterpole);
+}
+
+bool tryEndEventCameraIfPlaying(EventFlowNode* node, const char* cameraName, s32 priority,
+                                bool isInterpole) {
+    IUseEventFlowData* eventFlowUser = node;
+    EventFlowDataHolder* holder = eventFlowUser->getEventFlowDataHolder();
+    LiveActor* actor = node->getActor();
+    IUseCamera* cameraUser = actor != nullptr ? static_cast<IUseCamera*>(actor) : nullptr;
+    return holder->tryEndEventCameraIfPlaying(cameraUser, cameraName, priority, isInterpole);
+}
+
+bool isEndInterpoleEventCamera(const EventFlowNode* node, const char* cameraName) {
+    const IUseEventFlowData* eventFlowUser = node;
+    const EventFlowDataHolder* holder = eventFlowUser->getEventFlowDataHolder();
+    const LiveActor* actor = node->getActor();
+    const IUseCamera* cameraUser =
+        actor != nullptr ? static_cast<const IUseCamera*>(actor) : nullptr;
+    return holder->isEndInterpoleCamera(cameraUser, cameraName);
+}
+
+bool isPlayingEventAnimCamera(const EventFlowNode* node, const char* cameraName) {
+    const IUseEventFlowData* eventFlowUser = node;
+    return eventFlowUser->getEventFlowDataHolder()->isPlayingEventAnimCamera(cameraName);
+}
+
+void requestDemoAction(EventFlowNode* node, const char* actionName, bool isResetPlayerDynamics) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->requestDemoAction(actionName);
+    if (isResetPlayerDynamics)
+        eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->setResetDemoPlayerDynamics();
+}
+
+void requestPlayerDemoAction(EventFlowNode* node, const char* actionName) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->setPlayerDemoActionName(actionName);
+}
+
+bool isEndDemoAction(const EventFlowNode* node) {
+    const IUseEventFlowData* eventFlowUser = node;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->getDemoActionName() ==
+           nullptr;
+}
+
+void setDemoTalkAction(EventFlowNode* node, const char* actionName) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->setDemoTalkActionName(actionName);
+}
+
+void resetDemoTalkAction(EventFlowNode* node) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->resetDemoTalkActionName();
+}
+
+void requestDemoCamera(EventFlowNode* node, const char* cameraName) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->requestDemoCamera(cameraName);
+}
+
+bool isEndRequestDemoCamera(const EventFlowNode* node) {
+    const IUseEventFlowData* eventFlowUser = node;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->getDemoCameraAnimName() ==
+           nullptr;
+}
+
+bool isHideDemoPlayer(const EventFlowNode* node) {
+    const IUseEventFlowData* eventFlowUser = node;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isHideDemoPlayer();
+}
+
+void requestHideDemoPlayer(EventFlowNode* node) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->requestHideDemoPlayer();
+}
+
+void requestShowDemoPlayer(EventFlowNode* node) {
+    IUseEventFlowData* eventFlowUser = node;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->requestShowDemoPlayer();
+}
+
+void calcPlayerWatchTrans(sead::Vector3f* outWatchTrans, const EventFlowNode* node) {
+    const IUseEventFlowData* eventFlowUser = node;
+    const EventFlowWatchParam* watchParam =
+        eventFlowUser->getEventFlowDataHolder()->getWatchParam();
+    const LiveActor* actor = node->getActor();
+
+    if (watchParam != nullptr) {
+        watchParam->calcWatchTrans(outWatchTrans, actor);
+        return;
+    }
+
+    const sead::Vector3f& actorTrans = getTrans(actor);
+    outWatchTrans->set(actorTrans);
+}
+
+void requestCommandCloseTalkMessageLayout(EventFlowNode* node) {
+    node->getSceneEventFlowMsg()->requestCommand("CloseTalkMessageLayout");
+}
+
+bool isActive(const EventFlowExecutor* executor) {
+    return executor->getCurrentEntryName() != nullptr && executor->getCurrentNode() != nullptr;
+}
+
+bool isScare(const IUseEventFlowData* user) {
+    if (user->getEventFlowDataHolder()->getScareCtrl() == nullptr)
+        return false;
+    return user->getEventFlowDataHolder()->getScareCtrl()->isScare();
+}
+
+bool tryGetScareEnemyPos(sead::Vector3f* outScareEnemyPos, const IUseEventFlowData* user) {
+    if (user->getEventFlowDataHolder()->getScareCtrl() == nullptr)
+        return false;
+    return user->getEventFlowDataHolder()->getScareCtrl()->tryGetScareEnemyPos(outScareEnemyPos);
+}
+
+void invalidateUiCollisionCheck(EventFlowExecutor* executor) {
+    executor->getState()->isInvalidUiCollisionCheck = true;
+}
+
+void onExistLookAtJointCtrl(EventFlowExecutor* executor) {
+    executor->getState()->hasLookAtJointCtrl = true;
+}
+
+void setTalkSubActorName(EventFlowExecutor* executor, const char* actorName) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->setTalkSubActorName(actorName);
+}
+
+void resetTalkSubActorName(EventFlowExecutor* executor) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->clearTalkSubActorName();
+}
+
+void startEventAction(LiveActor* actor, const IUseEventFlowData* user, const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    startAction(actor, eventActionName.cstr());
+}
+
+void makeEventActionName(sead::BufferedSafeStringBase<char>* outActionName,
+                         const IUseEventFlowData* user, const char* actionName) {
+    user->getEventFlowDataHolder()->convertActionName(outActionName, actionName);
+}
+
+void startEventActionAtRandomFrame(LiveActor* actor, const IUseEventFlowData* user,
+                                   const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    startAction(actor, eventActionName.cstr());
+
+    f32 randomFrame = getRandom(0.0f, getSklAnimFrameMax(actor, 0));
+    setSklAnimFrame(actor, randomFrame, 0);
+
+    if (isVisAnimPlayingForAction(actor)) {
+        if (getVisAnimFrameMaxForAction(actor) > 0.0f) {
+            f32 visAnimFrameMax = getVisAnimFrameMaxForAction(actor);
+            setVisAnimFrameForAction(actor,
+                                     modf(randomFrame + visAnimFrameMax, visAnimFrameMax) + 0.0f);
+        }
+    }
+}
+
+bool tryStartEventActionIfNotPlaying(LiveActor* actor, const IUseEventFlowData* user,
+                                     const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    return tryStartActionIfNotPlaying(actor, eventActionName.cstr());
+}
+
+bool isPlayingEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                          const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    return isActionPlaying(actor, eventActionName.cstr());
+}
+
+bool isExistEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                        const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    return isExistAction(actor, eventActionName.cstr());
+}
+
+bool isOneTimeEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                          const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    return isActionOneTime(actor, eventActionName.cstr());
+}
+
+f32 getEventActionFrameMax(const LiveActor* actor, const IUseEventFlowData* user,
+                           const char* actionName) {
+    StringTmp<128> eventActionName("");
+    user->getEventFlowDataHolder()->convertActionName(&eventActionName, actionName);
+    return getActionFrameMax(actor, eventActionName.cstr());
+}
+
+f32 getParamMoveSpeed(const IUseEventFlowData* user) {
+    return user->getEventFlowDataHolder()->getDefaultActorParam()->moveSpeed;
+}
+
+f32 getParamTurnSpeedDegree(const IUseEventFlowData* user) {
+    return user->getEventFlowDataHolder()->getDefaultActorParam()->turnSpeedDegree;
+}
+
+const sead::Vector3f& getRecordActorFront(const IUseEventFlowData* user) {
+    return user->getEventFlowDataHolder()->getActorFront();
+}
+
+void recordActorFront(IUseEventFlowData* user, const sead::Vector3f& front) {
+    user->getEventFlowDataHolder()->setActorFront(front);
+}
+
+bool checkInsideTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                             const sead::Vector3f& position, f32 radiusOffset) {
+    sead::Vector3f territoryPosition = {0.0f, 0.0f, 0.0f};
+    const EventFlowDataHolder* holder = user->getEventFlowDataHolder();
+    multVecPose(&territoryPosition, actor, holder->getTerritory()->getLocalOffset());
+
+    sead::Vector3f distance = territoryPosition - position;
+    return distance.length() <
+           user->getEventFlowDataHolder()->getTerritory()->getRadius() + radiusOffset;
+}
+
+bool checkInsideEmotionTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                                    const sead::Vector3f& position) {
+    sead::Vector3f territoryPosition = {0.0f, 0.0f, 0.0f};
+    const EventFlowDataHolder* holder = user->getEventFlowDataHolder();
+    multVecPose(&territoryPosition, actor, holder->getTerritory()->getLocalOffset());
+
+    sead::Vector3f distance = territoryPosition - position;
+    return distance.length() < user->getEventFlowDataHolder()->getTerritory()->getEmotionRadius();
+}
+
+bool checkInsideEmotionLowPriorityTerritoryPos(const IUseEventFlowData* user,
+                                               const LiveActor* actor,
+                                               const sead::Vector3f& position) {
+    sead::Vector3f territoryPosition = {0.0f, 0.0f, 0.0f};
+    const EventFlowDataHolder* holder = user->getEventFlowDataHolder();
+    multVecPose(&territoryPosition, actor, holder->getTerritory()->getLocalOffset());
+
+    sead::Vector3f distance = territoryPosition - position;
+    return distance.length() <
+           user->getEventFlowDataHolder()->getTerritory()->getEmotionLowPriorityRadius();
+}
+
+bool checkInsideTalkTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                                 const sead::Vector3f& position) {
+    sead::Vector3f territoryPosition = {0.0f, 0.0f, 0.0f};
+    const EventFlowDataHolder* holder = user->getEventFlowDataHolder();
+    multVecPose(&territoryPosition, actor, holder->getTerritory()->getLocalOffset());
+
+    sead::Vector3f distance = territoryPosition - position;
+    return distance.length() < user->getEventFlowDataHolder()->getTerritory()->getTalkableRadius();
+}
+
+void calcBalloonOffset(sead::Vector3f* outOffset, const IUseEventFlowData* user,
+                       const LiveActor* actor) {
+    sead::Quatf actorQuat = sead::Quatf::unit;
+    calcQuat(&actorQuat, actor);
+
+    const EventFlowActorTerritory* territory = user->getEventFlowDataHolder()->getTerritory();
+    outOffset->setRotated(actorQuat, territory->getBalloonLocalOffset());
+}
+
+void setBalloonLocalOffset(EventFlowExecutor* executor, const sead::Vector3f& localOffset) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->getTerritory()->setBalloonLocalOffset(localOffset);
+}
+
+f32 getBalloonCollisionCheckOffsetRadius(const IUseEventFlowData* user) {
+    return user->getEventFlowDataHolder()->getTerritory()->getBalloonCollisionCheckOffsetRadius();
+}
+
+bool isDisableOpenBalloonByOrderGroup(const LiveActor* actor, const IUseEventFlowData* user) {
+    if (user->getEventFlowDataHolder()->getBalloonOrderGroup() == nullptr)
+        return false;
+    return !user->getEventFlowDataHolder()->getBalloonOrderGroup()->isEnableAppearBalloon(actor);
+}
+
+bool isEnableForceOpenBalloonByOrderGroup(const LiveActor* actor, const IUseEventFlowData* user) {
+    if (user->getEventFlowDataHolder()->getBalloonOrderGroup() == nullptr)
+        return false;
+    return user->getEventFlowDataHolder()->getBalloonOrderGroup()->isEnableAppearBalloon(actor);
+}
+
+bool isWaitAtPointMovement(const EventFlowExecutor* executor) {
+    return executor->isWaitAtPointMovement();
+}
+
+bool isStopMovement(const IUseEventFlowData* user) {
+    if (user->getEventFlowDataHolder()->isStopMovementByNode())
+        return true;
+    return user->getEventFlowDataHolder()->getExecutorState()->isStopMovement;
+}
+
+bool isRequestEventDemoAction(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isRequestDemoAction();
+}
+
+bool isPlayingEventDemoAction(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isPlayingDemoAction();
+}
+
+const char* getEventDemoActionName(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->getDemoActionName();
+}
+
+bool isExistEventDemoTalkAction(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isExistDemoTalkAction();
+}
+
+const char* getEventDemoTalkActionName(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->getDemoTalkActionName();
+}
+
+bool isResetEventDemoPlayerDynamics(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isResetDemoPlayerDynamics();
+}
+
+void startEventDemoAction(EventFlowExecutor* executor) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->startDemoAction();
+}
+
+void endEventDemoAction(EventFlowExecutor* executor) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->endDemoAction();
+}
+
+bool isRequestEventDemoCamera(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isRequestDemoCamera();
+}
+
+const char* getEventDemoCameraAnimName(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->getDemoCameraAnimName();
+}
+
+void clearEventDemoCameraRequest(EventFlowExecutor* executor) {
+    IUseEventFlowData* eventFlowUser = executor;
+    eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->clearDemoCameraRequest();
+}
+
+bool isHideDemoPlayer(const EventFlowExecutor* executor) {
+    const IUseEventFlowData* eventFlowUser = executor;
+    return eventFlowUser->getEventFlowDataHolder()->getRequestInfo()->isHideDemoPlayer();
+}
+
+bool isExistEventEntry(const EventFlowExecutor* executor, const char* entryName) {
+    return executor->isExistEntry(entryName);
+}
+
+bool isCurrentEventEntry(const EventFlowExecutor* executor, const char* entryName) {
+    const char* currentEntryName = executor->getCurrentEntryName();
+    if (currentEntryName != nullptr && executor->getCurrentNode() != nullptr)
+        return isEqualString(currentEntryName, entryName);
+    return false;
+}
+
+bool isEventName(const EventFlowEventData* eventData, const char* format, ...) {
+    std::va_list args;
+    va_start(args, format);
+
+    StringTmp<256> eventName("");
+    eventName.formatV(format, args);
+    va_end(args);
+
+    return isEqualString(eventData->getName(), eventName.cstr());
+}
+
+const char* getEventName(const EventFlowEventData* eventData) {
+    return eventData->getName();
+}
+
+const char* getEventDataParamString(const EventFlowEventData* eventData, const char* key) {
+    return getByamlKeyString(eventData->getByamlIter(), key);
+}
+
+bool isEventDataParamBool(const EventFlowEventData* eventData, const char* key) {
+    return getByamlKeyBool(eventData->getByamlIter(), key);
+}
+}  // namespace al
+
+namespace alEventFlowFunction {
+bool isReceiveCommandCloseTalkMessageLayout(const al::SceneEventFlowMsg* sceneEventFlowMsg) {
+    return sceneEventFlowMsg->isReceiveCommand("CloseTalkMessageLayout");
+}
+
+void clearSceneEventFlowMsg(al::SceneEventFlowMsg* sceneEventFlowMsg) {
+    sceneEventFlowMsg->clearCommand();
+}
+}  // namespace alEventFlowFunction

--- a/lib/al/Library/Event/EventFlowUtil.h
+++ b/lib/al/Library/Event/EventFlowUtil.h
@@ -16,85 +16,160 @@ class EventFlowRequestInfo {
 public:
     EventFlowRequestInfo();
     void reset();
-    void requestDemoAction(const char*);
-    void requestDemoCamera(const char*);
+    void requestDemoAction(const char* actionName);
+    void requestDemoCamera(const char* cameraName);
+
+    bool isRequestDemoAction() const { return !mIsDemoActionStarted && mDemoActionName != nullptr; }
+
+    bool isPlayingDemoAction() const { return mIsDemoActionStarted; }
+
+    const char* getDemoActionName() const { return mDemoActionName; }
+
+    bool isExistDemoTalkAction() const { return mDemoTalkActionName != nullptr; }
+
+    const char* getDemoTalkActionName() const { return mDemoTalkActionName; }
+
+    void setDemoTalkActionName(const char* actionName) { mDemoTalkActionName = actionName; }
+
+    void resetDemoTalkActionName() { mDemoTalkActionName = nullptr; }
+
+    void setPlayerDemoActionName(const char* actionName) { mPlayerDemoActionName = actionName; }
+
+    const char* getPlayerDemoActionName() const { return mPlayerDemoActionName; }
+
+    bool isRequestDemoCamera() const {
+        return !mIsDemoCameraStarted && mDemoCameraAnimName != nullptr;
+    }
+
+    const char* getDemoCameraAnimName() const { return mDemoCameraAnimName; }
+
+    void clearDemoCameraRequest() { mDemoCameraAnimName = nullptr; }
+
+    bool isHideDemoPlayer() const { return mIsHideDemoPlayer; }
+
+    void requestHideDemoPlayer() { mIsRequestHideDemoPlayer = true; }
+
+    void requestShowDemoPlayer() { mIsRequestShowDemoPlayer = true; }
+
+    void setResetDemoPlayerDynamics() { mIsResetDemoPlayerDynamics = true; }
+
+    bool isResetDemoPlayerDynamics() const { return mIsResetDemoPlayerDynamics; }
+
+    void startDemoAction() { mIsDemoActionStarted = true; }
+
+    void endDemoAction() {
+        mIsDemoActionStarted = false;
+        mDemoActionName = nullptr;
+    }
+
+private:
+    bool mIsDemoActionStarted;
+    bool mIsResetDemoPlayerDynamics;
+    u16 _02;
+    u32 _04;
+    const char* mDemoActionName;
+    const char* mDemoTalkActionName;
+    const char* mPlayerDemoActionName;
+    bool mIsDemoCameraStarted;
+    u8 _21;
+    u16 _22;
+    u32 _24;
+    const char* mDemoCameraAnimName;
+    bool mIsHideDemoPlayer;
+    bool mIsRequestHideDemoPlayer;
+    bool mIsRequestShowDemoPlayer;
+    u8 _33;
+    u32 _34;
 };
 
-bool isNodeName(const EventFlowNode*, const char*);
-const char16* getScareMessage(const EventFlowNode*);
-void startEventCamera(EventFlowNode*, const char*, s32);
-void startEventAnimCamera(EventFlowNode*, const char*, const char*, s32);
-void endEventCamera(EventFlowNode*, const char*, s32, bool);
-bool tryEndEventCameraIfPlaying(EventFlowNode*, const char*, s32, bool);
-bool isEndInterpoleEventCamera(const EventFlowNode*, const char*);
-bool isPlayingEventAnimCamera(const EventFlowNode*, const char*);
-void requestDemoAction(EventFlowNode*, const char*, bool);
-void requestPlayerDemoAction(EventFlowNode*, const char*);
-bool isEndDemoAction(const EventFlowNode*);
-void setDemoTalkAction(EventFlowNode*, const char*);
-void resetDemoTalkAction(EventFlowNode*);
-void requestDemoCamera(EventFlowNode*, const char*);
-bool isEndRequestDemoCamera(const EventFlowNode*);
-bool isHideDemoPlayer(const EventFlowNode*);
-void requestHideDemoPlayer(EventFlowNode*);
-void requestShowDemoPlayer(EventFlowNode*);
-void calcPlayerWatchTrans(sead::Vector3f*, const EventFlowNode*);
-void requestCommandCloseTalkMessageLayout(EventFlowNode*);
-bool isActive(const EventFlowExecutor*);
-bool isScare(const IUseEventFlowData*);
-bool tryGetScareEnemyPos(sead::Vector3f*, const IUseEventFlowData*);
-void invalidateUiCollisionCheck(EventFlowExecutor*);
-void onExistLookAtJointCtrl(EventFlowExecutor*);
-void setTalkSubActorName(EventFlowExecutor*, const char*);
-void resetTalkSubActorName(EventFlowExecutor*);
-void startEventAction(LiveActor*, const IUseEventFlowData*, const char*);
-void makeEventActionName(sead::BufferedSafeStringBase<char>*, const IUseEventFlowData*,
-                         const char*);
-void startEventActionAtRandomFrame(LiveActor*, const IUseEventFlowData*, const char*);
-bool tryStartEventActionIfNotPlaying(LiveActor*, const IUseEventFlowData*, const char*);
-bool isPlayingEventAction(const LiveActor*, const IUseEventFlowData*, const char*);
-bool isExistEventAction(const LiveActor*, const IUseEventFlowData*, const char*);
-bool isOneTimeEventAction(const LiveActor*, const IUseEventFlowData*, const char*);
-f32 getEventActionFrameMax(const LiveActor*, const IUseEventFlowData*, const char*);
-f32 getParamMoveSpeed(const IUseEventFlowData*);
-f32 getParamTurnSpeedDegree(const IUseEventFlowData*);
-const sead::Vector3f& getRecordActorFront(const IUseEventFlowData*);
-void recordActorFront(IUseEventFlowData*, const sead::Vector3f&);
-bool checkInsideTerritoryPos(const IUseEventFlowData*, const LiveActor*, const sead::Vector3f&,
-                             f32);
-bool checkInsideEmotionTerritoryPos(const IUseEventFlowData*, const LiveActor*,
-                                    const sead::Vector3f&);
-bool checkInsideEmotionLowPriorityTerritoryPos(const IUseEventFlowData*, const LiveActor*,
-                                               const sead::Vector3f&);
-bool checkInsideTalkTerritoryPos(const IUseEventFlowData*, const LiveActor*, const sead::Vector3f&);
-void calcBalloonOffset(sead::Vector3f*, const IUseEventFlowData*, const LiveActor*);
-void setBalloonLocalOffset(EventFlowExecutor*, const sead::Vector3f&);
-f32 getBalloonCollisionCheckOffsetRadius(const IUseEventFlowData*);
-bool isDisableOpenBalloonByOrderGroup(const LiveActor*, const IUseEventFlowData*);
-bool isEnableForceOpenBalloonByOrderGroup(const LiveActor*, const IUseEventFlowData*);
-bool isWaitAtPointMovement(const EventFlowExecutor*);
-bool isStopMovement(const IUseEventFlowData*);
-bool isRequestEventDemoAction(const EventFlowExecutor*);
-bool isPlayingEventDemoAction(const EventFlowExecutor*);
-const char* getEventDemoActionName(const EventFlowExecutor*);
-bool isExistEventDemoTalkAction(const EventFlowExecutor*);
-const char* getEventDemoTalkActionName(const EventFlowExecutor*);
-bool isResetEventDemoPlayerDynamics(const EventFlowExecutor*);
-void startEventDemoAction(EventFlowExecutor*);
-void endEventDemoAction(EventFlowExecutor*);
-bool isRequestEventDemoCamera(const EventFlowExecutor*);
-const char* getEventDemoCameraAnimName(const EventFlowExecutor*);
-void clearEventDemoCameraRequest(EventFlowExecutor*);
-bool isHideDemoPlayer(const EventFlowExecutor*);
-bool isExistEventEntry(const EventFlowExecutor*, const char*);
-bool isCurrentEventEntry(const EventFlowExecutor*, const char*);
-bool isEventName(const EventFlowEventData*, const char*, ...);
-const char* getEventName(const EventFlowEventData*);
-bool getEventDataParamString(const EventFlowEventData*, const char*);
-bool isEventDataParamBool(const EventFlowEventData*, const char*);
+bool isNodeName(const EventFlowNode* node, const char* nodeName);
+const char16* getScareMessage(const EventFlowNode* node);
+void startEventCamera(EventFlowNode* node, const char* cameraName, s32 priority);
+void startEventAnimCamera(EventFlowNode* node, const char* cameraName, const char* animName,
+                          s32 priority);
+void endEventCamera(EventFlowNode* node, const char* cameraName, s32 priority, bool isInterpole);
+bool tryEndEventCameraIfPlaying(EventFlowNode* node, const char* cameraName, s32 priority,
+                                bool isInterpole);
+bool isEndInterpoleEventCamera(const EventFlowNode* node, const char* cameraName);
+bool isPlayingEventAnimCamera(const EventFlowNode* node, const char* cameraName);
+void requestDemoAction(EventFlowNode* node, const char* actionName, bool isResetPlayerDynamics);
+void requestPlayerDemoAction(EventFlowNode* node, const char* actionName);
+bool isEndDemoAction(const EventFlowNode* node);
+void setDemoTalkAction(EventFlowNode* node, const char* actionName);
+void resetDemoTalkAction(EventFlowNode* node);
+void requestDemoCamera(EventFlowNode* node, const char* cameraName);
+bool isEndRequestDemoCamera(const EventFlowNode* node);
+bool isHideDemoPlayer(const EventFlowNode* node);
+void requestHideDemoPlayer(EventFlowNode* node);
+void requestShowDemoPlayer(EventFlowNode* node);
+void calcPlayerWatchTrans(sead::Vector3f* outWatchTrans, const EventFlowNode* node);
+void requestCommandCloseTalkMessageLayout(EventFlowNode* node);
+bool isActive(const EventFlowExecutor* executor);
+bool isScare(const IUseEventFlowData* user);
+bool tryGetScareEnemyPos(sead::Vector3f* outScareEnemyPos, const IUseEventFlowData* user);
+void invalidateUiCollisionCheck(EventFlowExecutor* executor);
+void onExistLookAtJointCtrl(EventFlowExecutor* executor);
+void setTalkSubActorName(EventFlowExecutor* executor, const char* actorName);
+void resetTalkSubActorName(EventFlowExecutor* executor);
+void startEventAction(LiveActor* actor, const IUseEventFlowData* user, const char* actionName);
+void makeEventActionName(sead::BufferedSafeStringBase<char>* outActionName,
+                         const IUseEventFlowData* user, const char* actionName);
+void startEventActionAtRandomFrame(LiveActor* actor, const IUseEventFlowData* user,
+                                   const char* actionName);
+bool tryStartEventActionIfNotPlaying(LiveActor* actor, const IUseEventFlowData* user,
+                                     const char* actionName);
+bool isPlayingEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                          const char* actionName);
+bool isExistEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                        const char* actionName);
+bool isOneTimeEventAction(const LiveActor* actor, const IUseEventFlowData* user,
+                          const char* actionName);
+f32 getEventActionFrameMax(const LiveActor* actor, const IUseEventFlowData* user,
+                           const char* actionName);
+f32 getParamMoveSpeed(const IUseEventFlowData* user);
+f32 getParamTurnSpeedDegree(const IUseEventFlowData* user);
+const sead::Vector3f& getRecordActorFront(const IUseEventFlowData* user);
+void recordActorFront(IUseEventFlowData* user, const sead::Vector3f& front);
+bool checkInsideTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                             const sead::Vector3f& position, f32 radiusOffset);
+bool checkInsideEmotionTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                                    const sead::Vector3f& position);
+bool checkInsideEmotionLowPriorityTerritoryPos(const IUseEventFlowData* user,
+                                               const LiveActor* actor,
+                                               const sead::Vector3f& position);
+bool checkInsideTalkTerritoryPos(const IUseEventFlowData* user, const LiveActor* actor,
+                                 const sead::Vector3f& position);
+void calcBalloonOffset(sead::Vector3f* outOffset, const IUseEventFlowData* user,
+                       const LiveActor* actor);
+void setBalloonLocalOffset(EventFlowExecutor* executor, const sead::Vector3f& localOffset);
+f32 getBalloonCollisionCheckOffsetRadius(const IUseEventFlowData* user);
+bool isDisableOpenBalloonByOrderGroup(const LiveActor* actor, const IUseEventFlowData* user);
+bool isEnableForceOpenBalloonByOrderGroup(const LiveActor* actor, const IUseEventFlowData* user);
+bool isWaitAtPointMovement(const EventFlowExecutor* executor);
+bool isStopMovement(const IUseEventFlowData* user);
+bool isRequestEventDemoAction(const EventFlowExecutor* executor);
+bool isPlayingEventDemoAction(const EventFlowExecutor* executor);
+const char* getEventDemoActionName(const EventFlowExecutor* executor);
+bool isExistEventDemoTalkAction(const EventFlowExecutor* executor);
+const char* getEventDemoTalkActionName(const EventFlowExecutor* executor);
+bool isResetEventDemoPlayerDynamics(const EventFlowExecutor* executor);
+void startEventDemoAction(EventFlowExecutor* executor);
+void endEventDemoAction(EventFlowExecutor* executor);
+bool isRequestEventDemoCamera(const EventFlowExecutor* executor);
+const char* getEventDemoCameraAnimName(const EventFlowExecutor* executor);
+void clearEventDemoCameraRequest(EventFlowExecutor* executor);
+bool isHideDemoPlayer(const EventFlowExecutor* executor);
+bool isExistEventEntry(const EventFlowExecutor* executor, const char* entryName);
+bool isCurrentEventEntry(const EventFlowExecutor* executor, const char* entryName);
+bool isEventName(const EventFlowEventData* eventData, const char* format, ...);
+const char* getEventName(const EventFlowEventData* eventData);
+const char* getEventDataParamString(const EventFlowEventData* eventData, const char* key);
+bool isEventDataParamBool(const EventFlowEventData* eventData, const char* key);
 }  // namespace al
 
 namespace alEventFlowFunction {
-bool isReceiveCommandCloseTalkMessageLayout(const al::SceneEventFlowMsg*);
-void clearSceneEventFlowMsg(al::SceneEventFlowMsg*);
+bool isReceiveCommandCloseTalkMessageLayout(const al::SceneEventFlowMsg* sceneEventFlowMsg);
+void clearSceneEventFlowMsg(al::SceneEventFlowMsg* sceneEventFlowMsg);
 }  // namespace alEventFlowFunction
+
+static_assert(sizeof(al::EventFlowRequestInfo) == 0x38);

--- a/lib/al/Library/Event/EventFlowWatchParam.h
+++ b/lib/al/Library/Event/EventFlowWatchParam.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+namespace al {
+class ByamlIter;
+class HitSensor;
+class LiveActor;
+
+class EventFlowWatchParam {
+public:
+    EventFlowWatchParam();
+
+    void load(const ByamlIter&);
+    bool isWatchSensor(const HitSensor*) const;
+    void calcWatchTrans(sead::Vector3f*, const LiveActor*) const;
+
+    const char* getSensorName() const { return mSensorName; }
+
+    const sead::Vector3f& getLocalOffset() const { return mLocalOffset; }
+
+private:
+    const char* mSensorName = nullptr;
+    sead::Vector3f mLocalOffset = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(EventFlowWatchParam) == 0x18);
+}  // namespace al

--- a/lib/al/Library/Event/SceneEventFlowMsg.h
+++ b/lib/al/Library/Event/SceneEventFlowMsg.h
@@ -10,6 +10,8 @@ public:
     bool isReceiveCommand(const char* cmd) const;
     void requestCommand(const char* cmd);
 
+    void clearCommand() { mCmd.clear(); }
+
 private:
     sead::FixedSafeString<64> mCmd = {""};
 };

--- a/lib/al/Project/Event/EventFlowActorTerritory.h
+++ b/lib/al/Project/Event/EventFlowActorTerritory.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+
+class EventFlowActorTerritory {
+public:
+    EventFlowActorTerritory(LiveActor*, const char*);
+
+    f32 getRadius() const { return mRadius; }
+
+    f32 getEmotionRadius() const { return mEmotionRadius; }
+
+    f32 getEmotionLowPriorityRadius() const { return mEmotionLowPriorityRadius; }
+
+    f32 getTalkableRadius() const { return mTalkableRadius; }
+
+    const sead::Vector3f& getLocalOffset() const { return mLocalOffset; }
+
+    const sead::Vector3f& getBalloonLocalOffset() const { return mBalloonLocalOffset; }
+
+    void setBalloonLocalOffset(const sead::Vector3f& localOffset) {
+        mBalloonLocalOffset.set(localOffset);
+    }
+
+    f32 getBalloonCollisionCheckOffsetRadius() const { return mBalloonCollisionCheckOffsetRadius; }
+
+private:
+    f32 mRadius = 1000.0f;
+    f32 mEmotionRadius = 4000.0f;
+    f32 mEmotionLowPriorityRadius = 1000.0f;
+    f32 mTalkableRadius = 400.0f;
+    sead::Vector3f mLocalOffset = sead::Vector3f::zero;
+    sead::Vector3f mBalloonLocalOffset = {0.0f, 300.0f, 0.0f};
+    f32 mBalloonCollisionCheckOffsetRadius = 0.0f;
+};
+
+static_assert(sizeof(EventFlowActorTerritory) == 0x2C);
+}  // namespace al

--- a/lib/al/Project/Event/EventFlowEventData.h
+++ b/lib/al/Project/Event/EventFlowEventData.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/Yaml/ByamlIter.h"
+
+namespace al {
+class EventFlowNodeInitInfo;
+
+class EventFlowEventData {
+public:
+    EventFlowEventData(const char* name, const EventFlowNodeInitInfo& info);
+
+    const char* getName() const { return mName; }
+
+    const ByamlIter& getByamlIter() const { return *mByamlIter; }
+
+private:
+    const char* mName = nullptr;
+    const ByamlIter* mByamlIter = nullptr;
+    void* _10 = nullptr;
+};
+
+static_assert(sizeof(EventFlowEventData) == 0x18);
+}  // namespace al


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1082)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - ccb7129)

📈 **Matched code**: 14.23% (+0.04%, +5060 bytes)

<details>
<summary>✅ 74 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Event/EventFlowUtil` | `al::calcBalloonOffset(sead::Vector3<float>*, al::IUseEventFlowData const*, al::LiveActor const*)` | +280 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::startEventActionAtRandomFrame(al::LiveActor*, al::IUseEventFlowData const*, char const*)` | +236 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isEventName(al::EventFlowEventData const*, char const*, ...)` | +216 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::checkInsideTerritoryPos(al::IUseEventFlowData const*, al::LiveActor const*, sead::Vector3<float> const&, float)` | +212 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::checkInsideEmotionTerritoryPos(al::IUseEventFlowData const*, al::LiveActor const*, sead::Vector3<float> const&)` | +204 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::checkInsideEmotionLowPriorityTerritoryPos(al::IUseEventFlowData const*, al::LiveActor const*, sead::Vector3<float> const&)` | +204 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::checkInsideTalkTerritoryPos(al::IUseEventFlowData const*, al::LiveActor const*, sead::Vector3<float> const&)` | +204 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::tryStartEventActionIfNotPlaying(al::LiveActor*, al::IUseEventFlowData const*, char const*)` | +128 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isPlayingEventAction(al::LiveActor const*, al::IUseEventFlowData const*, char const*)` | +128 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isExistEventAction(al::LiveActor const*, al::IUseEventFlowData const*, char const*)` | +128 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isOneTimeEventAction(al::LiveActor const*, al::IUseEventFlowData const*, char const*)` | +128 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::startEventAction(al::LiveActor*, al::IUseEventFlowData const*, char const*)` | +124 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::getEventActionFrameMax(al::LiveActor const*, al::IUseEventFlowData const*, char const*)` | +124 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::tryGetScareEnemyPos(sead::Vector3<float>*, al::IUseEventFlowData const*)` | +104 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::requestDemoAction(al::EventFlowNode*, char const*, bool)` | +100 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::calcPlayerWatchTrans(sead::Vector3<float>*, al::EventFlowNode const*)` | +100 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::getScareMessage(al::EventFlowNode const*)` | +96 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isEnableForceOpenBalloonByOrderGroup(al::LiveActor const*, al::IUseEventFlowData const*)` | +96 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isScare(al::IUseEventFlowData const*)` | +92 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isDisableOpenBalloonByOrderGroup(al::LiveActor const*, al::IUseEventFlowData const*)` | +92 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::startEventAnimCamera(al::EventFlowNode*, char const*, char const*, int)` | +88 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::endEventCamera(al::EventFlowNode*, char const*, int, bool)` | +88 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::tryEndEventCameraIfPlaying(al::EventFlowNode*, char const*, int, bool)` | +88 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isStopMovement(al::IUseEventFlowData const*)` | +88 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::startEventCamera(al::EventFlowNode*, char const*, int)` | +80 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isEndInterpoleEventCamera(al::EventFlowNode const*, char const*)` | +64 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isRequestEventDemoAction(al::EventFlowExecutor const*)` | +64 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::isRequestEventDemoCamera(al::EventFlowExecutor const*)` | +64 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::setBalloonLocalOffset(al::EventFlowExecutor*, sead::Vector3<float> const&)` | +60 | 0.00% | 100.00% |
| `Library/Event/EventFlowUtil` | `al::makeEventActionName(sead::BufferedSafeStringBase<char>*, al::IUseEventFlowData const*, char const*)` | +56 | 0.00% | 100.00% |

...and 44 more new matches
</details>


<!-- decomp.dev report end -->