### PR TITLE
Boss/BossKnuckle: Implement `BossKnuckleAnimCtrl`

### DIFF
--- a/src/Boss/BossKnuckle/BossKnuckle.h
+++ b/src/Boss/BossKnuckle/BossKnuckle.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class Nerve;
+class SensorMsg;
+}  // namespace al
+
+class BossKnuckle : public al::LiveActor, public IUseDemoSkip {
+public:
+    BossKnuckle(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void control() override;
+    void appear() override;
+
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+
+    void finishStartDemo(bool isSkip);
+    void exeWait();
+    void turnToPlayer();
+    void updateBodySyncPos();
+    void syncHandIfWaiting();
+    void checkHackAndSetNerve();
+    void exeRelay();
+    void updatePlayerDemo();
+    void exeAttackBeatStart();
+    void exeAttackBeat();
+    void genMummyAgainstPlayer(s32 mummyCount);
+    void relayNextNerve(const al::Nerve* nerve, s32 step, bool isImmediate);
+    void exeAttackHandFall();
+    s32 countAliveIce();
+    void exeAttackHandFallFirstPainDemo();
+    void exeAttackSideStamp();
+    void exeRunAwayStart();
+    void exeRunAway();
+    void breakAirIce();
+    void startPlayerDemo();
+    void exeDamage();
+    void exeRestoreHand();
+    void exeAttackRocketPunch();
+    void genMummy(const al::LiveActor* actor, s32 mummyCount);
+    void exeReturn();
+    void exeBeforeBattleStart();
+    void exeBeforeDemoBattleStartWait();
+    void exeDemoBattleStart();
+    void addDemoActorAll();
+    void exeDemoBattleEnd();
+    void exeAfterBattleEnd();
+    void breakAllIce();
+};

--- a/src/Boss/BossKnuckle/BossKnuckle.h
+++ b/src/Boss/BossKnuckle/BossKnuckle.h
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class Nerve;
+class SensorMsg;
+}  // namespace al
+
+class BossKnuckle : public al::LiveActor, public IUseDemoSkip {
+public:
+    BossKnuckle(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+    void control() override;
+    void appear() override;
+
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+
+    void finishStartDemo(bool isSkip);
+    void exeWait();
+    void turnToPlayer();
+    void updateBodySyncPos();
+    void syncHandIfWaiting();
+    bool checkHackAndSetNerve();
+    void exeRelay();
+    bool updatePlayerDemo();
+    void exeAttackBeatStart();
+    void exeAttackBeat();
+    void genMummyAgainstPlayer(s32 mummyCount);
+    void relayNextNerve(const al::Nerve* nerve, s32 step, bool isImmediate);
+    void exeAttackHandFall();
+    s32 countAliveIce();
+    void exeAttackHandFallFirstPainDemo();
+    void exeAttackSideStamp();
+    void exeRunAwayStart();
+    void exeRunAway();
+    void breakAirIce();
+    void startPlayerDemo();
+    void exeDamage();
+    void exeRestoreHand();
+    void exeAttackRocketPunch();
+    void genMummy(const al::LiveActor* actor, s32 mummyCount);
+    void exeReturn();
+    void exeBeforeBattleStart();
+    void exeBeforeDemoBattleStartWait();
+    void exeDemoBattleStart();
+    void addDemoActorAll();
+    void exeDemoBattleEnd();
+    void exeAfterBattleEnd();
+    void breakAllIce();
+
+private:
+    char _size[0x328];
+};
+
+static_assert(sizeof(BossKnuckle) == 0x438);

--- a/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.cpp
+++ b/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.cpp
@@ -1,0 +1,338 @@
+#include "Boss/BossKnuckle/BossKnuckleAnimCtrl.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/BossKnuckle/BossKnuckle.h"
+
+namespace {
+NERVE_IMPL(BossKnuckleAnimCtrl, BeforeStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, GraspMoveHit)
+NERVES_MAKE_NOSTRUCT(BossKnuckleAnimCtrl, BeforeStart, GraspMoveHit)
+
+NERVE_IMPL(BossKnuckleAnimCtrl, Wait)
+NERVE_IMPL(BossKnuckleAnimCtrl, AttackGraspSign)
+NERVE_IMPL(BossKnuckleAnimCtrl, Sand)
+NERVE_IMPL(BossKnuckleAnimCtrl, NumbnessStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryHighLoop)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryHighOneTime)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFrontStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFront)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFrontEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, FearStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, Numbness)
+NERVE_IMPL(BossKnuckleAnimCtrl, NumbnessEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, Angry)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, Fear)
+NERVE_IMPL(BossKnuckleAnimCtrl, FearEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, PlayerDamage)
+
+NERVES_MAKE_NOSTRUCT(BossKnuckleAnimCtrl, Wait, AttackGraspSign, Sand, NumbnessStart, AngryStart,
+                     AngryHighLoop, AngryHighOneTime, MoveFrontStart, MoveFront, MoveFrontEnd,
+                     FearStart, Numbness, NumbnessEnd, Angry, AngryEnd, Fear, FearEnd, PlayerDamage)
+}  // namespace
+
+BossKnuckleAnimCtrl::BossKnuckleAnimCtrl(BossKnuckle* bossKnuckle)
+    : al::NerveExecutor("ボスナックルアニメコントロール"), mBossKnuckle(bossKnuckle) {
+    initNerve(&BeforeStart, 0);
+}
+
+void BossKnuckleAnimCtrl::update() {
+    updateNerve();
+}
+
+void BossKnuckleAnimCtrl::startWait() {
+    al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::startAttackGraspSign() {
+    if (isPlayerDamage())
+        return;
+    if (isNumbness())
+        return;
+
+    al::setNerve(this, &AttackGraspSign);
+}
+
+void BossKnuckleAnimCtrl::startSand() {
+    if (isPlayerDamage())
+        return;
+    if (isNumbness())
+        return;
+
+    al::setNerve(this, &Sand);
+}
+
+void BossKnuckleAnimCtrl::startGraspMoveHit() {
+    al::setNerve(this, &GraspMoveHit);
+}
+
+void BossKnuckleAnimCtrl::startNumbnessIfNotPlaying() {
+    if (isPlayerDamage())
+        return;
+    if (isNumbness())
+        return;
+
+    al::setNerve(this, &NumbnessStart);
+}
+
+void BossKnuckleAnimCtrl::startAngryIfNotPlaying() {
+    if (isAngry())
+        return;
+
+    al::setNerve(this, &AngryStart);
+}
+
+void BossKnuckleAnimCtrl::startAngryHighLoopIfNotPlaying() {
+    if (al::isNerve(this, &AngryHighLoop))
+        return;
+
+    al::setNerve(this, &AngryHighLoop);
+}
+
+void BossKnuckleAnimCtrl::startAngryHighOneTimeIfNotPlaying() {
+    if (al::isNerve(this, &AngryHighOneTime))
+        return;
+
+    al::setNerve(this, &AngryHighOneTime);
+}
+
+void BossKnuckleAnimCtrl::startMoveFrontIfNotPlaying() {
+    if (al::isNerve(this, &MoveFrontStart))
+        return;
+    if (al::isNerve(this, &MoveFront))
+        return;
+    if (al::isNerve(this, &MoveFrontEnd))
+        return;
+
+    al::setNerve(this, &MoveFrontStart);
+}
+
+void BossKnuckleAnimCtrl::startFearIfNotPlaying() {
+    if (isFear())
+        return;
+
+    al::setNerve(this, &FearStart);
+}
+
+void BossKnuckleAnimCtrl::endMoveFrontIfPlaying() {
+    if (!al::isNerve(this, &MoveFront))
+        return;
+
+    al::setNerve(this, &MoveFrontEnd);
+}
+
+void BossKnuckleAnimCtrl::exeNumbnessStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AttackGraspNumbnessStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Numbness);
+}
+
+void BossKnuckleAnimCtrl::endNumbnessIfPlaying() {
+    if (!al::isNerve(this, &Numbness))
+        return;
+
+    al::setNerve(this, &NumbnessEnd);
+}
+
+void BossKnuckleAnimCtrl::exeAngryStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Angry);
+}
+
+void BossKnuckleAnimCtrl::endAngryIfPlaying() {
+    if (al::isNerve(this, &Angry)) {
+        al::setNerve(this, &AngryEnd);
+        return;
+    }
+
+    if (al::isNerve(this, &AngryHighLoop)) {
+        al::setNerve(this, &AngryEnd);
+        return;
+    }
+
+    if (!al::isNerve(this, &AngryHighOneTime))
+        return;
+
+    al::setNerve(this, &AngryEnd);
+}
+
+void BossKnuckleAnimCtrl::exeFearStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "FearStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Fear);
+}
+
+void BossKnuckleAnimCtrl::endFearIfPlaying() {
+    if (!al::isNerve(this, &Fear))
+        return;
+
+    al::setNerve(this, &FearEnd);
+}
+
+void BossKnuckleAnimCtrl::startPlayerDamage() {
+    if (al::isNerve(this, &PlayerDamage))
+        return;
+
+    if (al::isNerve(this, &AngryStart) || al::isNerve(this, &Angry) ||
+        al::isNerve(this, &AngryEnd) || al::isNerve(this, &AngryHighLoop) ||
+        al::isNerve(this, &AngryHighOneTime)) {
+        mPlayerDamageReturnNerve = &Angry;
+    } else if (al::isNerve(this, &NumbnessStart) || al::isNerve(this, &Numbness) ||
+               al::isNerve(this, &NumbnessEnd)) {
+        mPlayerDamageReturnNerve = &Numbness;
+    } else {
+        if (!al::isNerve(this, &FearStart) && !al::isNerve(this, &Fear) &&
+            !al::isNerve(this, &FearEnd)) {
+            mPlayerDamageReturnNerve = &Wait;
+            al::setNerve(this, &PlayerDamage);
+            return;
+        }
+
+        mPlayerDamageReturnNerve = &Fear;
+    }
+
+    al::setNerve(this, &PlayerDamage);
+}
+
+bool BossKnuckleAnimCtrl::isPlayerDamage() {
+    return al::isNerve(this, &PlayerDamage);
+}
+
+bool BossKnuckleAnimCtrl::isNumbness() {
+    return al::isNerve(this, &NumbnessStart) || al::isNerve(this, &Numbness) ||
+           al::isNerve(this, &NumbnessEnd);
+}
+
+bool BossKnuckleAnimCtrl::isAngry() {
+    return al::isNerve(this, &AngryStart) || al::isNerve(this, &Angry) ||
+           al::isNerve(this, &AngryEnd) || al::isNerve(this, &AngryHighLoop) ||
+           al::isNerve(this, &AngryHighOneTime);
+}
+
+bool BossKnuckleAnimCtrl::isFear() {
+    return al::isNerve(this, &FearStart) || al::isNerve(this, &Fear) || al::isNerve(this, &FearEnd);
+}
+
+void BossKnuckleAnimCtrl::exeBeforeStart() {}
+
+void BossKnuckleAnimCtrl::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "Wait");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeAttackGraspSign() {
+    if (al::isFirstStep(this)) {
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspSign");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeSand() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspSand");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeNumbness() {
+    if (al::isFirstStep(this)) {
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspNumbness");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeNumbnessEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AttackGraspNumbnessEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeGraspMoveHit() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "GraspMoveHit");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeAngry() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "Angry");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeAngryEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeAngryHighLoop() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "AngryHigh1");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeAngryHighOneTime() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryHigh2");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Angry);
+}
+
+void BossKnuckleAnimCtrl::exeFear() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "Fear");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeFearEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "FearEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeMoveFrontStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "MoveFrontStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &MoveFront);
+}
+
+void BossKnuckleAnimCtrl::exeMoveFront() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mBossKnuckle, "MoveFront");
+        return;
+    }
+}
+
+void BossKnuckleAnimCtrl::exeMoveFrontEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "MoveFrontEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exePlayerDamage() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "PlayerDamage");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, mPlayerDamageReturnNerve);
+}
+
+BossKnuckleAnimCtrl::~BossKnuckleAnimCtrl() = default;

--- a/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.cpp
+++ b/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.cpp
@@ -1,0 +1,287 @@
+#include "Boss/BossKnuckle/BossKnuckleAnimCtrl.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/BossKnuckle/BossKnuckle.h"
+
+namespace {
+NERVE_IMPL(BossKnuckleAnimCtrl, BeforeStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, GraspMoveHit)
+NERVES_MAKE_NOSTRUCT(BossKnuckleAnimCtrl, BeforeStart, GraspMoveHit)
+
+NERVE_IMPL(BossKnuckleAnimCtrl, Wait)
+NERVE_IMPL(BossKnuckleAnimCtrl, AttackGraspSign)
+NERVE_IMPL(BossKnuckleAnimCtrl, Sand)
+NERVE_IMPL(BossKnuckleAnimCtrl, NumbnessStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryHighLoop)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryHighOneTime)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFrontStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFront)
+NERVE_IMPL(BossKnuckleAnimCtrl, MoveFrontEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, FearStart)
+NERVE_IMPL(BossKnuckleAnimCtrl, Numbness)
+NERVE_IMPL(BossKnuckleAnimCtrl, NumbnessEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, Angry)
+NERVE_IMPL(BossKnuckleAnimCtrl, AngryEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, Fear)
+NERVE_IMPL(BossKnuckleAnimCtrl, FearEnd)
+NERVE_IMPL(BossKnuckleAnimCtrl, PlayerDamage)
+
+NERVES_MAKE_NOSTRUCT(BossKnuckleAnimCtrl, Wait, AttackGraspSign, Sand, NumbnessStart, AngryStart,
+                     AngryHighLoop, AngryHighOneTime, MoveFrontStart, MoveFront, MoveFrontEnd,
+                     FearStart, Numbness, NumbnessEnd, Angry, AngryEnd, Fear, FearEnd, PlayerDamage)
+}  // namespace
+
+BossKnuckleAnimCtrl::BossKnuckleAnimCtrl(BossKnuckle* bossKnuckle)
+    : al::NerveExecutor("ボスナックルアニメコントロール"), mBossKnuckle(bossKnuckle) {
+    initNerve(&BeforeStart, 0);
+}
+
+void BossKnuckleAnimCtrl::update() {
+    updateNerve();
+}
+
+void BossKnuckleAnimCtrl::startWait() {
+    al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::startAttackGraspSign() {
+    if (isPlayerDamage() || isNumbness())
+        return;
+
+    al::setNerve(this, &AttackGraspSign);
+}
+
+void BossKnuckleAnimCtrl::startSand() {
+    if (isPlayerDamage() || isNumbness())
+        return;
+
+    al::setNerve(this, &Sand);
+}
+
+void BossKnuckleAnimCtrl::startGraspMoveHit() {
+    al::setNerve(this, &GraspMoveHit);
+}
+
+void BossKnuckleAnimCtrl::startNumbnessIfNotPlaying() {
+    if (isPlayerDamage() || isNumbness())
+        return;
+
+    al::setNerve(this, &NumbnessStart);
+}
+
+void BossKnuckleAnimCtrl::startAngryIfNotPlaying() {
+    if (isAngry())
+        return;
+
+    al::setNerve(this, &AngryStart);
+}
+
+void BossKnuckleAnimCtrl::startAngryHighLoopIfNotPlaying() {
+    if (al::isNerve(this, &AngryHighLoop))
+        return;
+
+    al::setNerve(this, &AngryHighLoop);
+}
+
+void BossKnuckleAnimCtrl::startAngryHighOneTimeIfNotPlaying() {
+    if (al::isNerve(this, &AngryHighOneTime))
+        return;
+
+    al::setNerve(this, &AngryHighOneTime);
+}
+
+void BossKnuckleAnimCtrl::startMoveFrontIfNotPlaying() {
+    if (al::isNerve(this, &MoveFrontStart) || al::isNerve(this, &MoveFront) ||
+        al::isNerve(this, &MoveFrontEnd))
+        return;
+
+    al::setNerve(this, &MoveFrontStart);
+}
+
+void BossKnuckleAnimCtrl::startFearIfNotPlaying() {
+    if (isFear())
+        return;
+
+    al::setNerve(this, &FearStart);
+}
+
+void BossKnuckleAnimCtrl::endMoveFrontIfPlaying() {
+    if (al::isNerve(this, &MoveFront))
+        al::setNerve(this, &MoveFrontEnd);
+}
+
+void BossKnuckleAnimCtrl::exeNumbnessStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AttackGraspNumbnessStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Numbness);
+}
+
+void BossKnuckleAnimCtrl::endNumbnessIfPlaying() {
+    if (al::isNerve(this, &Numbness))
+        al::setNerve(this, &NumbnessEnd);
+}
+
+void BossKnuckleAnimCtrl::exeAngryStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Angry);
+}
+
+void BossKnuckleAnimCtrl::endAngryIfPlaying() {
+    if (al::isNerve(this, &Angry) || al::isNerve(this, &AngryHighLoop) ||
+        al::isNerve(this, &AngryHighOneTime))
+        al::setNerve(this, &AngryEnd);
+}
+
+void BossKnuckleAnimCtrl::exeFearStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "FearStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Fear);
+}
+
+void BossKnuckleAnimCtrl::endFearIfPlaying() {
+    if (al::isNerve(this, &Fear))
+        al::setNerve(this, &FearEnd);
+}
+
+void BossKnuckleAnimCtrl::startPlayerDamage() {
+    if (al::isNerve(this, &PlayerDamage))
+        return;
+
+    if (isAngry())
+        mPlayerDamageReturnNerve = &Angry;
+    else if (isNumbness())
+        mPlayerDamageReturnNerve = &Numbness;
+    else if (isFear()) {
+        mPlayerDamageReturnNerve = &Fear;
+        al::setNerve(this, &PlayerDamage);
+        return;
+    } else
+        mPlayerDamageReturnNerve = &Wait;
+
+    al::setNerve(this, &PlayerDamage);
+}
+
+bool BossKnuckleAnimCtrl::isPlayerDamage() {
+    return al::isNerve(this, &PlayerDamage);
+}
+
+bool BossKnuckleAnimCtrl::isNumbness() {
+    return al::isNerve(this, &NumbnessStart) || al::isNerve(this, &Numbness) ||
+           al::isNerve(this, &NumbnessEnd);
+}
+
+bool BossKnuckleAnimCtrl::isAngry() {
+    return al::isNerve(this, &AngryStart) || al::isNerve(this, &Angry) ||
+           al::isNerve(this, &AngryEnd) || al::isNerve(this, &AngryHighLoop) ||
+           al::isNerve(this, &AngryHighOneTime);
+}
+
+bool BossKnuckleAnimCtrl::isFear() {
+    return al::isNerve(this, &FearStart) || al::isNerve(this, &Fear) || al::isNerve(this, &FearEnd);
+}
+
+void BossKnuckleAnimCtrl::exeBeforeStart() {}
+
+void BossKnuckleAnimCtrl::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "Wait");
+}
+
+void BossKnuckleAnimCtrl::exeAttackGraspSign() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspSign");
+}
+
+void BossKnuckleAnimCtrl::exeSand() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspSand");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeNumbness() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(mBossKnuckle, "AttackGraspNumbness");
+}
+
+void BossKnuckleAnimCtrl::exeNumbnessEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AttackGraspNumbnessEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeGraspMoveHit() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "GraspMoveHit");
+}
+
+void BossKnuckleAnimCtrl::exeAngry() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "Angry");
+}
+
+void BossKnuckleAnimCtrl::exeAngryEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeAngryHighLoop() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryHigh1");
+}
+
+void BossKnuckleAnimCtrl::exeAngryHighOneTime() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "AngryHigh2");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Angry);
+}
+
+void BossKnuckleAnimCtrl::exeFear() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "Fear");
+}
+
+void BossKnuckleAnimCtrl::exeFearEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "FearEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exeMoveFrontStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "MoveFrontStart");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &MoveFront);
+}
+
+void BossKnuckleAnimCtrl::exeMoveFront() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "MoveFront");
+}
+
+void BossKnuckleAnimCtrl::exeMoveFrontEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "MoveFrontEnd");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, &Wait);
+}
+
+void BossKnuckleAnimCtrl::exePlayerDamage() {
+    if (al::isFirstStep(this))
+        al::startAction(mBossKnuckle, "PlayerDamage");
+    if (al::isActionEnd(mBossKnuckle))
+        al::setNerve(this, mPlayerDamageReturnNerve);
+}

--- a/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.h
+++ b/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+class BossKnuckle;
+
+class BossKnuckleAnimCtrl : public al::NerveExecutor {
+public:
+    BossKnuckleAnimCtrl(BossKnuckle* bossKnuckle);
+
+    void update();
+    void startWait();
+    void startAttackGraspSign();
+    bool isPlayerDamage();
+    bool isNumbness();
+    void startSand();
+    void startGraspMoveHit();
+    void startNumbnessIfNotPlaying();
+    void startAngryIfNotPlaying();
+    bool isAngry();
+    void startAngryHighLoopIfNotPlaying();
+    void startAngryHighOneTimeIfNotPlaying();
+    void startMoveFrontIfNotPlaying();
+    void startFearIfNotPlaying();
+    bool isFear();
+    void endNumbnessIfPlaying();
+    void endAngryIfPlaying();
+    void endFearIfPlaying();
+    void endMoveFrontIfPlaying();
+    void startPlayerDamage();
+    void exeBeforeStart();
+    void exeWait();
+    void exeAttackGraspSign();
+    void exeSand();
+    void exeNumbnessStart();
+    void exeNumbness();
+    void exeNumbnessEnd();
+    void exeGraspMoveHit();
+    void exeAngryStart();
+    void exeAngry();
+    void exeAngryEnd();
+    void exeAngryHighLoop();
+    void exeAngryHighOneTime();
+    void exeFearStart();
+    void exeFear();
+    void exeFearEnd();
+    void exeMoveFrontStart();
+    void exeMoveFront();
+    void exeMoveFrontEnd();
+    void exePlayerDamage();
+    ~BossKnuckleAnimCtrl();
+
+private:
+    BossKnuckle* mBossKnuckle = nullptr;
+    const al::Nerve* mPlayerDamageReturnNerve = nullptr;
+};
+
+static_assert(sizeof(BossKnuckleAnimCtrl) == 0x20);

--- a/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.h
+++ b/src/Boss/BossKnuckle/BossKnuckleAnimCtrl.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+class BossKnuckle;
+
+class BossKnuckleAnimCtrl : public al::NerveExecutor {
+public:
+    BossKnuckleAnimCtrl(BossKnuckle* bossKnuckle);
+
+    void update();
+    void startWait();
+    void startAttackGraspSign();
+    bool isPlayerDamage();
+    bool isNumbness();
+    void startSand();
+    void startGraspMoveHit();
+    void startNumbnessIfNotPlaying();
+    void startAngryIfNotPlaying();
+    bool isAngry();
+    void startAngryHighLoopIfNotPlaying();
+    void startAngryHighOneTimeIfNotPlaying();
+    void startMoveFrontIfNotPlaying();
+    void startFearIfNotPlaying();
+    bool isFear();
+    void endNumbnessIfPlaying();
+    void endAngryIfPlaying();
+    void endFearIfPlaying();
+    void endMoveFrontIfPlaying();
+    void startPlayerDamage();
+    void exeBeforeStart();
+    void exeWait();
+    void exeAttackGraspSign();
+    void exeSand();
+    void exeNumbnessStart();
+    void exeNumbness();
+    void exeNumbnessEnd();
+    void exeGraspMoveHit();
+    void exeAngryStart();
+    void exeAngry();
+    void exeAngryEnd();
+    void exeAngryHighLoop();
+    void exeAngryHighOneTime();
+    void exeFearStart();
+    void exeFear();
+    void exeFearEnd();
+    void exeMoveFrontStart();
+    void exeMoveFront();
+    void exeMoveFrontEnd();
+    void exePlayerDamage();
+
+private:
+    BossKnuckle* mBossKnuckle = nullptr;
+    const al::Nerve* mPlayerDamageReturnNerve = nullptr;
+};
+
+static_assert(sizeof(BossKnuckleAnimCtrl) == 0x20);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1108)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 09eb407)

📈 **Matched code**: 15.18% (+0.04%, +4872 bytes)

<details>
<summary>✅ 62 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startPlayerDamage()` | +276 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startAngryIfNotPlaying()` | +132 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::isAngry()` | +120 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startAttackGraspSign()` | +116 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startSand()` | +116 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startNumbnessIfNotPlaying()` | +116 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startMoveFrontIfNotPlaying()` | +100 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::startFearIfNotPlaying()` | +100 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::endAngryIfPlaying()` | +100 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvNumbnessStart::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvAngryStart::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvAngryHighOneTime::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvMoveFrontStart::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvFearStart::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeNumbnessStart()` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeAngryStart()` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeAngryHighOneTime()` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeFearStart()` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeMoveFrontStart()` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvSand::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvMoveFrontEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvNumbnessEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvAngryEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `(anonymous namespace)::BossKnuckleAnimCtrlNrvFearEnd::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::isNumbness()` | +88 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::isFear()` | +88 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeSand()` | +88 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeNumbnessEnd()` | +88 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeAngryEnd()` | +88 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleAnimCtrl` | `BossKnuckleAnimCtrl::exeFearEnd()` | +88 | 0.00% | 100.00% |

...and 32 more new matches
</details>


<!-- decomp.dev report end -->