### PR TITLE
Event: Implement `EventActorMovementRailTraffic`

### DIFF
--- a/lib/al/Library/Event/EventFlowActorStateRail.h
+++ b/lib/al/Library/Event/EventFlowActorStateRail.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Project/Event/EventFlowActorStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowMovement;
+
+class EventFlowActorStateRail : public EventFlowActorStateBase {
+public:
+    EventFlowActorStateRail(const char* name, EventFlowMovement* movement);
+
+    void initByPlacementInfo(const ActorInitInfo& info);
+    void appear() override;
+    void exeWalk();
+    void exeTurn();
+
+private:
+    sead::Vector3f mRailOffset = sead::Vector3f::zero;
+    s32 mRailMoveType = -1;
+};
+
+static_assert(sizeof(EventFlowActorStateRail) == 0x38);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowMovement.h
+++ b/lib/al/Library/Event/EventFlowMovement.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Event/IUseEventFlowData.h"
+#include "Library/Nerve/IUseNerve.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowDataHolder;
+class LiveActor;
+class Nerve;
+class NerveKeeper;
+
+class EventFlowMovement : public IUseEventFlowData, public IUseNerve {
+public:
+    EventFlowMovement(const char* name, LiveActor* actor);
+
+    void movement();
+    void initNerve(const Nerve* nerve, s32 stateCount);
+
+    virtual void init(const ActorInitInfo& info) = 0;
+
+    virtual void kill() {}
+
+    virtual void appear() {}
+
+    virtual void control() {}
+
+    NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
+
+    virtual bool isTurnMovement() const { return false; }
+
+    virtual bool isWaitAtPointMovement() const { return false; }
+
+    EventFlowDataHolder* getEventFlowDataHolder() const override { return mEventFlowDataHolder; }
+
+protected:
+    const char* mName = nullptr;
+    LiveActor* mActor = nullptr;
+    NerveKeeper* mNerveKeeper = nullptr;
+    EventFlowDataHolder* mEventFlowDataHolder = nullptr;
+};
+
+static_assert(sizeof(EventFlowMovement) == 0x30);
+}  // namespace al

--- a/src/Event/EventActorMovementRailTraffic.cpp
+++ b/src/Event/EventActorMovementRailTraffic.cpp
@@ -1,0 +1,52 @@
+#include "Event/EventActorMovementRailTraffic.h"
+
+#include "Library/Event/EventFlowActorStateRail.h"
+#include "Library/Event/EventFlowUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Npc/TrafficRailWatcherDirector.h"
+
+namespace {
+NERVE_IMPL(EventActorMovementRailTraffic, Move);
+NERVE_IMPL(EventActorMovementRailTraffic, StopByOtherNpc);
+NERVE_IMPL(EventActorMovementRailTraffic, StopAfter);
+
+NERVES_MAKE_NOSTRUCT(EventActorMovementRailTraffic, Move, StopByOtherNpc, StopAfter);
+}  // namespace
+
+EventActorMovementRailTraffic::EventActorMovementRailTraffic(const char* name, al::LiveActor* actor)
+    : al::EventFlowMovement(name, actor) {}
+
+void EventActorMovementRailTraffic::init(const al::ActorInitInfo& info) {
+    initNerve(&Move, 1);
+
+    al::EventFlowActorStateRail* railState = new al::EventFlowActorStateRail("", this);
+    railState->initByPlacementInfo(info);
+    al::initNerveState(this, railState, &Move, "");
+    rs::registerTrafficRailWatcher(mActor, info);
+    appear();
+}
+
+void EventActorMovementRailTraffic::appear() {
+    al::setNerve(this, getNerveKeeper()->getCurrentNerve());
+}
+
+void EventActorMovementRailTraffic::exeMove() {
+    if (rs::tryStopTrafficRailByOtherNpc(mActor))
+        al::setNerve(this, &StopByOtherNpc);
+    else
+        al::updateNerveState(this);
+}
+
+void EventActorMovementRailTraffic::exeStopByOtherNpc() {
+    if (al::isFirstStep(this))
+        al::tryStartEventActionIfNotPlaying(mActor, this, "Wait");
+
+    if (rs::tryRestartTrafficRailByOtherNpc(mActor))
+        al::setNerve(this, &StopAfter);
+}
+
+void EventActorMovementRailTraffic::exeStopAfter() {
+    al::setNerveAtGreaterEqualStep(this, &Move, 20);
+}

--- a/src/Event/EventActorMovementRailTraffic.h
+++ b/src/Event/EventActorMovementRailTraffic.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Event/EventFlowMovement.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class EventActorMovementRailTraffic : public al::EventFlowMovement {
+public:
+    EventActorMovementRailTraffic(const char* name, al::LiveActor* actor);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+
+    void exeMove();
+    void exeStopByOtherNpc();
+    void exeStopAfter();
+};
+
+static_assert(sizeof(EventActorMovementRailTraffic) == 0x30);

--- a/src/Npc/TrafficRailWatcherDirector.h
+++ b/src/Npc/TrafficRailWatcherDirector.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/ISceneObj.h"
+
+class TrafficRailWatcher;
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class TrafficRailWatcherDirector : public al::HioNode, public al::ISceneObj {
+public:
+    TrafficRailWatcherDirector();
+
+    void* registerActor(const al::LiveActor* actor, const al::ActorInitInfo& info);
+    TrafficRailWatcher* findActorRailWatcher(const al::LiveActor* actor) const;
+    const char* getSceneObjName() const override;
+
+private:
+    s32 mWatcherCount = 0;
+    TrafficRailWatcher** mWatchers = nullptr;
+};
+
+static_assert(sizeof(TrafficRailWatcherDirector) == 0x18);
+
+namespace rs {
+void* registerTrafficRailWatcher(const al::LiveActor* actor, const al::ActorInitInfo& info);
+void stopTrafficRailByTraffic(const al::LiveActor* actor);
+void restartTrafficRailByTraffic(const al::LiveActor* actor);
+bool tryStopTrafficRailByOtherNpc(const al::LiveActor* actor);
+bool tryRestartTrafficRailByOtherNpc(const al::LiveActor* actor);
+}  // namespace rs

--- a/src/Project/Event/EventFlowActorStateBase.h
+++ b/src/Project/Event/EventFlowActorStateBase.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/Event/IUseEventFlowData.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class EventFlowDataHolder;
+class EventFlowMovement;
+class LiveActor;
+
+class EventFlowActorStateBase : public NerveStateBase, public IUseEventFlowData {
+public:
+    EventFlowActorStateBase(const char* name, EventFlowMovement* movement);
+
+    LiveActor* getActor() const;
+    EventFlowDataHolder* getEventFlowDataHolder() const override;
+
+protected:
+    EventFlowMovement* mMovement = nullptr;
+};
+
+static_assert(sizeof(EventFlowActorStateBase) == 0x28);
+}  // namespace al


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1107)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9090655 - 2de273d)

📉 **Matched code**: 14.25% (-0.02%, -2180 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::init(al::ActorInitInfo const&)` | +156 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `(anonymous namespace)::EventActorMovementRailTrafficNrvStopByOtherNpc::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::exeStopByOtherNpc()` | +100 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `(anonymous namespace)::EventActorMovementRailTrafficNrvMove::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::exeMove()` | +68 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::EventActorMovementRailTraffic(char const*, al::LiveActor*)` | +52 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::appear()` | +52 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `(anonymous namespace)::EventActorMovementRailTrafficNrvStopAfter::execute(al::NerveKeeper*) const` | +36 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `EventActorMovementRailTraffic::exeStopAfter()` | +20 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::getEventFlowDataHolder() const` | +8 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::getNerveKeeper() const` | +8 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::isTurnMovement() const` | +8 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::isWaitAtPointMovement() const` | +8 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `non-virtual thunk to al::EventFlowMovement::getNerveKeeper() const` | +8 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::kill()` | +4 | 0.00% | 100.00% |
| `Event/EventActorMovementRailTraffic` | `al::EventFlowMovement::control()` | +4 | 0.00% | 100.00% |

</details>

<details open>
<summary>🥀 25 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/ClockMovement` | `al::ClockMovement::ClockMovement(al::ActorInitInfo const&)` | -448 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::init(al::ActorInitInfo const&)` | -336 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | -208 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotateSign()` | -204 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeRotate()` | -156 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -140 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::BossKnuckleFix(char const*)` | -128 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReactionLarge::execute(al::NerveKeeper*) const` | -108 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReactionLarge()` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -104 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeDelay()` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -100 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::exeWait()` | -96 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvReaction::execute(al::NerveKeeper*) const` | -92 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeReaction()` | -88 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotateSign() const` | -68 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepRotate() const` | -68 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `(anonymous namespace)::BossKnuckleFixNrvWait::execute(al::NerveKeeper*) const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepDelay() const` | -64 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::isFirstStepWait() const` | -64 | 100.00% | 0.00% |
| `MapObj/BossKnuckleFix` | `BossKnuckleFix::exeWait()` | -60 | 100.00% | 0.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleFix>(char const*)` | -52 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `al::ClockMovement::~ClockMovement()` | -36 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |
| `Library/Movement/ClockMovement` | `` | -8 | 100.00% | 0.00% |

</details>


<!-- decomp.dev report end -->