### PR TITLE
Boss/GiantWanderBoss: Implement `GiantWanderBossStateAttack`

### DIFF
--- a/src/Boss/GiantWanderBoss/GiantWanderBossBullet.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossBullet.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class GiantWanderBossBullet : public al::LiveActor {
+public:
+    GiantWanderBossBullet(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appearAttach(const sead::Matrix34f*, const sead::Vector3f*, bool);
+    void startLaunch();
+    bool isLaunched() const;
+    void exeAppearAttach();
+    void exeFly();
+    void resetPositionByAnim();
+    void checkCollideAndSendMsg();
+
+private:
+    u8 _108[0x78];
+};
+
+static_assert(sizeof(GiantWanderBossBullet) == 0x180);

--- a/src/Boss/GiantWanderBoss/GiantWanderBossMine.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossMine.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class GiantWanderBossMine : public al::LiveActor {
+public:
+    GiantWanderBossMine(const char*);
+
+    void init(const al::ActorInitInfo&) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appearAttach(const sead::Matrix34f*, const sead::Vector3f*);
+    bool isLaunched() const;
+    bool isEnableLaunch() const;
+    bool isAttach() const;
+    void startLaunchForOnGlass(const sead::Vector3f&);
+    void startLaunchForFirstPhase();
+    void startLaunchForEscape();
+    void startLaunchForLongRange();
+    void exeAppearAttach();
+    void exeFlyDown();
+    void resetPositionByAnim();
+    void checkCollideAndSendMsg();
+    void exeFlyParabolic();
+    void exeSignExplosion();
+    void exeExplosion();
+    void exeDie();
+
+private:
+    u8 _108[0xe8];
+};
+
+static_assert(sizeof(GiantWanderBossMine) == 0x1f0);

--- a/src/Boss/GiantWanderBoss/GiantWanderBossStateAttack.cpp
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossStateAttack.cpp
@@ -1,0 +1,157 @@
+#include "Boss/GiantWanderBoss/GiantWanderBossStateAttack.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/GiantWanderBoss/GiantWanderBossBullet.h"
+#include "Boss/GiantWanderBoss/GiantWanderBossMine.h"
+
+namespace {
+NERVE_IMPL(GiantWanderBossStateAttack, AttackSign)
+NERVE_IMPL(GiantWanderBossStateAttack, AttackSignWait)
+NERVE_IMPL(GiantWanderBossStateAttack, AttackStart)
+NERVE_IMPL(GiantWanderBossStateAttack, Attack)
+NERVE_IMPL(GiantWanderBossStateAttack, AttackEnd)
+
+NERVES_MAKE_NOSTRUCT(GiantWanderBossStateAttack, AttackSign, AttackSignWait, AttackStart, Attack,
+                     AttackEnd)
+}  // namespace
+
+GiantWanderBossStateAttack::GiantWanderBossStateAttack(al::LiveActor* actor)
+    : al::ActorStateBase("徘徊ボス攻撃", actor) {
+    initNerve(&AttackSign, 0);
+}
+
+void GiantWanderBossStateAttack::appear() {
+    NerveStateBase::appear();
+    al::setNerve(this, &AttackSign);
+}
+
+void GiantWanderBossStateAttack::kill() {
+    NerveStateBase::kill();
+
+    if (mBullet)
+        mBullet->startLaunch();
+
+    if (mMine)
+        mMine->startLaunchForFirstPhase();
+}
+
+void GiantWanderBossStateAttack::startWithBullet(GiantWanderBossBullet* bullet) {
+    mBullet = bullet;
+    mMine = nullptr;
+    al::setNerve(this, &AttackSign);
+}
+
+void GiantWanderBossStateAttack::startWithMineFirstPhase(GiantWanderBossMine* mine) {
+    mBullet = nullptr;
+    mMine = mine;
+    mMineAttackType = 1;
+    al::setNerve(this, &AttackSign);
+}
+
+void GiantWanderBossStateAttack::startWithMineEscape(GiantWanderBossMine* mine) {
+    mBullet = nullptr;
+    mMine = mine;
+    mMineAttackType = 2;
+    al::setNerve(this, &AttackSign);
+}
+
+void GiantWanderBossStateAttack::startWithMineLongRange(GiantWanderBossMine* mine) {
+    mBullet = nullptr;
+    mMine = mine;
+    mMineAttackType = 3;
+    al::setNerve(this, &AttackSign);
+}
+
+void GiantWanderBossStateAttack::exeAttackSign() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackSign");
+
+        if (mMine)
+            al::startAction(mMine, "AttackSign");
+
+        if (mBullet)
+            al::startAction(mBullet, "AttackSign");
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &AttackSignWait);
+}
+
+void GiantWanderBossStateAttack::exeAttackSignWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackSignWait");
+
+        if (mMine)
+            al::startAction(mMine, "AttackSignWait");
+
+        if (mBullet)
+            al::startAction(mBullet, "AttackSignWait");
+    }
+
+    if (al::isGreaterEqualStep(this, 30))
+        al::setNerve(this, &AttackStart);
+}
+
+void GiantWanderBossStateAttack::exeAttackStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackStart");
+
+        if (mMine)
+            al::startAction(mMine, "AttackStart");
+
+        if (mBullet)
+            al::startAction(mBullet, "AttackStart");
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &Attack);
+}
+
+void GiantWanderBossStateAttack::exeAttack() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "Attack");
+
+        if (mBullet) {
+            mBullet->startLaunch();
+            mBullet = nullptr;
+        } else {
+            GiantWanderBossMine** mine;
+
+            switch (mMineAttackType) {
+            case 3:
+                mine = &mMine;
+                mMine->startLaunchForLongRange();
+                break;
+            case 1:
+                mine = &mMine;
+                mMine->startLaunchForFirstPhase();
+                break;
+            case 2:
+                mine = &mMine;
+                mMine->startLaunchForEscape();
+                break;
+            default:
+                mine = &mMine;
+                break;
+            }
+
+            *mine = nullptr;
+        }
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &AttackEnd);
+}
+
+void GiantWanderBossStateAttack::exeAttackEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "AttackEnd");
+
+    if (al::isActionEnd(mActor)) {
+        al::NerveStateBase* state = this;
+        state->kill();
+    }
+}

--- a/src/Boss/GiantWanderBoss/GiantWanderBossStateAttack.h
+++ b/src/Boss/GiantWanderBoss/GiantWanderBossStateAttack.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class GiantWanderBossBullet;
+class GiantWanderBossMine;
+
+class GiantWanderBossStateAttack : public al::ActorStateBase {
+public:
+    GiantWanderBossStateAttack(al::LiveActor* actor);
+
+    void appear() override;
+    void kill() override;
+    void startWithBullet(GiantWanderBossBullet* bullet);
+    void startWithMineFirstPhase(GiantWanderBossMine* mine);
+    void startWithMineEscape(GiantWanderBossMine* mine);
+    void startWithMineLongRange(GiantWanderBossMine* mine);
+    void exeAttackSign();
+    void exeAttackSignWait();
+    void exeAttackStart();
+    void exeAttack();
+    void exeAttackEnd();
+
+    al::LiveActor* getActor() const { return mActor; }
+
+private:
+    GiantWanderBossBullet* mBullet = nullptr;
+    GiantWanderBossMine* mMine = nullptr;
+    s32 mMineAttackType = 0;
+};
+
+static_assert(sizeof(GiantWanderBossStateAttack) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1104)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - 8860030)

📉 **Matched code**: 14.25% (-0.01%, -1816 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::exeAttack()` | +192 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::exeAttackSignWait()` | +132 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::exeAttackSign()` | +128 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::exeAttackStart()` | +128 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `(anonymous namespace)::GiantWanderBossStateAttackNrvAttackEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::GiantWanderBossStateAttack(al::LiveActor*)` | +88 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::exeAttackEnd()` | +88 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::kill()` | +68 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::~GiantWanderBossStateAttack()` | +36 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::startWithMineFirstPhase(GiantWanderBossMine*)` | +24 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::startWithMineEscape(GiantWanderBossMine*)` | +24 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::startWithMineLongRange(GiantWanderBossMine*)` | +24 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::appear()` | +16 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `GiantWanderBossStateAttack::startWithBullet(GiantWanderBossBullet*)` | +16 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `(anonymous namespace)::GiantWanderBossStateAttackNrvAttackSign::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `(anonymous namespace)::GiantWanderBossStateAttackNrvAttackSignWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `(anonymous namespace)::GiantWanderBossStateAttackNrvAttackStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/GiantWanderBoss/GiantWanderBossStateAttack` | `(anonymous namespace)::GiantWanderBossStateAttackNrvAttack::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->