### PR TITLE
MapObj: Implement `HintRouteGuidePoint`

### DIFF
--- a/src/MapObj/HintRouteGuidePoint.cpp
+++ b/src/MapObj/HintRouteGuidePoint.cpp
@@ -1,0 +1,230 @@
+#include "MapObj/HintRouteGuidePoint.h"
+
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/RouteGuideDirector.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(HintRouteGuidePoint, Start)
+NERVE_IMPL(HintRouteGuidePoint, End)
+NERVE_IMPL(HintRouteGuidePoint, HintNpc)
+NERVE_IMPL(HintRouteGuidePoint, Home)
+NERVE_IMPL(HintRouteGuidePoint, Dedication)
+NERVE_IMPL(HintRouteGuidePoint, NearHint)
+
+NERVES_MAKE_NOSTRUCT(HintRouteGuidePoint, Start, End, HintNpc, Home, Dedication, NearHint)
+}  // namespace
+
+HintRouteGuidePoint::HintRouteGuidePoint(const char* name)
+    : al::LiveActor(name), RouteGuidePoint() {}
+
+void HintRouteGuidePoint::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+
+    if (rs::isKidsMode(this)) {
+        rs::addRouteGuidePointBufferCount(this, 1);
+        al::initExecutorWatchObj(this, info);
+        al::initNerve(this, &Start, 0);
+        makeActorAlive();
+        return;
+    }
+
+    makeActorDead();
+}
+
+void HintRouteGuidePoint::initAfterPlacement() {
+    rs::registerRouteGuidePoint(this, this);
+}
+
+const sead::Vector3f& HintRouteGuidePoint::getGuideTrans() const {
+    return mGuideTrans;
+}
+
+bool HintRouteGuidePoint::isValidateGuide() const {
+    if (al::isNerve(this, &Start))
+        return false;
+
+    if (al::isNerve(this, &End))
+        return false;
+
+    return RouteGuidePoint::isValidateGuide();
+}
+
+bool HintRouteGuidePoint::isHorizontalGuide() const {
+    return al::isNerve(this, &HintNpc) || al::isNerve(this, &Home) ||
+           al::isNerve(this, &Dedication);
+}
+
+void HintRouteGuidePoint::exeStart() {
+    if (tryGuideEnd())
+        return;
+
+    if (tryGuideHome())
+        return;
+
+    if (tryGuideNearHint())
+        return;
+
+    if (tryGuideDedication())
+        return;
+
+    al::setNerve(this, &HintNpc);
+}
+
+bool HintRouteGuidePoint::tryGuideEnd() {
+    if (!GameDataFunction::isUnlockedNextWorld(GameDataHolderAccessor(this)))
+        return false;
+
+    al::setNerve(this, &End);
+    return true;
+}
+
+bool HintRouteGuidePoint::tryGuideHome() {
+    if (!GameDataFunction::isCollectShineForNextWorldAndNotUnlockNextWorld(this))
+        return false;
+
+    al::setNerve(this, &Home);
+    return true;
+}
+
+bool HintRouteGuidePoint::tryGuideNearHint() {
+    if (!GameDataFunction::checkExistHint(GameDataHolderAccessor(this)))
+        return false;
+
+    al::setNerve(this, &NearHint);
+    return true;
+}
+
+bool HintRouteGuidePoint::tryGuideDedication() {
+    if (GameDataFunction::getCurrentShineNum(GameDataHolderAccessor(this)) < 1)
+        return false;
+
+    al::setNerve(this, &Dedication);
+    return true;
+}
+
+void HintRouteGuidePoint::exeEnd() {}
+
+void HintRouteGuidePoint::exeHome() {
+    u64 homeAccessorStorage;
+    u64 nextWorldAccessorStorage;
+
+    if (al::isFirstStep(this)) {
+        GameDataHolderAccessor* accessor =
+            new (&nextWorldAccessorStorage) GameDataHolderAccessor(this);
+        mGuideTrans = GameDataFunction::getHomeTrans(*accessor);
+    }
+
+    GameDataHolderAccessor* accessor = new (&homeAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::isUnlockedNextWorld(*accessor))
+        al::setNerve(this, &End);
+}
+
+void HintRouteGuidePoint::exeNearHint() {
+    if (tryGuideEnd())
+        return;
+
+    if (tryGuideHome())
+        return;
+
+    if (!updateNearHint())
+        return;
+
+    if (tryGuideDedication())
+        return;
+
+    al::setNerve(this, &HintNpc);
+}
+
+bool HintRouteGuidePoint::updateNearHint() {
+    bool isNotFound = true;
+
+    if (GameDataFunction::checkExistHint(GameDataHolderAccessor(this))) {
+        isNotFound = !GameDataFunction::calcHintTransMostNear(
+            &mGuideTrans, GameDataHolderAccessor(this), rs::getPlayerPos(this));
+    }
+
+    return isNotFound;
+}
+
+void HintRouteGuidePoint::exeDedication() {
+    u64 laterAccessorStorage;
+    u64 homeAccessorStorage;
+
+    if (al::isFirstStep(this)) {
+        GameDataHolderAccessor* accessor = new (&homeAccessorStorage) GameDataHolderAccessor(this);
+        mGuideTrans = GameDataFunction::getHomeTrans(*accessor);
+    }
+
+    GameDataHolderAccessor* nextWorldAccessor =
+        new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::isUnlockedNextWorld(*nextWorldAccessor)) {
+        al::setNerve(this, &End);
+        return;
+    }
+
+    if (GameDataFunction::isCollectShineForNextWorldAndNotUnlockNextWorld(this)) {
+        al::setNerve(this, &Home);
+        return;
+    }
+
+    GameDataHolderAccessor* hintAccessor = new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::checkExistHint(*hintAccessor)) {
+        al::setNerve(this, &NearHint);
+        return;
+    }
+
+    GameDataHolderAccessor* shineAccessor =
+        new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::getCurrentShineNum(*shineAccessor) > 0)
+        return;
+
+    al::setNerve(this, &HintNpc);
+}
+
+bool HintRouteGuidePoint::isEndDedication() const {
+    return GameDataFunction::getCurrentShineNum(GameDataHolderAccessor(this)) < 1;
+}
+
+void HintRouteGuidePoint::exeHintNpc() {
+    u64 laterAccessorStorage;
+    u64 hintNpcAccessorStorage;
+
+    if (al::isFirstStep(this)) {
+        GameDataHolderAccessor* accessor =
+            new (&hintNpcAccessorStorage) GameDataHolderAccessor(this);
+        mGuideTrans = GameDataFunction::getHintNpcTrans(*accessor);
+    }
+
+    GameDataHolderAccessor* nextWorldAccessor =
+        new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::isUnlockedNextWorld(*nextWorldAccessor)) {
+        al::setNerve(this, &End);
+        return;
+    }
+
+    if (GameDataFunction::isCollectShineForNextWorldAndNotUnlockNextWorld(this)) {
+        al::setNerve(this, &Home);
+        return;
+    }
+
+    GameDataHolderAccessor* hintAccessor = new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::checkExistHint(*hintAccessor)) {
+        al::setNerve(this, &NearHint);
+        return;
+    }
+
+    GameDataHolderAccessor* shineAccessor =
+        new (&laterAccessorStorage) GameDataHolderAccessor(this);
+    if (GameDataFunction::getCurrentShineNum(*shineAccessor) >= 1) {
+        al::setNerve(this, &Dedication);
+        return;
+    }
+}

--- a/src/MapObj/HintRouteGuidePoint.h
+++ b/src/MapObj/HintRouteGuidePoint.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "MapObj/RouteGuidePoint.h"
+
+namespace al {
+struct ActorInitInfo;
+}
+
+class HintRouteGuidePoint : public al::LiveActor, public RouteGuidePoint {
+public:
+    HintRouteGuidePoint(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+
+    const sead::Vector3f& getGuideTrans() const override;
+    bool isValidateGuide() const override;
+    bool isHorizontalGuide() const override;
+
+    void exeStart();
+    bool tryGuideEnd();
+    bool tryGuideHome();
+    bool tryGuideNearHint();
+    bool tryGuideDedication();
+    void exeEnd();
+    void exeHome();
+    void exeNearHint();
+    bool updateNearHint();
+    void exeDedication();
+    bool isEndDedication() const;
+    void exeHintNpc();
+
+private:
+    sead::Vector3f mGuideTrans = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(HintRouteGuidePoint) == 0x120);

--- a/src/MapObj/RouteGuidePoint.h
+++ b/src/MapObj/RouteGuidePoint.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/HostIO/IUseName.h"
+
+class RouteGuidePoint : public virtual al::IUseName {
+public:
+    RouteGuidePoint();
+
+    virtual const sead::Vector3f& getGuideTrans() const = 0;
+
+    virtual bool isHorizontalGuide() const { return mIsHorizontalGuide; }
+
+    virtual bool isValidateGuide() const { return mIsValidateGuide; }
+
+    void onHorizontalGuide();
+    void offHorizontalGuide();
+    void validateGuide();
+    void invalidateGuide();
+
+private:
+    bool mIsValidateGuide = true;
+    bool mIsHorizontalGuide = true;
+};
+
+static_assert(sizeof(RouteGuidePoint) == 0x10);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -83,6 +83,7 @@
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
+#include "MapObj/HintRouteGuidePoint.h"
 #include "MapObj/HipDropSwitch.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
@@ -351,7 +352,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HelpNpc", nullptr},
     {"HintNpc", nullptr},
     {"HintPhoto", nullptr},
-    {"HintRouteGuidePoint", nullptr},
+    {"HintRouteGuidePoint", al::createActorFunction<HintRouteGuidePoint>},
     {"HipDropSwitch", al::createActorFunction<HipDropSwitch>},
     {"HipDropSwitchSave", nullptr},
     {"HipDropSwitchTimer", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1112)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (7bb1c84 - 2439475)

📈 **Matched code**: 14.34% (+0.02%, +2560 bytes)

<details>
<summary>✅ 31 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeDedication()` | +248 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeHintNpc()` | +248 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeNearHint()` | +240 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeStart()` | +204 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::HintRouteGuidePoint(char const*)` | +180 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::HintRouteGuidePoint(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeHome()` | +136 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::updateNearHint()` | +128 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::init(al::ActorInitInfo const&)` | +116 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `non-virtual thunk to HintRouteGuidePoint::isValidateGuide() const` | +96 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::isValidateGuide() const` | +92 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `non-virtual thunk to HintRouteGuidePoint::isHorizontalGuide() const` | +92 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::isHorizontalGuide() const` | +88 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::tryGuideDedication()` | +88 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::tryGuideEnd()` | +84 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::tryGuideNearHint()` | +84 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::tryGuideHome()` | +68 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::isEndDedication() const` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HintRouteGuidePoint>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::initAfterPlacement()` | +16 | 0.00% | 100.00% |
| `MapObj/GrowPlantSeed` | `RouteGuidePoint::isHorizontalGuide() const` | +8 | 0.00% | 100.00% |
| `MapObj/GrowPlantSeed` | `RouteGuidePoint::isValidateGuide() const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::getGuideTrans() const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `non-virtual thunk to HintRouteGuidePoint::getGuideTrans() const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `(anonymous namespace)::HintRouteGuidePointNrvStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `(anonymous namespace)::HintRouteGuidePointNrvHintNpc::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `(anonymous namespace)::HintRouteGuidePointNrvHome::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `(anonymous namespace)::HintRouteGuidePointNrvDedication::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `(anonymous namespace)::HintRouteGuidePointNrvNearHint::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HintRouteGuidePoint` | `HintRouteGuidePoint::exeEnd()` | +4 | 0.00% | 100.00% |

...and 1 more new matches
</details>


<!-- decomp.dev report end -->