### PR TITLE
Enemy: Implement `ElectricExplosion`

### DIFF
--- a/src/Enemy/ElectricExplosion.cpp
+++ b/src/Enemy/ElectricExplosion.cpp
@@ -1,0 +1,64 @@
+#include "Enemy/ElectricExplosion.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(ElectricExplosion, Wait)
+NERVE_IMPL(ElectricExplosion, Attack)
+
+NERVES_MAKE_NOSTRUCT(ElectricExplosion, Wait, Attack)
+
+const f32 sAttackSensorRadiusTable[] = {
+    100.0f, 170.0f, 240.0f, 310.0f, 380.0f, 450.0f, 520.0f, 590.0f, 660.0f, 730.0f,
+};
+}  // namespace
+
+ElectricExplosion::ElectricExplosion(const char* name, al::LiveActor* hostActor)
+    : al::LiveActor(name), mHostActor(hostActor) {}
+
+void ElectricExplosion::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "ElectricExplosion", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::setTrans(this, al::getTrans(mHostActor));
+    makeActorDead();
+}
+
+void ElectricExplosion::attack(s32 attackLevel) {
+    if (al::isNerve(this, &Attack))
+        return;
+
+    al::setNerve(this, &Attack);
+    mAttackLevel = attackLevel;
+    al::setTrans(this, al::getTrans(mHostActor));
+    al::setSensorRadius(this, "Attack", sAttackSensorRadiusTable[mAttackLevel - 1]);
+    al::validateHitSensors(this);
+    appear();
+}
+
+void ElectricExplosion::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    rs::sendMsgHackAttack(other, self);
+}
+
+void ElectricExplosion::exeWait() {}
+
+void ElectricExplosion::exeAttack() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Attack");
+        al::startAction(this, "Level");
+    }
+
+    al::setTrans(this, al::getTrans(mHostActor));
+    al::setVisAnimFrameForAction(this, mAttackLevel - 1);
+    if (al::isGreaterEqualStep(this, 20)) {
+        al::setNerve(this, &Wait);
+        kill();
+    }
+}

--- a/src/Enemy/ElectricExplosion.h
+++ b/src/Enemy/ElectricExplosion.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+}  // namespace al
+
+class ElectricExplosion : public al::LiveActor {
+public:
+    ElectricExplosion(const char* name, al::LiveActor* hostActor);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attack(s32 attackLevel);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+
+    void exeWait();
+    void exeAttack();
+
+private:
+    al::LiveActor* mHostActor = nullptr;
+    s32 mAttackLevel = 0;
+};
+
+static_assert(sizeof(ElectricExplosion) == 0x118);

--- a/src/Enemy/ElectricExplosion.h
+++ b/src/Enemy/ElectricExplosion.h
@@ -24,5 +24,3 @@ private:
     al::LiveActor* mHostActor = nullptr;
     s32 mAttackLevel = 0;
 };
-
-static_assert(sizeof(ElectricExplosion) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1084)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (befc651 - d4f226b)

📈 **Matched code**: 15.42% (+0.01%, +760 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/ElectricExplosion` | `ElectricExplosion::exeAttack()` | +164 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::attack(int)` | +156 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::ElectricExplosion(char const*, al::LiveActor*)` | +144 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::ElectricExplosion(char const*, al::LiveActor*)` | +140 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::init(al::ActorInitInfo const&)` | +132 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::attackSensor(al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `(anonymous namespace)::ElectricExplosionNrvAttack::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `ElectricExplosion::exeWait()` | +4 | 0.00% | 100.00% |
| `Enemy/ElectricExplosion` | `(anonymous namespace)::ElectricExplosionNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->