### PR TITLE
MapObj: Implement `TalkMessageInfoDirectorStateAppearMessage`

### DIFF
--- a/src/Layout/ProjectReplaceTagProcessor.h
+++ b/src/Layout/ProjectReplaceTagProcessor.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <cstdarg>
+
+namespace al {
+class IUseMessageSystem;
+class IUseSceneObjHolder;
+class MessageTag;
+
+class ReplaceTagProcessorBase {
+public:
+    virtual s32 replacePictureGroup(char16* dst, const MessageTag& messageTag) const;
+    virtual s32 replaceNumberGroup(char16* dst, const MessageTag& messageTag,
+                                   std::va_list args) const;
+    virtual s32 replaceStringGroup(char16* dst, const MessageTag& messageTag,
+                                   std::va_list args) const;
+    virtual s32 replaceTagLabel(char16* dst, const MessageTag& messageTag) const;
+    virtual s32 replaceProjectTag(char16* dst, const MessageTag& messageTag,
+                                  const IUseMessageSystem* messageSystem) const;
+};
+
+static_assert(sizeof(ReplaceTagProcessorBase) == 0x8);
+}  // namespace al
+
+class ProjectReplaceTagProcessor : public al::ReplaceTagProcessorBase {
+public:
+    explicit ProjectReplaceTagProcessor(const al::IUseSceneObjHolder* sceneObjHolder);
+
+    s32 replaceProjectTag(char16* dst, const al::MessageTag& messageTag,
+                          const al::IUseMessageSystem* messageSystem) const override;
+
+private:
+    const al::IUseSceneObjHolder* mSceneObjHolder = nullptr;
+};
+
+static_assert(sizeof(ProjectReplaceTagProcessor) == 0x10);

--- a/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.cpp
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.cpp
@@ -1,0 +1,143 @@
+#include "MapObj/TalkMessageInfoDirectorStateAppearMessage.h"
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+
+#include "Layout/ProjectReplaceTagProcessor.h"
+#include "System/GameDataUtil.h"
+
+namespace {
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearMessage, Appear)
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearMessage, AppearWait)
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearMessage, FollowText)
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearMessage, Wait)
+NERVE_IMPL(TalkMessageInfoDirectorStateAppearMessage, End)
+
+NERVES_MAKE_NOSTRUCT(TalkMessageInfoDirectorStateAppearMessage, Appear, AppearWait, FollowText,
+                     Wait, End)
+}  // namespace
+
+TalkMessageInfoDirectorStateAppearMessage::TalkMessageInfoDirectorStateAppearMessage(
+    TalkMessageInfoDirector* director, al::SimpleLayoutAppearWaitEnd* layout)
+    : al::HostStateBase<TalkMessageInfoDirector>("メッセージ表示", director), mLayout(layout) {}
+
+void TalkMessageInfoDirectorStateAppearMessage::init() {
+    initNerve(&Appear, 0);
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::appear() {
+    s32 delay = mDelay;
+    al::NerveStateBase::appear();
+
+    if (delay >= 1)
+        al::setNerve(this, &AppearWait);
+    else
+        al::setNerve(this, &Appear);
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::kill() {
+    mLayout->kill();
+    al::NerveStateBase::kill();
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::exeAppearWait() {
+    if (al::isGreaterEqualStep(this, mDelay))
+        al::setNerve(this, &Appear);
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::exeAppear() {
+    if (al::isFirstStep(this)) {
+        mLayout->appear();
+        al::startAction(mLayout, "Appear");
+    }
+
+    if (al::isActionEnd(mLayout))
+        al::setNerve(this, &FollowText);
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::exeFollowText() {
+    if (al::isFirstStep(this) && !al::isActionPlaying(mLayout, "Wait"))
+        al::startAction(mLayout, "Wait");
+
+    if (al::isEndTextPaneAnim(mLayout, false))
+        al::setNerve(this, &Wait);
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::exeWait() {
+    if (al::isGreaterEqualStep(this, mWaitFrame)) {
+        ProjectReplaceTagProcessor replaceTagProcessor(mLayout);
+
+        if (al::tryChangeNextPage(mLayout, nullptr, &replaceTagProcessor))
+            al::setNerve(this, &FollowText);
+        else
+            al::setNerve(this, &End);
+    }
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mLayout, "End");
+
+    if (al::isActionEnd(mLayout))
+        kill();
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::setWaitFrame(s32 waitFrame) {
+    const al::LayoutActor* layout = mLayout;
+    mWaitFrame = waitFrame;
+
+    if (rs::isKidsMode(layout))
+        mWaitFrame *= 2;
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::setDelay(s32 delay) {
+    mDelay = delay;
+}
+
+void TalkMessageInfoDirectorStateAppearMessage::setLabelName(const char* labelName) {
+    mLabelName = al::StringTmp<128>(labelName);
+}
+
+const char* TalkMessageInfoDirectorStateAppearMessage::getLabelName() const {
+    return mLabelName.cstr();
+}
+
+bool TalkMessageInfoDirectorStateAppearMessage::isActiveCapMessage(const char* labelName) const {
+    if (!isDead()) {
+        bool isActive;
+
+        if (al::isNerve(this, &Appear))
+            isActive = true;
+        else if (al::isNerve(this, &FollowText))
+            isActive = true;
+        else if (al::isNerve(this, &Wait))
+            isActive = true;
+        else
+            isActive = al::isNerve(this, &End);
+
+        if (labelName) {
+            if ((isActive & al::isEqualString(labelName, mLabelName.cstr())) != 0)
+                return true;
+        } else if (isActive) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool TalkMessageInfoDirectorStateAppearMessage::isDelayCapMessage(const char* labelName) const {
+    if (isDead())
+        return false;
+
+    if (labelName) {
+        if (al::isEqualString(labelName, mLabelName.cstr()) && al::isNerve(this, &AppearWait))
+            return true;
+    } else if (al::isNerve(this, &AppearWait)) {
+        return true;
+    }
+
+    return false;
+}

--- a/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.h
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class SimpleLayoutAppearWaitEnd;
+}  // namespace al
+
+class TalkMessageInfoDirector;
+
+class TalkMessageInfoDirectorStateAppearMessage
+    : public al::HostStateBase<TalkMessageInfoDirector> {
+public:
+    TalkMessageInfoDirectorStateAppearMessage(TalkMessageInfoDirector* director,
+                                              al::SimpleLayoutAppearWaitEnd* layout);
+
+    void init() override;
+    void appear() override;
+    void kill() override;
+
+    void exeAppearWait();
+    void exeAppear();
+    void exeFollowText();
+    void exeWait();
+    void exeEnd();
+
+    void setWaitFrame(s32 waitFrame);
+    void setDelay(s32 delay);
+    void setLabelName(const char* labelName);
+    const char* getLabelName() const;
+    bool isActiveCapMessage(const char* labelName) const;
+    bool isDelayCapMessage(const char* labelName) const;
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mLayout = nullptr;
+    s32 mWaitFrame = 90;
+    s32 mDelay = 0;
+    al::StringTmp<128> mLabelName;
+};
+
+static_assert(sizeof(TalkMessageInfoDirectorStateAppearMessage) == 0xC8);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1117)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d3bab22 - cec0e3f)

📈 **Matched code**: 14.35% (+0.02%, +2236 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::setLabelName(char const*)` | +240 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::isActiveCapMessage(char const*) const` | +208 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::TalkMessageInfoDirectorStateAppearMessage(TalkMessageInfoDirector*, al::SimpleLayoutAppearWaitEnd*)` | +164 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::isDelayCapMessage(char const*) const` | +156 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearMessageNrvFollowText::execute(al::NerveKeeper*) const` | +152 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::exeFollowText()` | +148 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearMessageNrvAppear::execute(al::NerveKeeper*) const` | +144 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::exeAppear()` | +140 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearMessageNrvWait::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearMessageNrvEnd::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::exeWait()` | +120 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::exeEnd()` | +120 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `(anonymous namespace)::TalkMessageInfoDirectorStateAppearMessageNrvAppearWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::exeAppearWait()` | +64 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::setWaitFrame(int)` | +56 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::kill()` | +52 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::getLabelName() const` | +48 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::appear()` | +44 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::~TalkMessageInfoDirectorStateAppearMessage()` | +36 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::init()` | +16 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::setDelay(int)` | +8 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirectorStateAppearMessage` | `TalkMessageInfoDirectorStateAppearMessage::~TalkMessageInfoDirectorStateAppearMessage()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->