### PR TITLE
Enemy: Implement ElectricBall

### DIFF
--- a/src/Enemy/ElectricBall.cpp
+++ b/src/Enemy/ElectricBall.cpp
@@ -1,0 +1,62 @@
+#include "Enemy/ElectricBall.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+
+namespace {
+NERVE_IMPL(ElectricBall, Wait)
+
+NERVES_MAKE_NOSTRUCT(ElectricBall, Wait)
+}  // namespace
+
+ElectricBall::ElectricBall(const char* name, al::LiveActor* parentActor)
+    : LiveActor(name), mParentActor(parentActor) {}
+
+void ElectricBall::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "ElectricBall", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::setTrans(this, al::getTrans(mParentActor));
+    al::startAction(this, "Wait");
+    makeActorDead();
+}
+
+void ElectricBall::control() {
+    return al::setTrans(this, al::getTrans(mParentActor));
+}
+
+void ElectricBall::setChargeLevel(s32 chargeLevel) {
+    if (chargeLevel <= 0) {
+        al::hideModelIfShow(this);
+
+        if (!al::isDead(this))
+            return kill();
+
+        return;
+    }
+
+    if (al::isDead(this))
+        appear();
+
+    al::setTrans(this, al::getTrans(mParentActor));
+    al::showModelIfHide(this);
+
+    if (!al::isActionPlaying(this, "Level"))
+        al::startAction(this, "Level");
+
+    mChargeLevel = chargeLevel;
+}
+
+void ElectricBall::exeWait() {
+    if (mChargeLevel < 1)
+        return;
+
+    if (!al::isActionPlaying(this, "Level"))
+        al::startAction(this, "Level");
+
+    return al::setVisAnimFrameForAction(this, mChargeLevel - 1);
+}

--- a/src/Enemy/ElectricBall.h
+++ b/src/Enemy/ElectricBall.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class ElectricBall : public al::LiveActor {
+public:
+    ElectricBall(const char* name, al::LiveActor* parentActor);
+
+    void init(const al::ActorInitInfo& info) override;
+    void control() override;
+    void setChargeLevel(s32 chargeLevel);
+    void exeWait();
+
+private:
+    al::LiveActor* mParentActor = nullptr;
+    s32 mChargeLevel = 0;
+};
+
+static_assert(sizeof(ElectricBall) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1085)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - bad50e8)

📈 **Matched code**: 14.20% (+0.01%, +860 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/ElectricBall` | `ElectricBall::setChargeLevel(int)` | +176 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `ElectricBall::init(al::ActorInitInfo const&)` | +148 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `ElectricBall::ElectricBall(char const*, al::LiveActor*)` | +144 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `ElectricBall::ElectricBall(char const*, al::LiveActor*)` | +140 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `ElectricBall::exeWait()` | +104 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `(anonymous namespace)::ElectricBallNrvWait::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Enemy/ElectricBall` | `ElectricBall::control()` | +44 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->