### PR TITLE
Layout: Implement `CursorParts`

### DIFF
--- a/src/Layout/CursorParts.cpp
+++ b/src/Layout/CursorParts.cpp
@@ -1,0 +1,68 @@
+#include "Layout/CursorParts.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(CursorParts, Appear);
+NERVE_IMPL(CursorParts, End);
+NERVE_IMPL(CursorParts, Hide);
+NERVE_IMPL(CursorParts, Wait);
+
+NERVES_MAKE_NOSTRUCT(CursorParts, End, Wait, Appear, Hide);
+}  // namespace
+
+CursorParts::CursorParts(al::LayoutActor* parentLayout, const al::LayoutInitInfo& info,
+                         const char* name, const char* archiveName)
+    : al::LayoutActor(name) {
+    al::initLayoutPartsActor(this, parentLayout, info, archiveName);
+    initNerve(&Appear);
+}
+
+void CursorParts::appearStart() {
+    al::startAction(this, "Appear");
+    al::LayoutActor::appear();
+    al::setNerve(this, &Appear);
+}
+
+void CursorParts::end() {
+    if (al::isNerve(this, &End))
+        return;
+
+    al::startAction(this, "End");
+    al::setNerve(this, &End);
+}
+
+void CursorParts::hide() {
+    al::startAction(this, "Hide");
+    al::setNerve(this, &Hide);
+}
+
+void CursorParts::tryAppearIfHide() {
+    if (al::isNerve(this, &Hide)) {
+        al::startAction(this, "Appear");
+        al::LayoutActor::appear();
+        al::setNerve(this, &Appear);
+    }
+}
+
+void CursorParts::exeAppear() {
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void CursorParts::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void CursorParts::exeEnd() {
+    if (al::isActionEnd(this))
+        kill();
+}
+
+void CursorParts::exeHide() {
+    kill();
+}

--- a/src/Layout/CursorParts.h
+++ b/src/Layout/CursorParts.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}
+
+class CursorParts : public al::LayoutActor {
+public:
+    CursorParts(al::LayoutActor* parentLayout, const al::LayoutInitInfo& info, const char* name,
+                const char* archiveName);
+
+    void appearStart();
+    void end();
+    void hide();
+    void tryAppearIfHide();
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void exeHide();
+};

--- a/src/Layout/CursorParts.h
+++ b/src/Layout/CursorParts.h
@@ -20,3 +20,5 @@ public:
     void exeEnd();
     void exeHide();
 };
+
+static_assert(sizeof(CursorParts) == 0x130);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1105)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - f41edd5)

📈 **Matched code**: 15.50% (+0.01%, +1116 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Layout/CursorParts` | `CursorParts::CursorParts(al::LayoutActor*, al::LayoutInitInfo const&, char const*, char const*)` | +184 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::CursorParts(al::LayoutActor*, al::LayoutInitInfo const&, char const*, char const*)` | +180 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::tryAppearIfHide()` | +100 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::end()` | +88 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::appearStart()` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::exeAppear()` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::exeEnd()` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `(anonymous namespace)::CursorPartsNrvAppear::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `(anonymous namespace)::CursorPartsNrvEnd::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `(anonymous namespace)::CursorPartsNrvWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::hide()` | +64 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::exeWait()` | +64 | 0.00% | 100.00% |
| `Layout/CursorParts` | `(anonymous namespace)::CursorPartsNrvHide::execute(al::NerveKeeper*) const` | +16 | 0.00% | 100.00% |
| `Layout/CursorParts` | `CursorParts::exeHide()` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->