### PR TITLE
ModeBalloon: Implement `TimeBalloonCircle`

### DIFF
--- a/src/ModeBalloon/TimeBalloonCircle.cpp
+++ b/src/ModeBalloon/TimeBalloonCircle.cpp
@@ -1,0 +1,89 @@
+#include "ModeBalloon/TimeBalloonCircle.h"
+
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Npc/DecalJointCtrl.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(TimeBalloonCircle, Wait)
+NERVE_IMPL(TimeBalloonCircle, In)
+NERVE_IMPL(TimeBalloonCircle, Out)
+
+NERVES_MAKE_NOSTRUCT(TimeBalloonCircle, Wait, In, Out)
+}  // namespace
+
+TimeBalloonCircle::TimeBalloonCircle() : al::LiveActor("TimeBalloonCircle") {}
+
+void TimeBalloonCircle::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "TimeBalloonCircle", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::invalidateHitSensors(this);
+    al::initJointControllerKeeper(this, 25);
+    mDecalJointCtrl = new DecalJointCtrl(this, 25);
+    makeActorDead();
+}
+
+void TimeBalloonCircle::appear() {
+    al::LiveActor::appear();
+    al::setNerve(this, &Wait);
+}
+
+void TimeBalloonCircle::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (!al::sendMsgPush(other, self))
+        rs::sendMsgPushToPlayer(other, self);
+}
+
+bool TimeBalloonCircle::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(message) ||
+        rs::isMsgPlayerDisregardTargetMarker(message))
+        return true;
+    return al::isMsgPlayerDisregard(message);
+}
+
+void TimeBalloonCircle::setTrans(const sead::Vector3f& trans) {
+    mTrans = trans;
+    al::resetPosition(this, mTrans);
+    mDecalJointCtrl->calc();
+}
+
+void TimeBalloonCircle::startStandby() {
+    al::invalidateHitSensors(this);
+    al::showModelIfHide(this);
+    al::startAction(this, "In");
+    al::setNerve(this, &In);
+}
+
+void TimeBalloonCircle::startPlay() {
+    al::validateHitSensors(this);
+    al::showModelIfHide(this);
+    al::startAction(this, "Out");
+    al::setNerve(this, &Out);
+}
+
+void TimeBalloonCircle::hideModel() {
+    al::hideModelIfShow(this);
+}
+
+void TimeBalloonCircle::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void TimeBalloonCircle::exeOut() {
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void TimeBalloonCircle::exeIn() {
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}

--- a/src/ModeBalloon/TimeBalloonCircle.h
+++ b/src/ModeBalloon/TimeBalloonCircle.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class DecalJointCtrl;
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class TimeBalloonCircle : public al::LiveActor {
+public:
+    TimeBalloonCircle();
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void setTrans(const sead::Vector3f& trans);
+    void startStandby();
+    void startPlay();
+    void hideModel();
+
+    void exeWait();
+    void exeOut();
+    void exeIn();
+
+private:
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+    DecalJointCtrl* mDecalJointCtrl = nullptr;
+};
+
+static_assert(sizeof(TimeBalloonCircle) == 0x120);

--- a/src/Npc/DecalJointCtrl.h
+++ b/src/Npc/DecalJointCtrl.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class DecalJointCtrl {
+public:
+    DecalJointCtrl(al::LiveActor* actor, s32 count);
+    void calc();
+
+private:
+    u8 _0[0x28];
+};
+
+static_assert(sizeof(DecalJointCtrl) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1092)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - 642de29)

📈 **Matched code**: 14.24% (+0.01%, +1248 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::init(al::ActorInitInfo const&)` | +172 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::TimeBalloonCircle()` | +160 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::TimeBalloonCircle()` | +156 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +72 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::setTrans(sead::Vector3<float> const&)` | +68 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::startStandby()` | +68 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::startPlay()` | +68 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::attackSensor(al::HitSensor*, al::HitSensor*)` | +64 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `(anonymous namespace)::TimeBalloonCircleNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `(anonymous namespace)::TimeBalloonCircleNrvIn::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `(anonymous namespace)::TimeBalloonCircleNrvOut::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::exeWait()` | +60 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::exeOut()` | +60 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::exeIn()` | +60 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::appear()` | +44 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonCircle` | `TimeBalloonCircle::hideModel()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->