### PR TITLE
Scene: Implement `QuestInfoHolder` and `QuestInfo`

### DIFF
--- a/src/Scene/QuestInfo.cpp
+++ b/src/Scene/QuestInfo.cpp
@@ -79,7 +79,7 @@ void QuestInfo::setLabel(const char* label) {
 }
 
 void QuestInfo::copy(const QuestInfo* quest) {
-    // BUG: does not copy `mIsInvalid
+    // BUG: does not copy `mIsInvalid`
     mTrans.set(quest->getTrans());
     mQuestNo = quest->getQuestNo();
     mIsMainQuest = quest->isMainQuest();

--- a/src/Scene/QuestInfo.cpp
+++ b/src/Scene/QuestInfo.cpp
@@ -1,0 +1,113 @@
+#include "Scene/QuestInfo.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+
+#include "System/GameDataFunction.h"
+#include "Util/StageLayoutFunction.h"
+
+QuestInfo::QuestInfo() {}
+
+void QuestInfo::clear() {
+    mQuestNo = -1;
+    mTrans.set(sead::Vector3f::zero);
+    mIsMainQuest = false;
+    mIsInvalid = false;
+    mSceneObjHolder = nullptr;
+    mScenarioName.clear();
+    mStageName.clear();
+    mPlacementStageName.clear();
+    mPlacementId.clear();
+    mIsSingle = false;
+}
+
+void QuestInfo::init(const al::ActorInitInfo& initInfo) {
+    init(al::getPlacementInfo(initInfo), initInfo);
+}
+
+void QuestInfo::init(const al::PlacementInfo& placementInfo, const al::ActorInitInfo& initInfo) {
+    init(placementInfo, initInfo.actorSceneInfo.sceneObjHolder);
+}
+
+void QuestInfo::init(const al::PlacementInfo& placementInfo, al::SceneObjHolder* holder) {
+    mIsMainQuest = true;
+    mSceneObjHolder = holder;
+    al::tryGetTrans(&mTrans, placementInfo);
+    al::tryGetArg(&mQuestNo, placementInfo, "QuestNo");
+    al::tryGetArg(&mIsMainQuest, placementInfo, "IsMainQuest");
+    al::tryGetArg(&mIsSingle, placementInfo, "IsSingle");
+
+    al::PlacementId placementId;
+    al::tryGetPlacementId(&placementId, placementInfo);
+    mPlacementId = al::makeStringPlacementId(&placementId);
+
+    mPlacementStageName.format("%s", rs::getPlacementStageName(this, placementInfo));
+
+    const char* className = nullptr;
+    if (!al::tryGetClassName(&className, placementInfo) ||
+        !al::searchSubString(className, "Shine")) {
+        mScenarioName.clear();
+        mStageName.clear();
+        return;
+    }
+
+    if (al::isObjectName(placementInfo, "ShineDummy")) {
+        const char* stageName = nullptr;
+        const char* label = nullptr;
+        al::getStringArg(&stageName, placementInfo, "StageName");
+        al::getStringArg(&label, placementInfo, "ObjId");
+        setStageName(stageName);
+        setLabel(label);
+        return;
+    }
+
+    rs::makeMessageLabel(&mScenarioName, placementInfo, "ScenarioName");
+    mStageName.format(rs::getPlacementStageName(this, placementInfo));
+}
+
+void QuestInfo::setStageName(const char* stageName) {
+    mStageName.format("%s", stageName);
+}
+
+void QuestInfo::setLabel(const char* label) {
+    mScenarioName.format("ScenarioName_%s", label);
+}
+
+void QuestInfo::copy(const QuestInfo* quest) {
+    mTrans.set(quest->getTrans());
+    mQuestNo = quest->getQuestNo();
+    mIsMainQuest = quest->isMainQuest();
+    mSceneObjHolder = quest->getSceneObjHolder();
+    mScenarioName = quest->getScenarioName();
+    mStageName = quest->getStageName();
+    mIsSingle = quest->isSingle();
+    mPlacementId = quest->getPlacementId();
+    mPlacementStageName = quest->getPlacementStageName();
+}
+
+void QuestInfo::end() {
+    mIsInvalid = !GameDataFunction::isWorldCity(this) || mQuestNo != 8;
+}
+
+bool QuestInfo::isEqual(const QuestInfo* quest) const {
+    if (mQuestNo != quest->getQuestNo() || mIsMainQuest != quest->isMainQuest())
+        return false;
+
+    if (!mScenarioName.isEmpty() && !mStageName.isEmpty()) {
+        return al::isEqualString(mScenarioName.cstr(), quest->getScenarioName()) &&
+               al::isEqualString(mStageName.cstr(), quest->getStageName());
+    }
+
+    if (mIsSingle && quest->isSingle())
+        return true;
+
+    if (mPlacementStageName == quest->getPlacementStageName() &&
+        mPlacementId == quest->getPlacementId())
+        return true;
+
+    return al::isNear(mTrans, quest->getTrans());
+}

--- a/src/Scene/QuestInfo.cpp
+++ b/src/Scene/QuestInfo.cpp
@@ -10,7 +10,7 @@
 #include "System/GameDataFunction.h"
 #include "Util/StageLayoutFunction.h"
 
-QuestInfo::QuestInfo() {}
+QuestInfo::QuestInfo() = default;
 
 void QuestInfo::clear() {
     mQuestNo = -1;
@@ -66,6 +66,7 @@ void QuestInfo::init(const al::PlacementInfo& placementInfo, al::SceneObjHolder*
     }
 
     rs::makeMessageLabel(&mScenarioName, placementInfo, "ScenarioName");
+    // NOTE: variable format string
     mStageName.format(rs::getPlacementStageName(this, placementInfo));
 }
 
@@ -78,6 +79,7 @@ void QuestInfo::setLabel(const char* label) {
 }
 
 void QuestInfo::copy(const QuestInfo* quest) {
+    // BUG: does not copy `mIsInvalid
     mTrans.set(quest->getTrans());
     mQuestNo = quest->getQuestNo();
     mIsMainQuest = quest->isMainQuest();
@@ -90,7 +92,8 @@ void QuestInfo::copy(const QuestInfo* quest) {
 }
 
 void QuestInfo::end() {
-    mIsInvalid = !GameDataFunction::isWorldCity(this) || mQuestNo != 8;
+    // NOTE: special handling to story moon in Metro's festival
+    mIsInvalid = !(GameDataFunction::isWorldCity(this) && mQuestNo == 8);
 }
 
 bool QuestInfo::isEqual(const QuestInfo* quest) const {

--- a/src/Scene/QuestInfo.h
+++ b/src/Scene/QuestInfo.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadVector.h>
 #include <prim/seadSafeString.h>
 
 #include "Library/Scene/IUseSceneObjHolder.h"
@@ -15,30 +16,50 @@ class QuestInfo : public al::IUseSceneObjHolder {
 public:
     QuestInfo();
     void clear();
-    void init(const al::ActorInitInfo&);
-    void init(const al::PlacementInfo&, const al::ActorInitInfo&);
-    void init(const al::PlacementInfo&, al::SceneObjHolder*);
-    void setStageName(const char*);
-    void setLabel(const char*);
-    void copy(const QuestInfo*);
+    void init(const al::ActorInitInfo& initInfo);
+    void init(const al::PlacementInfo& placementInfo, const al::ActorInitInfo& initInfo);
+    void init(const al::PlacementInfo& placementInfo, al::SceneObjHolder* holder);
+    void setStageName(const char* stageName);
+    void setLabel(const char* label);
+    void copy(const QuestInfo* quest);
     void end();
-    bool isEqual(const QuestInfo*) const;
-
-    al::SceneObjHolder* getSceneObjHolder() const override { return mSceneObjHolder; }
+    bool isEqual(const QuestInfo* quest) const;
 
     s32 getQuestNo() const { return mQuestNo; }
 
+    const sead::Vector3f& getTrans() const { return mTrans; }
+
+    bool isMainQuest() const { return mIsMainQuest; }
+
+    bool isInvalid() const { return mIsInvalid; }
+
+    void setInvalid(bool isInvalid) { mIsInvalid = isInvalid; }
+
+    void setSceneObjHolder(al::SceneObjHolder* holder) { mSceneObjHolder = holder; }
+
+    al::SceneObjHolder* getSceneObjHolder() const override { return mSceneObjHolder; }
+
+    const sead::FixedSafeString<128>& getScenarioName() const { return mScenarioName; }
+
+    const sead::FixedSafeString<128>& getStageName() const { return mStageName; }
+
+    bool isSingle() const { return mIsSingle; }
+
+    const sead::FixedSafeString<128>& getPlacementId() const { return mPlacementId; }
+
+    const sead::FixedSafeString<128>& getPlacementStageName() const { return mPlacementStageName; }
+
 private:
-    s32 mQuestNo;
-    void* filler_10;
-    bool mIsMainQuest;
-    al::SceneObjHolder* mSceneObjHolder;
-    sead::SafeString* mScenarioName;
-    void* filler_30[0x12];
-    sead::SafeString* mStageName;
-    void* filler_c8[0x12];
-    bool mIsSingle;
-    void* filler_160[0x26];
+    s32 mQuestNo = -1;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    bool mIsMainQuest = false;
+    bool mIsInvalid = false;
+    al::SceneObjHolder* mSceneObjHolder = nullptr;
+    sead::FixedSafeString<128> mScenarioName;
+    sead::FixedSafeString<128> mStageName;
+    bool mIsSingle = false;
+    sead::FixedSafeString<128> mPlacementId;
+    sead::FixedSafeString<128> mPlacementStageName;
 };
 
 static_assert(sizeof(QuestInfo) == 0x290);

--- a/src/Scene/QuestInfoHolder.cpp
+++ b/src/Scene/QuestInfoHolder.cpp
@@ -1,0 +1,357 @@
+#include "Scene/QuestInfoHolder.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Scene/QuestInfo.h"
+#include "System/GameDataFunction.h"
+
+QuestInfoHolder::QuestInfoHolder(s32 capacity) : mCapacity(capacity) {
+    mQuests = new QuestInfo[mCapacity];
+    mActiveQuests = new QuestInfo*[mCapacity];
+    mIsMainQuest = new bool[mCapacity];
+
+    for (s32 i = 0; i < mCapacity; i++) {
+        mActiveQuests[i] = nullptr;
+        mIsMainQuest[i] = false;
+    }
+}
+
+void QuestInfoHolder::clearAll() {
+    for (s32 i = 0; i < mCapacity; i++) {
+        mQuests[i].clear();
+        mActiveQuests[i] = nullptr;
+        mIsMainQuest[i] = false;
+    }
+    mSize = 0;
+    mActiveQuestNum = 0;
+}
+
+void QuestInfoHolder::finalizeForScene() {
+    mIsInitialized = false;
+}
+
+void QuestInfoHolder::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    mIsInitialized = true;
+}
+
+void QuestInfoHolder::initAfterPlacementQuestObj(s32 questNo) {
+    mActiveMainQuestNo = -1;
+    s32 foundQuestNo = -1;
+
+    for (s32 i = 0; i <= mMaxMainQuestNo; i++) {
+        bool hasMainQuest = false;
+        for (s32 j = 0; j < mSize; j++) {
+            s32 currentQuestNo = mQuests[j].getQuestNo();
+
+            if (currentQuestNo == questNo)
+                foundQuestNo = questNo;
+
+            if (currentQuestNo == i && mQuests[j].isMainQuest()) {
+                if (hasMainQuest | mQuests[j].getScenarioName().isEmpty())
+                    mIsMainQuest[i] = true;
+                else
+                    hasMainQuest = true;
+            }
+        }
+    }
+
+    if (foundQuestNo > -1)
+        updateActiveList(foundQuestNo);
+    else
+        clearMainQuest();
+
+    if (GameDataFunction::isWorldCity(mQuests) && mActiveMainQuestNo == 8 &&
+        GameDataFunction::getScenarioNoPlacement(mQuests) != 7 &&
+        GameDataFunction::getScenarioNoPlacement(mQuests) != 11) {
+        clearMainQuest();
+    }
+}
+
+void QuestInfoHolder::updateActiveList(s32 questNo) {
+    clearMainQuest();
+
+    for (s32 i = 0; i < mSize; i++) {
+        QuestInfo* quest = &mQuests[i];
+        if (!quest->isInvalid() && quest->getQuestNo() == questNo) {
+            mActiveQuests[mActiveQuestNum] = quest;
+            mActiveQuestNum++;
+            if (mQuests[i].isMainQuest())
+                mActiveMainQuestNo = mQuests[i].getQuestNo();
+            mActiveQuestNo = mQuests[i].getQuestNo();
+        }
+    }
+}
+
+void QuestInfoHolder::clearMainQuest() {
+    for (s32 i = 0; i < mCapacity; i++)
+        mActiveQuests[i] = nullptr;
+    mActiveQuestNum = 0;
+}
+
+void QuestInfoHolder::initSceneObjHolder(al::SceneObjHolder* holder) {
+    for (s32 i = 0; i < mCapacity; i++)
+        mQuests[i].setSceneObjHolder(holder);
+}
+
+QuestInfo* QuestInfoHolder::registerQuestInfo(const QuestInfo* quest) {
+    QuestInfo* newQuest = &mQuests[mSize];
+    newQuest->copy(quest);
+    mSize++;
+
+    if (quest->isMainQuest())
+        mMaxMainQuestNo = sead::Mathi::max(mMaxMainQuestNo, quest->getQuestNo());
+
+    return newQuest;
+}
+
+void QuestInfoHolder::validateQuest(const QuestInfo* quest) {
+    // BUG: No bounds checking. Will soflock if entry is not found.
+    for (s32 i = 0; true; i++) {
+        if (mQuests[i].isEqual(quest)) {
+            mQuests[i].setInvalid(false);
+            return;
+        }
+    }
+}
+
+void QuestInfoHolder::invalidateQuest(const QuestInfo* quest) {
+    QuestInfo* entry = tryFindQuest(quest);
+
+    if (entry->isInvalid())
+        return;
+
+    entry->end();
+
+    if (mActiveQuestNo > entry->getQuestNo() || !mIsInitialized)
+        return;
+
+    updateActiveList(entry->getQuestNo());
+
+    if (mActiveQuestNum == 0) {
+        updateActiveList(entry->getQuestNo() + 1);
+        GameDataFunction::setMainScenarioNo(quest, entry->getQuestNo() + 1);
+    }
+}
+
+s32 QuestInfoHolder::getQuestNum(s32 questNo) const {
+    s32 questNum = 0;
+    for (s32 i = 0; i < mSize; i++)
+        if (mQuests[i].getQuestNo() == questNo)
+            questNum++;
+
+    return questNum;
+}
+
+al::StringTmp<128> QuestInfoHolder::getActiveQuestLabel() const {
+    if (mIsMainQuest[mActiveQuestNo])
+        return al::StringTmp<128>("Quest_%02d", mActiveQuestNo);
+
+    return mActiveQuests[0]->getScenarioName().cstr();
+}
+
+al::StringTmp<128>
+QuestInfoHolder::getActiveQuestStageName(const al::IUseSceneObjHolder* holder) const {
+    if (mIsMainQuest[mActiveQuestNo])
+        return GameDataFunction::tryGetCurrentMainStageName(holder);
+
+    return mActiveQuests[0]->getStageName().cstr();
+}
+
+bool QuestInfoHolder::isActiveQuest(const QuestInfo* quest) const {
+    for (s32 i = 0; i < mActiveQuestNum; i++)
+        if (mActiveQuests[i]->isEqual(quest))
+            return true;
+
+    return false;
+}
+
+QuestInfo* QuestInfoHolder::tryFindQuest(const QuestInfo* quest) const {
+    for (s32 i = 0; i < mCapacity; i++)
+        if (mQuests[i].isEqual(quest))
+            return &mQuests[i];
+    return nullptr;
+}
+
+QuestInfo* QuestInfoHolder::tryFindQuest(const al::PlacementInfo& placementInfo,
+                                         al::SceneObjHolder* holder) const {
+    QuestInfo quest;
+    quest.init(placementInfo, holder);
+    return tryFindQuest(&quest);
+}
+
+namespace rs {
+QuestInfoHolder* getQuestInfoHolder(const al::IUseSceneObjHolder* holder) {
+    return al::getSceneObj<QuestInfoHolder>(holder);
+}
+
+QuestInfo* tryCreateAndRegisterQuestInfoToHolder(const al::LiveActor* actor,
+                                                 const al::ActorInitInfo& info) {
+    s32 questNo = -1;
+    al::tryGetArg(&questNo, info, "QuestNo");
+
+    if (questNo == -1)
+        return nullptr;
+
+    QuestInfo* foundQuest = getQuestInfoHolder(actor)->tryFindQuest(
+        al::getPlacementInfo(info), info.actorSceneInfo.sceneObjHolder);
+    if (foundQuest)
+        return foundQuest;
+
+    QuestInfo quest;
+    quest.init(info);
+    return getQuestInfoHolder(actor)->registerQuestInfo(&quest);
+}
+
+QuestInfo* createAndRegisterQuestInfoToHolderFromLinkedObj(const al::LiveActor* actor,
+                                                           const al::PlacementInfo& info,
+                                                           bool isDummy) {
+    s32 questNo = -1;
+    al::tryGetArg(&questNo, info, "QuestNo");
+
+    if (questNo == -1)
+        return nullptr;
+
+    QuestInfo* foundQuest =
+        getQuestInfoHolder(actor)->tryFindQuest(info, actor->getSceneInfo()->sceneObjHolder);
+    if (foundQuest)
+        return foundQuest;
+
+    QuestInfo quest;
+    quest.init(info, actor->getSceneObjHolder());
+    if (isDummy) {
+        const char* stageName = nullptr;
+        const char* objId = nullptr;
+        al::getStringArg(&stageName, info, "StageName");
+        al::getStringArg(&objId, info, "ObjId");
+        quest.setStageName(stageName);
+        quest.setLabel(objId);
+    }
+
+    QuestInfo* newQuest = getQuestInfoHolder(actor)->registerQuestInfo(&quest);
+    if (isDummy) {
+        const char* stageName = nullptr;
+        const char* objId = nullptr;
+        al::getStringArg(&stageName, info, "StageName");
+        al::getStringArg(&objId, info, "ObjId");
+        if (GameDataFunction::isGotShine(actor, stageName, objId))
+            invalidateQuest(&quest);
+    }
+
+    return newQuest;
+}
+
+sead::PtrArray<QuestInfo>*
+tryCreateAndRegisterQuestInfoToHolderFromLinkedObj(const al::LiveActor* actor,
+                                                   const al::ActorInitInfo& info) {
+    al::PlacementInfo placementInfo;
+    s32 noDeleteShines = al::calcLinkChildNum(info, "NoDelete_Shine");
+    s32 shineDummies = al::calcLinkChildNum(info, "ShineDummy");
+    if (shineDummies + noDeleteShines == 0)
+        return nullptr;
+
+    sead::PtrArray<QuestInfo>* quests = new sead::PtrArray<QuestInfo>;
+    quests->allocBuffer(shineDummies + noDeleteShines, nullptr);
+    for (s32 i = 0; i < noDeleteShines; i++) {
+        al::getLinksInfoByIndex(&placementInfo, info, "NoDelete_Shine", i);
+        QuestInfo* quest =
+            createAndRegisterQuestInfoToHolderFromLinkedObj(actor, placementInfo, false);
+        if (quest)
+            quests->pushBack(quest);
+    }
+
+    if (shineDummies < 1) {
+        if (quests->isEmpty())
+            return nullptr;
+
+        return quests;
+    }
+
+    for (s32 i = 0; i < shineDummies; i++) {
+        al::getLinksInfoByIndex(&placementInfo, info, "ShineDummy", i);
+        QuestInfo* quest =
+            createAndRegisterQuestInfoToHolderFromLinkedObj(actor, placementInfo, true);
+        if (quest)
+            quests->pushBack(quest);
+    }
+
+    if (quests->isEmpty())
+        return nullptr;
+
+    return quests;
+}
+
+void validateQuest(const QuestInfo* quest) {
+    if (!quest)
+        return;
+
+    getQuestInfoHolder(quest)->validateQuest(quest);
+}
+
+void invalidateQuest(const QuestInfo* quest) {
+    if (!quest)
+        return;
+    getQuestInfoHolder(quest)->invalidateQuest(quest);
+}
+
+const QuestInfo* const* getActiveQuestList(const al::IUseSceneObjHolder* holder) {
+    return getQuestInfoHolder(holder)->getActiveQuestList();
+}
+
+s32 getActiveQuestNum(const al::IUseSceneObjHolder* holder) {
+    return getQuestInfoHolder(holder)->getActiveQuestNum();
+}
+
+s32 getActiveQuestNumForMap(const al::IUseSceneObjHolder* holder) {
+    s32 questNum = getActiveQuestNum(holder);
+    bool isWorldSnow = GameDataFunction::isWorldSnow(holder);
+
+    return (1 < questNum) & isWorldSnow ? 1 : questNum;
+}
+
+bool isActiveQuestAllEqualNo(const al::IUseSceneObjHolder* holder) {
+    return getActiveQuestNum(holder) ==
+           getQuestInfoHolder(holder)->getQuestNum(getActiveQuestNo(holder));
+}
+
+al::StringTmp<128> getActiveQuestLabel(const al::IUseSceneObjHolder* holder) {
+    return getQuestInfoHolder(holder)->getActiveQuestLabel();
+}
+
+al::StringTmp<128> getActiveQuestStageName(const al::IUseSceneObjHolder* holder) {
+    return getQuestInfoHolder(holder)->getActiveQuestStageName(holder);
+}
+
+bool isActiveQuest(const QuestInfo* quest) {
+    if (!quest || !quest->QuestInfo::getSceneObjHolder())
+        return false;
+
+    return getQuestInfoHolder(quest)->isActiveQuest(quest);
+}
+
+bool isActiveQuest(const sead::PtrArray<QuestInfo>* questList) {
+    if (!questList)
+        return false;
+
+    s32 size = questList->size();
+    for (s32 i = 0; i < size; i++) {
+        QuestInfo* quest = questList->at(i);
+        if (!quest->QuestInfo::getSceneObjHolder())
+            return false;
+        if (getQuestInfoHolder(quest)->isActiveQuest(quest))
+            return true;
+    }
+
+    return false;
+}
+
+s32 getActiveQuestNo(const al::IUseSceneObjHolder* holder) {
+    return getQuestInfoHolder(holder)->getActiveQuestNo();
+}
+}  // namespace rs

--- a/src/Scene/QuestInfoHolder.cpp
+++ b/src/Scene/QuestInfoHolder.cpp
@@ -54,7 +54,7 @@ void QuestInfoHolder::initAfterPlacementQuestObj(s32 questNo) {
                 foundQuestNo = questNo;
 
             if (currentQuestNo == i && mQuests[j].isMainQuest()) {
-                if (hasMainQuest | mQuests[j].getScenarioName().isEmpty())
+                if (mQuests[j].getScenarioName().isEmpty() || hasMainQuest)
                     mIsMainQuest[i] = true;
                 else
                     hasMainQuest = true;
@@ -67,6 +67,7 @@ void QuestInfoHolder::initAfterPlacementQuestObj(s32 questNo) {
     else
         clearMainQuest();
 
+    // NOTE: special case for Metro festival's story moon
     if (GameDataFunction::isWorldCity(mQuests) && mActiveMainQuestNo == 8 &&
         GameDataFunction::getScenarioNoPlacement(mQuests) != 7 &&
         GameDataFunction::getScenarioNoPlacement(mQuests) != 11) {
@@ -112,7 +113,7 @@ QuestInfo* QuestInfoHolder::registerQuestInfo(const QuestInfo* quest) {
 }
 
 void QuestInfoHolder::validateQuest(const QuestInfo* quest) {
-    // BUG: No bounds checking. Will soflock if entry is not found.
+    // BUG: No bounds checking. Will softlock if entry is not found.
     for (s32 i = 0; true; i++) {
         if (mQuests[i].isEqual(quest)) {
             mQuests[i].setInvalid(false);
@@ -297,6 +298,7 @@ void validateQuest(const QuestInfo* quest) {
 void invalidateQuest(const QuestInfo* quest) {
     if (!quest)
         return;
+
     getQuestInfoHolder(quest)->invalidateQuest(quest);
 }
 
@@ -310,9 +312,11 @@ s32 getActiveQuestNum(const al::IUseSceneObjHolder* holder) {
 
 s32 getActiveQuestNumForMap(const al::IUseSceneObjHolder* holder) {
     s32 questNum = getActiveQuestNum(holder);
-    bool isWorldSnow = GameDataFunction::isWorldSnow(holder);
 
-    return (1 < questNum) & isWorldSnow ? 1 : questNum;
+    if (GameDataFunction::isWorldSnow(holder))
+        return sead::Mathi::clampMax(questNum, 1);
+
+    return questNum;
 }
 
 bool isActiveQuestAllEqualNo(const al::IUseSceneObjHolder* holder) {

--- a/src/Scene/QuestInfoHolder.h
+++ b/src/Scene/QuestInfoHolder.h
@@ -24,24 +24,29 @@ public:
 
     void clearAll();
     void finalizeForScene();
-    void initAfterPlacementSceneObj(const al::ActorInitInfo& _info) override;
-    void initAfterPlacementQuestObj(s32 quest_no);
-    void updateActiveList(s32 quest_no);
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+    void initAfterPlacementQuestObj(s32 questNo);
+    void updateActiveList(s32 questNo);
     void clearMainQuest();
-    void initSceneObjHolder(al::SceneObjHolder* scene_obj_holder);
-    QuestInfo* registerQuestInfo(const QuestInfo* info);
-    void validateQuest(const QuestInfo* info);
-    void invalidateQuest(const QuestInfo* info);
-    s32 getQuestNum(s32 quest_no) const;
+    void initSceneObjHolder(al::SceneObjHolder* holder);
+    QuestInfo* registerQuestInfo(const QuestInfo* quest);
+    void validateQuest(const QuestInfo* quest);
+    void invalidateQuest(const QuestInfo* quest);
+    s32 getQuestNum(s32 questNo) const;
     al::StringTmp<128> getActiveQuestLabel() const;
-    al::StringTmp<128>
-    getActiveQuestStageName(const al::IUseSceneObjHolder* scene_obj_holder) const;
-    bool isActiveQuest(const QuestInfo* info) const;
-    QuestInfo* tryFindQuest(const QuestInfo* info) const;
-    QuestInfo* tryFindQuest(const al::PlacementInfo& placement_info,
-                            al::SceneObjHolder* scene_obj_holder) const;
+    al::StringTmp<128> getActiveQuestStageName(const al::IUseSceneObjHolder* holder) const;
+    bool isActiveQuest(const QuestInfo* quest) const;
+    QuestInfo* tryFindQuest(const QuestInfo* quest) const;
+    QuestInfo* tryFindQuest(const al::PlacementInfo& placementInfo,
+                            al::SceneObjHolder* holder) const;
 
     const char* getSceneObjName() const override { return "クエスト情報保持者"; }
+
+    s32 getActiveQuestNo() const { return mActiveQuestNo; }
+
+    s32 getActiveQuestNum() const { return mActiveQuestNum; }
+
+    QuestInfo** getActiveQuestList() const { return mActiveQuests; }
 
 private:
     s32 mCapacity;
@@ -59,24 +64,24 @@ private:
 static_assert(sizeof(QuestInfoHolder) == 0x40);
 
 namespace rs {
-QuestInfoHolder* getQuestInfoHolder(const al::IUseSceneObjHolder* scene_obj_holder);
+QuestInfoHolder* getQuestInfoHolder(const al::IUseSceneObjHolder* holder);
 QuestInfo* tryCreateAndRegisterQuestInfoToHolder(const al::LiveActor* actor,
                                                  const al::ActorInitInfo& info);
 QuestInfo* createAndRegisterQuestInfoToHolderFromLinkedObj(const al::LiveActor* actor,
-                                                           const al::PlacementInfo& placement_info,
+                                                           const al::PlacementInfo& placementInfo,
                                                            bool is_dummy);
 sead::PtrArray<QuestInfo>*
 tryCreateAndRegisterQuestInfoToHolderFromLinkedObj(const al::LiveActor* actor,
                                                    const al::ActorInitInfo& info);
-void validateQuest(const QuestInfo* info);
-void invalidateQuest(const QuestInfo* info);
-const QuestInfo* const* getActiveQuestList(const al::IUseSceneObjHolder* scene_obj_holder);
-s32 getActiveQuestNum(const al::IUseSceneObjHolder* scene_obj_holder);
-s32 getActiveQuestNumForMap(const al::IUseSceneObjHolder* scene_obj_holder);
-bool isActiveQuestAllEqualNo(const al::IUseSceneObjHolder* scene_obj_holder);
-al::StringTmp<128> getActiveQuestLabel(const al::IUseSceneObjHolder* scene_obj_holder);
-al::StringTmp<128> getActiveQuestStageName(const al::IUseSceneObjHolder* scene_obj_holder);
-bool isActiveQuest(const QuestInfo* info);
+void validateQuest(const QuestInfo* quest);
+void invalidateQuest(const QuestInfo* quest);
+const QuestInfo* const* getActiveQuestList(const al::IUseSceneObjHolder* holder);
+s32 getActiveQuestNum(const al::IUseSceneObjHolder* holder);
+s32 getActiveQuestNumForMap(const al::IUseSceneObjHolder* holder);
+bool isActiveQuestAllEqualNo(const al::IUseSceneObjHolder* holder);
+al::StringTmp<128> getActiveQuestLabel(const al::IUseSceneObjHolder* holder);
+al::StringTmp<128> getActiveQuestStageName(const al::IUseSceneObjHolder* holder);
+bool isActiveQuest(const QuestInfo* quest);
 bool isActiveQuest(const sead::PtrArray<QuestInfo>* list);
-s32 getActiveQuestNo(const al::IUseSceneObjHolder* scene_obj_holder);
+s32 getActiveQuestNo(const al::IUseSceneObjHolder* holder);
 }  // namespace rs


### PR DESCRIPTION
Implements all questInfo logic. ~~I have one minor mismatch `tryCreateAndRegisterQuestInfoToHolderFromLinkedObj`(https://decomp.me/scratch/Imq4X) is not using the correct operator for one of the loops but is functionally the same.~~ Fixed

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1086)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (7bb1c84 - 355e974)

📈 **Matched code**: 14.39% (+0.06%, +7936 bytes)

<details>
<summary>✅ 45 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/QuestInfo` | `QuestInfo::copy(QuestInfo const*)` | +876 | 0.00% | 100.00% |
| `Scene/QuestInfo` | `QuestInfo::init(al::PlacementInfo const&, al::SceneObjHolder*)` | +656 | 0.00% | 100.00% |
| `Scene/QuestInfo` | `QuestInfo::isEqual(QuestInfo const*) const` | +608 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::initAfterPlacementQuestObj(int)` | +584 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::createAndRegisterQuestInfoToHolderFromLinkedObj(al::LiveActor const*, al::PlacementInfo const&, bool)` | +548 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::invalidateQuest(QuestInfo const*)` | +540 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::tryCreateAndRegisterQuestInfoToHolderFromLinkedObj(al::LiveActor const*, al::ActorInitInfo const&)` | +396 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::tryCreateAndRegisterQuestInfoToHolder(al::LiveActor const*, al::ActorInitInfo const&)` | +352 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::QuestInfoHolder(int)` | +320 | 0.00% | 100.00% |
| `Scene/QuestInfo` | `QuestInfo::QuestInfo()` | +300 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::isActiveQuest(sead::PtrArray<QuestInfo> const*)` | +224 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::isActiveQuestAllEqualNo(al::IUseSceneObjHolder const*)` | +208 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::updateActiveList(int)` | +172 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::tryFindQuest(al::PlacementInfo const&, al::SceneObjHolder*) const` | +152 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::getQuestNum(int) const` | +132 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::getActiveQuestStageName(al::IUseSceneObjHolder const*) const` | +128 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::getActiveQuestStageName(al::IUseSceneObjHolder const*)` | +128 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::isActiveQuest(QuestInfo const*)` | +128 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::tryFindQuest(QuestInfo const*) const` | +116 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::clearAll()` | +112 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::registerQuestInfo(QuestInfo const*)` | +108 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::getActiveQuestLabel(al::IUseSceneObjHolder const*)` | +108 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::isActiveQuest(QuestInfo const*) const` | +104 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::getActiveQuestLabel() const` | +100 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::validateQuest(QuestInfo const*)` | +96 | 0.00% | 100.00% |
| `Scene/QuestInfo` | `QuestInfo::clear()` | +92 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::getActiveQuestNumForMap(al::IUseSceneObjHolder const*)` | +88 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `QuestInfoHolder::validateQuest(QuestInfo const*)` | +80 | 0.00% | 100.00% |
| `Scene/QuestInfo` | `QuestInfo::end()` | +76 | 0.00% | 100.00% |
| `Scene/QuestInfoHolder` | `rs::invalidateQuest(QuestInfo const*)` | +60 | 0.00% | 100.00% |

...and 15 more new matches
</details>


<!-- decomp.dev report end -->