### PR TITLE
ModeBalloon: Implement `TimeBalloonDataAccessorState`

### DIFF
--- a/src/ModeBalloon/TimeBalloonAchievementLayout.h
+++ b/src/ModeBalloon/TimeBalloonAchievementLayout.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadVector.h>
 
 #include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
 
@@ -9,6 +10,32 @@ class IBalloonFindMyAchievementHolder;
 namespace al {
 class LayoutInitInfo;
 }  // namespace al
+
+namespace TimeBalloon {
+class BalloonDataServer {
+public:
+    BalloonDataServer();
+    virtual ~BalloonDataServer();
+
+    void setNoticeDataId(u64 noticeDataId) { mNoticeDataId = noticeDataId; }
+
+private:
+    s32 mDataTypeCurrentWorldId = 0;
+    bool mIsInvalid = false;
+    s32 _10 = 0;
+    sead::Vector3f mBalloonPos = sead::Vector3f::zero;
+    u64 mNoticeDataId = 0;
+    u64 _28 = 0;
+    u64 _30 = 0;
+    u64 _38 = 0;
+    u64 _40 = 0;
+    u64 _48 = 0;
+    void* _50 = nullptr;
+    void* _58 = nullptr;
+};
+
+static_assert(sizeof(BalloonDataServer) == 0x60);
+}  // namespace TimeBalloon
 
 class TimeBalloonAchievementLayout : public al::SimpleLayoutAppearWaitEnd {
 public:

--- a/src/ModeBalloon/TimeBalloonBalloonDataHolder.h
+++ b/src/ModeBalloon/TimeBalloonBalloonDataHolder.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class FriendsProfileDataHolder;
+
+namespace nn::nex {
+template <typename K, typename V>
+class qMap;
+struct DataStoreRatingInfo;
+}  // namespace nn::nex
+
+namespace TimeBalloon {
+class BalloonData;
+struct BalloonDataMetaBinary;
+}  // namespace TimeBalloon
+
+class TimeBalloonBalloonDataHolder {
+public:
+    TimeBalloonBalloonDataHolder(s32 dataMax);
+
+    void reset();
+    void setData(const TimeBalloon::BalloonDataMetaBinary* metaBinary, u64 dataId, u64 ownerId,
+                 u32 worldTypeId,
+                 const nn::nex::qMap<s8, nn::nex::DataStoreRatingInfo>& ratingInfoMap,
+                 FriendsProfileDataHolder* profileDataHolder, bool isGotBalloon);
+    bool trySetData(const TimeBalloon::BalloonDataMetaBinary* metaBinary, u64 dataId, u64 ownerId,
+                    u32 worldTypeId,
+                    const nn::nex::qMap<s8, nn::nex::DataStoreRatingInfo>& ratingInfoMap,
+                    FriendsProfileDataHolder* profileDataHolder, bool isGotBalloon);
+    void clearData(s32 index);
+    const TimeBalloon::BalloonData& getData(s32 index) const;
+    const TimeBalloon::BalloonData* tryGetData(s32 index) const;
+    const TimeBalloon::BalloonData* tryGetData(u64 dataId) const;
+    const TimeBalloon::BalloonData* tryGetDataByWorldTypeId(u32 worldTypeId) const;
+    bool tryClearData(u64 dataId);
+
+    s32 getCurrentCount() const { return mCurrentCount; }
+
+private:
+    u8 _0[0x10];
+    s32 mCurrentCount = 0;
+};

--- a/src/ModeBalloon/TimeBalloonData.h
+++ b/src/ModeBalloon/TimeBalloonData.h
@@ -20,11 +20,7 @@ struct DataStoreSearchBalloonResult;
 }  // namespace nn::nex
 
 namespace TimeBalloon {
-class BalloonDataServer {
-public:
-    BalloonDataServer();
-    virtual ~BalloonDataServer();
-};
+class BalloonDataServer;
 
 class BalloonData {
 public:

--- a/src/ModeBalloon/TimeBalloonDataAccessor.h
+++ b/src/ModeBalloon/TimeBalloonDataAccessor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "ModeBalloon/TimeBalloonBalloonDataHolder.h"
+
+namespace TimeBalloon {
+class BalloonDataServer;
+}
+
+class TimeBalloonDataAccessor {
+public:
+    bool tryDeleteNoticeDataOne(u64 noticeDataId);
+    bool isEnd() const;
+    void deleteNotice(s32 worldId);
+    bool tryCreateNoticeDataOne();
+    u64 getCreateNoticeDataOneLast() const;
+    void registerNewNotice(u64 noticeDataId, s32 worldId);
+    bool tryCreateBalloonDataOne(const TimeBalloon::BalloonDataServer* balloonDataServer);
+    u64 getBalloonDataIdLast() const;
+    bool trySearchOwnAll();
+    bool tryDownloadBalloonDataOwnAllBufferQueue();
+    bool trySearchBalloon();
+    bool tryDownloadAchievementOther();
+    bool tryRateUpBalloonRating(u64 dataId, u64 ownerId, bool isInvalidRating);
+    bool tryUpdateBalloonPlayed(u64 dataId);
+    bool tryGotBalloon(u64 dataId, u64 ownerId, s32 arg4, s32 arg5);
+    bool tryUpdateNoticeGot(u64 noticeDataId);
+    bool tryGotBalloonTutorial();
+    bool tryGetAndSaveAchievementIfExist();
+    bool isExistAchievementData() const;
+    bool tryCreateAndSaveAchievement();
+
+    s32 getOwnBalloonCount() const { return mBalloonDataHolder->getCurrentCount(); }
+
+    u16 getAchievementDataId() const { return mAchievementDataId; }
+
+private:
+    u8 _00[0x60];
+    TimeBalloonBalloonDataHolder* mBalloonDataHolder = nullptr;
+    u8 _68[0x10];
+    u16 mAchievementDataId = 0;
+    u8 _7a[0x86];
+};
+
+static_assert(sizeof(TimeBalloonDataAccessor) == 0x100);

--- a/src/ModeBalloon/TimeBalloonDataAccessorState.cpp
+++ b/src/ModeBalloon/TimeBalloonDataAccessorState.cpp
@@ -1,0 +1,393 @@
+#include "ModeBalloon/TimeBalloonDataAccessorState.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "ModeBalloon/TimeBalloonAchievementLayout.h"
+#include "ModeBalloon/TimeBalloonDataAccessor.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+
+namespace TimeBalloonDataState {
+
+TimeBalloonDataAccessorExecutorStateBase::TimeBalloonDataAccessorExecutorStateBase(
+    TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : al::NerveStateBase(""), mExecutor(executor), mAccessor(accessor) {}
+
+void TimeBalloonDataAccessorExecutorStateBase::appear() {
+    al::NerveStateBase::appear();
+    mIsError = false;
+}
+
+void TimeBalloonDataAccessorExecutorStateBase::errorAndKill() {
+    mIsError = true;
+    kill();
+}
+
+void TimeBalloonDataAccessorExecutorStateBase::errorConnectionAndKill() {
+    mIsError = true;
+    kill();
+}
+
+namespace UpdatePutBalloonOwn {
+
+NERVE_IMPL(State, DeleteNotice)
+NERVE_IMPL(State, CreateNotice)
+NERVE_IMPL(State, CreateBalloon)
+
+NERVES_MAKE_NOSTRUCT(State, DeleteNotice, CreateNotice, CreateBalloon)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&DeleteNotice, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &DeleteNotice);
+}
+
+void State::setAccessor(al::LiveActor* accessor) {
+    mAccessorActor = accessor;
+}
+
+void State::setting(TimeBalloon::BalloonDataServer* balloonDataServer, u64 previousDataId,
+                    u64 noticeDataId) {
+    mBalloonDataServer = balloonDataServer;
+    mPreviousDataId = previousDataId;
+    mNoticeDataId = noticeDataId;
+}
+
+void State::exeDeleteNotice() {
+    if (mNoticeDataId == 0) {
+        al::setNerve(this, &CreateBalloon);
+        return;
+    }
+
+    if (al::isFirstStep(this) && !mAccessor->tryDeleteNoticeDataOne(mNoticeDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        mAccessor->deleteNotice(GameDataFunction::getCurrentWorldId(mAccessorActor) & 0xFFFF);
+        al::setNerve(this, &CreateNotice);
+    }
+}
+
+void State::exeCreateNotice() {
+    if (al::isFirstStep(this) && !mAccessor->tryCreateNoticeDataOne()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        mNoticeDataId = mAccessor->getCreateNoticeDataOneLast();
+        mBalloonDataServer->setNoticeDataId(mNoticeDataId);
+
+        mAccessor->registerNewNotice(mNoticeDataId,
+                                     GameDataFunction::getCurrentWorldId(mAccessorActor) & 0xFFFF);
+
+        al::setNerve(this, &CreateBalloon);
+    }
+}
+
+void State::exeCreateBalloon() {
+    if (al::isFirstStep(this))
+        mAccessor->tryCreateBalloonDataOne(mBalloonDataServer);
+
+    if (mAccessor->isEnd()) {
+        mAccessor->getBalloonDataIdLast();
+        kill();
+    }
+}
+
+}  // namespace UpdatePutBalloonOwn
+
+namespace DownloadAllBalloonDataOwn {
+
+NERVE_IMPL(State, SearchAll)
+NERVE_IMPL(State, DownloadBufferQueueAll)
+
+NERVES_MAKE_NOSTRUCT(State, SearchAll, DownloadBufferQueueAll)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor), mSearchAccessor(accessor) {
+    initNerve(&SearchAll, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &SearchAll);
+}
+
+void State::exeSearchAll() {
+    if (al::isFirstStep(this) && !mSearchAccessor->trySearchOwnAll()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mSearchAccessor->isEnd()) {
+        if (mSearchAccessor->getOwnBalloonCount() >= 1)
+            al::setNerve(this, &DownloadBufferQueueAll);
+        else
+            kill();
+    }
+}
+
+void State::exeDownloadBufferQueueAll() {
+    if (al::isFirstStep(this) && !mSearchAccessor->tryDownloadBalloonDataOwnAllBufferQueue()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mSearchAccessor->isEnd())
+        kill();
+}
+
+}  // namespace DownloadAllBalloonDataOwn
+
+namespace DownloadFindBalloon {
+
+NERVE_IMPL(State, SearchBalloon)
+NERVE_IMPL(State, DownloadAchievementAll)
+
+NERVES_MAKE_NOSTRUCT(State, SearchBalloon, DownloadAchievementAll)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&SearchBalloon, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &SearchBalloon);
+}
+
+void State::exeSearchBalloon() {
+    if (al::isFirstStep(this) && !mAccessor->trySearchBalloon()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        al::setNerve(this, &DownloadAchievementAll);
+}
+
+void State::exeDownloadAchievementAll() {
+    if (al::isFirstStep(this) && !mAccessor->tryDownloadAchievementOther()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace DownloadFindBalloon
+
+namespace RateUpBalloon {
+
+NERVE_IMPL(State, UpdateRating)
+NERVE_IMPL(State, UpdateBufferQueuePlayed)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating, UpdateBufferQueuePlayed)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::setting(u64 dataId, u64 unused, u64 ownerId, bool isInvalidRating) {
+    mDataId = dataId;
+    _38 = unused;
+    mOwnerId = ownerId;
+    _48 = isInvalidRating;
+}
+
+void State::exeUpdateRating() {
+    if (al::isFirstStep(this) && !mAccessor->tryRateUpBalloonRating(mDataId, mOwnerId, false)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        al::setNerve(this, &UpdateBufferQueuePlayed);
+}
+
+void State::exeUpdateBufferQueuePlayed() {
+    if (al::isFirstStep(this) && !mAccessor->tryUpdateBalloonPlayed(mDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace RateUpBalloon
+
+namespace UpdateGetBalloon {
+
+NERVE_IMPL(State, UpdateRating)
+NERVE_IMPL(State, UpdateNotice)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating, UpdateNotice)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::setting(u64 dataId, u64 noticeDataId, u64 ownerId, s32 arg4, s32 arg5) {
+    mDataId = dataId;
+    mNoticeDataId = noticeDataId;
+    mOwnerId = ownerId;
+    mArg4 = arg4;
+    mArg5 = arg5;
+}
+
+void State::exeUpdateRating() {
+    if (mDataId != 0) {
+        if (!al::isFirstStep(this) || mAccessor->tryGotBalloon(mDataId, mOwnerId, mArg4, mArg5)) {
+            if (mAccessor->isEnd())
+                al::setNerve(this, &UpdateNotice);
+            return;
+        }
+    }
+
+    mIsError = true;
+    kill();
+}
+
+void State::exeUpdateNotice() {
+    if (mNoticeDataId == 0) {
+        kill();
+        return;
+    }
+
+    if (al::isFirstStep(this) && !mAccessor->tryUpdateNoticeGot(mNoticeDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace UpdateGetBalloon
+
+namespace UpdateGetBalloonTutorial {
+
+NERVE_IMPL(State, UpdateRating)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::exeUpdateRating() {
+    if (al::isFirstStep(this) && !mAccessor->tryGotBalloonTutorial()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace UpdateGetBalloonTutorial
+
+namespace TryCreateAchievementData {
+
+NERVE_IMPL(State, GetDataId)
+NERVE_IMPL(State, Create)
+
+NERVES_MAKE_NOSTRUCT(State, GetDataId, Create)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&GetDataId, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &GetDataId);
+}
+
+void State::setAccessor(al::LiveActor* accessor) {
+    mAccessorActor = accessor;
+}
+
+void State::exeGetDataId() {
+    if (al::isFirstStep(this) && !mAccessor->tryGetAndSaveAchievementIfExist()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        if (mAccessor->isExistAchievementData()) {
+            kill();
+            return;
+        }
+
+        u32 achievementDataId = mAccessor->getAchievementDataId();
+        u8 lowByte = achievementDataId;
+
+        if (lowByte == 0) {
+            kill();
+            return;
+        }
+
+        if (!(achievementDataId < 0x100u)) {
+            al::setNerve(this, &Create);
+            return;
+        }
+
+        mIsError = true;
+        kill();
+    }
+}
+
+void State::exeCreate() {
+    if (al::isFirstStep(this) && !mAccessor->tryCreateAndSaveAchievement()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace TryCreateAchievementData
+
+}  // namespace TimeBalloonDataState

--- a/src/ModeBalloon/TimeBalloonDataAccessorState.cpp
+++ b/src/ModeBalloon/TimeBalloonDataAccessorState.cpp
@@ -1,0 +1,394 @@
+#include "ModeBalloon/TimeBalloonDataAccessorState.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "ModeBalloon/TimeBalloonAchievementLayout.h"
+#include "ModeBalloon/TimeBalloonDataAccessor.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+
+namespace TimeBalloonDataState {
+
+TimeBalloonDataAccessorExecutorStateBase::TimeBalloonDataAccessorExecutorStateBase(
+    TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : al::NerveStateBase(""), mExecutor(executor), mAccessor(accessor) {}
+
+void TimeBalloonDataAccessorExecutorStateBase::appear() {
+    al::NerveStateBase::appear();
+    mIsError = false;
+}
+
+void TimeBalloonDataAccessorExecutorStateBase::errorAndKill() {
+    mIsError = true;
+    kill();
+}
+
+void TimeBalloonDataAccessorExecutorStateBase::errorConnectionAndKill() {
+    mIsError = true;
+    kill();
+}
+
+namespace UpdatePutBalloonOwn {
+
+NERVE_IMPL(State, DeleteNotice)
+NERVE_IMPL(State, CreateNotice)
+NERVE_IMPL(State, CreateBalloon)
+
+NERVES_MAKE_NOSTRUCT(State, DeleteNotice, CreateNotice, CreateBalloon)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&DeleteNotice, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &DeleteNotice);
+}
+
+void State::setAccessor(al::LiveActor* accessor) {
+    mAccessorActor = accessor;
+}
+
+void State::setting(TimeBalloon::BalloonDataServer* balloonDataServer, u64 previousDataId,
+                    u64 noticeDataId) {
+    mBalloonDataServer = balloonDataServer;
+    mPreviousDataId = previousDataId;
+    mNoticeDataId = noticeDataId;
+}
+
+void State::exeDeleteNotice() {
+    if (mNoticeDataId == 0) {
+        al::setNerve(this, &CreateBalloon);
+        return;
+    }
+
+    if (al::isFirstStep(this) && !mAccessor->tryDeleteNoticeDataOne(mNoticeDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        mAccessor->deleteNotice(
+            static_cast<u16>(GameDataFunction::getCurrentWorldId(mAccessorActor)));
+        al::setNerve(this, &CreateNotice);
+    }
+}
+
+void State::exeCreateNotice() {
+    if (al::isFirstStep(this) && !mAccessor->tryCreateNoticeDataOne()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        mNoticeDataId = mAccessor->getCreateNoticeDataOneLast();
+        mBalloonDataServer->setNoticeDataId(mNoticeDataId);
+
+        mAccessor->registerNewNotice(
+            mNoticeDataId, static_cast<u16>(GameDataFunction::getCurrentWorldId(mAccessorActor)));
+
+        al::setNerve(this, &CreateBalloon);
+    }
+}
+
+void State::exeCreateBalloon() {
+    if (al::isFirstStep(this))
+        mAccessor->tryCreateBalloonDataOne(mBalloonDataServer);
+
+    if (mAccessor->isEnd()) {
+        mAccessor->getBalloonDataIdLast();
+        kill();
+    }
+}
+
+}  // namespace UpdatePutBalloonOwn
+
+namespace DownloadAllBalloonDataOwn {
+
+NERVE_IMPL(State, SearchAll)
+NERVE_IMPL(State, DownloadBufferQueueAll)
+
+NERVES_MAKE_NOSTRUCT(State, SearchAll, DownloadBufferQueueAll)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor), mSearchAccessor(accessor) {
+    initNerve(&SearchAll, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &SearchAll);
+}
+
+void State::exeSearchAll() {
+    if (al::isFirstStep(this) && !mSearchAccessor->trySearchOwnAll()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mSearchAccessor->isEnd()) {
+        if (mSearchAccessor->getOwnBalloonCount() >= 1)
+            al::setNerve(this, &DownloadBufferQueueAll);
+        else
+            kill();
+    }
+}
+
+void State::exeDownloadBufferQueueAll() {
+    if (al::isFirstStep(this) && !mSearchAccessor->tryDownloadBalloonDataOwnAllBufferQueue()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mSearchAccessor->isEnd())
+        kill();
+}
+
+}  // namespace DownloadAllBalloonDataOwn
+
+namespace DownloadFindBalloon {
+
+NERVE_IMPL(State, SearchBalloon)
+NERVE_IMPL(State, DownloadAchievementAll)
+
+NERVES_MAKE_NOSTRUCT(State, SearchBalloon, DownloadAchievementAll)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&SearchBalloon, 0);
+}
+
+void State::appear() {
+    TimeBalloonDataAccessorExecutorStateBase::appear();
+    al::setNerve(this, &SearchBalloon);
+}
+
+void State::exeSearchBalloon() {
+    if (al::isFirstStep(this) && !mAccessor->trySearchBalloon()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        al::setNerve(this, &DownloadAchievementAll);
+}
+
+void State::exeDownloadAchievementAll() {
+    if (al::isFirstStep(this) && !mAccessor->tryDownloadAchievementOther()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace DownloadFindBalloon
+
+namespace RateUpBalloon {
+
+NERVE_IMPL(State, UpdateRating)
+NERVE_IMPL(State, UpdateBufferQueuePlayed)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating, UpdateBufferQueuePlayed)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::setting(u64 dataId, u64 unused, u64 ownerId, bool isInvalidRating) {
+    mDataId = dataId;
+    _38 = unused;
+    mOwnerId = ownerId;
+    _48 = isInvalidRating;
+}
+
+void State::exeUpdateRating() {
+    if (al::isFirstStep(this) && !mAccessor->tryRateUpBalloonRating(mDataId, mOwnerId, false)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        al::setNerve(this, &UpdateBufferQueuePlayed);
+}
+
+void State::exeUpdateBufferQueuePlayed() {
+    if (al::isFirstStep(this) && !mAccessor->tryUpdateBalloonPlayed(mDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace RateUpBalloon
+
+namespace UpdateGetBalloon {
+
+NERVE_IMPL(State, UpdateRating)
+NERVE_IMPL(State, UpdateNotice)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating, UpdateNotice)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::setting(u64 dataId, u64 noticeDataId, u64 ownerId, s32 arg4, s32 arg5) {
+    mDataId = dataId;
+    mNoticeDataId = noticeDataId;
+    mOwnerId = ownerId;
+    mArg4 = arg4;
+    mArg5 = arg5;
+}
+
+void State::exeUpdateRating() {
+    if (mDataId != 0) {
+        if (!al::isFirstStep(this) || mAccessor->tryGotBalloon(mDataId, mOwnerId, mArg4, mArg5)) {
+            if (mAccessor->isEnd())
+                al::setNerve(this, &UpdateNotice);
+            return;
+        }
+    }
+
+    mIsError = true;
+    kill();
+}
+
+void State::exeUpdateNotice() {
+    if (mNoticeDataId == 0) {
+        kill();
+        return;
+    }
+
+    if (al::isFirstStep(this) && !mAccessor->tryUpdateNoticeGot(mNoticeDataId)) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace UpdateGetBalloon
+
+namespace UpdateGetBalloonTutorial {
+
+NERVE_IMPL(State, UpdateRating)
+
+NERVES_MAKE_NOSTRUCT(State, UpdateRating)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&UpdateRating, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &UpdateRating);
+}
+
+void State::exeUpdateRating() {
+    if (al::isFirstStep(this) && !mAccessor->tryGotBalloonTutorial()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace UpdateGetBalloonTutorial
+
+namespace TryCreateAchievementData {
+
+NERVE_IMPL(State, GetDataId)
+NERVE_IMPL(State, Create)
+
+NERVES_MAKE_NOSTRUCT(State, GetDataId, Create)
+
+State::State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor)
+    : TimeBalloonDataAccessorExecutorStateBase(executor, accessor) {
+    initNerve(&GetDataId, 0);
+}
+
+void State::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &GetDataId);
+}
+
+void State::setAccessor(al::LiveActor* accessor) {
+    mAccessorActor = accessor;
+}
+
+void State::exeGetDataId() {
+    if (al::isFirstStep(this) && !mAccessor->tryGetAndSaveAchievementIfExist()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd()) {
+        if (mAccessor->isExistAchievementData()) {
+            kill();
+            return;
+        }
+
+        u32 achievementDataId = mAccessor->getAchievementDataId();
+        u8 lowByte = achievementDataId;
+
+        if (lowByte == 0) {
+            kill();
+            return;
+        }
+
+        if (!(achievementDataId < 0x100u)) {
+            al::setNerve(this, &Create);
+            return;
+        }
+
+        mIsError = true;
+        kill();
+    }
+}
+
+void State::exeCreate() {
+    if (al::isFirstStep(this) && !mAccessor->tryCreateAndSaveAchievement()) {
+        mIsError = true;
+        kill();
+        return;
+    }
+
+    if (mAccessor->isEnd())
+        kill();
+}
+
+}  // namespace TryCreateAchievementData
+
+}  // namespace TimeBalloonDataState

--- a/src/ModeBalloon/TimeBalloonDataAccessorState.h
+++ b/src/ModeBalloon/TimeBalloonDataAccessorState.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+namespace TimeBalloon {
+class BalloonDataServer;
+}
+
+class TimeBalloonDataAccessor;
+class TimeBalloonDataAccessorExecutor;
+
+namespace TimeBalloonDataState {
+
+class TimeBalloonDataAccessorExecutorStateBase : public al::NerveStateBase {
+public:
+    TimeBalloonDataAccessorExecutorStateBase(TimeBalloonDataAccessorExecutor* executor,
+                                             TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void errorAndKill();
+    void errorConnectionAndKill();
+
+protected:
+    TimeBalloonDataAccessorExecutor* mExecutor;
+    TimeBalloonDataAccessor* mAccessor;
+    bool mIsError = false;
+};
+
+static_assert(sizeof(TimeBalloonDataAccessorExecutorStateBase) == 0x30);
+
+namespace UpdatePutBalloonOwn {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void setAccessor(al::LiveActor* accessor);
+    void setting(TimeBalloon::BalloonDataServer* balloonDataServer, u64 previousDataId,
+                 u64 noticeDataId);
+    void exeDeleteNotice();
+    void exeCreateNotice();
+    void exeCreateBalloon();
+
+private:
+    al::LiveActor* mAccessorActor = nullptr;
+    TimeBalloon::BalloonDataServer* mBalloonDataServer = nullptr;
+    u64 mPreviousDataId = 0;
+    u64 mNoticeDataId = 0;
+};
+
+static_assert(sizeof(State) == 0x50);
+}  // namespace UpdatePutBalloonOwn
+
+namespace DownloadAllBalloonDataOwn {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void exeSearchAll();
+    void exeDownloadBufferQueueAll();
+
+private:
+    TimeBalloonDataAccessor* mSearchAccessor = nullptr;
+};
+
+static_assert(sizeof(State) == 0x38);
+}  // namespace DownloadAllBalloonDataOwn
+
+namespace DownloadFindBalloon {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void exeSearchBalloon();
+    void exeDownloadAchievementAll();
+};
+
+static_assert(sizeof(State) == 0x30);
+}  // namespace DownloadFindBalloon
+
+namespace RateUpBalloon {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void setting(u64 dataId, u64 unused, u64 ownerId, bool isInvalidRating);
+    void exeUpdateRating();
+    void exeUpdateBufferQueuePlayed();
+
+private:
+    u64 mDataId = 0;
+    u64 _38 = 0;
+    u64 mOwnerId = 0;
+    bool _48 = false;
+};
+
+static_assert(sizeof(State) == 0x50);
+}  // namespace RateUpBalloon
+
+namespace UpdateGetBalloon {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void setting(u64 dataId, u64 noticeDataId, u64 ownerId, s32 arg4, s32 arg5);
+    void exeUpdateRating();
+    void exeUpdateNotice();
+
+    u64 mDataId = 0;
+    u64 mNoticeDataId = 0;
+    u64 mOwnerId = 0;
+    s32 mArg4 = 0;
+    s32 mArg5 = 0;
+};
+
+static_assert(sizeof(State) == 0x50);
+}  // namespace UpdateGetBalloon
+
+namespace UpdateGetBalloonTutorial {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void exeUpdateRating();
+};
+
+static_assert(sizeof(State) == 0x30);
+}  // namespace UpdateGetBalloonTutorial
+
+namespace TryCreateAchievementData {
+class State : public TimeBalloonDataAccessorExecutorStateBase {
+public:
+    State(TimeBalloonDataAccessorExecutor* executor, TimeBalloonDataAccessor* accessor);
+
+    void appear() override;
+    void setAccessor(al::LiveActor* accessor);
+    void exeGetDataId();
+    void exeCreate();
+
+    al::LiveActor* mAccessorActor = nullptr;
+};
+
+static_assert(sizeof(State) == 0x38);
+}  // namespace TryCreateAchievementData
+
+}  // namespace TimeBalloonDataState


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1101)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (774e056 - c29cec8)

📈 **Matched code**: 14.90% (+0.03%, +4304 bytes)

<details>
<summary>✅ 59 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdatePutBalloonOwn::State::exeDeleteNotice()` | +212 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdatePutBalloonOwn::State::exeCreateNotice()` | +196 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::TryCreateAchievementData::State::exeGetDataId()` | +152 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloon::State::exeUpdateRating()` | +140 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadAllBalloonDataOwn::StateNrvSearchAll::execute(al::NerveKeeper*) const` | +140 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloon::StateNrvUpdateRating::execute(al::NerveKeeper*) const` | +140 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadAllBalloonDataOwn::State::exeSearchAll()` | +136 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::RateUpBalloon::StateNrvUpdateRating::execute(al::NerveKeeper*) const` | +132 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::RateUpBalloon::State::exeUpdateRating()` | +128 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadFindBalloon::StateNrvSearchBalloon::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadFindBalloon::State::exeSearchBalloon()` | +116 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::RateUpBalloon::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +108 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloon::State::exeUpdateNotice()` | +108 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloon::StateNrvUpdateNotice::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdatePutBalloonOwn::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +104 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloon::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +104 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadAllBalloonDataOwn::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +100 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::TryCreateAchievementData::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +100 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::RateUpBalloon::StateNrvUpdateBufferQueuePlayed::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadFindBalloon::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::RateUpBalloon::State::exeUpdateBufferQueuePlayed()` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloonTutorial::State::State(TimeBalloonDataAccessorExecutor*, TimeBalloonDataAccessor*)` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdatePutBalloonOwn::StateNrvCreateBalloon::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadAllBalloonDataOwn::StateNrvDownloadBufferQueueAll::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadFindBalloon::StateNrvDownloadAchievementAll::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdateGetBalloonTutorial::StateNrvUpdateRating::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::TryCreateAchievementData::StateNrvCreate::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::UpdatePutBalloonOwn::State::exeCreateBalloon()` | +92 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadAllBalloonDataOwn::State::exeDownloadBufferQueueAll()` | +92 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonDataAccessorState` | `TimeBalloonDataState::DownloadFindBalloon::State::exeDownloadAchievementAll()` | +92 | 0.00% | 100.00% |

...and 29 more new matches
</details>


<!-- decomp.dev report end -->