### PR TITLE
ModeBalloon: Implement `TimeBalloonStateFindBalloonFailed`

### DIFF
--- a/src/ModeBalloon/TimeBalloonDistanceLayout.h
+++ b/src/ModeBalloon/TimeBalloonDistanceLayout.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LayoutInitInfo;
+class LayoutActor;
+class LiveActor;
+}  // namespace al
+
+class TimeBalloonDistanceLayout {
+public:
+    TimeBalloonDistanceLayout(const al::LayoutInitInfo& info);
+
+    void tryAppear();
+    void tryEnd();
+    f32 calcDistance(const al::LiveActor* actor);
+};
+
+namespace TimeBalloon {
+void appearAndStartAction(al::LayoutActor* layout, const char* actionName);
+void appearGuideLayout(al::LayoutActor* layout, const char* actionName);
+}  // namespace TimeBalloon

--- a/src/ModeBalloon/TimeBalloonStateFindBalloonFailed.cpp
+++ b/src/ModeBalloon/TimeBalloonStateFindBalloonFailed.cpp
@@ -1,0 +1,97 @@
+#include "ModeBalloon/TimeBalloonStateFindBalloonFailed.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Layout/DecideIconLayout.h"
+#include "ModeBalloon/TimeBalloonDistanceLayout.h"
+#include "Npc/TimeBalloonNpc.h"
+
+namespace {
+NERVE_IMPL(TimeBalloonStateFindBalloonFailed, FailedWait)
+NERVE_IMPL(TimeBalloonStateFindBalloonFailed, FailedEnd)
+NERVE_IMPL(TimeBalloonStateFindBalloonFailed, ViewAroundStageDecideWait)
+NERVE_IMPL(TimeBalloonStateFindBalloonFailed, ViewAroundStageEnd)
+NERVE_IMPL(TimeBalloonStateFindBalloonFailed, ViewAroundStageDefaultCamera)
+
+NERVES_MAKE_NOSTRUCT(TimeBalloonStateFindBalloonFailed, FailedWait, FailedEnd,
+                     ViewAroundStageDecideWait, ViewAroundStageEnd, ViewAroundStageDefaultCamera)
+}  // namespace
+
+TimeBalloonStateFindBalloonFailed::TimeBalloonStateFindBalloonFailed(
+    StageSceneStateTimeBalloon* timeBalloon, TimeBalloonNpc* npc,
+    al::SimpleLayoutAppearWaitEnd* failedLayout, al::LayoutActor* actionLayout,
+    al::SimpleLayoutAppearWaitEnd* guideLayout, const al::ActorInitInfo& info,
+    TimeBalloonDistanceLayout* distanceLayout)
+    : al::HostStateBase<StageSceneStateTimeBalloon>("探す状態(風船ゲーム)", timeBalloon), mNpc(npc),
+      mFailedLayout(failedLayout), mActionLayout(actionLayout), mGuideLayout(guideLayout),
+      mDistanceLayout(distanceLayout) {
+    mDecideIconLayout =
+        new DecideIconLayout("[風船ゲーム]決定アイコン", al::getLayoutInitInfo(info));
+}
+
+void TimeBalloonStateFindBalloonFailed::init() {
+    initNerve(&FailedWait, 0);
+}
+
+void TimeBalloonStateFindBalloonFailed::control() {
+    mDecideIconLayout->updateNerve();
+}
+
+void TimeBalloonStateFindBalloonFailed::exeFailedWait() {
+    if (al::isFirstStep(this)) {
+        mDistanceLayout->tryEnd();
+        TimeBalloon::appearAndStartAction(mActionLayout, "TimeUp");
+        al::startSe(mNpc, "SysTimeUp2");
+    }
+
+    if (al::isActionEnd(mActionLayout, nullptr)) {
+        mFailedLayout->end();
+        TimeBalloon::appearGuideLayout(mGuideLayout, "TimeBalloonNpc");
+        al::setNerve(this, &FailedEnd);
+    }
+}
+
+void TimeBalloonStateFindBalloonFailed::exeFailedEnd() {}
+
+void TimeBalloonStateFindBalloonFailed::exeViewAroundStageDefaultCamera() {
+    if (al::isFirstStep(this))
+        mDistanceLayout->tryAppear();
+
+    if (mDecideIconLayout->isDecide())
+        al::setNerve(this, &ViewAroundStageDecideWait);
+}
+
+void TimeBalloonStateFindBalloonFailed::exeViewAroundStageDecideWait() {
+    if (al::isFirstStep(this))
+        mGuideLayout->end();
+
+    if (mDecideIconLayout->isEnd())
+        al::setNerve(this, &ViewAroundStageEnd);
+}
+
+void TimeBalloonStateFindBalloonFailed::exeViewAroundStageEnd() {
+    if (al::isFirstStep(this))
+        mDistanceLayout->tryEnd();
+}
+
+bool TimeBalloonStateFindBalloonFailed::isNerveFailedEnd() const {
+    return al::isNerve(this, &FailedEnd);
+}
+
+bool TimeBalloonStateFindBalloonFailed::isNerveViewAroundStageEnd() const {
+    return al::isNerve(this, &ViewAroundStageEnd);
+}
+
+void TimeBalloonStateFindBalloonFailed::setNerveFailedWait() {
+    al::setNerve(this, &FailedWait);
+}
+
+void TimeBalloonStateFindBalloonFailed::setNerveViewAroundStage() {
+    mDecideIconLayout->appear();
+    al::setNerve(this, &ViewAroundStageDefaultCamera);
+}

--- a/src/ModeBalloon/TimeBalloonStateFindBalloonFailed.h
+++ b/src/ModeBalloon/TimeBalloonStateFindBalloonFailed.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class LayoutActor;
+class SimpleLayoutAppearWaitEnd;
+}  // namespace al
+
+class DecideIconLayout;
+class StageSceneStateTimeBalloon;
+class TimeBalloonDistanceLayout;
+class TimeBalloonNpc;
+
+class TimeBalloonStateFindBalloonFailed : public al::HostStateBase<StageSceneStateTimeBalloon> {
+public:
+    TimeBalloonStateFindBalloonFailed(StageSceneStateTimeBalloon* timeBalloon, TimeBalloonNpc* npc,
+                                      al::SimpleLayoutAppearWaitEnd* failedLayout,
+                                      al::LayoutActor* actionLayout,
+                                      al::SimpleLayoutAppearWaitEnd* guideLayout,
+                                      const al::ActorInitInfo& info,
+                                      TimeBalloonDistanceLayout* distanceLayout);
+
+    void init() override;
+    void control() override;
+
+    void exeFailedWait();
+    void exeFailedEnd();
+    void exeViewAroundStageDefaultCamera();
+    void exeViewAroundStageDecideWait();
+    void exeViewAroundStageEnd();
+
+    bool isNerveFailedEnd() const;
+    bool isNerveViewAroundStageEnd() const;
+
+    void setNerveFailedWait();
+    void setNerveViewAroundStage();
+
+private:
+    TimeBalloonNpc* mNpc = nullptr;
+    al::SimpleLayoutAppearWaitEnd* mFailedLayout = nullptr;
+    al::LayoutActor* mActionLayout = nullptr;
+    s32 _38 = 0;
+    u8 _3c[4];
+    al::SimpleLayoutAppearWaitEnd* mGuideLayout = nullptr;
+    TimeBalloonDistanceLayout* mDistanceLayout = nullptr;
+    DecideIconLayout* mDecideIconLayout = nullptr;
+};
+
+static_assert(sizeof(TimeBalloonStateFindBalloonFailed) == 0x58);

--- a/src/Npc/TimeBalloonNpc.h
+++ b/src/Npc/TimeBalloonNpc.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class TimeBalloonNpc : public al::LiveActor {
+public:
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    void exeEvent();
+    void exeReaction();
+    bool isReaction() const;
+    void exeScared();
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1106)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - 1a94676)

📉 **Matched code**: 14.25% (-0.02%, -1936 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::exeFailedWait()` | +200 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::TimeBalloonStateFindBalloonFailed(StageSceneStateTimeBalloon*, TimeBalloonNpc*, al::SimpleLayoutAppearWaitEnd*, al::LayoutActor*, al::SimpleLayoutAppearWaitEnd*, al::ActorInitInfo const&, TimeBalloonDistanceLayout*)` | +172 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `(anonymous namespace)::TimeBalloonStateFindBalloonFailedNrvViewAroundStageDecideWait::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `(anonymous namespace)::TimeBalloonStateFindBalloonFailedNrvViewAroundStageDefaultCamera::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::exeViewAroundStageDefaultCamera()` | +80 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::exeViewAroundStageDecideWait()` | +80 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `(anonymous namespace)::TimeBalloonStateFindBalloonFailedNrvViewAroundStageEnd::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::exeViewAroundStageEnd()` | +52 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::setNerveViewAroundStage()` | +48 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::~TimeBalloonStateFindBalloonFailed()` | +36 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::init()` | +16 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::isNerveFailedEnd() const` | +12 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::isNerveViewAroundStageEnd() const` | +12 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::setNerveFailedWait()` | +12 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::control()` | +8 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `(anonymous namespace)::TimeBalloonStateFindBalloonFailedNrvFailedWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `TimeBalloonStateFindBalloonFailed::exeFailedEnd()` | +4 | 0.00% | 100.00% |
| `ModeBalloon/TimeBalloonStateFindBalloonFailed` | `(anonymous namespace)::TimeBalloonStateFindBalloonFailedNrvFailedEnd::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->