### PR TITLE
Enemy: Implement `JangoCapStateTalkDemo`

### DIFF
--- a/src/Enemy/JangoCapStateTalkDemo.cpp
+++ b/src/Enemy/JangoCapStateTalkDemo.cpp
@@ -1,0 +1,79 @@
+#include "Enemy/JangoCapStateTalkDemo.h"
+
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/Event/EventFlowUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/PlayerDemoUtil.h"
+
+namespace {
+NERVE_IMPL(JangoCapStateTalkDemo, RequestDemo)
+NERVE_IMPL(JangoCapStateTalkDemo, WipeOut)
+NERVE_IMPL(JangoCapStateTalkDemo, WipeWait)
+NERVE_IMPL(JangoCapStateTalkDemo, WipeIn)
+
+NERVES_MAKE_NOSTRUCT(JangoCapStateTalkDemo, RequestDemo, WipeOut, WipeWait, WipeIn);
+}  // namespace
+
+JangoCapStateTalkDemo::JangoCapStateTalkDemo(al::LiveActor* actor,
+                                             const al::ActorInitInfo& initInfo)
+    : al::ActorStateBase("ジャンゴ帽子会話デモ", actor), mInitInfo(initInfo) {}
+
+void JangoCapStateTalkDemo::init() {
+    initNerve(&RequestDemo, 0);
+    mEventFlowExecutor = rs::initEventFlow(mActor, mInitInfo, "Jango", nullptr);
+    al::initEventReceiver(mEventFlowExecutor, this);
+    al::tryGetLinksQT(&mDemoPlayerQuat, &mDemoPlayerTrans, mInitInfo, "TalkDemoPlayerPos");
+}
+
+void JangoCapStateTalkDemo::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &RequestDemo);
+}
+
+bool JangoCapStateTalkDemo::receiveEvent(const al::EventFlowEventData* event) {
+    al::LiveActor* actor = mActor;
+    const al::EventFlowEventData* eventData = event;
+
+    if (al::isEventName(eventData, "WipeOutEnd")) {
+        rs::replaceDemoPlayer(actor, mDemoPlayerTrans, mDemoPlayerQuat);
+        al::setNerve(this, &WipeWait);
+        return true;
+    }
+
+    if (al::isEventName(eventData, "WipeInEnd")) {
+        rs::endEventCutSceneDemo(actor);
+        al::tryOnStageSwitch(actor, "CapGetOn");
+        kill();
+        return true;
+    }
+
+    return false;
+}
+
+void JangoCapStateTalkDemo::exeRequestDemo() {
+    if (rs::tryStartEventCutSceneDemo(mActor)) {
+        rs::startEventFlow(mEventFlowExecutor, "WipeOut");
+        al::setNerve(this, &WipeOut);
+    }
+}
+
+void JangoCapStateTalkDemo::exeWipeOut() {
+    rs::updateEventFlow(mEventFlowExecutor);
+}
+
+void JangoCapStateTalkDemo::exeWipeWait() {
+    if (al::isGreaterEqualStep(this, 60)) {
+        rs::startEventFlow(mEventFlowExecutor, "WipeIn");
+        al::setNerve(this, &WipeIn);
+    }
+}
+
+void JangoCapStateTalkDemo::exeWipeIn() {
+    rs::updateEventFlow(mEventFlowExecutor);
+}

--- a/src/Enemy/JangoCapStateTalkDemo.h
+++ b/src/Enemy/JangoCapStateTalkDemo.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Event/IEventFlowEventReceiver.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowEventData;
+class EventFlowExecutor;
+class LiveActor;
+}  // namespace al
+
+class JangoCapStateTalkDemo : public al::ActorStateBase, public al::IEventFlowEventReceiver {
+public:
+    JangoCapStateTalkDemo(al::LiveActor* actor, const al::ActorInitInfo& initInfo);
+
+    void init() override;
+    void appear() override;
+    bool receiveEvent(const al::EventFlowEventData* event) override;
+
+    void exeRequestDemo();
+    void exeWipeOut();
+    void exeWipeWait();
+    void exeWipeIn();
+
+private:
+    al::EventFlowExecutor* mEventFlowExecutor = nullptr;
+    const al::ActorInitInfo& mInitInfo;
+    sead::Vector3f mDemoPlayerTrans = sead::Vector3f::zero;
+    sead::Quatf mDemoPlayerQuat = sead::Quatf::unit;
+};
+
+static_assert(sizeof(JangoCapStateTalkDemo) == 0x58);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -16,6 +16,8 @@ al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitIn
                                            const char*, const char*);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
+bool tryStartEventCutSceneDemo(al::LiveActor*);
+void endEventCutSceneDemo(al::LiveActor*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);
 void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
                            const char* name);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1103)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - 46f086c)

📉 **Matched code**: 14.25% (-0.02%, -2072 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::receiveEvent(al::EventFlowEventData const*)` | +180 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::JangoCapStateTalkDemo(al::LiveActor*, al::ActorInitInfo const&)` | +128 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::init()` | +100 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `(anonymous namespace)::JangoCapStateTalkDemoNrvWipeWait::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::exeRequestDemo()` | +80 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::exeWipeWait()` | +80 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `(anonymous namespace)::JangoCapStateTalkDemoNrvRequestDemo::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::~JangoCapStateTalkDemo()` | +36 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::appear()` | +16 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `(anonymous namespace)::JangoCapStateTalkDemoNrvWipeOut::execute(al::NerveKeeper*) const` | +12 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `(anonymous namespace)::JangoCapStateTalkDemoNrvWipeIn::execute(al::NerveKeeper*) const` | +12 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `non-virtual thunk to JangoCapStateTalkDemo::receiveEvent(al::EventFlowEventData const*)` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::exeWipeOut()` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapStateTalkDemo` | `JangoCapStateTalkDemo::exeWipeIn()` | +8 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->