### PR TITLE
MapObj: Implement `CapMessageDirector`

### DIFF
--- a/src/Layout/CapMessageLayout.h
+++ b/src/Layout/CapMessageLayout.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class CapMessageShowInfo;
+
+class CapMessageLayout : public al::LayoutActor {
+public:
+    CapMessageLayout(const char* name, const char* layoutName, const al::LayoutInitInfo& initInfo,
+                     const char* archiveName, bool isLocalized);
+
+    void appear() override;
+    void kill() override;
+
+    void end();
+    void start(const CapMessageShowInfo* showInfo);
+    void startCore(const CapMessageShowInfo* showInfo, bool isContinue);
+    void startContinue(const CapMessageShowInfo* showInfo);
+    void setContinueShow(bool isContinueShow);
+    void tryEnd();
+    bool tryEndExistContinueDemo();
+    void exeDelay();
+    void exeAppear();
+    void exeFollowText();
+    void exeWait();
+    void exeEnd();
+    bool isDelay(const char* labelName) const;
+    bool isShow(const char* labelName) const;
+
+private:
+    sead::FixedSafeString<0x100> mMessageName;
+    sead::FixedSafeString<0x100> mLabelName;
+    char _360[0x230];
+    sead::FixedSafeString<0x40> mReplaceTagName;
+    s32 mReplaceNumber = 0;
+    bool mIsContinueShow = false;
+    u8 _5ed[3] = {};
+};
+
+static_assert(sizeof(CapMessageLayout) == 0x5F0, "CapMessageLayout");

--- a/src/Layout/CapMessageLayout.h
+++ b/src/Layout/CapMessageLayout.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+}  // namespace al
+
+class CapMessageShowInfo;
+
+class CapMessageLayout : public al::LayoutActor {
+public:
+    CapMessageLayout(const char* name, const char* layoutName, const al::LayoutInitInfo& initInfo,
+                     const char* archiveName, bool isLocalized);
+
+    void appear() override;
+    void kill() override;
+
+    void end();
+    void start(const CapMessageShowInfo* showInfo);
+    void startCore(const CapMessageShowInfo* showInfo, bool isContinue);
+    void startContinue(const CapMessageShowInfo* showInfo);
+    void setContinueShow(bool isContinueShow);
+    bool tryEnd();
+    bool tryEndExistContinueDemo();
+    void exeDelay();
+    void exeAppear();
+    void exeFollowText();
+    void exeWait();
+    void exeEnd();
+    bool isDelay(const char* labelName) const;
+    bool isShow(const char* labelName) const;
+
+private:
+    sead::FixedSafeString<0x100> mMessageName;
+    sead::FixedSafeString<0x100> mLabelName;
+    char _360[0x230];
+    sead::FixedSafeString<0x40> mReplaceTagName;
+    s32 mReplaceNumber = 0;
+    bool mIsContinueShow = false;
+};
+
+static_assert(sizeof(CapMessageLayout) == 0x5F0, "CapMessageLayout");

--- a/src/MapObj/CapMessageDirector.cpp
+++ b/src/MapObj/CapMessageDirector.cpp
@@ -1,0 +1,322 @@
+#include "MapObj/CapMessageDirector.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Layout/CapMessageLayout.h"
+#include "MapObj/CapMessageGameDataChecker.h"
+#include "MapObj/CapMessageKeeper.h"
+#include "MapObj/CapMessagePlacement.h"
+#include "MapObj/CapMessageShowInfo.h"
+
+namespace {
+NERVE_IMPL(CapMessageDirector, ShowSystem)
+NERVE_IMPL(CapMessageDirector, Wait)
+NERVE_IMPL(CapMessageDirector, DelayPlacement)
+NERVE_IMPL(CapMessageDirector, ShowPlacement)
+NERVE_IMPL(CapMessageDirector, ShowSystemLow)
+NERVE_IMPL(CapMessageDirector, ShowSystemContinue)
+NERVE_IMPL(CapMessageDirector, End)
+
+struct CapMessageDirectorNrvGroup {
+    CapMessageDirectorNrvWait Wait;
+    CapMessageDirectorNrvDelayPlacement DelayPlacement;
+    CapMessageDirectorNrvShowPlacement ShowPlacement;
+    CapMessageDirectorNrvShowSystemLow ShowSystemLow;
+    CapMessageDirectorNrvShowSystemContinue ShowSystemContinue;
+    CapMessageDirectorNrvEnd End;
+};
+
+CapMessageDirectorNrvShowSystem sCapMessageDirectorNrvShowSystem;
+CapMessageDirectorNrvGroup sCapMessageDirectorNrvGroup;
+
+CapMessageGameDataChecker sDefaultCapMessageGameDataChecker;
+}  // namespace
+
+CapMessageDirector::CapMessageDirector()
+    : al::LiveActor("帽子メッセージディレクター(新)"), mLayout(nullptr), mPlacementGroup(nullptr),
+      mCurrentPlacement(nullptr), mMessageKeeper(nullptr), mIsAppearCapMessageValid(true) {
+    mPlacementGroup =
+        new al::DeriveActorGroup<CapMessagePlacement>("配置帽子メッセージグループ", 32);
+}
+
+void CapMessageDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorUpdate(this, info, "監視オブジェ");
+    al::initNerve(this, &sCapMessageDirectorNrvGroup.Wait, 0);
+
+    mLayout = new CapMessageLayout("帽子メッセージ レイアウト", "TalkMessageInfo",
+                                   al::getLayoutInitInfo(info), nullptr, false);
+    mMessageKeeper = new CapMessageKeeper();
+
+    makeActorAlive();
+}
+
+void CapMessageDirector::exeWait() {
+    al::isFirstStep(this);
+    tryStartShowPlacement();
+}
+
+bool CapMessageDirector::tryStartShowPlacement() {
+    if (!mIsAppearCapMessageValid)
+        return false;
+
+    if (mPlacementGroup->getActorCount() < 1) {
+        mCurrentPlacement = nullptr;
+        return false;
+    }
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    s32 bestPriority = -1;
+
+    for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+        CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+        if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+            placement->checkEnbale()) {
+            bestPriority = placement->getAppearPriority();
+            bestPlacement = placement;
+        }
+    }
+
+    mCurrentPlacement = bestPlacement;
+    if (bestPlacement == nullptr)
+        return false;
+
+    if (bestPlacement->getDelayTime() > 0)
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.DelayPlacement);
+    else
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.ShowPlacement);
+
+    return true;
+}
+
+void CapMessageDirector::exeDelayPlacement() {
+    al::isFirstStep(this);
+
+    if (!mCurrentPlacement->isActive()) {
+        mCurrentPlacement = nullptr;
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+        return;
+    }
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    if (mPlacementGroup->getActorCount() >= 1) {
+        s32 bestPriority = -1;
+
+        for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+            CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+            if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+                placement->checkEnbale()) {
+                bestPriority = placement->getAppearPriority();
+                bestPlacement = placement;
+            }
+        }
+    }
+
+    if (bestPlacement == nullptr && mCurrentPlacement->isDelayCancel()) {
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+        return;
+    }
+
+    if (bestPlacement != nullptr && mCurrentPlacement != bestPlacement) {
+        mCurrentPlacement = bestPlacement;
+        if (bestPlacement->getDelayTime() > 0)
+            al::setNerve(this, &sCapMessageDirectorNrvGroup.DelayPlacement);
+        else
+            al::setNerve(this, &sCapMessageDirectorNrvGroup.ShowPlacement);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, mCurrentPlacement->getDelayTime()))
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.ShowPlacement);
+}
+
+CapMessagePlacement* CapMessageDirector::findPlacement() const {
+    if (mPlacementGroup->getActorCount() < 1)
+        return nullptr;
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    s32 bestPriority = -1;
+
+    for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+        CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+        if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+            placement->checkEnbale()) {
+            bestPriority = placement->getAppearPriority();
+            bestPlacement = placement;
+        }
+    }
+
+    return bestPlacement;
+}
+
+void CapMessageDirector::exeShowPlacement() {
+    if (al::isFirstStep(this)) {
+        mLayout->start(mCurrentPlacement->getShowInfo());
+        mCurrentPlacement->showStart();
+    }
+
+    if (!mCurrentPlacement->isActive()) {
+        mCurrentPlacement->showEnd();
+        mLayout->tryEnd();
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.End);
+        return;
+    }
+
+    bool isEnable = mCurrentPlacement->checkEnbale();
+    mLayout->setContinueShow(isEnable && mCurrentPlacement->isKeepDisp());
+
+    if (!mLayout->isAlive()) {
+        mCurrentPlacement->showEnd();
+        if (!isEnable)
+            al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+    }
+}
+
+void CapMessageDirector::forceEndInner() {
+    mLayout->tryEnd();
+    al::setNerve(this, &sCapMessageDirectorNrvGroup.End);
+}
+
+void CapMessageDirector::exeShowSystemLow() {
+    if (!tryStartShowPlacement() && !mLayout->isAlive())
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+}
+
+void CapMessageDirector::exeShowSystem() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+}
+
+void CapMessageDirector::exeShowSystemContinue() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+}
+
+void CapMessageDirector::exeEnd() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.Wait);
+}
+
+bool CapMessageDirector::isShow(const char* labelName) const {
+    return mLayout->isShow(labelName);
+}
+
+bool CapMessageDirector::isDelay(const char* labelName) const {
+    if (!al::isNerve(this, &sCapMessageDirectorNrvGroup.DelayPlacement))
+        return mLayout->isDelay(labelName);
+
+    if (labelName == nullptr)
+        return true;
+
+    if (mCurrentPlacement != nullptr)
+        return al::isEqualString(labelName, mCurrentPlacement->getShowInfo()->getLabelName());
+
+    return mLayout->isDelay(labelName);
+}
+
+bool CapMessageDirector::isActive(const char* labelName) const {
+    if (mLayout->isShow(labelName))
+        return true;
+
+    if (al::isNerve(this, &sCapMessageDirectorNrvGroup.DelayPlacement)) {
+        if (labelName == nullptr)
+            return true;
+
+        if (mCurrentPlacement != nullptr)
+            return al::isEqualString(labelName, mCurrentPlacement->getShowInfo()->getLabelName());
+    }
+
+    return mLayout->isDelay(labelName);
+}
+
+s32 CapMessageDirector::registerCapMessagePlacement(CapMessagePlacement* placement) {
+    return mPlacementGroup->registerActor(placement);
+}
+
+bool CapMessageDirector::tryShowMessageSystem(const CapMessageShowInfo* showInfo,
+                                              const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    mLayout->start(showInfo);
+    al::setNerve(this, &sCapMessageDirectorNrvShowSystem);
+    return true;
+}
+
+bool CapMessageDirector::tryCheck(const CapMessageGameDataChecker* checker) const {
+    if (checker != nullptr)
+        return checker->check(this);
+
+    return sDefaultCapMessageGameDataChecker.check(this);
+}
+
+bool CapMessageDirector::tryShowMessageSystemLow(const CapMessageShowInfo* showInfo,
+                                                 const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    if (!al::isNerve(this, &sCapMessageDirectorNrvGroup.Wait))
+        return false;
+
+    mLayout->start(showInfo);
+    al::setNerve(this, &sCapMessageDirectorNrvGroup.ShowSystemLow);
+    return true;
+}
+
+bool CapMessageDirector::tryShowMessageSystemContinue(const CapMessageShowInfo* showInfo,
+                                                      const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    mLayout->startContinue(showInfo);
+    al::setNerve(this, &sCapMessageDirectorNrvGroup.ShowSystemContinue);
+    return true;
+}
+
+void CapMessageDirector::endCapMessageSystemContinue() {
+    if (al::isNerve(this, &sCapMessageDirectorNrvGroup.ShowSystemContinue)) {
+        mLayout->tryEnd();
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.End);
+    }
+}
+
+void CapMessageDirector::invalidateAppearCapMessage() {
+    if (mLayout->tryEndExistContinueDemo()) {
+        if (al::isNerve(this, &sCapMessageDirectorNrvGroup.ShowPlacement) &&
+            mCurrentPlacement != nullptr) {
+            mCurrentPlacement->showEnd();
+        }
+
+        al::setNerve(this, &sCapMessageDirectorNrvGroup.End);
+    }
+
+    mIsAppearCapMessageValid = false;
+}
+
+void CapMessageDirector::validateAppearCapMessage() {
+    mIsAppearCapMessageValid = true;
+}
+
+void CapMessageDirector::forceEnd() {
+    mLayout->tryEnd();
+    al::setNerve(this, &sCapMessageDirectorNrvGroup.End);
+}

--- a/src/MapObj/CapMessageDirector.cpp
+++ b/src/MapObj/CapMessageDirector.cpp
@@ -1,0 +1,407 @@
+#include "MapObj/CapMessageDirector.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Layout/CapMessageLayout.h"
+#include "MapObj/CapMessageGameDataChecker.h"
+#include "MapObj/CapMessageKeeper.h"
+#include "MapObj/CapMessagePlacement.h"
+#include "MapObj/CapMessageShowInfo.h"
+
+namespace {
+NERVE_IMPL(CapMessageDirector, ShowSystem)
+NERVE_IMPL(CapMessageDirector, Wait)
+NERVE_IMPL(CapMessageDirector, DelayPlacement)
+NERVE_IMPL(CapMessageDirector, ShowPlacement)
+NERVE_IMPL(CapMessageDirector, ShowSystemLow)
+NERVE_IMPL(CapMessageDirector, ShowSystemContinue)
+NERVE_IMPL(CapMessageDirector, End)
+
+NERVES_MAKE_STRUCT(CapMessageDirector, Wait, DelayPlacement, ShowPlacement, ShowSystemLow,
+                   ShowSystemContinue, End)
+NERVES_MAKE_NOSTRUCT(CapMessageDirector, ShowSystem)
+
+CapMessageGameDataChecker sDefaultCapMessageGameDataChecker;
+}  // namespace
+
+CapMessageDirector::CapMessageDirector() : al::LiveActor("帽子メッセージディレクター(新)") {
+    mPlacementGroup =
+        new al::DeriveActorGroup<CapMessagePlacement>("配置帽子メッセージグループ", 32);
+}
+
+void CapMessageDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorUpdate(this, info, "監視オブジェ");
+    al::initNerve(this, &NrvCapMessageDirector.Wait, 0);
+
+    mLayout = new CapMessageLayout("帽子メッセージ レイアウト", "TalkMessageInfo",
+                                   al::getLayoutInitInfo(info), nullptr, false);
+    mMessageKeeper = new CapMessageKeeper();
+
+    makeActorAlive();
+}
+
+void CapMessageDirector::exeWait() {
+    al::isFirstStep(this);
+    tryStartShowPlacement();
+}
+
+bool CapMessageDirector::tryStartShowPlacement() {
+    if (!mIsAppearCapMessageValid)
+        return false;
+
+    if (mPlacementGroup->getActorCount() < 1) {
+        mCurrentPlacement = nullptr;
+        return false;
+    }
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    s32 bestPriority = -1;
+
+    for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+        CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+        if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+            placement->checkEnbale()) {
+            bestPriority = placement->getAppearPriority();
+            bestPlacement = placement;
+        }
+    }
+
+    mCurrentPlacement = bestPlacement;
+    if (bestPlacement == nullptr)
+        return false;
+
+    if (bestPlacement->getDelay() > 0)
+        al::setNerve(this, &NrvCapMessageDirector.DelayPlacement);
+    else
+        al::setNerve(this, &NrvCapMessageDirector.ShowPlacement);
+
+    return true;
+}
+
+void CapMessageDirector::exeDelayPlacement() {
+    al::isFirstStep(this);
+
+    if (!mCurrentPlacement->isActive()) {
+        mCurrentPlacement = nullptr;
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+        return;
+    }
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    if (mPlacementGroup->getActorCount() >= 1) {
+        s32 bestPriority = -1;
+
+        for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+            CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+            if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+                placement->checkEnbale()) {
+                bestPriority = placement->getAppearPriority();
+                bestPlacement = placement;
+            }
+        }
+    }
+
+    if (bestPlacement == nullptr && mCurrentPlacement->isDelayCancel()) {
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+        return;
+    }
+
+    if (bestPlacement != nullptr && mCurrentPlacement != bestPlacement) {
+        mCurrentPlacement = bestPlacement;
+        if (bestPlacement->getDelay() > 0)
+            al::setNerve(this, &NrvCapMessageDirector.DelayPlacement);
+        else
+            al::setNerve(this, &NrvCapMessageDirector.ShowPlacement);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, mCurrentPlacement->getDelay()))
+        al::setNerve(this, &NrvCapMessageDirector.ShowPlacement);
+}
+
+CapMessagePlacement* CapMessageDirector::findPlacement() const {
+    if (mPlacementGroup->getActorCount() < 1)
+        return nullptr;
+
+    CapMessagePlacement* bestPlacement = nullptr;
+    s32 bestPriority = -1;
+
+    for (s32 i = 0; i < mPlacementGroup->getActorCount(); i++) {
+        CapMessagePlacement* placement = mPlacementGroup->getDeriveActor(i);
+
+        if (placement->getAppearPriority() > bestPriority && placement->isActive() &&
+            placement->checkEnbale()) {
+            bestPriority = placement->getAppearPriority();
+            bestPlacement = placement;
+        }
+    }
+
+    return bestPlacement;
+}
+
+void CapMessageDirector::exeShowPlacement() {
+    if (al::isFirstStep(this)) {
+        mLayout->start(mCurrentPlacement->getShowInfo());
+        mCurrentPlacement->showStart();
+    }
+
+    if (!mCurrentPlacement->isActive()) {
+        mCurrentPlacement->showEnd();
+        mLayout->tryEnd();
+        al::setNerve(this, &NrvCapMessageDirector.End);
+        return;
+    }
+
+    bool isEnable = mCurrentPlacement->checkEnbale();
+    mLayout->setContinueShow(isEnable && mCurrentPlacement->isKeepDisp());
+
+    if (!mLayout->isAlive()) {
+        mCurrentPlacement->showEnd();
+        if (!isEnable)
+            al::setNerve(this, &NrvCapMessageDirector.Wait);
+    }
+}
+
+void CapMessageDirector::forceEndInner() {
+    mLayout->tryEnd();
+    al::setNerve(this, &NrvCapMessageDirector.End);
+}
+
+void CapMessageDirector::exeShowSystemLow() {
+    if (!tryStartShowPlacement() && !mLayout->isAlive())
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+}
+
+void CapMessageDirector::exeShowSystem() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+}
+
+void CapMessageDirector::exeShowSystemContinue() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+}
+
+void CapMessageDirector::exeEnd() {
+    if (!mLayout->isAlive())
+        al::setNerve(this, &NrvCapMessageDirector.Wait);
+}
+
+bool CapMessageDirector::isShow(const char* labelName) const {
+    return mLayout->isShow(labelName);
+}
+
+bool CapMessageDirector::isDelay(const char* labelName) const {
+    if (!al::isNerve(this, &NrvCapMessageDirector.DelayPlacement))
+        return mLayout->isDelay(labelName);
+
+    if (labelName == nullptr)
+        return true;
+
+    if (mCurrentPlacement != nullptr)
+        return al::isEqualString(labelName, mCurrentPlacement->getShowInfo()->getLabelName());
+
+    return mLayout->isDelay(labelName);
+}
+
+bool CapMessageDirector::isActive(const char* labelName) const {
+    if (isShow(labelName))
+        return true;
+
+    if (al::isNerve(this, &NrvCapMessageDirector.DelayPlacement)) {
+        if (labelName == nullptr)
+            return true;
+
+        if (mCurrentPlacement != nullptr)
+            return al::isEqualString(labelName, mCurrentPlacement->getShowInfo()->getLabelName());
+    }
+
+    return mLayout->isDelay(labelName);
+}
+
+s32 CapMessageDirector::registerCapMessagePlacement(CapMessagePlacement* placement) {
+    return mPlacementGroup->registerActor(placement);
+}
+
+bool CapMessageDirector::tryShowMessageSystem(const CapMessageShowInfo* showInfo,
+                                              const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    mLayout->start(showInfo);
+    al::setNerve(this, &ShowSystem);
+    return true;
+}
+
+bool CapMessageDirector::tryCheck(const CapMessageGameDataChecker* checker) const {
+    if (checker != nullptr)
+        return checker->check(this);
+
+    return sDefaultCapMessageGameDataChecker.check(this);
+}
+
+bool CapMessageDirector::tryShowMessageSystemLow(const CapMessageShowInfo* showInfo,
+                                                 const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    if (!al::isNerve(this, &NrvCapMessageDirector.Wait))
+        return false;
+
+    mLayout->start(showInfo);
+    al::setNerve(this, &NrvCapMessageDirector.ShowSystemLow);
+    return true;
+}
+
+bool CapMessageDirector::tryShowMessageSystemContinue(const CapMessageShowInfo* showInfo,
+                                                      const CapMessageGameDataChecker* checker) {
+    if (checker != nullptr) {
+        if (!checker->check(this))
+            return false;
+    } else if (!sDefaultCapMessageGameDataChecker.check(this)) {
+        return false;
+    }
+
+    mLayout->startContinue(showInfo);
+    al::setNerve(this, &NrvCapMessageDirector.ShowSystemContinue);
+    return true;
+}
+
+void CapMessageDirector::endCapMessageSystemContinue() {
+    if (al::isNerve(this, &NrvCapMessageDirector.ShowSystemContinue)) {
+        mLayout->tryEnd();
+        al::setNerve(this, &NrvCapMessageDirector.End);
+    }
+}
+
+void CapMessageDirector::invalidateAppearCapMessage() {
+    if (mLayout->tryEndExistContinueDemo()) {
+        if (al::isNerve(this, &NrvCapMessageDirector.ShowPlacement) && mCurrentPlacement != nullptr)
+            mCurrentPlacement->showEnd();
+
+        al::setNerve(this, &NrvCapMessageDirector.End);
+    }
+
+    mIsAppearCapMessageValid = false;
+}
+
+void CapMessageDirector::validateAppearCapMessage() {
+    mIsAppearCapMessageValid = true;
+}
+
+void CapMessageDirector::forceEnd() {
+    mLayout->tryEnd();
+    al::setNerve(this, &NrvCapMessageDirector.End);
+}
+
+namespace CapMessageDirectorFunction {
+
+s32 registerCapMessagePlacement(CapMessagePlacement* placement) {
+    return al::createSceneObj<CapMessageDirector>(placement)->registerCapMessagePlacement(
+        placement);
+}
+
+bool tryShowCapMessageSystem(const al::IUseSceneObjHolder* sceneObjHolder,
+                             const CapMessageShowInfo* showInfo,
+                             const CapMessageGameDataChecker* checker) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)
+        ->tryShowMessageSystem(showInfo, checker);
+}
+
+bool tryShowCapMessageSystemLow(const al::IUseSceneObjHolder* sceneObjHolder,
+                                const CapMessageShowInfo* showInfo,
+                                const CapMessageGameDataChecker* checker) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)
+        ->tryShowMessageSystemLow(showInfo, checker);
+}
+
+bool tryShowCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder,
+                                     const CapMessageShowInfo* showInfo,
+                                     const CapMessageGameDataChecker* checker) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)
+        ->tryShowMessageSystemContinue(showInfo, checker);
+}
+
+void endCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder) {
+    if (al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        al::createSceneObj<CapMessageDirector>(sceneObjHolder)->endCapMessageSystemContinue();
+}
+
+void invalidateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder) {
+    if (al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        al::createSceneObj<CapMessageDirector>(sceneObjHolder)->invalidateAppearCapMessage();
+}
+
+void validateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder) {
+    if (al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        al::createSceneObj<CapMessageDirector>(sceneObjHolder)->validateAppearCapMessage();
+}
+
+void forceEndCapMessage(const al::IUseSceneObjHolder* sceneObjHolder) {
+    if (al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        al::createSceneObj<CapMessageDirector>(sceneObjHolder)->forceEnd();
+}
+
+bool tryCancelCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    CapMessageDirector* director = al::createSceneObj<CapMessageDirector>(sceneObjHolder);
+    if (!director->isActive(labelName))
+        return false;
+
+    director->forceEndInner();
+    return true;
+}
+
+bool isShowCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)->isShow(labelName);
+}
+
+bool isDelayCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)->isDelay(labelName);
+}
+
+bool isActiveCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName) {
+    if (!al::isExistSceneObj<CapMessageDirector>(sceneObjHolder))
+        return false;
+
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)->isActive(labelName);
+}
+
+CapMessageKeeper* getCapMessageKeeper(const al::IUseSceneObjHolder* sceneObjHolder) {
+    return al::createSceneObj<CapMessageDirector>(sceneObjHolder)->getCapMessageKeeper();
+}
+
+}  // namespace CapMessageDirectorFunction

--- a/src/MapObj/CapMessageDirector.h
+++ b/src/MapObj/CapMessageDirector.h
@@ -1,0 +1,88 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class CapMessageGameDataChecker;
+class CapMessageKeeper;
+class CapMessageLayout;
+class CapMessagePlacement;
+class CapMessageShowInfo;
+
+class CapMessageDirector : public al::LiveActor, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_CapMessageDirector;
+
+    CapMessageDirector();
+    ~CapMessageDirector() override;
+
+    const char* getSceneObjName() const override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    bool tryStartShowPlacement();
+    void exeDelayPlacement();
+    CapMessagePlacement* findPlacement() const;
+    void exeShowPlacement();
+    void forceEndInner();
+    void exeShowSystemLow();
+    void exeShowSystem();
+    void exeShowSystemContinue();
+    void exeEnd();
+    bool isShow(const char* labelName) const;
+    bool isDelay(const char* labelName) const;
+    bool isActive(const char* labelName) const;
+    s32 registerCapMessagePlacement(CapMessagePlacement* placement);
+    bool tryShowMessageSystem(const CapMessageShowInfo* showInfo,
+                              const CapMessageGameDataChecker* checker);
+    bool tryCheck(const CapMessageGameDataChecker* checker) const;
+    bool tryShowMessageSystemLow(const CapMessageShowInfo* showInfo,
+                                 const CapMessageGameDataChecker* checker);
+    bool tryShowMessageSystemContinue(const CapMessageShowInfo* showInfo,
+                                      const CapMessageGameDataChecker* checker);
+    void endCapMessageSystemContinue();
+    void invalidateAppearCapMessage();
+    void validateAppearCapMessage();
+    void forceEnd();
+
+private:
+    CapMessageLayout* mLayout;
+    al::DeriveActorGroup<CapMessagePlacement>* mPlacementGroup;
+    CapMessagePlacement* mCurrentPlacement;
+    CapMessageKeeper* mMessageKeeper;
+    bool mIsAppearCapMessageValid;
+};
+
+static_assert(sizeof(CapMessageDirector) == 0x138, "CapMessageDirector");
+
+namespace CapMessageDirectorFunction {
+s32 registerCapMessagePlacement(CapMessagePlacement* placement);
+bool tryShowCapMessageSystem(const al::IUseSceneObjHolder* sceneObjHolder,
+                             const CapMessageShowInfo* showInfo,
+                             const CapMessageGameDataChecker* checker);
+bool tryShowCapMessageSystemLow(const al::IUseSceneObjHolder* sceneObjHolder,
+                                const CapMessageShowInfo* showInfo,
+                                const CapMessageGameDataChecker* checker);
+bool tryShowCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder,
+                                     const CapMessageShowInfo* showInfo,
+                                     const CapMessageGameDataChecker* checker);
+void endCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder);
+void invalidateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder);
+void validateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder);
+void forceEndCapMessage(const al::IUseSceneObjHolder* sceneObjHolder);
+bool tryCancelCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isShowCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isDelayCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isActiveCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+CapMessageKeeper* getCapMessageKeeper(const al::IUseSceneObjHolder* sceneObjHolder);
+}  // namespace CapMessageDirectorFunction

--- a/src/MapObj/CapMessageDirector.h
+++ b/src/MapObj/CapMessageDirector.h
@@ -1,0 +1,90 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class CapMessageGameDataChecker;
+class CapMessageKeeper;
+class CapMessageLayout;
+class CapMessagePlacement;
+class CapMessageShowInfo;
+
+class CapMessageDirector : public al::LiveActor, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_CapMessageDirector;
+
+    CapMessageDirector();
+
+    const char* getSceneObjName() const override { return "帽子メッセージディレクター(新)"; }
+
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    bool tryStartShowPlacement();
+    void exeDelayPlacement();
+    CapMessagePlacement* findPlacement() const;
+    void exeShowPlacement();
+    void forceEndInner();
+    void exeShowSystemLow();
+    void exeShowSystem();
+    void exeShowSystemContinue();
+    void exeEnd();
+    bool isShow(const char* labelName) const;
+    bool isDelay(const char* labelName) const;
+    bool isActive(const char* labelName) const;
+    s32 registerCapMessagePlacement(CapMessagePlacement* placement);
+    bool tryShowMessageSystem(const CapMessageShowInfo* showInfo,
+                              const CapMessageGameDataChecker* checker);
+    bool tryCheck(const CapMessageGameDataChecker* checker) const;
+    bool tryShowMessageSystemLow(const CapMessageShowInfo* showInfo,
+                                 const CapMessageGameDataChecker* checker);
+    bool tryShowMessageSystemContinue(const CapMessageShowInfo* showInfo,
+                                      const CapMessageGameDataChecker* checker);
+    void endCapMessageSystemContinue();
+    void invalidateAppearCapMessage();
+    void validateAppearCapMessage();
+    void forceEnd();
+
+    CapMessageKeeper* getCapMessageKeeper() const { return mMessageKeeper; }
+
+private:
+    CapMessageLayout* mLayout = nullptr;
+    al::DeriveActorGroup<CapMessagePlacement>* mPlacementGroup = nullptr;
+    CapMessagePlacement* mCurrentPlacement = nullptr;
+    CapMessageKeeper* mMessageKeeper = nullptr;
+    bool mIsAppearCapMessageValid = true;
+};
+
+static_assert(sizeof(CapMessageDirector) == 0x138, "CapMessageDirector");
+
+namespace CapMessageDirectorFunction {
+s32 registerCapMessagePlacement(CapMessagePlacement* placement);
+bool tryShowCapMessageSystem(const al::IUseSceneObjHolder* sceneObjHolder,
+                             const CapMessageShowInfo* showInfo,
+                             const CapMessageGameDataChecker* checker);
+bool tryShowCapMessageSystemLow(const al::IUseSceneObjHolder* sceneObjHolder,
+                                const CapMessageShowInfo* showInfo,
+                                const CapMessageGameDataChecker* checker);
+bool tryShowCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder,
+                                     const CapMessageShowInfo* showInfo,
+                                     const CapMessageGameDataChecker* checker);
+void endCapMessageSystemContinue(const al::IUseSceneObjHolder* sceneObjHolder);
+void invalidateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder);
+void validateAppearCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder);
+void forceEndCapMessage(const al::IUseSceneObjHolder* sceneObjHolder);
+bool tryCancelCapMessageNew(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isShowCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isDelayCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+bool isActiveCapMessage(const al::IUseSceneObjHolder* sceneObjHolder, const char* labelName);
+CapMessageKeeper* getCapMessageKeeper(const al::IUseSceneObjHolder* sceneObjHolder);
+}  // namespace CapMessageDirectorFunction

--- a/src/MapObj/CapMessageGameDataChecker.h
+++ b/src/MapObj/CapMessageGameDataChecker.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class CapMessageGameDataChecker {
+public:
+    CapMessageGameDataChecker();
+
+    void initByPlacementInfo(const al::ActorInitInfo& info);
+    void invalidateKidsMode();
+    void invalidatePlayerSeparate();
+    void invalidateGameClear();
+    void enableNoCap();
+    void enableGiantWanderBoss();
+    bool check(const al::IUseSceneObjHolder* sceneObjHolder) const;
+
+private:
+    bool mIsInvalidateKidsMode = false;
+    bool mIsInvalidatePlayerSeparate = false;
+    bool mIsInvalidateGameClear = false;
+    bool mIsEnableNoCap = false;
+    bool mIsEnableGiantWanderBoss = false;
+    u8 _5[3] = {};
+};
+
+static_assert(sizeof(CapMessageGameDataChecker) == 0x8, "CapMessageGameDataChecker");

--- a/src/MapObj/CapMessageGameDataChecker.h
+++ b/src/MapObj/CapMessageGameDataChecker.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class CapMessageGameDataChecker {
+public:
+    CapMessageGameDataChecker();
+
+    void initByPlacementInfo(const al::ActorInitInfo& info);
+    void invalidateKidsMode();
+    void invalidatePlayerSeparate();
+    void invalidateGameClear();
+    void enableNoCap();
+    void enableGiantWanderBoss();
+    bool check(const al::IUseSceneObjHolder* sceneObjHolder) const;
+
+private:
+    bool mIsInvalidateKidsMode = false;
+    bool mIsInvalidatePlayerSeparate = false;
+    bool mIsInvalidateGameClear = false;
+    bool mIsEnableNoCap = false;
+    bool mIsEnableGiantWanderBoss = false;
+};
+
+static_assert(sizeof(CapMessageGameDataChecker) == 0x5, "CapMessageGameDataChecker");

--- a/src/MapObj/CapMessageKeeper.h
+++ b/src/MapObj/CapMessageKeeper.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class IUseSceneObjHolder;
+class Resource;
+}  // namespace al
+
+class CapMessageEnableChecker;
+
+class CapMessageKeeper {
+public:
+    struct CapMsgType {
+        struct ValueArray {
+            ValueArray();
+        };
+
+        static const char* text_(s32 value);
+
+        s32 mValue = 0;
+    };
+
+    CapMessageKeeper();
+
+    void createAndReadYamlAll();
+    bool isShowCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, s32 id);
+    bool isShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                  const CapMsgType& type);
+    bool tryShowSaveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                           bool isSave);
+    bool tryShowCapMsgPrivate(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                              const char* messageName, s32 id, bool isDemo, bool isSave);
+    bool tryCheckShowCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                            CapMessageEnableChecker* enableChecker, bool isSave);
+    void saveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, s32 id);
+    bool tryShowCapMsgPriorityLow(const al::IUseSceneObjHolder* sceneObjHolder,
+                                  const CapMsgType& type, s32 delayTime, s32 waitTime);
+    bool tryReadYamlOne(const al::Resource* resource, const char* messageName, s32* delayTime,
+                        s32* waitTime);
+    bool tryShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                   const CapMsgType& type);
+    void saveCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                const CapMsgType& type);
+    void saveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const char* messageName);
+    s32* getCapMessageParam(const CapMsgType& type);
+
+private:
+    s32** mCapMessageParamTable = nullptr;
+    s32 mDefaultDelay = -1;
+    s32 mDefaultWaitFrame = -1;
+    void* mParamArray = nullptr;
+    s32 mUnused = 0;
+    u32 _1c = 0;
+};
+
+static_assert(sizeof(CapMessageKeeper) == 0x20, "CapMessageKeeper");
+
+namespace CapMessageKeeperFuncrion {
+CapMessageKeeper* getCapMsgKeeper(const al::IUseSceneObjHolder* sceneObjHolder);
+}  // namespace CapMessageKeeperFuncrion

--- a/src/MapObj/CapMessageKeeper.h
+++ b/src/MapObj/CapMessageKeeper.h
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadEnum.h>
+
+namespace al {
+class IUseSceneObjHolder;
+class Resource;
+}  // namespace al
+
+class CapMessageEnableChecker;
+
+class CapMessageKeeper {
+public:
+    SEAD_ENUM(CapMsgTypeNoSave,
+              GrowFlowerPotLookFirst , WorldWarpEnterAlready , WarpDisableInMiniGame ,
+              YukimaruTutorial);
+
+    SEAD_ENUM(CapMsgType,
+                 PlayerInIceWaterFirst = 0 , PlayerSinkSandFirst = 1 ,
+                 CatchBombCatchFirst = 32 , PackunFireChokeCap = 34 ,
+                 PackunFireRescueCap = 35 , WorldWarpOutFirst = 40 ,
+                 WorldWarpOutAgain = 60 , CorkNearFirst = 81 ,
+                 CorkNearLaunchedFirst = 82 , CorkNearSecond = 83 ,
+                 WorldWarpLookFirst = 84 , CollectCoinGetFirst = 85 ,
+                 ShineChipGetFirst = 88 , KakkuHideFirst = 89 ,
+                 MoonRockLookFirst = 96 , MoonRockLookFirstMoonWorld = 97 ,
+                 MoonRockLookMoonWorld = 98 , CatupultLookFirst = 99 ,
+                 CatupultAfterShootFirst = 100 , GrowFlowerSeedLookFirst = 101 ,
+                 GrowFlowerPotAfterImplant = 103 , GrowFlowerPotAfterImplantWater = 104 ,
+                 MoonGetSpecial1 = 105 , MoonGetSpecial2 = 106 , IntroducePowerStar = 107 ,
+                 WorldWarpCloseLookFirst = 115 , MoonRockLookLongTime = 116 ,
+                 CapThrow = 250);
+
+    CapMessageKeeper();
+
+    void createAndReadYamlAll();
+    bool isShowCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, s32 id);
+    bool isShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                  const CapMsgType& type);
+    bool tryShowSaveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                           bool isSave);
+    bool tryShowCapMsgPrivate(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                              const char* messageName, s32 id, bool isDemo, bool isSave);
+    bool tryCheckShowCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const CapMsgType& type,
+                            CapMessageEnableChecker* enableChecker, bool isSave);
+    void saveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, s32 id);
+    bool tryShowCapMsgPriorityLow(const al::IUseSceneObjHolder* sceneObjHolder,
+                                  const CapMsgType& type, s32 delayTime, s32 waitTime);
+    bool tryReadYamlOne(const al::Resource* resource, const char* messageName, s32* delayTime,
+                        s32* waitTime);
+    bool tryShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                   const CapMsgType& type);
+    void saveCapMsgCurrentWorld(const al::IUseSceneObjHolder* sceneObjHolder,
+                                const CapMsgType& type);
+    void saveCapMsg(const al::IUseSceneObjHolder* sceneObjHolder, const char* messageName);
+    s32* getCapMessageParam(const CapMsgType& type);
+
+private:
+    s32** mCapMessageParamTable = nullptr;
+    s32 mDefaultDelay = -1;
+    s32 mDefaultWaitFrame = -1;
+    void* mParamArray = nullptr;
+    s32 mUnused = 0;
+    u32 _1c = 0;
+};
+
+static_assert(sizeof(CapMessageKeeper) == 0x20, "CapMessageKeeper");
+
+namespace CapMessageKeeperFuncrion {
+CapMessageKeeper* getCapMsgKeeper(const al::IUseSceneObjHolder* sceneObjHolder);
+}  // namespace CapMessageKeeperFuncrion

--- a/src/MapObj/CapMessagePlacement.h
+++ b/src/MapObj/CapMessagePlacement.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class CapMessageAreaChecker;
+class CapMessageEnableChecker;
+class CapMessageGameDataChecker;
+class CapMessageShowInfo;
+struct SaveObjInfo;
+
+class CapMessagePlacement : public al::LiveActor {
+public:
+    CapMessagePlacement(const char* name);
+
+    void init(const al::ActorInitInfo& info);
+    void onKill();
+    void onAppear();
+    void initAfterPlacement();
+    void showStart();
+    void trySave();
+    void showEnd();
+    bool isActive() const;
+    bool checkEnbale() const;
+
+    const CapMessageShowInfo* getShowInfo() const { return mShowInfo; }
+
+    s32 getAppearPriority() const { return mAppearPriority; }
+
+    s32 getDelayTime() const { return mDelayTime; }
+
+    bool isDelayCancel() const { return mIsDelayCancel; }
+
+    bool isKeepDisp() const { return mIsKeepDisp; }
+
+private:
+    CapMessageGameDataChecker* mGameDataChecker = nullptr;
+    CapMessageAreaChecker* mAreaChecker = nullptr;
+    CapMessageShowInfo* mShowInfo = nullptr;
+    sead::FixedSafeString<0x100> mMessageName;
+    sead::FixedSafeString<0x100> mLabelName;
+    bool mIsStageMessage = false;
+    u8 _351[7] = {};
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    s32 mAppearPriority = 0;
+    s32 mStartNum = 0;
+    s32 mDelayTime = 0;
+    bool mIsDelayCancel = false;
+    bool mIsSaveObjInfoOn = false;
+    bool mIsAppearSwitchOff = false;
+    bool mIsKilledBySwitch = false;
+    bool mIsKeepDisp = false;
+};

--- a/src/MapObj/CapMessagePlacement.h
+++ b/src/MapObj/CapMessagePlacement.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class CapMessageAreaChecker;
+class CapMessageEnableChecker;
+class CapMessageGameDataChecker;
+class CapMessageShowInfo;
+struct SaveObjInfo;
+
+class CapMessagePlacement : public al::LiveActor {
+public:
+    CapMessagePlacement(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void onKill();
+    void onAppear();
+    void initAfterPlacement() override;
+    void showStart();
+    void trySave();
+    void showEnd();
+    bool isActive() const;
+    bool checkEnbale() const;
+
+    const CapMessageShowInfo* getShowInfo() const { return mShowInfo; }
+
+    s32 getAppearPriority() const { return mAppearPriority; }
+
+    s32 getDelay() const { return mDelay; }
+
+    bool isDelayCancel() const { return mIsDelayCancel; }
+
+    bool isKeepDisp() const { return mIsKeepDisp; }
+
+private:
+    CapMessageGameDataChecker* mGameDataChecker = nullptr;
+    CapMessageAreaChecker* mAreaChecker = nullptr;
+    CapMessageShowInfo* mShowInfo = nullptr;
+    sead::FixedSafeString<0x100> mMessageName;
+    sead::FixedSafeString<0x100> mLabelName;
+    bool mIsStageMessage = false;
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    s32 mAppearPriority = 0;
+    s32 mStartNum = 0;
+    s32 mDelay = 0;
+    bool mIsDelayCancel = false;
+    bool mIsOnSaveObjInfo = false;
+    bool mIsAppearedBySwitch = false;
+    bool mIsKilledBySwitch = false;
+    bool mIsKeepDisp = false;
+};

--- a/src/Scene/SceneObjFactory.cpp
+++ b/src/Scene/SceneObjFactory.cpp
@@ -9,6 +9,7 @@
 #include "Item/CoinCollectHolder.h"
 #include "Item/CoinCollectWatcher.h"
 #include "Layout/KidsModeLayoutAccessor.h"
+#include "MapObj/CapMessageDirector.h"
 #include "MapObj/RouteGuideDirector.h"
 #include "Scene/HintPhotoLayoutHolder.h"
 
@@ -24,7 +25,7 @@ static al::ISceneObj* sceneObjCreator(s32 id) {
         return nullptr;
 
     case SceneObjID_CapMessageDirector:
-        return nullptr;
+        return new CapMessageDirector();
 
     case SceneObjID_CapMessageMoonNotifier:
         return nullptr;

--- a/src/Scene/SceneObjFactory.cpp
+++ b/src/Scene/SceneObjFactory.cpp
@@ -9,6 +9,7 @@
 #include "Item/CoinCollectHolder.h"
 #include "Item/CoinCollectWatcher.h"
 #include "Layout/KidsModeLayoutAccessor.h"
+#include "MapObj/CapMessageDirector.h"
 #include "MapObj/RhyhtmInfoWatcher.h"
 #include "MapObj/RouteGuideDirector.h"
 #include "Scene/HintPhotoLayoutHolder.h"
@@ -25,7 +26,7 @@ static al::ISceneObj* sceneObjCreator(s32 id) {
         return nullptr;
 
     case SceneObjID_CapMessageDirector:
-        return nullptr;
+        return new CapMessageDirector();
 
     case SceneObjID_CapMessageMoonNotifier:
         return nullptr;


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1109)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (befc651 - 3ddf3b5)

📈 **Matched code**: 15.45% (+0.04%, +4772 bytes)

<details>
<summary>✅ 53 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CapMessageDirector` | `CapMessageDirector::exeDelayPlacement()` | +300 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::tryStartShowPlacement()` | +240 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::exeShowPlacement()` | +224 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::CapMessageDirector()` | +216 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::tryCancelCapMessageNew(al::IUseSceneObjHolder const*, char const*)` | +208 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::CapMessageDirector()` | +204 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::isActiveCapMessage(al::IUseSceneObjHolder const*, char const*)` | +188 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `non-virtual thunk to CapMessageDirector::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +184 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +176 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::tryShowCapMessageSystemLow(al::IUseSceneObjHolder const*, CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +172 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::isDelayCapMessage(al::IUseSceneObjHolder const*, char const*)` | +164 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::findPlacement() const` | +156 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::tryShowCapMessageSystemContinue(al::IUseSceneObjHolder const*, CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +156 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::tryShowCapMessageSystem(al::IUseSceneObjHolder const*, CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +152 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::isActive(char const*) const` | +132 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::tryShowMessageSystemLow(CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +132 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::invalidateAppearCapMessageNew(al::IUseSceneObjHolder const*)` | +128 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::isDelay(char const*) const` | +116 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::endCapMessageSystemContinue(al::IUseSceneObjHolder const*)` | +116 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::tryShowMessageSystemContinue(CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +108 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::tryShowMessageSystem(CapMessageShowInfo const*, CapMessageGameDataChecker const*)` | +104 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::forceEndCapMessage(al::IUseSceneObjHolder const*)` | +100 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::invalidateAppearCapMessage()` | +92 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::isShowCapMessage(al::IUseSceneObjHolder const*, char const*)` | +92 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::endCapMessageSystemContinue()` | +76 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::registerCapMessagePlacement(CapMessagePlacement*)` | +76 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `(anonymous namespace)::CapMessageDirectorNrvShowSystemLow::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::exeShowSystemLow()` | +72 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirectorFunction::validateAppearCapMessageNew(al::IUseSceneObjHolder const*)` | +72 | 0.00% | 100.00% |
| `MapObj/CapMessageDirector` | `CapMessageDirector::forceEndInner()` | +52 | 0.00% | 100.00% |

...and 23 more new matches
</details>


<!-- decomp.dev report end -->