### PR TITLE
Boss/Koopa: Implement `KoopaStateDeadAndDemoBattleEnd`

### DIFF
--- a/src/Boss/Koopa/KoopaCap.h
+++ b/src/Boss/Koopa/KoopaCap.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class KoopaCapPlayerBinder;
+
+class KoopaCap : public al::LiveActor {
+public:
+    static KoopaCap* create(const al::LiveActor*, const al::ActorInitInfo&, KoopaCapPlayerBinder*,
+                            bool);
+
+    KoopaCap(const char*, const al::LiveActor*);
+
+    void init(const al::ActorInitInfo&) override;
+    void makeActorDead() override;
+    void appear() override;
+    void kill() override;
+    void disappear();
+    void control() override;
+    void updateCollider() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    bool isEquip() const;
+    bool isWaitHover() const;
+    bool isDown() const;
+    bool isEndWaitHoverStart() const;
+    bool isSpinMove() const;
+    bool isAttach() const;
+    bool isNecessaryUpdateAttachQT() const;
+    bool isFlyBack() const;
+    bool isEndFlyBack() const;
+    bool isDownRecover() const;
+    bool isPlayingCatchDemo() const;
+    bool isPlayerBinding() const;
+    void startDemo();
+    void endDemo();
+    void startAttach(const char*);
+    void startWaitHover(s32);
+    void startSpinThrowChase(const sead::Vector3f*, f32, bool);
+    void startDownRecover();
+    void forceStartFlyBackIfNearPlayerToKoopa();
+    void requestStartAction(const char*);
+    void onFinish();
+    void offFinish();
+    void setFastPunchRate(f32);
+    void endEquipAndBlowDown();
+    void endEquipAndKill();
+    void exeDemo();
+    void exeAppear();
+    void exeWait();
+    void exeAttach();
+    void exeWaitHoverDelay();
+    void exeWaitHoverStart();
+    void exeWaitHover();
+    void exeSpinThrow();
+    void exeFlyBack();
+    void exeFlyBackAfter();
+    void exeSpinHit();
+    void exeDownJumpStart();
+    void exeDownJump();
+    void exeDownJumpEnd();
+    void exeDown();
+    void exeDownRecoverStart();
+    void exeDownRecover();
+    void exeDownRecoverEnd();
+    void exeEquip();
+
+private:
+    const al::LiveActor* mOwner = nullptr;
+    u8 _110[0x60];
+};
+
+static_assert(sizeof(KoopaCap) == 0x170);

--- a/src/Boss/Koopa/KoopaDemoExecutor.h
+++ b/src/Boss/Koopa/KoopaDemoExecutor.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class AddDemoInfo;
+class EventFlowExecutor;
+class LiveActor;
+}  // namespace al
+
+class ChurchDoor;
+class IUseDemoSkip;
+class KoopaCameraCtrl;
+class KoopaCap;
+class KoopaShip;
+class Peach;
+
+class KoopaDemoExecutor {
+public:
+    KoopaDemoExecutor();
+
+    void init(al::LiveActor*, const al::ActorInitInfo&, al::EventFlowExecutor*, KoopaCameraCtrl*,
+              Peach*);
+    void initLv1(const al::ActorInitInfo&, al::LiveActor*, KoopaCap*, KoopaShip*);
+    void registerDemoModel(al::LiveActor*);
+    void initMoonChurch(const al::ActorInitInfo&, ChurchDoor*, al::LiveActor*);
+    void initLv2(const al::ActorInitInfo&, al::LiveActor*, KoopaCap*, al::LiveActor*);
+    bool update();
+    void startDemoAction(const char*, bool);
+    void skip();
+    void killAll();
+    bool tryStartChurchEnterDemo(IUseDemoSkip*, al::AddDemoInfo*);
+    void start(const char*);
+    bool tryStartChurchStartDemo(IUseDemoSkip*, al::AddDemoInfo*);
+    bool tryStartBattleStartDemo(IUseDemoSkip*);
+    bool tryStartBattleEndDemo(IUseDemoSkip* demoSkip);
+    bool tryStartClashBasementDemo(IUseDemoSkip*);
+
+private:
+    u8 _0[0x120];
+};
+
+static_assert(sizeof(KoopaDemoExecutor) == 0x120);

--- a/src/Boss/Koopa/KoopaStateDeadAndDemoBattleEnd.cpp
+++ b/src/Boss/Koopa/KoopaStateDeadAndDemoBattleEnd.cpp
@@ -1,0 +1,107 @@
+#include "Boss/Koopa/KoopaStateDeadAndDemoBattleEnd.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/BossUtil/BossUtil.h"
+#include "Boss/Koopa/KoopaCap.h"
+#include "Boss/Koopa/KoopaDemoExecutor.h"
+#include "Boss/Koopa/KoopaFunction.h"
+#include "Boss/Koopa/KoopaWeaponHolder.h"
+#include "Util/DemoUtil.h"
+
+namespace {
+IUseDemoSkip* getDemoSkip(KoopaStateDeadAndDemoBattleEnd* state) {
+    return state;
+}
+
+NERVE_IMPL(KoopaStateDeadAndDemoBattleEnd, Dead);
+NERVE_IMPL(KoopaStateDeadAndDemoBattleEnd, Demo);
+NERVE_IMPL(KoopaStateDeadAndDemoBattleEnd, Skip);
+NERVE_IMPL(KoopaStateDeadAndDemoBattleEnd, Start);
+NERVES_MAKE_NOSTRUCT(KoopaStateDeadAndDemoBattleEnd, Dead, Demo, Skip, Start);
+}  // namespace
+
+KoopaStateDeadAndDemoBattleEnd::KoopaStateDeadAndDemoBattleEnd(
+    al::LiveActor* actor, KoopaDemoExecutor* demoExecutor, KoopaCap* cap,
+    KoopaWeaponHolder* weaponHolder, al::LiveActor* demoActor, bool isKoopaLv2)
+    : al::ActorStateBase("死亡~戦闘終了デモ", actor), mDemoExecutor(demoExecutor), mCap(cap),
+      mWeaponHolder(weaponHolder), mDemoActor(demoActor), mIsKoopaLv2(isKoopaLv2) {
+    initNerve(&Dead, 0);
+}
+
+void KoopaStateDeadAndDemoBattleEnd::appear() {
+    NerveStateBase::appear();
+    al::setNerve(this, &Dead);
+    al::invalidateHitSensors(mActor);
+}
+
+void KoopaStateDeadAndDemoBattleEnd::kill() {
+    NerveStateBase::kill();
+    rs::requestEndDemoWithPlayer(mActor);
+    if (mIsKoopaLv2)
+        rs::saveShowDemoBossBattleEndKoopaLv2(mActor);
+    mDemoActor->makeActorDead();
+}
+
+bool KoopaStateDeadAndDemoBattleEnd::isFirstDemo() const {
+    if (mIsKoopaLv2)
+        return rs::isAlreadyShowDemoBossBattleEndKoopaLv2(mActor) ^ 1;
+    return true;
+}
+
+bool KoopaStateDeadAndDemoBattleEnd::isEnableSkipDemo() const {
+    if (al::isNerve(this, &Demo))
+        return al::isFirstStep(this) ^ 1;
+    return false;
+}
+
+void KoopaStateDeadAndDemoBattleEnd::skipDemo() {
+    mDemoExecutor->skip();
+    KoopaFunction::onSwitchGraphicsLevelBattleEnd(mActor);
+    al::setNerve(this, &Skip);
+    kill();
+}
+
+void KoopaStateDeadAndDemoBattleEnd::exeDead() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "Die");
+        al::setVelocityZero(mActor);
+    }
+
+    if (al::isStep(this, 1))
+        al::startHitReaction(mActor, "ダメージとどめ");
+
+    if (al::isActionEnd(mActor)) {
+        KoopaStateDeadAndDemoBattleEnd* demoSkip = this;
+        if (mDemoExecutor->tryStartBattleEndDemo(demoSkip)) {
+            al::setNerve(this, &Demo);
+            return;
+        }
+        al::setNerve(this, &Start);
+    }
+}
+
+void KoopaStateDeadAndDemoBattleEnd::exeStart() {
+    if (mDemoExecutor->tryStartBattleEndDemo(getDemoSkip(this)))
+        al::setNerve(this, &Demo);
+}
+
+void KoopaStateDeadAndDemoBattleEnd::exeDemo() {
+    if (al::isFirstStep(this)) {
+        mCap->endEquipAndKill();
+        mWeaponHolder->makeActorDeadAll();
+        KoopaFunction::offSwitchBattleKeepOn(mActor);
+    }
+
+    if (al::isGreaterEqualStep(this, 436))
+        KoopaFunction::onSwitchGraphicsLevelBattleEnd(mActor);
+
+    if (mDemoExecutor->update())
+        kill();
+}
+
+void KoopaStateDeadAndDemoBattleEnd::exeSkip() {}

--- a/src/Boss/Koopa/KoopaStateDeadAndDemoBattleEnd.h
+++ b/src/Boss/Koopa/KoopaStateDeadAndDemoBattleEnd.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaCap;
+class KoopaDemoExecutor;
+class KoopaWeaponHolder;
+
+class KoopaStateDeadAndDemoBattleEnd : public al::ActorStateBase, public IUseDemoSkip {
+public:
+    KoopaStateDeadAndDemoBattleEnd(al::LiveActor* actor, KoopaDemoExecutor* demoExecutor,
+                                   KoopaCap* cap, KoopaWeaponHolder* weaponHolder,
+                                   al::LiveActor* demoActor, bool isKoopaLv2);
+
+    void appear() override;
+    void kill() override;
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+
+    void exeDead();
+    void exeStart();
+    void exeDemo();
+    void exeSkip();
+
+private:
+    KoopaDemoExecutor* mDemoExecutor = nullptr;
+    KoopaCap* mCap = nullptr;
+    KoopaWeaponHolder* mWeaponHolder = nullptr;
+    al::LiveActor* mDemoActor = nullptr;
+    bool mIsKoopaLv2 = false;
+};
+
+static_assert(sizeof(KoopaStateDeadAndDemoBattleEnd) == 0x50);

--- a/src/Boss/Koopa/KoopaWeaponHolder.h
+++ b/src/Boss/Koopa/KoopaWeaponHolder.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class KoopaCap;
+
+class KoopaWeaponHolder {
+public:
+    static KoopaWeaponHolder* create(const al::LiveActor*, const al::ActorInitInfo&, s32);
+
+    KoopaWeaponHolder();
+    void makeActorDeadAll();
+    void killAll();
+    void cancelAll();
+    void* findDeadDamageBall() const;
+    void* findDeadDamageBallBomb() const;
+    void disappearAllDummyCap();
+    void killAllDummyCapWaitHover();
+    bool isAllAliveDummyCapWaitHover() const;
+    KoopaCap* getDummyCap(s32) const;
+    KoopaCap* findDeadDummyCap() const;
+    void resetWeaponItemGenerateLimitByDamage();
+
+private:
+    void* mItemHolder = nullptr;
+    void* mRingBeamEmitter = nullptr;
+    void* mWeaponCapGroup = nullptr;
+    void* mDamageBallGroup = nullptr;
+    void* mDamageBallBombGroup = nullptr;
+};
+
+static_assert(sizeof(KoopaWeaponHolder) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1096)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - 153cb9b)

📉 **Matched code**: 14.25% (-0.01%, -1756 bytes)

<details>
<summary>✅ 19 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::exeDead()` | +160 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::KoopaStateDeadAndDemoBattleEnd(al::LiveActor*, KoopaDemoExecutor*, KoopaCap*, KoopaWeaponHolder*, al::LiveActor*, bool)` | +140 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::exeDemo()` | +120 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `non-virtual thunk to KoopaStateDeadAndDemoBattleEnd::skipDemo()` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::exeStart()` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `(anonymous namespace)::KoopaStateDeadAndDemoBattleEndNrvStart::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::kill()` | +72 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `non-virtual thunk to KoopaStateDeadAndDemoBattleEnd::isEnableSkipDemo() const` | +72 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::skipDemo()` | +72 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::isEnableSkipDemo() const` | +68 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::isFirstDemo() const` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `non-virtual thunk to KoopaStateDeadAndDemoBattleEnd::isFirstDemo() const` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::appear()` | +48 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::~KoopaStateDeadAndDemoBattleEnd()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `(anonymous namespace)::KoopaStateDeadAndDemoBattleEndNrvDead::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `(anonymous namespace)::KoopaStateDeadAndDemoBattleEndNrvDemo::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossForest/BossForest` | `IUseDemoSkip::updateOnlyDemoGraphics()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `KoopaStateDeadAndDemoBattleEnd::exeSkip()` | +4 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateDeadAndDemoBattleEnd` | `(anonymous namespace)::KoopaStateDeadAndDemoBattleEndNrvSkip::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->