### PR TITLE
Library/Sequence: Fix vtable of `Sequence`

### DIFF
--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -17,7 +17,6 @@ class Scene;
 class Sequence : public NerveExecutor, public IUseAudioKeeper, public IUseSceneCreator {
 public:
     Sequence(const char* name);
-    ~Sequence() override;
 
     virtual void init(const SequenceInitInfo& initInfo);
 
@@ -26,6 +25,8 @@ public:
     virtual void drawMain() const;
     virtual void drawSub() const;
 
+    AudioKeeper* getAudioKeeper() const override { return mAudioKeeper; }
+
     virtual bool isDisposable() const;
 
     virtual Scene* getCurrentScene() const { return nullptr; }
@@ -33,8 +34,6 @@ public:
     SceneCreator* getSceneCreator() const override { return mSceneCreator; }
 
     void setSceneCreator(SceneCreator* sceneCreator) override { mSceneCreator = sceneCreator; }
-
-    AudioKeeper* getAudioKeeper() const override { return mAudioKeeper; }
 
     void initAudio(const GameSystemInfo&, const char*, s32, s32, s32, const char*);
     void initAudioKeeper(const char*);

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -17,6 +17,7 @@ class Scene;
 class Sequence : public NerveExecutor, public IUseAudioKeeper, public IUseSceneCreator {
 public:
     Sequence(const char* name);
+    ~Sequence() override;
 
     virtual void init(const SequenceInitInfo& initInfo);
 


### PR DESCRIPTION
`@massi8580` (Discord) noticed that our current vtable on `al::Sequence` is wrong, as it puts `getAudioKeeper` at the very bottom instead of the correct position, somewhere in the middle. This PR fixes that, and removes the declaration of the auto-generated destructor along the way.

This change has been verified by opening the binary built by this project in a decompiler again, and checking that the vtable now has the correct layout.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1087)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - ac6d827)

No changes

<!-- decomp.dev report end -->