### PR TITLE
MapObj: Implement `SkyWorldKoopaFire`

### DIFF
--- a/src/MapObj/SkyWorldKoopaFire.cpp
+++ b/src/MapObj/SkyWorldKoopaFire.cpp
@@ -1,0 +1,192 @@
+#include "MapObj/SkyWorldKoopaFire.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Demo/DemoFunction.h"
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/DemoUtil.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+const al::IUseAudioKeeper* getAudioKeeperPtr(const SkyWorldKoopaFire* actor) {
+    return actor;
+}
+
+NERVE_ACTION_IMPL(SkyWorldKoopaFire, Wait)
+NERVE_ACTION_IMPL(SkyWorldKoopaFire, HighTension)
+
+NERVE_ACTIONS_MAKE_STRUCT(SkyWorldKoopaFire, Wait, HighTension)
+
+NERVE_IMPL(SkyWorldKoopaFrame, Wait)
+NERVE_IMPL(SkyWorldKoopaFrame, Reaction)
+NERVE_IMPL(SkyWorldKoopaFrame, Fall)
+NERVE_IMPL(SkyWorldKoopaFrame, FallNoCollider)
+NERVE_IMPL(SkyWorldKoopaFrame, FallEndWait)
+
+NERVES_MAKE_NOSTRUCT(SkyWorldKoopaFrame, Wait, Reaction, Fall, FallNoCollider, FallEndWait)
+}  // namespace
+
+SkyWorldKoopaFire::SkyWorldKoopaFire(const char* actorName) : al::LiveActor(actorName) {}
+
+void SkyWorldKoopaFire::init(const al::ActorInitInfo& info) {
+    using SkyWorldKoopaFireFunctor =
+        al::FunctorV0M<SkyWorldKoopaFire*, void (SkyWorldKoopaFire::*)()>;
+
+    al::initNerveAction(this, "Wait", &NrvSkyWorldKoopaFire.collector, 0);
+    al::initActor(this, info);
+    al::onUpdateMovementEffectAudioCollisionSensor(this);
+    al::setEffectNamedMtxPtr(this, "EffectEmitPos", &mEffectEmitPos);
+
+    if (al::listenStageSwitchOnOffAppear(
+            this, SkyWorldKoopaFireFunctor(this, &SkyWorldKoopaFire::listenAppear),
+            SkyWorldKoopaFireFunctor(this, &SkyWorldKoopaFire::listenKill))) {
+        makeActorDead();
+    } else {
+        makeActorAlive();
+    }
+
+    al::registActorToDemoInfo(this, info);
+}
+
+void SkyWorldKoopaFire::listenAppear() {
+    mCapAttackCooldown = 0;
+    appear();
+    al::startNerveAction(this, "Wait");
+}
+
+void SkyWorldKoopaFire::listenKill() {
+    kill();
+}
+
+void SkyWorldKoopaFire::exeWait() {
+    mCapAttackCooldown -= mCapAttackCooldown > 0;
+
+    if (al::isRunningBgm(getAudioKeeperPtr(this), "WorldMain2"))
+        al::startNerveAction(this, "HighTension");
+}
+
+void SkyWorldKoopaFire::exeHighTension() {
+    mCapAttackCooldown -= mCapAttackCooldown > 0;
+
+    if (!al::isRunningBgm(getAudioKeeperPtr(this), "WorldMain2"))
+        al::startNerveAction(this, "Wait");
+}
+
+void SkyWorldKoopaFire::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    al::sendMsgEnemyAttackFire(other, self, nullptr);
+}
+
+bool SkyWorldKoopaFire::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+
+    if (!rs::isMsgCapAttack(message) || mCapAttackCooldown > 0)
+        return false;
+
+    mEffectEmitPos.setTranslation(al::getSensorPos(self));
+    al::startHitReaction(this, "帽子ヒット");
+    mCapAttackCooldown = 120;
+    return false;
+}
+
+SkyWorldKoopaFrame::SkyWorldKoopaFrame(const char* actorName) : al::LiveActor(actorName) {
+    mDemoCamera = nullptr;
+    mShine = nullptr;
+}
+
+void SkyWorldKoopaFrame::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "SkyWorldHomeFrame", nullptr);
+    al::initNerve(this, &Wait, 0);
+    mDemoCamera = al::initObjectCamera(this, info, "デモカメラ", nullptr);
+    mShine = rs::tryInitLinkShine(info, "ShineActor", 0);
+    makeActorAlive();
+}
+
+bool SkyWorldKoopaFrame::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                    al::HitSensor* self) {
+    if (!rs::isMsgCapAttackCollide(message) && !rs::isMsgPlayerRollingWallHitMove(message) &&
+        !rs::isMsgCapHipDrop(message)) {
+        return false;
+    }
+
+    if (!al::isNerve(this, &Wait))
+        return false;
+
+    al::setNerve(this, &Reaction);
+    al::startHitReaction(this, "落下開始");
+    return true;
+}
+
+void SkyWorldKoopaFrame::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::validateClipping(this);
+        al::offCollide(this);
+    }
+}
+
+void SkyWorldKoopaFrame::exeReaction() {
+    if (al::isFirstStep(this)) {
+        if (!rs::requestStartDemoNormal(this, false)) {
+            al::setNerve(this, &Reaction);
+            return;
+        }
+
+        al::startAction(this, "Reaction");
+        al::startCamera(this, mDemoCamera, -1);
+        al::invalidateClipping(this);
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Fall);
+}
+
+void SkyWorldKoopaFrame::exeFall() {
+    al::addVelocityToGravity(this, 1.8);
+    al::scaleVelocity(this, 0.98);
+
+    if (al::isStep(this, 40))
+        al::onCollide(this);
+
+    if (al::isCollidedGround(this)) {
+        al::offCollide(this);
+        al::setNerve(this, &FallNoCollider);
+    }
+}
+
+void SkyWorldKoopaFrame::exeFallNoCollider() {
+    al::addVelocityToGravity(this, 1.8);
+    al::scaleVelocity(this, 0.98);
+
+    if (al::isStep(this, 4)) {
+        al::startHitReaction(this, "破壊");
+        al::hideModel(this);
+        al::setVelocityZero(this);
+        al::offCollide(this);
+        al::setNerve(this, &FallEndWait);
+    }
+}
+
+void SkyWorldKoopaFrame::exeFallEndWait() {
+    if (al::isGreaterEqualStep(this, 60)) {
+        rs::requestEndDemoNormal(this);
+        al::endCamera(this, mDemoCamera, -1, false);
+        kill();
+        rs::appearPopupShine(mShine);
+    }
+}

--- a/src/MapObj/SkyWorldKoopaFire.cpp
+++ b/src/MapObj/SkyWorldKoopaFire.cpp
@@ -1,0 +1,193 @@
+#include "MapObj/SkyWorldKoopaFire.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Demo/DemoFunction.h"
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/DemoUtil.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+const al::IUseAudioKeeper* getAudioKeeperPtr(const SkyWorldKoopaFire* actor) {
+    return actor;
+}
+
+NERVE_ACTION_IMPL(SkyWorldKoopaFire, Wait)
+NERVE_ACTION_IMPL(SkyWorldKoopaFire, HighTension)
+
+NERVE_ACTIONS_MAKE_STRUCT(SkyWorldKoopaFire, Wait, HighTension)
+
+NERVE_IMPL(SkyWorldKoopaFrame, Wait)
+NERVE_IMPL(SkyWorldKoopaFrame, Reaction)
+NERVE_IMPL(SkyWorldKoopaFrame, Fall)
+NERVE_IMPL(SkyWorldKoopaFrame, FallNoCollider)
+NERVE_IMPL(SkyWorldKoopaFrame, FallEndWait)
+
+NERVES_MAKE_NOSTRUCT(SkyWorldKoopaFrame, Wait, Reaction, Fall, FallNoCollider, FallEndWait)
+}  // namespace
+
+SkyWorldKoopaFire::SkyWorldKoopaFire(const char* actorName) : al::LiveActor(actorName) {}
+
+void SkyWorldKoopaFire::init(const al::ActorInitInfo& info) {
+    using SkyWorldKoopaFireFunctor =
+        al::FunctorV0M<SkyWorldKoopaFire*, void (SkyWorldKoopaFire::*)()>;
+
+    al::initNerveAction(this, "Wait", &NrvSkyWorldKoopaFire.collector, 0);
+    al::initActor(this, info);
+    al::onUpdateMovementEffectAudioCollisionSensor(this);
+    al::setEffectNamedMtxPtr(this, "EffectEmitPos", &mEffectEmitPos);
+
+    if (al::listenStageSwitchOnOffAppear(
+            this, SkyWorldKoopaFireFunctor(this, &SkyWorldKoopaFire::listenAppear),
+            SkyWorldKoopaFireFunctor(this, &SkyWorldKoopaFire::listenKill))) {
+        makeActorDead();
+    } else {
+        makeActorAlive();
+    }
+
+    al::registActorToDemoInfo(this, info);
+}
+
+void SkyWorldKoopaFire::listenAppear() {
+    mCapAttackCooldown = 0;
+    appear();
+    al::startNerveAction(this, "Wait");
+}
+
+void SkyWorldKoopaFire::listenKill() {
+    kill();
+}
+
+void SkyWorldKoopaFire::exeWait() {
+    mCapAttackCooldown = (mCapAttackCooldown > 0) ? mCapAttackCooldown - 1 : mCapAttackCooldown;
+
+    if (al::isRunningBgm(getAudioKeeperPtr(this), "WorldMain2"))
+        al::startNerveAction(this, "HighTension");
+}
+
+void SkyWorldKoopaFire::exeHighTension() {
+    mCapAttackCooldown = (mCapAttackCooldown > 0) ? mCapAttackCooldown - 1 : mCapAttackCooldown;
+
+    if (!al::isRunningBgm(getAudioKeeperPtr(this), "WorldMain2"))
+        al::startNerveAction(this, "Wait");
+}
+
+void SkyWorldKoopaFire::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    al::sendMsgEnemyAttackFire(other, self, nullptr);
+}
+
+bool SkyWorldKoopaFire::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+
+    if (!rs::isMsgCapAttack(message) || mCapAttackCooldown > 0)
+        return false;
+
+    mEffectEmitPos.setTranslation(al::getSensorPos(self));
+    al::startHitReaction(this, "帽子ヒット");
+    mCapAttackCooldown = 120;
+    return false;
+}
+
+SkyWorldKoopaFrame::SkyWorldKoopaFrame(const char* actorName) : al::LiveActor(actorName) {
+    mDemoCamera = nullptr;
+    mShine = nullptr;
+}
+
+void SkyWorldKoopaFrame::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "SkyWorldHomeFrame", nullptr);
+    al::initNerve(this, &Wait, 0);
+    mDemoCamera = al::initObjectCamera(this, info, "デモカメラ", nullptr);
+    mShine = rs::tryInitLinkShine(info, "ShineActor", 0);
+    makeActorAlive();
+}
+
+bool SkyWorldKoopaFrame::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                    al::HitSensor* self) {
+    if (!rs::isMsgCapAttackCollide(message) && !rs::isMsgPlayerRollingWallHitMove(message) &&
+        !rs::isMsgCapHipDrop(message)) {
+        return false;
+    }
+
+    if (al::isNerve(this, &Wait)) {
+        al::setNerve(this, &Reaction);
+        al::startHitReaction(this, "落下開始");
+        return true;
+    }
+
+    return false;
+}
+
+void SkyWorldKoopaFrame::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::validateClipping(this);
+        al::offCollide(this);
+    }
+}
+
+void SkyWorldKoopaFrame::exeReaction() {
+    if (al::isFirstStep(this)) {
+        if (!rs::requestStartDemoNormal(this, false)) {
+            al::setNerve(this, &Reaction);
+            return;
+        }
+
+        al::startAction(this, "Reaction");
+        al::startCamera(this, mDemoCamera, -1);
+        al::invalidateClipping(this);
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Fall);
+}
+
+void SkyWorldKoopaFrame::exeFall() {
+    al::addVelocityToGravity(this, 1.8);
+    al::scaleVelocity(this, 0.98);
+
+    if (al::isStep(this, 40))
+        al::onCollide(this);
+
+    if (al::isCollidedGround(this)) {
+        al::offCollide(this);
+        al::setNerve(this, &FallNoCollider);
+    }
+}
+
+void SkyWorldKoopaFrame::exeFallNoCollider() {
+    al::addVelocityToGravity(this, 1.8);
+    al::scaleVelocity(this, 0.98);
+
+    if (al::isStep(this, 4)) {
+        al::startHitReaction(this, "破壊");
+        al::hideModel(this);
+        al::setVelocityZero(this);
+        al::offCollide(this);
+        al::setNerve(this, &FallEndWait);
+    }
+}
+
+void SkyWorldKoopaFrame::exeFallEndWait() {
+    if (al::isGreaterEqualStep(this, 60)) {
+        rs::requestEndDemoNormal(this);
+        al::endCamera(this, mDemoCamera, -1, false);
+        kill();
+        rs::appearPopupShine(mShine);
+    }
+}

--- a/src/MapObj/SkyWorldKoopaFire.h
+++ b/src/MapObj/SkyWorldKoopaFire.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CameraTicket;
+}  // namespace al
+
+class Shine;
+
+class SkyWorldKoopaFire : public al::LiveActor {
+public:
+    SkyWorldKoopaFire(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void listenAppear();
+    void listenKill();
+    void exeWait();
+    void exeHighTension();
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+private:
+    sead::Matrix34f mEffectEmitPos = sead::Matrix34f::ident;
+    s32 mCapAttackCooldown = 0;
+};
+
+static_assert(sizeof(SkyWorldKoopaFire) == 0x140);
+
+class SkyWorldKoopaFrame : public al::LiveActor {
+public:
+    SkyWorldKoopaFrame(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void exeWait();
+    void exeReaction();
+    void exeFall();
+    void exeFallNoCollider();
+    void exeFallEndWait();
+
+private:
+    al::CameraTicket* mDemoCamera = nullptr;
+    Shine* mShine = nullptr;
+};
+
+static_assert(sizeof(SkyWorldKoopaFrame) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -100,6 +100,7 @@
 #include "MapObj/SaveFlagCheckObj.h"
 #include "MapObj/ShineTowerRocket.h"
 #include "MapObj/SignBoardDanger.h"
+#include "MapObj/SkyWorldKoopaFire.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
 #include "MapObj/TrampleBush.h"
@@ -546,8 +547,8 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"SignBoardLayoutTexture", nullptr},
     {"SkyFukankunZoomCapMessage", nullptr},
     {"SkyWorldCloud", nullptr},
-    {"SkyWorldKoopaFire", nullptr},
-    {"SkyWorldKoopaFrame", nullptr},
+    {"SkyWorldKoopaFire", al::createActorFunction<SkyWorldKoopaFire>},
+    {"SkyWorldKoopaFrame", al::createActorFunction<SkyWorldKoopaFrame>},
     {"SkyWorldMiddleViewCloud", nullptr},
     {"SignBoard", nullptr},
     {"SnowWorldBigIcicle", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1113)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (774e056 - e669927)

📈 **Matched code**: 14.89% (+0.02%, +2912 bytes)

<details>
<summary>✅ 33 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::init(al::ActorInitInfo const&)` | +212 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::init(al::ActorInitInfo const&)` | +168 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::SkyWorldKoopaFire(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +156 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::exeReaction()` | +148 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::SkyWorldKoopaFire(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::SkyWorldKoopaFrame(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::exeFallNoCollider()` | +136 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +132 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFrameNrvFall::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::SkyWorldKoopaFrame(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::exeFall()` | +124 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFrameNrvFallEndWait::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::exeWait()` | +100 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::exeHighTension()` | +100 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFireNrvWait::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFireNrvHighTension::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::exeFallEndWait()` | +100 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `_GLOBAL__sub_I_SkyWorldKoopaFire.cpp` | +88 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `al::FunctorV0M<SkyWorldKoopaFire*, void (SkyWorldKoopaFire::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFrameNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFrame::exeWait()` | +60 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::listenAppear()` | +56 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SkyWorldKoopaFire>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SkyWorldKoopaFrame>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `al::FunctorV0M<SkyWorldKoopaFire*, void (SkyWorldKoopaFire::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::listenKill()` | +12 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `SkyWorldKoopaFire::attackSensor(al::HitSensor*, al::HitSensor*)` | +12 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFireNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SkyWorldKoopaFire` | `(anonymous namespace)::SkyWorldKoopaFireNrvHighTension::getActionName() const` | +12 | 0.00% | 100.00% |

...and 3 more new matches
</details>


<!-- decomp.dev report end -->