### PR TITLE
Enemy: Implement JokuArm

### DIFF
--- a/src/Enemy/JokuArm.cpp
+++ b/src/Enemy/JokuArm.cpp
@@ -1,0 +1,68 @@
+#include "Enemy/JokuArm.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(JokuArm, Wait)
+NERVE_IMPL(JokuArm, Damage)
+NERVES_MAKE_NOSTRUCT(JokuArm, Wait, Damage)
+}  // namespace
+
+JokuArm::JokuArm(const char* name) : al::LiveActor(name) {}
+
+void JokuArm::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "JokuArm", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::invalidateClipping(this);
+    makeActorDead();
+}
+
+void JokuArm::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorName(self, "Attack"))
+        al::sendMsgEnemyAttack(other, self) || al::sendMsgExplosion(other, self, nullptr);
+    if (al::isSensorName(self, "Body"))
+        al::sendMsgPush(other, self);
+}
+
+bool JokuArm::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(msg))
+        return true;
+    return rs::isMsgPlayerDisregardTargetMarker(msg);
+}
+
+void JokuArm::control() {
+    al::updatePoseMtx(this, mJointMtx);
+}
+
+void JokuArm::appear() {
+    al::setNerve(this, &Wait);
+    al::LiveActor::appear();
+    al::updatePoseMtx(this, mJointMtx);
+    al::hideModelIfShow(this);
+}
+
+void JokuArm::damage() {
+    al::setNerve(this, &Damage);
+}
+
+void JokuArm::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Wait");
+        al::showModelIfHide(this);
+    }
+}
+
+void JokuArm::exeDamage() {
+    if (al::isFirstStep(this))
+        al::startHitReaction(this, "ダメージ");
+    kill();
+}

--- a/src/Enemy/JokuArm.h
+++ b/src/Enemy/JokuArm.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class JokuArm : public al::LiveActor {
+public:
+    JokuArm(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void control() override;
+    void appear() override;
+
+    void damage();
+
+    void exeWait();
+    void exeDamage();
+
+private:
+    const sead::Matrix34f* mJointMtx = nullptr;
+};
+
+static_assert(sizeof(JokuArm) == 0x110);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1088)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8f46da6 - c9c17ce)

📈 **Matched code**: 14.20% (+0.01%, +920 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/JokuArm` | `JokuArm::JokuArm(char const*)` | +136 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::JokuArm(char const*)` | +124 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::attackSensor(al::HitSensor*, al::HitSensor*)` | +124 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::init(al::ActorInitInfo const&)` | +120 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `(anonymous namespace)::JokuArmNrvWait::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::exeWait()` | +68 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `(anonymous namespace)::JokuArmNrvDamage::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::appear()` | +64 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::exeDamage()` | +64 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +60 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::damage()` | +12 | 0.00% | 100.00% |
| `Enemy/JokuArm` | `JokuArm::control()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->