### PR TITLE
Boss/BombTail: Implement `BombTailDamage`

### DIFF
--- a/src/Boss/BombTail/BombTailDamage.cpp
+++ b/src/Boss/BombTail/BombTailDamage.cpp
@@ -1,0 +1,142 @@
+#include "Boss/BombTail/BombTailDamage.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_ACTION_IMPL(BombTailDamage, BeforeBattle)
+NERVE_ACTION_IMPL(BombTailDamage, Delay)
+NERVE_ACTION_IMPL(BombTailDamage, Appear)
+NERVE_ACTION_IMPL(BombTailDamage, Wait)
+NERVE_ACTION_IMPL(BombTailDamage, Disappear)
+NERVE_ACTION_IMPL(BombTailDamage, AppearChance)
+NERVE_ACTION_IMPL(BombTailDamage, WaitChance)
+NERVE_ACTION_IMPL(BombTailDamage, DisappearChance)
+
+NERVE_ACTIONS_MAKE_STRUCT(BombTailDamage, BeforeBattle, Delay, Appear, Wait, Disappear,
+                          AppearChance, WaitChance, DisappearChance)
+}  // namespace
+
+BombTailDamage::BombTailDamage() : al::LiveActor("BombTailDamage") {}
+
+void BombTailDamage::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "BeforeBattle", &NrvBombTailDamage.collector, 0);
+    al::initActorWithArchiveName(this, info, "BombTailDamage", nullptr);
+    al::invalidateClipping(this);
+    makeActorDead();
+}
+
+void BombTailDamage::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isDead(this))
+        return;
+
+    if (al::isNerve(this, NrvBombTailDamage.Delay.data()))
+        return;
+
+    if (al::isNerve(this, NrvBombTailDamage.Appear.data()))
+        return;
+
+    if (al::isNerve(this, NrvBombTailDamage.AppearChance.data()))
+        return;
+
+    if (!al::isSensorEnemyAttack(self))
+        return;
+
+    if (!al::isSensorPlayer(other))
+        return;
+
+    if (al::getVelocity(al::getSensorHost(other)).y > 0.0f)
+        return;
+
+    if (!rs::isPlayerCollidedGround(this))
+        return;
+
+    al::sendMsgEnemyAttackFire(other, self, nullptr);
+}
+
+bool BombTailDamage::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message) || rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+
+    return rs::isMsgPlayerDisregardTargetMarker(message);
+}
+
+void BombTailDamage::startAppear(const sead::Vector3f& trans, s32 delayStep, bool isChance) {
+    const char* sensorName = "Attack";
+
+    al::LiveActor::appear();
+    al::setTrans(this, trans);
+    al::resetPosition(this);
+    mDelayStep = delayStep;
+    mIsChance = isChance;
+
+    if (isChance)
+        al::setSensorRadius(this, sensorName, 227.5f);
+    else
+        al::setSensorRadius(this, sensorName, 130.0f);
+
+    al::startNerveAction(this, "Delay");
+}
+
+void BombTailDamage::forceDisappear() {
+    if (al::isDead(this))
+        return;
+
+    if (mIsChance)
+        al::startNerveAction(this, "DisappearChance");
+    else
+        al::startNerveAction(this, "Disappear");
+}
+
+void BombTailDamage::exeBeforeBattle() {}
+
+void BombTailDamage::exeDelay() {
+    if (!al::isGreaterEqualStep(this, mDelayStep))
+        return;
+
+    if (mIsChance)
+        al::startNerveAction(this, "AppearChance");
+    else
+        al::startNerveAction(this, "Appear");
+}
+
+void BombTailDamage::exeAppear() {
+    if (al::isGreaterEqualStep(this, 30))
+        al::startNerveAction(this, "Wait");
+}
+
+void BombTailDamage::exeWait() {
+    if (al::isGreaterEqualStep(this, 800))
+        al::startNerveAction(this, "Disappear");
+}
+
+void BombTailDamage::exeDisappear() {
+    if (al::isGreaterEqualStep(this, 15))
+        kill();
+}
+
+void BombTailDamage::exeAppearChance() {
+    if (al::isGreaterEqualStep(this, 30))
+        al::startNerveAction(this, "WaitChance");
+}
+
+void BombTailDamage::exeWaitChance() {
+    if (al::isGreaterEqualStep(this, 800))
+        al::startNerveAction(this, "DisappearChance");
+}
+
+void BombTailDamage::exeDisappearChance() {
+    if (al::isGreaterEqualStep(this, 15))
+        kill();
+}

--- a/src/Boss/BombTail/BombTailDamage.cpp
+++ b/src/Boss/BombTail/BombTailDamage.cpp
@@ -1,0 +1,126 @@
+#include "Boss/BombTail/BombTailDamage.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_ACTION_IMPL(BombTailDamage, BeforeBattle)
+NERVE_ACTION_IMPL(BombTailDamage, Delay)
+NERVE_ACTION_IMPL(BombTailDamage, Appear)
+NERVE_ACTION_IMPL(BombTailDamage, Wait)
+NERVE_ACTION_IMPL(BombTailDamage, Disappear)
+NERVE_ACTION_IMPL(BombTailDamage, AppearChance)
+NERVE_ACTION_IMPL(BombTailDamage, WaitChance)
+NERVE_ACTION_IMPL(BombTailDamage, DisappearChance)
+
+NERVE_ACTIONS_MAKE_STRUCT(BombTailDamage, BeforeBattle, Delay, Appear, Wait, Disappear,
+                          AppearChance, WaitChance, DisappearChance)
+}  // namespace
+
+BombTailDamage::BombTailDamage() : al::LiveActor("BombTailDamage") {}
+
+void BombTailDamage::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "BeforeBattle", &NrvBombTailDamage.collector, 0);
+    al::initActorWithArchiveName(this, info, "BombTailDamage", nullptr);
+    al::invalidateClipping(this);
+    makeActorDead();
+}
+
+void BombTailDamage::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isDead(this))
+        return;
+    if (al::isNerve(this, NrvBombTailDamage.Delay.data()) ||
+        al::isNerve(this, NrvBombTailDamage.Appear.data()) ||
+        al::isNerve(this, NrvBombTailDamage.AppearChance.data()))
+        return;
+    if (al::isSensorEnemyAttack(self) && al::isSensorPlayer(other) &&
+        !(al::getVelocity(al::getSensorHost(other)).y > 0.0f) && rs::isPlayerCollidedGround(this))
+        al::sendMsgEnemyAttackFire(other, self, nullptr);
+}
+
+bool BombTailDamage::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    if (rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+    if (rs::isMsgPlayerDisregardTargetMarker(message))
+        return true;
+    return false;
+}
+
+void BombTailDamage::startAppear(const sead::Vector3f& trans, s32 delayStep, bool isChance) {
+    al::LiveActor::appear();
+    al::setTrans(this, trans);
+    al::resetPosition(this);
+    mDelayStep = delayStep;
+    mIsChance = isChance;
+
+    if (isChance)
+        al::setSensorRadius(this, "Attack", 227.5f);
+    else
+        al::setSensorRadius(this, "Attack", 130.0f);
+
+    al::startNerveAction(this, "Delay");
+}
+
+void BombTailDamage::forceDisappear() {
+    if (al::isDead(this))
+        return;
+
+    if (mIsChance)
+        al::startNerveAction(this, "DisappearChance");
+    else
+        al::startNerveAction(this, "Disappear");
+}
+
+void BombTailDamage::exeBeforeBattle() {}
+
+void BombTailDamage::exeDelay() {
+    if (al::isGreaterEqualStep(this, mDelayStep)) {
+        if (mIsChance)
+            al::startNerveAction(this, "AppearChance");
+        else
+            al::startNerveAction(this, "Appear");
+    }
+}
+
+void BombTailDamage::exeAppear() {
+    if (al::isGreaterEqualStep(this, 30))
+        al::startNerveAction(this, "Wait");
+}
+
+void BombTailDamage::exeWait() {
+    if (al::isGreaterEqualStep(this, 800))
+        al::startNerveAction(this, "Disappear");
+}
+
+void BombTailDamage::exeDisappear() {
+    if (al::isGreaterEqualStep(this, 15))
+        kill();
+}
+
+void BombTailDamage::exeAppearChance() {
+    if (al::isGreaterEqualStep(this, 30))
+        al::startNerveAction(this, "WaitChance");
+}
+
+void BombTailDamage::exeWaitChance() {
+    if (al::isGreaterEqualStep(this, 800))
+        al::startNerveAction(this, "DisappearChance");
+}
+
+void BombTailDamage::exeDisappearChance() {
+    if (al::isGreaterEqualStep(this, 15))
+        kill();
+}

--- a/src/Boss/BombTail/BombTailDamage.h
+++ b/src/Boss/BombTail/BombTailDamage.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BombTailDamage : public al::LiveActor {
+public:
+    BombTailDamage();
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void startAppear(const sead::Vector3f& trans, s32 delayStep, bool isChance);
+    void forceDisappear();
+
+    void exeBeforeBattle();
+    void exeDelay();
+    void exeAppear();
+    void exeWait();
+    void exeDisappear();
+    void exeAppearChance();
+    void exeWaitChance();
+    void exeDisappearChance();
+
+private:
+    s32 mDelayStep = 0;
+    bool mIsChance = false;
+};
+
+static_assert(sizeof(BombTailDamage) == 0x110);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1116)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 66c04db)

📈 **Matched code**: 15.16% (+0.02%, +1976 bytes)

<details>
<summary>✅ 31 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::attackSensor(al::HitSensor*, al::HitSensor*)` | +196 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::startAppear(sead::Vector3<float> const&, int, bool)` | +144 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::BombTailDamage()` | +140 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::init(al::ActorInitInfo const&)` | +140 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::BombTailDamage()` | +136 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDelay::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeDelay()` | +84 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::forceDisappear()` | +80 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +72 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvAppear::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDisappear::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvAppearChance::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvWaitChance::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDisappearChance::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeAppear()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeWait()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeDisappear()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeAppearChance()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeWaitChance()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeDisappearChance()` | +64 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvBeforeBattle::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDelay::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvAppear::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDisappear::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvAppearChance::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvWaitChance::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `(anonymous namespace)::BombTailDamageNrvDisappearChance::getActionName() const` | +12 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailDamage` | `BombTailDamage::exeBeforeBattle()` | +4 | 0.00% | 100.00% |

...and 1 more new matches
</details>


<!-- decomp.dev report end -->