### PR TITLE
Boss/FireBlower: Implement `FireBlowerCap`

### DIFF
--- a/lib/al/Library/Obj/PartsModel.h
+++ b/lib/al/Library/Obj/PartsModel.h
@@ -33,6 +33,8 @@ public:
     void offSyncAppearAndHide();
     void onSyncAppearAndHide();
 
+    void setPoseUpdate(bool isUpdate) { mIsUpdate = isUpdate; }
+
 private:
     LiveActor* mParentModel = nullptr;
     const sead::Matrix34f* mJointMtx = nullptr;

--- a/src/Boss/FireBlower/FireBlowerCap.cpp
+++ b/src/Boss/FireBlower/FireBlowerCap.cpp
@@ -1,0 +1,77 @@
+#include "Boss/FireBlower/FireBlowerCap.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Movement/EnemyStateBlowDown.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL_(FireBlowerCap, CapWait, Wait)
+NERVE_IMPL_(FireBlowerCap, CapDisappear, Disappear)
+NERVE_IMPL_(FireBlowerCap, CapAppear, Appear)
+NERVE_IMPL_(FireBlowerCap, CapResetAttackStart, ResetAttackStart)
+
+NERVES_MAKE_NOSTRUCT(FireBlowerCap, CapAppear, CapResetAttackStart, CapWait, CapDisappear)
+
+static al::EnemyStateBlowDownParam sFireBlowerCapBlowDownParam =
+    al::EnemyStateBlowDownParam("Disappear", 18.0f, 35.0f, 1.0f, 0.9f, 120, true);
+}  // namespace
+
+FireBlowerCap::FireBlowerCap() : al::PartsModel("FireBlowerCap") {}
+
+void FireBlowerCap::initCap(al::LiveActor* actor, const al::ActorInitInfo& initInfo) {
+    initPartsFixFile(actor, initInfo, "FireBlowerCap", nullptr, "Cap");
+    al::initNerve(this, &CapWait, 1);
+
+    mStateBlowDown = new al::EnemyStateBlowDown(this, &sFireBlowerCapBlowDownParam, "吹き飛び状態");
+    al::initNerveState(this, mStateBlowDown, &CapDisappear, "帽子吹き飛び挙動");
+
+    makeActorAlive();
+}
+
+void FireBlowerCap::appear() {
+    setPoseUpdate(true);
+    al::LiveActor::appear();
+    al::setNerve(this, &CapAppear);
+}
+
+void FireBlowerCap::disappear(const al::HitSensor* sourceSensor,
+                              const al::HitSensor* targetSensor) {
+    setPoseUpdate(false);
+    mStateBlowDown->start(sourceSensor, targetSensor);
+    al::setNerve(this, &CapDisappear);
+}
+
+void FireBlowerCap::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &CapWait);
+}
+
+void FireBlowerCap::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void FireBlowerCap::appearResetAttackStart() {
+    setPoseUpdate(true);
+    al::LiveActor::appear();
+    al::setNerve(this, &CapResetAttackStart);
+}
+
+void FireBlowerCap::exeResetAttackStart() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "ResetAttackStart");
+}
+
+void FireBlowerCap::exeDisappear() {
+    if (al::updateNerveState(this))
+        kill();
+}
+
+bool FireBlowerCap::isDisappear() const {
+    return al::isNerve(this, &CapDisappear);
+}

--- a/src/Boss/FireBlower/FireBlowerCap.h
+++ b/src/Boss/FireBlower/FireBlowerCap.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Library/Obj/PartsModel.h"
+
+namespace al {
+struct ActorInitInfo;
+class EnemyStateBlowDown;
+class HitSensor;
+class LiveActor;
+}  // namespace al
+
+class FireBlowerCap : public al::PartsModel {
+public:
+    FireBlowerCap();
+
+    void initCap(al::LiveActor* actor, const al::ActorInitInfo& initInfo);
+    void appear() override;
+    void disappear(const al::HitSensor* sourceSensor, const al::HitSensor* targetSensor);
+    void exeAppear();
+    void exeWait();
+    void appearResetAttackStart();
+    void exeResetAttackStart();
+    void exeDisappear();
+    bool isDisappear() const;
+
+private:
+    al::EnemyStateBlowDown* mStateBlowDown = nullptr;
+};
+
+static_assert(sizeof(FireBlowerCap) == 0x150);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1090)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - 1d97204)

📈 **Matched code**: 14.24% (+0.01%, +1156 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::initCap(al::LiveActor*, al::ActorInitInfo const&)` | +160 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::FireBlowerCap()` | +136 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::FireBlowerCap()` | +132 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `(anonymous namespace)::FireBlowerCapNrvCapAppear::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::exeAppear()` | +88 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `(anonymous namespace)::FireBlowerCapNrvCapWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `(anonymous namespace)::FireBlowerCapNrvCapDisappear::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `(anonymous namespace)::FireBlowerCapNrvCapResetAttackStart::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::exeWait()` | +60 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::exeResetAttackStart()` | +60 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::exeDisappear()` | +60 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::disappear(al::HitSensor const*, al::HitSensor const*)` | +56 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::appear()` | +52 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::appearResetAttackStart()` | +52 | 0.00% | 100.00% |
| `Boss/FireBlower/FireBlowerCap` | `FireBlowerCap::isDisappear() const` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->