### PR TITLE
Item: Implement `ShineFukankunWatchObj`

### DIFF
--- a/src/Item/ShineFukankunWatchObj.cpp
+++ b/src/Item/ShineFukankunWatchObj.cpp
@@ -1,0 +1,55 @@
+#include "Item/ShineFukankunWatchObj.h"
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+
+#include "Item/Shine.h"
+#include "MapObj/FukankunZoomTargetFunction.h"
+#include "Util/ItemUtil.h"
+
+namespace {
+NERVE_IMPL(ShineFukankunWatchObj, Wait);
+
+NERVES_MAKE_NOSTRUCT(ShineFukankunWatchObj, Wait);
+}  // namespace
+
+ShineFukankunWatchObj::ShineFukankunWatchObj(const char* name) : al::LiveActor(name) {}
+
+void ShineFukankunWatchObj::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorPoseTQSV(this);
+    al::initActorSRT(this, info);
+    al::initExecutorWatchObj(this, info);
+    al::initActorClipping(this, info);
+    al::setClippingInfo(this, 500.0f, nullptr);
+    al::initNerve(this, &Wait, 0);
+    FukankunZoomTargetFunction::declareUseFukankunZoomTargetActor(this);
+
+    mShine = rs::initShineByPlacementInfo(info);
+    mShine->initAppearDemoFromHost(info, al::getTrans(this));
+
+    makeActorAlive();
+}
+
+void ShineFukankunWatchObj::initAfterPlacement() {
+    return FukankunZoomTargetFunction::registerFukankunZoomTargetActor(
+        this, 0, sead::Vector3f::zero, nullptr);
+}
+
+void ShineFukankunWatchObj::exeWait() {
+    if (FukankunZoomTargetFunction::getWatchCount(this) >= 121) {
+        const sead::Matrix34f* linkedShineMtx = nullptr;
+        if (FukankunZoomTargetFunction::tryGetActiveFukankunLinkedShineMtx(&linkedShineMtx, this)) {
+            sead::Vector3f linkedShinePos;
+            linkedShineMtx->getTranslation(linkedShinePos);
+            mShine->appearWarp(al::getTrans(this), linkedShinePos);
+            kill();
+        }
+    }
+}

--- a/src/Item/ShineFukankunWatchObj.h
+++ b/src/Item/ShineFukankunWatchObj.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Shine;
+
+class ShineFukankunWatchObj : public al::LiveActor {
+public:
+    ShineFukankunWatchObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+
+    void exeWait();
+
+private:
+    Shine* mShine = nullptr;
+};
+
+static_assert(sizeof(ShineFukankunWatchObj) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -66,6 +66,7 @@
 #include "Item/LifeMaxUpItem2D.h"
 #include "Item/LifeUpItem.h"
 #include "Item/LifeUpItem2D.h"
+#include "Item/ShineFukankunWatchObj.h"
 #include "MapObj/AllDeadWatcherWithShine.h"
 #include "MapObj/AnagramAlphabet.h"
 #include "MapObj/BlockEmpty2D.h"
@@ -537,7 +538,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"ShineWithAppearCamera", nullptr},
     {"ShineChipWatcher", nullptr},
     {"ShineDot", nullptr},
-    {"ShineFukankunWatchObj", nullptr},
+    {"ShineFukankunWatchObj", al::createActorFunction<ShineFukankunWatchObj>},
     {"ShineTowerRocket", al::createActorFunction<ShineTowerRocket>},
     {"ShopBgmPlayer", nullptr},
     {"ShopMark", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1098)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f550e5 - bea6449)

📈 **Matched code**: 14.31% (+0.01%, +804 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/ShineFukankunWatchObj` | `ShineFukankunWatchObj::init(al::ActorInitInfo const&)` | +188 | 0.00% | 100.00% |
| `Item/ShineFukankunWatchObj` | `(anonymous namespace)::ShineFukankunWatchObjNrvWait::execute(al::NerveKeeper*) const` | +144 | 0.00% | 100.00% |
| `Item/ShineFukankunWatchObj` | `ShineFukankunWatchObj::exeWait()` | +140 | 0.00% | 100.00% |
| `Item/ShineFukankunWatchObj` | `ShineFukankunWatchObj::ShineFukankunWatchObj(char const*)` | +136 | 0.00% | 100.00% |
| `Item/ShineFukankunWatchObj` | `ShineFukankunWatchObj::ShineFukankunWatchObj(char const*)` | +124 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<ShineFukankunWatchObj>(char const*)` | +52 | 0.00% | 100.00% |
| `Item/ShineFukankunWatchObj` | `ShineFukankunWatchObj::initAfterPlacement()` | +20 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->