### PR TITLE
Boss/SmallWanderBoss: Implement SmallWanterBossStateAttack

### DIFF
--- a/src/Boss/SmallWanderBoss/SmallWanderBossBullet.h
+++ b/src/Boss/SmallWanderBoss/SmallWanderBossBullet.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SmallWanderBossBullet : public al::LiveActor {
+public:
+    SmallWanderBossBullet(const char*);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void appearAttach(const sead::Matrix34f* baseMtx, const sead::Vector3f* localTrans);
+    void appearAttachParabolic(const sead::Matrix34f* baseMtx, const sead::Vector3f* localTrans);
+    bool tryStartFlyParabolic(const sead::Vector3f& direction, f32 speed);
+    void startLaunch();
+    void exeAppearAttach();
+    void exeFly();
+    void resetPositionByAnim();
+    void exeFlyDown();
+    void exeSignExplosion();
+    void exeExplosion();
+};

--- a/src/Boss/SmallWanderBoss/SmallWanderBossStateAttack.cpp
+++ b/src/Boss/SmallWanderBoss/SmallWanderBossStateAttack.cpp
@@ -1,0 +1,89 @@
+#include "Boss/SmallWanderBoss/SmallWanderBossStateAttack.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/SmallWanderBoss/SmallWanderBossBullet.h"
+
+namespace {
+NERVE_IMPL(SmallWanderBossStateAttack, AttackSign);
+NERVE_IMPL(SmallWanderBossStateAttack, AttackSignWait);
+NERVE_IMPL(SmallWanderBossStateAttack, AttackStart);
+NERVE_IMPL(SmallWanderBossStateAttack, Attack);
+NERVE_IMPL(SmallWanderBossStateAttack, AttackEnd);
+
+NERVES_MAKE_NOSTRUCT(SmallWanderBossStateAttack, AttackSign, AttackSignWait, AttackStart, Attack,
+                     AttackEnd);
+}  // namespace
+
+SmallWanderBossStateAttack::SmallWanderBossStateAttack(al::LiveActor* actor)
+    : al::ActorStateBase("ザコ徘徊攻撃", actor), mBullet(nullptr) {
+    initNerve(&AttackSign, 0);
+}
+
+void SmallWanderBossStateAttack::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &AttackSign);
+}
+
+void SmallWanderBossStateAttack::kill() {
+    al::NerveStateBase::kill();
+
+    if (mBullet)
+        mBullet->startLaunch();
+}
+
+void SmallWanderBossStateAttack::startWithBullet(SmallWanderBossBullet* bullet) {
+    mBullet = bullet;
+    al::setNerve(this, &AttackSign);
+}
+
+void SmallWanderBossStateAttack::exeAttackSign() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackSign");
+        al::startAction(mBullet, "AttackSign");
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &AttackSignWait);
+}
+
+void SmallWanderBossStateAttack::exeAttackSignWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackSignWait");
+        al::startAction(mBullet, "AttackSignWait");
+    }
+
+    if (al::isGreaterEqualStep(this, 30))
+        al::setNerve(this, &AttackStart);
+}
+
+void SmallWanderBossStateAttack::exeAttackStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackStart");
+        al::startAction(mBullet, "AttackStart");
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Attack);
+}
+
+void SmallWanderBossStateAttack::exeAttack() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "Attack");
+        mBullet->startLaunch();
+        mBullet = nullptr;
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &AttackEnd);
+}
+
+void SmallWanderBossStateAttack::exeAttackEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "AttackEnd");
+
+    if (al::isActionEnd(mActor))
+        kill();
+}

--- a/src/Boss/SmallWanderBoss/SmallWanderBossStateAttack.h
+++ b/src/Boss/SmallWanderBoss/SmallWanderBossStateAttack.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class SmallWanderBossBullet;
+
+class SmallWanderBossStateAttack : public al::ActorStateBase {
+public:
+    SmallWanderBossStateAttack(al::LiveActor* actor);
+
+    void appear() override;
+    void kill() override;
+
+    void startWithBullet(SmallWanderBossBullet* bullet);
+    void exeAttackSign();
+    void exeAttackSignWait();
+    void exeAttackStart();
+    void exeAttack();
+    void exeAttackEnd();
+
+private:
+    SmallWanderBossBullet* mBullet;
+};
+
+static_assert(sizeof(SmallWanderBossStateAttack) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1089)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24464f3 - bbe9322)

📈 **Matched code**: 14.21% (+0.01%, +1208 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `(anonymous namespace)::SmallWanderBossStateAttackNrvAttackSignWait::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::exeAttackSignWait()` | +108 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `(anonymous namespace)::SmallWanderBossStateAttackNrvAttackSign::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `(anonymous namespace)::SmallWanderBossStateAttackNrvAttackStart::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::exeAttackSign()` | +104 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::exeAttackStart()` | +104 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `(anonymous namespace)::SmallWanderBossStateAttackNrvAttack::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::exeAttack()` | +100 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `(anonymous namespace)::SmallWanderBossStateAttackNrvAttackEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::exeAttackEnd()` | +88 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::SmallWanderBossStateAttack(al::LiveActor*)` | +84 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::~SmallWanderBossStateAttack()` | +36 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::kill()` | +24 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::startWithBullet(SmallWanderBossBullet*)` | +20 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossStateAttack` | `SmallWanderBossStateAttack::appear()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->