### PR TITLE
Boss/GolemClimb: Implement `GolemDownBreakState`

### DIFF
--- a/src/Boss/GolemClimb/GolemDownBreakState.cpp
+++ b/src/Boss/GolemClimb/GolemDownBreakState.cpp
@@ -1,0 +1,72 @@
+#include "Boss/GolemClimb/GolemDownBreakState.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/GolemClimb/GolemClimbWeakPoint.h"
+#include "Boss/GolemClimb/GolemShoutState.h"
+#include "Boss/GolemClimb/IUseGolemState.h"
+
+namespace {
+NERVE_IMPL(GolemDownBreakState, Damage);
+NERVE_IMPL(GolemDownBreakState, Shout);
+NERVE_IMPL(GolemDownBreakState, Recover);
+NERVES_MAKE_NOSTRUCT(GolemDownBreakState, Damage, Shout, Recover);
+}  // namespace
+
+GolemDownBreakState::GolemDownBreakState(const char* name, IUseGolemState* golemState,
+                                         GolemShoutState* shoutState)
+    : al::HostStateBase<IUseGolemState>(name, golemState), mShoutState(shoutState) {
+    initNerve(&Damage, 0);
+}
+
+void GolemDownBreakState::appear() {
+    al::setVelocityZero(getHost()->getActor());
+    al::startHitReaction(getHost()->getActor(), "弱点ヒット");
+    al::setNerve(this, &Damage);
+    NerveStateBase::appear();
+}
+
+void GolemDownBreakState::kill() {
+    mWeakPoint = nullptr;
+    mDamageActionName = nullptr;
+    mRecoverActionName = nullptr;
+    getHost()->endPushSensor();
+    NerveStateBase::kill();
+}
+
+void GolemDownBreakState::exeDamage() {
+    if (al::isFirstStep(this)) {
+        mWeakPoint->startBreak();
+        al::startAction(getHost()->getActor(), mDamageActionName);
+    }
+    if (mWeakPoint->isBreak())
+        al::setNerve(this, &Shout);
+}
+
+void GolemDownBreakState::exeShout() {
+    if (al::isFirstStep(this))
+        mShoutState->appear();
+    mShoutState->control();
+    if (al::isStep(this, 120)) {
+        mShoutState->kill();
+        al::setNerve(this, &Recover);
+    }
+}
+
+void GolemDownBreakState::exeRecover() {
+    if (al::isFirstStep(this))
+        al::startAction(getHost()->getActor(), mRecoverActionName);
+    getHost()->updatePushSensor();
+    if (al::isActionEnd(getHost()->getActor()) && getHost()->tryNextPushSensor())
+        kill();
+}
+
+void GolemDownBreakState::startBreak(GolemClimbWeakPoint* weakPoint, const char* damageActionName,
+                                     const char* recoverActionName) {
+    mWeakPoint = weakPoint;
+    mDamageActionName = damageActionName;
+    mRecoverActionName = recoverActionName;
+}

--- a/src/Boss/GolemClimb/GolemDownBreakState.h
+++ b/src/Boss/GolemClimb/GolemDownBreakState.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class GolemClimbWeakPoint;
+class GolemShoutState;
+class IUseGolemState;
+
+class GolemDownBreakState : public al::HostStateBase<IUseGolemState> {
+public:
+    GolemDownBreakState(const char* name, IUseGolemState* golemState, GolemShoutState* shoutState);
+    void appear() override;
+    void kill() override;
+    void exeDamage();
+    void exeShout();
+    void exeRecover();
+    void startBreak(GolemClimbWeakPoint* weakPoint, const char* damageActionName,
+                    const char* recoverActionName);
+
+private:
+    GolemShoutState* mShoutState = nullptr;
+    GolemClimbWeakPoint* mWeakPoint = nullptr;
+    const char* mDamageActionName = nullptr;
+    const char* mRecoverActionName = nullptr;
+};
+
+static_assert(sizeof(GolemDownBreakState) == 0x40);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1100)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - e538836)

📉 **Matched code**: 14.25% (-0.01%, -1852 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/GolemClimb/GolemDownBreakState` | `(anonymous namespace)::GolemDownBreakStateNrvRecover::execute(al::NerveKeeper*) const` | +148 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::exeRecover()` | +144 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `(anonymous namespace)::GolemDownBreakStateNrvShout::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::exeShout()` | +124 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `(anonymous namespace)::GolemDownBreakStateNrvDamage::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::exeDamage()` | +104 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::appear()` | +96 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::GolemDownBreakState(char const*, IUseGolemState*, GolemShoutState*)` | +92 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::kill()` | +60 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::~GolemDownBreakState()` | +36 | 0.00% | 100.00% |
| `Boss/GolemClimb/GolemDownBreakState` | `GolemDownBreakState::startBreak(GolemClimbWeakPoint*, char const*, char const*)` | +12 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->