### PR TITLE
Boss/SmallWanderBoss: Implement `SmallWanderBossBullet`

### DIFF
--- a/src/Boss/SmallWanderBoss/SmallWanderBossBullet.cpp
+++ b/src/Boss/SmallWanderBoss/SmallWanderBossBullet.cpp
@@ -1,0 +1,243 @@
+#include "Boss/SmallWanderBoss/SmallWanderBossBullet.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Math/ParabolicPath.h"
+#include "Library/Nature/NatureUtil.h"
+#include "Library/Nature/WaterSurfaceFinder.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/SensorMsgFunction.h"
+#include "Util/WaterSurfaceShadow.h"
+
+namespace {
+NERVE_IMPL(SmallWanderBossBullet, Fly)
+NERVE_IMPL(SmallWanderBossBullet, Explosion)
+NERVE_IMPL(SmallWanderBossBullet, AppearAttach)
+NERVE_IMPL_(SmallWanderBossBullet, AppearAttachParabolic, AppearAttach)
+NERVE_IMPL(SmallWanderBossBullet, FlyDown)
+NERVE_IMPL(SmallWanderBossBullet, SignExplosion)
+
+NERVES_MAKE_NOSTRUCT(SmallWanderBossBullet, Fly, FlyDown, SignExplosion, Explosion, AppearAttach,
+                     AppearAttachParabolic)
+}  // namespace
+
+SmallWanderBossBullet::SmallWanderBossBullet(const char* name) : al::LiveActor(name) {}
+
+void SmallWanderBossBullet::init(const al::ActorInitInfo& initInfo) {
+    al::initActorWithArchiveName(this, initInfo, "SmallWanderBossBullet", nullptr);
+    al::initNerve(this, &Fly, 0);
+    al::setSensorRadius(this, "Attack", 60.0f);
+    al::setSensorRadius(this, "Body", 75.0f);
+    al::setColliderRadius(this, 40.0f);
+
+    mParabolicPath = new al::ParabolicPath();
+    mWaterSurfaceFinder = new al::WaterSurfaceFinder(this);
+    mWaterSurfaceShadow = new WaterSurfaceShadow(initInfo, "WaterSurfaceShadow");
+    mWaterSurfaceShadow->setScale(8.0f);
+
+    makeActorDead();
+}
+
+void SmallWanderBossBullet::appear() {
+    al::LiveActor::appear();
+    al::showModelIfHide(this);
+    al::offCollide(this);
+}
+
+void SmallWanderBossBullet::kill() {
+    al::LiveActor::kill();
+    mWaterSurfaceShadow->disappearShadow();
+}
+
+void SmallWanderBossBullet::control() {
+    if (al::isNerve(this, &Explosion))
+        return;
+
+    f32 distance = 7500.0f;
+    sead::Vector3f groundPos = {0.0f, 0.0f, 0.0f};
+    rs::calcGroundHeight(&distance, &groundPos, this, al::getTrans(this), -al::getGravity(this),
+                         0.0f, distance);
+
+    mWaterSurfaceShadow->update(al::getTrans(this), -al::getGravity(this), distance);
+}
+
+void SmallWanderBossBullet::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &Explosion) || !al::isSensorEnemyAttack(self) ||
+        al::isNerve(this, &AppearAttach) || al::isNerve(this, &AppearAttachParabolic))
+        return;
+
+    if (al::sendMsgEnemyAttack(other, self))
+        al::setNerve(this, &Explosion);
+}
+
+bool SmallWanderBossBullet::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                       al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardTargetMarker(message) ||
+        rs::isMsgPlayerDisregardHomingAttack(message)) {
+        return true;
+    }
+
+    if (rs::isMsgKillByMoonRockDemo(message)) {
+        al::killForceBeforeDemo(this);
+        return true;
+    }
+
+    if (!al::isSensorEnemyBody(self) || al::isNerve(this, &Explosion))
+        return false;
+
+    if (rs::isMsgCapReflect(message) || al::isMsgKickStoneAttackReflect(message) ||
+        rs::isMsgSeedAttack(message)) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::setNerve(this, &Explosion);
+        return true;
+    }
+
+    return false;
+}
+
+void SmallWanderBossBullet::appearAttach(const sead::Matrix34f* attachMtx,
+                                         const sead::Vector3f* attachOffset) {
+    mAttachMtx = attachMtx;
+    mAttachOffset = attachOffset;
+
+    al::getTransPtr(this)->setMul(*attachMtx, attachOffset ? *attachOffset : sead::Vector3f::zero);
+    attachMtx->getBase(*al::getFrontPtr(this), 2);
+
+    appear();
+    al::setNerve(this, &AppearAttach);
+}
+
+void SmallWanderBossBullet::appearAttachParabolic(const sead::Matrix34f* attachMtx,
+                                                  const sead::Vector3f* attachOffset) {
+    mAttachMtx = attachMtx;
+    mAttachOffset = attachOffset;
+
+    al::getTransPtr(this)->setMul(*attachMtx, attachOffset ? *attachOffset : sead::Vector3f::zero);
+    attachMtx->getBase(*al::getFrontPtr(this), 2);
+
+    appear();
+    al::setNerve(this, &AppearAttachParabolic);
+}
+
+bool SmallWanderBossBullet::tryStartFlyParabolic(const sead::Vector3f& front, f32 launchSpeed) {
+    if (!al::isGreaterEqualStep(this, 5))
+        return false;
+
+    al::setFront(this, front);
+    mLaunchSpeed = launchSpeed;
+    al::setNerve(this, &FlyDown);
+    return true;
+}
+
+void SmallWanderBossBullet::startLaunch() {
+    al::setVelocity(this, al::getFront(this) * 10.0f);
+    al::setNerve(this, &Fly);
+}
+
+void SmallWanderBossBullet::exeAppearAttach() {
+    const sead::Matrix34f* attachMtx = mAttachMtx;
+    const sead::Vector3f* attachOffset = mAttachOffset;
+
+    al::getTransPtr(this)->setMul(*attachMtx, attachOffset ? *attachOffset : sead::Vector3f::zero);
+    attachMtx->getBase(*al::getFrontPtr(this), 2);
+}
+
+void SmallWanderBossBullet::exeFly() {
+    mWaterSurfaceFinder->update(al::getTrans(this), sead::Vector3f::ey, 100.0f);
+
+    if (al::isFirstStep(this)) {
+        resetPositionByAnim();
+        al::startAction(this, "Fly");
+        al::onCollide(this);
+    }
+
+    if (al::isCollided(this) || mWaterSurfaceFinder->isFoundSurface()) {
+        if (mWaterSurfaceFinder->isFoundSurface())
+            al::tryAddRippleLarge(this, mWaterSurfaceFinder->getSurfacePosition());
+
+        al::startHitReaction(this, "破壊");
+        kill();
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 600))
+        kill();
+}
+
+void SmallWanderBossBullet::resetPositionByAnim() {
+    sead::Vector3f jointPos = sead::Vector3f::zero;
+    al::calcJointPos(&jointPos, this, "SmallWanderBossBullet");
+    al::resetPosition(this, jointPos);
+}
+
+void SmallWanderBossBullet::exeFlyDown() {
+    if (al::isFirstStep(this)) {
+        al::onCollide(this);
+        al::setVelocitySeparateHV(this, al::getFront(this), al::getRandom(-200.0f, 200.0f) + 300.0f,
+                                  100.0f);
+    }
+
+    al::addVelocityToGravity(this, 0.98f);
+    al::scaleVelocityHV(this, 0.96f, 0.98f);
+    mWaterSurfaceFinder->update(al::getTrans(this), sead::Vector3f::ey, 40.0f);
+
+    if (al::isCollided(this) || mWaterSurfaceFinder->isFoundSurface()) {
+        if (mWaterSurfaceFinder->isFoundSurface())
+            al::tryAddRippleLarge(this, mWaterSurfaceFinder->getSurfacePosition());
+
+        al::offCollide(this);
+        al::setNerve(this, &SignExplosion);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 600)) {
+        al::offCollide(this);
+        al::setNerve(this, &SignExplosion);
+    }
+}
+
+void SmallWanderBossBullet::exeSignExplosion() {
+    mWaterSurfaceFinder->update(al::getTrans(this), sead::Vector3f::ey, 40.0f);
+
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "SignExplosion");
+        mExplosionStepMax = 1200;
+    }
+
+    if (mExplosionStepMax == 1200 && al::isNearPlayer(this, 3000.0f))
+        mExplosionStepMax = sead::Mathi::min(al::getNerveStep(this) + 90, 1200);
+
+    al::approachWaterSurfaceSpringDumper(this, mWaterSurfaceFinder, 0.0f, 12.0f, 1.0f, 0.022f,
+                                         0.93f);
+
+    if (al::isGreaterEqualStep(this, mExplosionStepMax))
+        al::setNerve(this, &Explosion);
+}
+
+void SmallWanderBossBullet::exeExplosion() {
+    if (al::isFirstStep(this)) {
+        if (mWaterSurfaceFinder->isFoundSurface()) {
+            al::tryAddRippleWithRange(this, mWaterSurfaceFinder->getSurfacePosition(), 0.25f,
+                                      300.0f, 1000.0f, 1000.0f);
+        }
+
+        al::startHitReaction(this, "破壊");
+        al::hideModelIfShow(this);
+        mWaterSurfaceShadow->disappearShadow();
+    }
+
+    if (al::isGreaterEqualStep(this, 30))
+        kill();
+}

--- a/src/Boss/SmallWanderBoss/SmallWanderBossBullet.h
+++ b/src/Boss/SmallWanderBoss/SmallWanderBossBullet.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class ParabolicPath;
+class SensorMsg;
+class WaterSurfaceFinder;
+}  // namespace al
+
+class WaterSurfaceShadow;
+
+class SmallWanderBossBullet : public al::LiveActor {
+public:
+    SmallWanderBossBullet(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void appearAttach(const sead::Matrix34f* attachMtx, const sead::Vector3f* attachOffset);
+    void appearAttachParabolic(const sead::Matrix34f* attachMtx,
+                               const sead::Vector3f* attachOffset);
+    bool tryStartFlyParabolic(const sead::Vector3f& front, f32 launchSpeed);
+    void startLaunch();
+    void exeAppearAttach();
+    void exeFly();
+    void resetPositionByAnim();
+    void exeFlyDown();
+    void exeSignExplosion();
+    void exeExplosion();
+
+private:
+    sead::Vector3f _108 = {1.0f, 1.0f, 1.0f};
+    const sead::Matrix34f* mAttachMtx = nullptr;
+    const sead::Vector3f* mAttachOffset = nullptr;
+    al::ParabolicPath* mParabolicPath = nullptr;
+    al::WaterSurfaceFinder* mWaterSurfaceFinder = nullptr;
+    WaterSurfaceShadow* mWaterSurfaceShadow;
+    f32 mLaunchSpeed;  // TODO: verify exact usage
+    s32 mExplosionStepMax = 1200;
+};
+
+static_assert(sizeof(SmallWanderBossBullet) == 0x148);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1094)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (7bb1c84 - 8823cb4)

📈 **Matched code**: 14.35% (+0.03%, +3700 bytes)

<details>
<summary>✅ 24 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::exeFlyDown()` | +292 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::init(al::ActorInitInfo const&)` | +276 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::exeFly()` | +260 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::exeSignExplosion()` | +252 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::appearAttach(sead::Matrix34<float> const*, sead::Vector3<float> const*)` | +248 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::appearAttachParabolic(sead::Matrix34<float> const*, sead::Vector3<float> const*)` | +248 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::control()` | +240 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +216 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvAppearAttach::execute(al::NerveKeeper*) const` | +212 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvAppearAttachParabolic::execute(al::NerveKeeper*) const` | +212 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::exeAppearAttach()` | +208 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::SmallWanderBossBullet(char const*)` | +168 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::SmallWanderBossBullet(char const*)` | +156 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::exeExplosion()` | +156 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::attackSensor(al::HitSensor*, al::HitSensor*)` | +152 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::tryStartFlyParabolic(sead::Vector3<float> const&, float)` | +100 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::startLaunch()` | +100 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::resetPositionByAnim()` | +92 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::appear()` | +44 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `SmallWanderBossBullet::kill()` | +36 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvFly::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvExplosion::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvFlyDown::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/SmallWanderBoss/SmallWanderBossBullet` | `(anonymous namespace)::SmallWanderBossBulletNrvSignExplosion::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->