### PR TITLE
Boss/Koopa: Implement `KoopaStateDemoClashBasement`

### DIFF
--- a/src/Boss/Koopa/KoopaDemoExecutor.h
+++ b/src/Boss/Koopa/KoopaDemoExecutor.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class AddDemoInfo;
+class EventFlowExecutor;
+class LiveActor;
+}  // namespace al
+
+class ChurchDoor;
+class IUseDemoSkip;
+class KoopaCameraCtrl;
+class KoopaCap;
+class KoopaShip;
+class Peach;
+
+class KoopaDemoExecutor {
+public:
+    KoopaDemoExecutor();
+
+    void init(al::LiveActor* actor, const al::ActorInitInfo& info,
+              al::EventFlowExecutor* eventFlowExecutor, KoopaCameraCtrl* cameraCtrl, Peach* peach);
+    void initLv1(const al::ActorInitInfo& info, al::LiveActor* actor, KoopaCap* cap,
+                 KoopaShip* ship);
+    void registerDemoModel(al::LiveActor* actor);
+    void initMoonChurch(const al::ActorInitInfo& info, ChurchDoor* churchDoor,
+                        al::LiveActor* actor);
+    void initLv2(const al::ActorInitInfo& info, al::LiveActor* actor, KoopaCap* cap,
+                 al::LiveActor* demoModel);
+    bool update();
+    void startDemoAction(const char* actionName, bool isNoPadRumble);
+    void skip();
+    void killAll();
+    bool tryStartChurchEnterDemo(IUseDemoSkip* demoSkip, al::AddDemoInfo* demoInfo);
+    void start(const char* demoName);
+    bool tryStartChurchStartDemo(IUseDemoSkip* demoSkip, al::AddDemoInfo* demoInfo);
+    bool tryStartBattleStartDemo(IUseDemoSkip* demoSkip);
+    bool tryStartBattleEndDemo(IUseDemoSkip* demoSkip);
+    bool tryStartClashBasementDemo(IUseDemoSkip* demoSkip);
+
+private:
+    u8 _0[0x120];
+};
+
+static_assert(sizeof(KoopaDemoExecutor) == 0x120);

--- a/src/Boss/Koopa/KoopaStateDemoClashBasement.cpp
+++ b/src/Boss/Koopa/KoopaStateDemoClashBasement.cpp
@@ -1,0 +1,108 @@
+#include "Boss/Koopa/KoopaStateDemoClashBasement.h"
+
+#include "Library/Area/AreaObjGroup.h"
+#include "Library/Area/AreaObjUtil.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Boss/BossUtil/BossUtil.h"
+#include "Boss/Koopa/KoopaDemoExecutor.h"
+#include "Util/DemoUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+IUseDemoSkip* getDemoSkip(KoopaStateDemoClashBasement* state) {
+    return state;
+}
+
+NERVE_IMPL(KoopaStateDemoClashBasement, Prepare);
+NERVE_IMPL(KoopaStateDemoClashBasement, Start);
+NERVE_IMPL(KoopaStateDemoClashBasement, Demo);
+NERVE_IMPL(KoopaStateDemoClashBasement, Skip);
+NERVE_IMPL(KoopaStateDemoClashBasement, End);
+NERVES_MAKE_NOSTRUCT(KoopaStateDemoClashBasement, Prepare, Start, Demo, Skip, End);
+}  // namespace
+
+KoopaStateDemoClashBasement*
+KoopaStateDemoClashBasement::tryCreate(al::LiveActor* actor, const al::ActorInitInfo& info,
+                                       KoopaDemoExecutor* demoExecutor) {
+    if (!al::isExistLinkChild(info, "DemoClashBasementArea", 0))
+        return nullptr;
+
+    al::AreaObjGroup* areaGroup =
+        al::createLinkAreaGroup(actor, info, "DemoClashBasementArea",
+                                "クッパ崩落デモ起動エリアグループ", "クッパ崩落デモ起動エリア");
+    return new KoopaStateDemoClashBasement(actor, demoExecutor, areaGroup);
+}
+
+KoopaStateDemoClashBasement::KoopaStateDemoClashBasement(al::LiveActor* actor,
+                                                         KoopaDemoExecutor* demoExecutor,
+                                                         const al::AreaObjGroup* areaGroup)
+    : al::ActorStateBase("崩落開始デモ", actor), mDemoExecutor(demoExecutor),
+      mAreaGroup(areaGroup) {
+    initNerve(&Prepare, 0);
+}
+
+void KoopaStateDemoClashBasement::appear() {
+    NerveStateBase::appear();
+    if (mAreaGroup) {
+        al::setNerve(this, &Prepare);
+        return;
+    }
+
+    al::setNerve(this, &Start);
+}
+
+void KoopaStateDemoClashBasement::kill() {
+    NerveStateBase::kill();
+    rs::saveShowDemoMoonBasementCollapse(mActor);
+    al::onStageSwitch(mActor, "SwitchDemoClashBasementAfterOn");
+}
+
+bool KoopaStateDemoClashBasement::isFirstDemo() const {
+    return !rs::isAlreadyShowDemoMoonBasementCollapse(mActor);
+}
+
+bool KoopaStateDemoClashBasement::isEnableSkipDemo() const {
+    return true;
+}
+
+void KoopaStateDemoClashBasement::skipDemo() {
+    mDemoExecutor->skip();
+    rs::requestEndDemoWithPlayer(mActor);
+    al::setNerve(this, &Skip);
+    kill();
+}
+
+void KoopaStateDemoClashBasement::exePrepare() {
+    if (!al::isInAreaObj(mAreaGroup, rs::getPlayerPos(mActor)))
+        return;
+
+    if (mDemoExecutor->tryStartClashBasementDemo(this)) {
+        al::setNerve(this, &Demo);
+        return;
+    }
+
+    al::setNerve(this, &Start);
+}
+
+void KoopaStateDemoClashBasement::exeStart() {
+    if (mDemoExecutor->tryStartClashBasementDemo(getDemoSkip(this)))
+        al::setNerve(this, &Demo);
+}
+
+void KoopaStateDemoClashBasement::exeDemo() {
+    if (!mDemoExecutor->update())
+        return;
+
+    al::setNerve(this, &End);
+    kill();
+}
+
+void KoopaStateDemoClashBasement::exeSkip() {}
+
+void KoopaStateDemoClashBasement::exeEnd() {}

--- a/src/Boss/Koopa/KoopaStateDemoClashBasement.h
+++ b/src/Boss/Koopa/KoopaStateDemoClashBasement.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+struct ActorInitInfo;
+class AreaObjGroup;
+class LiveActor;
+}  // namespace al
+
+class KoopaDemoExecutor;
+
+class KoopaStateDemoClashBasement : public al::ActorStateBase, public IUseDemoSkip {
+public:
+    static KoopaStateDemoClashBasement*
+    tryCreate(al::LiveActor* actor, const al::ActorInitInfo& info, KoopaDemoExecutor* demoExecutor);
+
+    KoopaStateDemoClashBasement(al::LiveActor* actor, KoopaDemoExecutor* demoExecutor,
+                                const al::AreaObjGroup* areaGroup);
+
+    void appear() override;
+    void kill() override;
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+
+    void exePrepare();
+    void exeStart();
+    void exeDemo();
+    void exeSkip();
+    void exeEnd();
+
+private:
+    KoopaDemoExecutor* mDemoExecutor = nullptr;
+    const al::AreaObjGroup* mAreaGroup = nullptr;
+};
+
+static_assert(sizeof(KoopaStateDemoClashBasement) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1093)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3c9de3e - 0b1bd33)

📈 **Matched code**: 14.24% (+0.01%, +1232 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::tryCreate(al::LiveActor*, al::ActorInitInfo const&, KoopaDemoExecutor*)` | +196 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::KoopaStateDemoClashBasement(al::LiveActor*, KoopaDemoExecutor*, al::AreaObjGroup const*)` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::exePrepare()` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `(anonymous namespace)::KoopaStateDemoClashBasementNrvPrepare::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::exeStart()` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::exeDemo()` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `(anonymous namespace)::KoopaStateDemoClashBasementNrvStart::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `(anonymous namespace)::KoopaStateDemoClashBasementNrvDemo::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `non-virtual thunk to KoopaStateDemoClashBasement::skipDemo()` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::skipDemo()` | +72 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::kill()` | +68 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::appear()` | +40 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::~KoopaStateDemoClashBasement()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::isFirstDemo() const` | +32 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `non-virtual thunk to KoopaStateDemoClashBasement::isFirstDemo() const` | +32 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `non-virtual thunk to KoopaStateDemoClashBasement::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `IUseDemoSkip::updateOnlyDemoGraphics()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::exeSkip()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `KoopaStateDemoClashBasement::exeEnd()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `(anonymous namespace)::KoopaStateDemoClashBasementNrvSkip::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDemoClashBasement` | `(anonymous namespace)::KoopaStateDemoClashBasementNrvEnd::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->