### PR TITLE
Boss/Koopa: Implement `KoopaHintHolder`

### DIFF
--- a/src/Boss/Koopa/KoopaHintHolder.cpp
+++ b/src/Boss/Koopa/KoopaHintHolder.cpp
@@ -1,0 +1,77 @@
+#include "Boss/Koopa/KoopaHintHolder.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/CapMessageShowInfo.h"
+
+namespace {
+NERVE_IMPL(KoopaHintHolder, Wait)
+NERVE_IMPL(KoopaHintHolder, HintCapReflect)
+NERVE_IMPL(KoopaHintHolder, MessageDamage)
+NERVE_IMPL(KoopaHintHolder, HintCapAttachBomb)
+
+NERVES_MAKE_NOSTRUCT(KoopaHintHolder, HintCapReflect, HintCapAttachBomb, Wait, MessageDamage)
+}  // namespace
+
+KoopaBombHintRequestInfo::KoopaBombHintRequestInfo() : isRequested(false) {}
+
+KoopaHintHolder::KoopaHintHolder(al::SceneObjHolder* sceneObjHolder)
+    : al::NerveExecutor("クッパヒント保持"), mSceneObjHolder(sceneObjHolder),
+      mIsHintCapAttachBombRequested(false), mIsHintCapReflectEnabled(true), mBombHeadHintIndex(-1) {
+    initNerve(&Wait, 0);
+}
+
+void KoopaHintHolder::update() {
+    updateNerve();
+}
+
+bool KoopaHintHolder::tryAppearHintCapReflect() {
+    if (!mIsHintCapReflectEnabled)
+        return false;
+
+    mIsHintCapReflectEnabled = false;
+    al::setNerve(this, &HintCapReflect);
+    return true;
+}
+
+bool KoopaHintHolder::tryAppearMessageDamage(s32 damageType) {
+    if (!al::isNerve(this, &Wait))
+        return false;
+
+    rs::showCapMessageBossDamage(this, al::StringTmp<64>("Koopa_Damage_%d", damageType).cstr(), 30,
+                                 30);
+    al::setNerve(this, &MessageDamage);
+    return true;
+}
+
+void KoopaHintHolder::exeWait() {
+    if (!mIsHintCapAttachBombRequested)
+        return;
+
+    mIsHintCapAttachBombRequested = false;
+    al::setNerve(this, &HintCapAttachBomb);
+}
+
+void KoopaHintHolder::exeHintCapReflect() {
+    if (al::isFirstStep(this))
+        rs::showCapMessage(this, "KoopaHintCapReflect", 60, 30);
+
+    al::setNerveAtGreaterEqualStep(this, &Wait, 60);
+}
+
+void KoopaHintHolder::exeHintCapAttachBomb() {
+    if (al::isFirstStep(this)) {
+        mBombHeadHintIndex = al::modi(mBombHeadHintIndex + 4, 3);
+        al::StringTmp<64> label("KoopaHintCapAttachBombHead_%02d", mBombHeadHintIndex);
+        rs::showCapMessage(this, label.cstr(), 60, 0);
+    }
+
+    al::setNerveAtGreaterEqualStep(this, &Wait, 60);
+}
+
+void KoopaHintHolder::exeMessageDamage() {
+    al::setNerveAtGreaterEqualStep(this, &Wait, 30);
+}

--- a/src/Boss/Koopa/KoopaHintHolder.h
+++ b/src/Boss/Koopa/KoopaHintHolder.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+#include "Library/Scene/IUseSceneObjHolder.h"
+
+namespace al {
+class SceneObjHolder;
+}  // namespace al
+
+struct KoopaBombHintRequestInfo {
+    KoopaBombHintRequestInfo();
+
+    bool isRequested = false;
+};
+
+static_assert(sizeof(KoopaBombHintRequestInfo) == 0x1);
+
+class KoopaHintHolder : public al::NerveExecutor, public al::IUseSceneObjHolder {
+public:
+    KoopaHintHolder(al::SceneObjHolder* sceneObjHolder);
+
+    void update();
+    bool tryAppearHintCapReflect();
+    bool tryAppearMessageDamage(s32 damageType);
+    void exeWait();
+    void exeHintCapReflect();
+    void exeHintCapAttachBomb();
+    void exeMessageDamage();
+
+    al::SceneObjHolder* getSceneObjHolder() const override { return mSceneObjHolder; }
+
+private:
+    al::SceneObjHolder* mSceneObjHolder = nullptr;
+    bool mIsHintCapAttachBombRequested = false;
+    bool mIsHintCapReflectEnabled = true;
+    s32 mBombHeadHintIndex = -1;
+};
+
+static_assert(sizeof(KoopaHintHolder) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1083)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - 1e3f95e)

📈 **Matched code**: 14.24% (+0.01%, +924 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::tryAppearMessageDamage(int)` | +152 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `(anonymous namespace)::KoopaHintHolderNrvHintCapAttachBomb::execute(al::NerveKeeper*) const` | +152 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::exeHintCapAttachBomb()` | +148 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::KoopaHintHolder(al::SceneObjHolder*)` | +104 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `(anonymous namespace)::KoopaHintHolderNrvHintCapReflect::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::exeHintCapReflect()` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::tryAppearHintCapReflect()` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::~KoopaHintHolder()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `(anonymous namespace)::KoopaHintHolderNrvWait::execute(al::NerveKeeper*) const` | +32 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::exeWait()` | +28 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `(anonymous namespace)::KoopaHintHolderNrvMessageDamage::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::exeMessageDamage()` | +16 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaBombHintRequestInfo::KoopaBombHintRequestInfo()` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::getSceneObjHolder() const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `non-virtual thunk to KoopaHintHolder::getSceneObjHolder() const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaHintHolder` | `KoopaHintHolder::update()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->