### PR TITLE
Util: Implement `InputSeparator`

### DIFF
--- a/src/Util/InputSeparator.cpp
+++ b/src/Util/InputSeparator.cpp
@@ -1,0 +1,123 @@
+#include "Util/InputSeparator.h"
+
+#include "Util/StageInputFunction.h"
+
+InputSeparator::InputSeparator(const al::IUseSceneObjHolder* sceneObjHolder, bool isVertical)
+    : mSceneObjHolder(sceneObjHolder), mIsVertical(isVertical) {}
+
+void InputSeparator::reset() {
+    mIsDominant = false;
+    mDominantTimer = 0;
+}
+
+void InputSeparator::update() {
+    mIsDominant = false;
+
+    if (mDominantTimer > 0)
+        mDominantTimer--;
+
+    if (mIsVertical) {
+        if (rs::isHoldUiUp(mSceneObjHolder) || rs::isHoldUiDown(mSceneObjHolder)) {
+            mIsDominant = true;
+            mDominantTimer = mDominantBorder;
+        }
+
+        if (rs::isTriggerUiUp(mSceneObjHolder) || rs::isTriggerUiDown(mSceneObjHolder))
+            mDominantTimer = mDominantBorder;
+
+        return;
+    }
+
+    if (rs::isHoldUiRight(mSceneObjHolder) || rs::isHoldUiLeft(mSceneObjHolder)) {
+        mIsDominant = true;
+        mDominantTimer = mDominantBorder;
+    }
+
+    if (rs::isTriggerUiRight(mSceneObjHolder) || rs::isTriggerUiLeft(mSceneObjHolder))
+        mDominantTimer = mDominantBorder;
+}
+
+void InputSeparator::updateForSnapShotMode() {
+    mIsDominant = false;
+
+    if (mDominantTimer > 0)
+        mDominantTimer--;
+
+    if (rs::isTriggerIncrementPostProcessingFilterPreset(mSceneObjHolder) ||
+        rs::isTriggerDecrementPostProcessingFilterPreset(mSceneObjHolder))
+        mDominantTimer = mDominantBorder;
+}
+
+bool InputSeparator::isTriggerUiLeft() {
+    return !checkDominant(false) && rs::isTriggerUiLeft(mSceneObjHolder);
+}
+
+bool InputSeparator::checkDominant(bool isVertical) {
+    if (mIsVertical != isVertical) {
+        if (mIsDominant)
+            return true;
+
+        if (mDominantTimer > 0)
+            return true;
+    }
+
+    return false;
+}
+
+bool InputSeparator::isTriggerUiRight() {
+    return !checkDominant(false) && rs::isTriggerUiRight(mSceneObjHolder);
+}
+
+bool InputSeparator::isTriggerUiUp() {
+    return !checkDominant(true) && rs::isTriggerUiUp(mSceneObjHolder);
+}
+
+bool InputSeparator::isTriggerUiDown() {
+    return !checkDominant(true) && rs::isTriggerUiDown(mSceneObjHolder);
+}
+
+bool InputSeparator::isHoldUiLeft() {
+    return !checkDominant(false) && rs::isHoldUiLeft(mSceneObjHolder);
+}
+
+bool InputSeparator::isHoldUiRight() {
+    return !checkDominant(false) && rs::isHoldUiRight(mSceneObjHolder);
+}
+
+bool InputSeparator::isHoldUiUp() {
+    return !checkDominant(true) && rs::isHoldUiUp(mSceneObjHolder);
+}
+
+bool InputSeparator::isHoldUiDown() {
+    return !checkDominant(true) && rs::isHoldUiDown(mSceneObjHolder);
+}
+
+bool InputSeparator::isRepeatUiLeft() {
+    return !checkDominant(false) && rs::isRepeatUiLeft(mSceneObjHolder);
+}
+
+bool InputSeparator::isRepeatUiRight() {
+    return !checkDominant(false) && rs::isRepeatUiRight(mSceneObjHolder);
+}
+
+bool InputSeparator::isRepeatUiUp() {
+    return !checkDominant(true) && rs::isRepeatUiUp(mSceneObjHolder);
+}
+
+bool InputSeparator::isRepeatUiDown() {
+    return !checkDominant(true) && rs::isRepeatUiDown(mSceneObjHolder);
+}
+
+bool InputSeparator::isTriggerSnapShotMode() {
+    return !checkDominant(true) && rs::isTriggerSnapShotMode(mSceneObjHolder);
+}
+
+bool InputSeparator::isTriggerIncrementPostProcessingFilterPreset() {
+    return !checkDominant(false) &&
+           rs::isTriggerIncrementPostProcessingFilterPreset(mSceneObjHolder);
+}
+
+bool InputSeparator::isTriggerDecrementPostProcessingFilterPreset() {
+    return !checkDominant(false) &&
+           rs::isTriggerDecrementPostProcessingFilterPreset(mSceneObjHolder);
+}

--- a/src/Util/InputSeparator.cpp
+++ b/src/Util/InputSeparator.cpp
@@ -6,46 +6,45 @@ InputSeparator::InputSeparator(const al::IUseSceneObjHolder* sceneObjHolder, boo
     : mSceneObjHolder(sceneObjHolder), mIsVertical(isVertical) {}
 
 void InputSeparator::reset() {
-    mIsDominant = false;
+    mIsHoldDominant = false;
     mDominantTimer = 0;
 }
 
 void InputSeparator::update() {
-    mIsDominant = false;
+    mIsHoldDominant = false;
 
     if (mDominantTimer > 0)
         mDominantTimer--;
 
     if (mIsVertical) {
         if (rs::isHoldUiUp(mSceneObjHolder) || rs::isHoldUiDown(mSceneObjHolder)) {
-            mIsDominant = true;
-            mDominantTimer = mDominantBorder;
+            mIsHoldDominant = true;
+            mDominantTimer = mDominantCooldown;
         }
 
         if (rs::isTriggerUiUp(mSceneObjHolder) || rs::isTriggerUiDown(mSceneObjHolder))
-            mDominantTimer = mDominantBorder;
+            mDominantTimer = mDominantCooldown;
 
-        return;
+    } else {
+        if (rs::isHoldUiRight(mSceneObjHolder) || rs::isHoldUiLeft(mSceneObjHolder)) {
+            mIsHoldDominant = true;
+            mDominantTimer = mDominantCooldown;
+        }
+
+        if (rs::isTriggerUiRight(mSceneObjHolder) || rs::isTriggerUiLeft(mSceneObjHolder))
+            mDominantTimer = mDominantCooldown;
     }
-
-    if (rs::isHoldUiRight(mSceneObjHolder) || rs::isHoldUiLeft(mSceneObjHolder)) {
-        mIsDominant = true;
-        mDominantTimer = mDominantBorder;
-    }
-
-    if (rs::isTriggerUiRight(mSceneObjHolder) || rs::isTriggerUiLeft(mSceneObjHolder))
-        mDominantTimer = mDominantBorder;
 }
 
 void InputSeparator::updateForSnapShotMode() {
-    mIsDominant = false;
+    mIsHoldDominant = false;
 
     if (mDominantTimer > 0)
         mDominantTimer--;
 
     if (rs::isTriggerIncrementPostProcessingFilterPreset(mSceneObjHolder) ||
         rs::isTriggerDecrementPostProcessingFilterPreset(mSceneObjHolder))
-        mDominantTimer = mDominantBorder;
+        mDominantTimer = mDominantCooldown;
 }
 
 bool InputSeparator::isTriggerUiLeft() {
@@ -54,7 +53,7 @@ bool InputSeparator::isTriggerUiLeft() {
 
 bool InputSeparator::checkDominant(bool isVertical) {
     if (mIsVertical != isVertical) {
-        if (mIsDominant)
+        if (mIsHoldDominant)
             return true;
 
         if (mDominantTimer > 0)

--- a/src/Util/InputSeparator.h
+++ b/src/Util/InputSeparator.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class IUseSceneObjHolder;
+}  // namespace al
+
+class InputSeparator {
+public:
+    InputSeparator(const al::IUseSceneObjHolder* sceneObjHolder, bool isVertical);
+
+    void reset();
+    void update();
+    void updateForSnapShotMode();
+    bool isTriggerUiLeft();
+    bool checkDominant(bool isVertical);
+    bool isTriggerUiRight();
+    bool isTriggerUiUp();
+    bool isTriggerUiDown();
+    bool isHoldUiLeft();
+    bool isHoldUiRight();
+    bool isHoldUiUp();
+    bool isHoldUiDown();
+    bool isRepeatUiLeft();
+    bool isRepeatUiRight();
+    bool isRepeatUiUp();
+    bool isRepeatUiDown();
+    bool isTriggerSnapShotMode();
+    bool isTriggerIncrementPostProcessingFilterPreset();
+    bool isTriggerDecrementPostProcessingFilterPreset();
+
+private:
+    const al::IUseSceneObjHolder* mSceneObjHolder;
+    bool mIsVertical;
+    bool mIsDominant = false;
+    s32 mDominantBorder = 8;
+    s32 mDominantTimer = 0;
+};
+
+static_assert(sizeof(InputSeparator) == 0x18);

--- a/src/Util/InputSeparator.h
+++ b/src/Util/InputSeparator.h
@@ -33,8 +33,8 @@ public:
 private:
     const al::IUseSceneObjHolder* mSceneObjHolder;
     bool mIsVertical;
-    bool mIsDominant = false;
-    s32 mDominantBorder = 8;
+    bool mIsHoldDominant = false;
+    s32 mDominantCooldown = 8;
     s32 mDominantTimer = 0;
 };
 


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1099)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 56ebb4d)

📈 **Matched code**: 15.50% (+0.01%, +1124 bytes)

<details>
<summary>✅ 20 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/InputSeparator` | `InputSeparator::update()` | +192 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::updateForSnapShotMode()` | +80 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::checkDominant(bool)` | +64 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerUiUp()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerUiDown()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isHoldUiUp()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isHoldUiDown()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isRepeatUiUp()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isRepeatUiDown()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerSnapShotMode()` | +52 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerUiLeft()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerUiRight()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isHoldUiLeft()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isHoldUiRight()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isRepeatUiLeft()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isRepeatUiRight()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerIncrementPostProcessingFilterPreset()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::isTriggerDecrementPostProcessingFilterPreset()` | +48 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::InputSeparator(al::IUseSceneObjHolder const*, bool)` | +28 | 0.00% | 100.00% |
| `Util/InputSeparator` | `InputSeparator::reset()` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->