### PR TITLE
Enemy: Implement `JangoStateWaitTree`

### DIFF
--- a/src/Enemy/JangoStateWaitTree.cpp
+++ b/src/Enemy/JangoStateWaitTree.cpp
@@ -1,0 +1,102 @@
+#include "Enemy/JangoStateWaitTree.h"
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(JangoStateWaitTree, WaitOnSwitch)
+NERVE_IMPL_(JangoStateWaitTree, EndFind, End)
+NERVE_IMPL_(JangoStateWaitTree, EndDemo, End)
+NERVE_IMPL(JangoStateWaitTree, WaitPlayerOnGround)
+
+NERVES_MAKE_NOSTRUCT(JangoStateWaitTree, WaitOnSwitch, EndFind, EndDemo, WaitPlayerOnGround);
+}  // namespace
+
+JangoStateWaitTree::JangoStateWaitTree(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                       JangoWaitTreeType waitTreeType)
+    : al::ActorStateBase("木で待機", actor), mWaitTreeType(waitTreeType) {}
+
+void JangoStateWaitTree::init() {
+    mMtxConnector = al::createMtxConnector(mActor, mQuat);
+    initNerve(&WaitOnSwitch, 0);
+}
+
+void JangoStateWaitTree::appear() {
+    al::LiveActor* actor = mActor;
+
+    al::NerveStateBase::appear();
+    al::setNerve(this, &WaitOnSwitch);
+    al::offCollide(actor);
+    al::attachMtxConnectorToCollision(mMtxConnector, actor, 0.0f, 200.0f);
+    mTrans = al::getTrans(actor);
+    al::setVelocityZero(actor);
+}
+
+void JangoStateWaitTree::control() {
+    al::LiveActor* actor = mActor;
+    const sead::Vector3f& trans = al::getTrans(actor);
+
+    if ((rs::getPlayerPos(actor) - trans).length() < 600.0f) {
+        al::setNerve(this, &EndFind);
+        kill();
+        return;
+    }
+
+    al::connectPoseTrans(actor, mMtxConnector, mTrans);
+}
+
+bool JangoStateWaitTree::isEndDemo() const {
+    return al::isNerve(this, &EndDemo);
+}
+
+bool JangoStateWaitTree::isEndFind() const {
+    return al::isNerve(this, &EndFind);
+}
+
+void JangoStateWaitTree::exeWaitOnSwitch() {
+    al::LiveActor* actor = mActor;
+
+    if (al::isFirstStep(this))
+        al::startAction(actor, "WaitTree");
+
+    if (!al::isOnSwitchStart(actor))
+        return;
+
+    switch (mWaitTreeType) {
+    case JangoWaitTreeType::Find:
+        al::setNerve(this, &WaitPlayerOnGround);
+        break;
+    case JangoWaitTreeType::Demo:
+        al::setNerve(this, &EndDemo);
+        kill();
+        break;
+    default:
+        return;
+    }
+}
+
+void JangoStateWaitTree::exeWaitPlayerOnGround() {
+    al::LiveActor* actor = mActor;
+
+    if (!rs::isPlayerCollidedGround(actor) || rs::isPlayerSafetyPointRecovery(actor)) {
+        al::setNerve(this, &WaitPlayerOnGround);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 2)) {
+        al::onCollide(actor);
+        al::setNerve(this, &EndDemo);
+        kill();
+    }
+}
+
+void JangoStateWaitTree::exeEnd() {}

--- a/src/Enemy/JangoStateWaitTree.h
+++ b/src/Enemy/JangoStateWaitTree.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+#include <prim/seadEnum.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+class MtxConnector;
+}  // namespace al
+
+SEAD_ENUM(JangoWaitTreeType, Find, Demo);
+
+class JangoStateWaitTree : public al::ActorStateBase {
+public:
+    JangoStateWaitTree(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                       JangoWaitTreeType waitTreeType);
+
+    void init() override;
+    void appear() override;
+    void control() override;
+
+    bool isEndDemo() const;
+    bool isEndFind() const;
+    void exeWaitOnSwitch();
+    void exeWaitPlayerOnGround();
+    void exeEnd();
+
+private:
+    JangoWaitTreeType mWaitTreeType;
+    al::MtxConnector* mMtxConnector = nullptr;
+    sead::Quatf mQuat = sead::Quatf::unit;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(JangoStateWaitTree) == 0x50);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1095)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f550e5 - f3baf75)

📈 **Matched code**: 14.31% (+0.01%, +1192 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::control()` | +200 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `(anonymous namespace)::JangoStateWaitTreeNrvWaitOnSwitch::execute(al::NerveKeeper*) const` | +164 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::exeWaitOnSwitch()` | +160 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::exeWaitPlayerOnGround()` | +148 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `(anonymous namespace)::JangoStateWaitTreeNrvWaitPlayerOnGround::execute(al::NerveKeeper*) const` | +148 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::JangoStateWaitTree(al::LiveActor*, al::ActorInitInfo const&, JangoWaitTreeType)` | +124 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::appear()` | +116 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::init()` | +60 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::~JangoStateWaitTree()` | +36 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::isEndDemo() const` | +12 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::isEndFind() const` | +12 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `JangoStateWaitTree::exeEnd()` | +4 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `(anonymous namespace)::JangoStateWaitTreeNrvEndFind::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `Enemy/JangoStateWaitTree` | `(anonymous namespace)::JangoStateWaitTreeNrvEndDemo::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->