### PR TITLE
MapObj: Implement `FastenerKnob`

### DIFF
--- a/src/MapObj/Fastener.h
+++ b/src/MapObj/Fastener.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+
+struct FastenerVertex {
+    s32 calcValidEdgeNum() const;
+    s32 calcValidEdgeNumFastener() const;
+
+    u8 _0[0x14];
+    sead::Vector3f trans;
+    u8 _20[0x24b];
+    bool _26b;
+    u8 _26c[0x14];
+    u32 _280;
+    u8 _284[0x4];
+};
+
+static_assert(sizeof(FastenerVertex) == 0x288);
+
+namespace FastenerFunction {
+bool tryMakeQuatResetKnob(sead::Quatf* quat, const FastenerVertex* vertex);
+void resetKnobPose(al::LiveActor* actor, const FastenerVertex* vertex);
+}  // namespace FastenerFunction

--- a/src/MapObj/FastenerKnob.cpp
+++ b/src/MapObj/FastenerKnob.cpp
@@ -1,0 +1,101 @@
+#include "MapObj/FastenerKnob.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/Fastener.h"
+
+namespace {
+NERVE_IMPL(FastenerKnob, Wait)
+NERVE_IMPL(FastenerKnob, HackEnd)
+NERVE_IMPL(FastenerKnob, Reset)
+
+NERVES_MAKE_NOSTRUCT(FastenerKnob, Wait, HackEnd, Reset)
+}  // namespace
+
+FastenerKnob::FastenerKnob(const char* name) : al::LiveActor(name) {}
+
+void FastenerKnob::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "Fastener", nullptr);
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+}
+
+void FastenerKnob::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Standby");
+
+    al::resetPosition(this, mCurrentVertex->trans);
+
+    if (mCurrentVertex->_280 != 0) {
+        if (mCurrentVertex->_26b)
+            return FastenerFunction::resetKnobPose(this, mCurrentVertex);
+        return;
+    }
+
+    if (mCurrentVertex->_26b)
+        FastenerFunction::tryMakeQuatResetKnob(&mResetQuat, mCurrentVertex);
+
+    sead::Quatf* quat = al::getQuatPtr(this);
+    return al::slerpQuat(quat, *quat, mResetQuat, 0.2f);
+}
+
+void FastenerKnob::exeHackEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "HackEnd");
+
+    if (mCurrentVertex->_280 == 0) {
+        if (mCurrentVertex->_26b)
+            FastenerFunction::tryMakeQuatResetKnob(&mResetQuat, mCurrentVertex);
+
+        sead::Quatf* quat = al::getQuatPtr(this);
+        al::slerpQuat(quat, *quat, mResetQuat, 0.2f);
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void FastenerKnob::onHackEnd(const sead::Quatf& quat, const FastenerVertex* vertex) {
+    mCurrentVertex = vertex;
+    al::resetQuatPosition(this, quat, vertex->trans);
+    al::setNerve(this, &HackEnd);
+}
+
+void FastenerKnob::reset() {
+    al::startHitReaction(this, "消滅");
+    al::hideSilhouetteModelIfShow(this);
+    al::invalidateClipping(this);
+    al::setNerve(this, &Reset);
+}
+
+void FastenerKnob::disappear() {
+    al::startHitReaction(this, "消滅");
+    return al::LiveActor::kill();
+}
+
+void FastenerKnob::exeReset() {
+    if (!al::isGreaterStep(this, 1))
+        return;
+
+    mCurrentVertex = mStartVertex;
+    FastenerFunction::resetKnobPose(this, mCurrentVertex);
+    al::resetPosition(this, mCurrentVertex->trans);
+
+    al::startHitReaction(this, "出現");
+    al::validateClipping(this);
+    al::showModelIfHide(this);
+    al::setNerve(this, &Wait);
+}
+
+bool FastenerKnob::isEnableCapture() const {
+    return al::isNerve(this, &Wait);
+}

--- a/src/MapObj/FastenerKnob.h
+++ b/src/MapObj/FastenerKnob.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+struct FastenerVertex;
+
+class FastenerKnob : public al::LiveActor {
+public:
+    FastenerKnob(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    void exeHackEnd();
+    void onHackEnd(const sead::Quatf& quat, const FastenerVertex* vertex);
+    void reset();
+    void disappear();
+    void exeReset();
+    bool isEnableCapture() const;
+
+private:
+    u64 _108 = 0;
+    bool mIsUnknown110 = false;
+    const FastenerVertex* mStartVertex = nullptr;
+    const FastenerVertex* mCurrentVertex = nullptr;
+    sead::Quatf mResetQuat = sead::Quatf::unit;
+};
+
+static_assert(sizeof(FastenerKnob) == 0x138);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1097)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f550e5 - a2aea07)

📈 **Matched code**: 14.31% (+0.01%, +1068 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FastenerKnob` | `FastenerKnob::FastenerKnob(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::FastenerKnob(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::exeWait()` | +156 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::exeHackEnd()` | +148 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::exeReset()` | +128 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::init(al::ActorInitInfo const&)` | +112 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::reset()` | +68 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::onHackEnd(sead::Quat<float> const&, FastenerVertex const*)` | +52 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::disappear()` | +44 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `FastenerKnob::isEnableCapture() const` | +12 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `(anonymous namespace)::FastenerKnobNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `(anonymous namespace)::FastenerKnobNrvHackEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/FastenerKnob` | `(anonymous namespace)::FastenerKnobNrvReset::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->