### PR TITLE
Boss/GiantWanderBoss: Implement `GiantWanderBossStateEscapeCancel`

### DIFF
--- a/src/Boss/GiantWanderBoss/GiantWanderBoss.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBoss.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GiantWanderBoss : public al::LiveActor {
+public:
+    const sead::Matrix34f* getBulletMtx() const;
+};

--- a/src/Boss/GiantWanderBoss/GiantWanderBossMine.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossMine.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class GiantWanderBossMine : public al::LiveActor {
+public:
+    GiantWanderBossMine(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appearAttach(const sead::Matrix34f*, const sead::Vector3f*);
+    bool isLaunched() const;
+    bool isEnableLaunch() const;
+    bool isAttach() const;
+    void startLaunchForOnGlass(const sead::Vector3f&);
+    void startLaunchForFirstPhase();
+    void startLaunchForEscape();
+    void startLaunchForLongRange();
+    void exeAppearAttach();
+    void exeFlyDown();
+    void resetPositionByAnim();
+    void checkCollideAndSendMsg();
+    void exeFlyParabolic();
+    void exeSignExplosion();
+    void exeExplosion();
+    void exeDie();
+
+private:
+    u8 _108[0xe8];
+};
+
+static_assert(sizeof(GiantWanderBossMine) == 0x1f0);

--- a/src/Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel.cpp
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel.cpp
@@ -1,0 +1,102 @@
+#include "Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/GiantWanderBoss/GiantWanderBoss.h"
+#include "Boss/GiantWanderBoss/GiantWanderBossMine.h"
+
+namespace {
+NERVE_IMPL(GiantWanderBossStateEscapeCancel, Angry)
+NERVE_IMPL(GiantWanderBossStateEscapeCancel, AppearMine)
+NERVE_IMPL(GiantWanderBossStateEscapeCancel, Launch)
+NERVE_IMPL(GiantWanderBossStateEscapeCancel, LaunchEnd)
+
+NERVES_MAKE_NOSTRUCT(GiantWanderBossStateEscapeCancel, Angry, AppearMine, Launch, LaunchEnd)
+
+const sead::Vector3f sMineAttachOffset = sead::Vector3f::zero;
+}  // namespace
+
+GiantWanderBossStateEscapeCancel::GiantWanderBossStateEscapeCancel(
+    GiantWanderBoss* boss, al::DeriveActorGroup<GiantWanderBossMine>* mineGroup)
+    : al::HostStateBase<GiantWanderBoss>("逃げキャンセル", boss), mMineGroup(mineGroup) {
+    initNerve(&Angry, 0);
+}
+
+GiantWanderBossStateEscapeCancel::~GiantWanderBossStateEscapeCancel() = default;
+
+void GiantWanderBossStateEscapeCancel::appear() {
+    NerveStateBase::appear();
+    mLaunchCount = 0;
+    al::setNerve(this, &Angry);
+}
+
+void GiantWanderBossStateEscapeCancel::exeAngry() {
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(getHost());
+        al::startAction(getHost(), "Angry");
+    }
+
+    if (al::isActionEnd(getHost()))
+        al::setNerve(this, &AppearMine);
+}
+
+void GiantWanderBossStateEscapeCancel::exeAppearMine() {
+    if (al::isFirstStep(this)) {
+        mMine = mMineGroup->tryFindDeadDeriveActor();
+
+        if (!mMine) {
+            al::NerveStateBase* state = this;
+            state->kill();
+            return;
+        }
+
+        mMine->appearAttach(getHost()->getBulletMtx(), &sMineAttachOffset);
+        al::startAction(getHost(), "AttackSign");
+    }
+
+    if (al::isActionEnd(getHost()))
+        al::setNerve(this, &Launch);
+}
+
+void GiantWanderBossStateEscapeCancel::exeLaunch() {
+    if (al::isFirstStep(this)) {
+        al::startAction(getHost(), "Attack");
+        mMine->startLaunchForFirstPhase();
+        mLaunchCount++;
+    }
+
+    al::turnFront(getHost(), 3.0f);
+
+    if (!al::isGreaterEqualStep(this, 20))
+        return;
+
+    if (mLaunchCount >= 6) {
+        al::setNerve(this, &LaunchEnd);
+        return;
+    }
+
+    mMine = mMineGroup->tryFindDeadDeriveActor();
+
+    if (!mMine) {
+        al::setNerve(this, &LaunchEnd);
+        return;
+    }
+
+    mMine->appearAttach(getHost()->getBulletMtx(), &sMineAttachOffset);
+    al::setNerve(this, &Launch);
+}
+
+void GiantWanderBossStateEscapeCancel::exeLaunchEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(getHost(), "AttackEnd");
+
+    if (al::isActionEnd(getHost())) {
+        al::NerveStateBase* state = this;
+        state->kill();
+    }
+}

--- a/src/Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+class GiantWanderBoss;
+class GiantWanderBossMine;
+
+class GiantWanderBossStateEscapeCancel : public al::HostStateBase<GiantWanderBoss> {
+public:
+    GiantWanderBossStateEscapeCancel(GiantWanderBoss* boss,
+                                     al::DeriveActorGroup<GiantWanderBossMine>* mineGroup);
+    ~GiantWanderBossStateEscapeCancel() override;
+
+    void appear() override;
+
+    void exeAngry();
+    void exeAppearMine();
+    void exeLaunch();
+    void exeLaunchEnd();
+
+private:
+    al::DeriveActorGroup<GiantWanderBossMine>* mMineGroup = nullptr;
+    GiantWanderBossMine* mMine = nullptr;
+    s32 mLaunchCount = 0;
+};
+
+static_assert(sizeof(GiantWanderBossStateEscapeCancel) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1102)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - a13a1b4)

📉 **Matched code**: 14.25% (-0.02%, -1968 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::exeLaunch()` | +200 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::exeAppearMine()` | +188 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::GiantWanderBossStateEscapeCancel(GiantWanderBoss*, al::DeriveActorGroup<GiantWanderBossMine>*)` | +100 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `(anonymous namespace)::GiantWanderBossStateEscapeCancelNrvAngry::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::exeAngry()` | +96 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `(anonymous namespace)::GiantWanderBossStateEscapeCancelNrvLaunchEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::exeLaunchEnd()` | +88 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::~GiantWanderBossStateEscapeCancel()` | +36 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `GiantWanderBossStateEscapeCancel::appear()` | +20 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `(anonymous namespace)::GiantWanderBossStateEscapeCancelNrvAppearMine::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateEscapeCancel` | `(anonymous namespace)::GiantWanderBossStateEscapeCancelNrvLaunch::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->