### PR TITLE
MapObj: Implement `HomeBed`

### DIFF
--- a/src/MapObj/ChairStateBind.h
+++ b/src/MapObj/ChairStateBind.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerPuppet;
+
+class ChairStateBindSitDown : public al::ActorStateBase {
+public:
+    ChairStateBindSitDown(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet,
+                          const char* startAction1, const char* startAction2,
+                          const char* sitDownAction);
+    void appear() override;
+    void exeWaitPlayerLand();
+    void exeSitDownStart();
+    void exeSitDown();
+
+    s32 getResult() const { return mResult; }
+
+    void setUseLongStartStep(bool useLongStartStep) { mIsLongStartStep = useLongStartStep; }
+
+    void setEnableStartInterpolation(bool enableStartInterpolation) {
+        mIsStartInterpolationEnabled = enableStartInterpolation;
+    }
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+    s32 mResult = 3;
+    sead::Vector3f mStartOffset = sead::Vector3f::zero;
+    bool mIsMoveX = false;
+    sead::Quatf mStartPuppetQuat = sead::Quatf::unit;
+    sead::Vector3f mStartPuppetTrans = sead::Vector3f::zero;
+    const char* mStartAction1 = nullptr;
+    const char* mStartAction2 = nullptr;
+    const char* mSitDownAction = nullptr;
+    u8 _70[2] = {};
+    bool mIsLongStartStep = false;
+    u8 _73 = 0;
+    s32 mStartStepMax = 0;
+    bool mIsStartInterpolationEnabled = true;
+    u8 _79[7] = {};
+};
+
+static_assert(sizeof(ChairStateBindSitDown) == 0x80);
+
+class ChairStateBindStandUp : public al::ActorStateBase {
+public:
+    ChairStateBindStandUp(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet);
+    void appear() override;
+    void exeStandUp();
+
+    s32 getResult() const { return mResult; }
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+    s32 mResult = 3;
+};
+
+static_assert(sizeof(ChairStateBindStandUp) == 0x30);
+
+class ChairStateBindJump : public al::ActorStateBase {
+public:
+    ChairStateBindJump(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet);
+    void appear() override;
+    void exeJump();
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+};
+
+static_assert(sizeof(ChairStateBindJump) == 0x28);
+
+namespace rs {
+bool tryEndBindCapThrowOnChair(IUsePlayerPuppet** playerPuppet);
+bool tryBindJumpOnChair(IUsePlayerPuppet* playerPuppet);
+bool tryBindStandUpOnChair(IUsePlayerPuppet* playerPuppet);
+}  // namespace rs

--- a/src/MapObj/ChairStateBind.h
+++ b/src/MapObj/ChairStateBind.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerPuppet;
+
+class ChairStateBindSitDown : public al::ActorStateBase {
+public:
+    ChairStateBindSitDown(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet,
+                          const char* startAction1, const char* startAction2,
+                          const char* sitDownAction);
+    void appear() override;
+    void exeWaitPlayerLand();
+    void exeSitDownStart();
+    void exeSitDown();
+
+    s32 getResult() const { return mResult; }
+
+    void setUseLongStartStep(bool useLongStartStep) { mIsLongStartStep = useLongStartStep; }
+
+    void setEnableStartInterpolation(bool enableStartInterpolation) {
+        mIsStartInterpolationEnabled = enableStartInterpolation;
+    }
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+    s32 mResult = 3;
+    sead::Vector3f mStartOffset = sead::Vector3f::zero;
+    bool mIsMoveX = false;
+    sead::Quatf mStartPuppetQuat = sead::Quatf::unit;
+    sead::Vector3f mStartPuppetTrans = sead::Vector3f::zero;
+    const char* mStartAction1 = nullptr;
+    const char* mStartAction2 = nullptr;
+    const char* mSitDownAction = nullptr;
+    bool _70 = false;
+    bool _71 = false;
+    bool mIsLongStartStep = false;
+    bool _73 = false;
+    s32 mStartStepMax = 0;
+    bool mIsStartInterpolationEnabled = true;
+    bool _79 = false;
+    bool _7a = false;
+    bool _7b = false;
+    bool _7c = false;
+    bool _7d = false;
+    bool _7e = false;
+    bool _7f = false;
+};
+
+static_assert(sizeof(ChairStateBindSitDown) == 0x80);
+
+class ChairStateBindStandUp : public al::ActorStateBase {
+public:
+    ChairStateBindStandUp(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet);
+    void appear() override;
+    void exeStandUp();
+
+    s32 getResult() const { return mResult; }
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+    s32 mResult = 3;
+};
+
+static_assert(sizeof(ChairStateBindStandUp) == 0x30);
+
+class ChairStateBindJump : public al::ActorStateBase {
+public:
+    ChairStateBindJump(al::LiveActor* actor, IUsePlayerPuppet** playerPuppet);
+    void appear() override;
+    void exeJump();
+
+private:
+    IUsePlayerPuppet** mPlayerPuppet = nullptr;
+};
+
+static_assert(sizeof(ChairStateBindJump) == 0x28);
+
+namespace rs {
+bool tryEndBindCapThrowOnChair(IUsePlayerPuppet** playerPuppet);
+bool tryBindJumpOnChair(IUsePlayerPuppet* playerPuppet);
+bool tryBindStandUpOnChair(IUsePlayerPuppet* playerPuppet);
+}  // namespace rs

--- a/src/MapObj/HomeBed.cpp
+++ b/src/MapObj/HomeBed.cpp
@@ -1,0 +1,200 @@
+#include "MapObj/HomeBed.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/ChairStateBind.h"
+#include "MapObj/FurnitureStateWait.h"
+#include "Util/PlayerPuppetFunction.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(HomeBed, Wait);
+NERVE_IMPL(HomeBed, SleepStart);
+NERVE_IMPL(HomeBed, StandUp);
+NERVE_IMPL(HomeBed, SnoozeStart);
+NERVE_IMPL(HomeBed, WaitNoSleep);
+NERVE_IMPL(HomeBed, BindJump);
+NERVE_IMPL(HomeBed, Snooze);
+NERVE_IMPL(HomeBed, Sleep);
+
+NERVES_MAKE_STRUCT(HomeBed, Wait, SleepStart, StandUp, SnoozeStart, WaitNoSleep, BindJump, Snooze,
+                   Sleep);
+}  // namespace
+
+HomeBed::HomeBed(const char* name) : al::LiveActor(name) {}
+
+void HomeBed::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &NrvHomeBed.Wait, 3);
+
+    mStateWait = new FurnitureStateWait(this, FurnitureType::Bed);
+    al::initNerveState(this, mStateWait, &NrvHomeBed.Wait, "座るまで");
+
+    mStateBindSitDown = new ChairStateBindSitDown(this, &mPlayerPuppet, "BedSleepStart",
+                                                  "BedSleepStart", "BedSleep");
+    al::initNerveState(this, mStateBindSitDown, &NrvHomeBed.SleepStart, "寝るまでの状態");
+    mStateBindSitDown->setEnableStartInterpolation(false);
+
+    mStateBindStandUp = new ChairStateBindStandUp(this, &mPlayerPuppet);
+    al::initNerveState(this, mStateBindStandUp, &NrvHomeBed.StandUp, "立つ");
+
+    makeActorAlive();
+}
+
+bool HomeBed::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    IUsePlayerPuppet** playerPuppet = &mPlayerPuppet;
+
+    if (mPlayerPuppet == nullptr) {
+        if (al::isMsgBindStart(message))
+            return rs::isPlayerNoInput(this);
+
+        if (al::isMsgBindInit(message)) {
+            if (!rs::isPlayerNoInput(this))
+                return false;
+
+            mPlayerPuppet = rs::startPuppet(self, other);
+            mStateBindSitDown->setUseLongStartStep(true);
+            al::setNerve(this, &NrvHomeBed.SnoozeStart);
+            return true;
+        }
+
+        if (*playerPuppet == nullptr)
+            return false;
+    }
+
+    if (rs::tryReceiveBindCancelMsgAndPuppetNull(playerPuppet, message)) {
+        al::setNerve(this, &NrvHomeBed.Wait);
+        return true;
+    }
+
+    return false;
+}
+
+void HomeBed::exeWait() {
+    al::updateNerveState(this);
+
+    if (mStateWait->isEnableBindRequest())
+        rs::requestBindPlayer(this, al::getHitSensor(this, "Collision"));
+}
+
+void HomeBed::exeSnoozeStart() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "BedSnoozeStart");
+
+    if (rs::isPuppetMoveStickOn(mPlayerPuppet)) {
+        rs::endBindAndPuppetNull(&mPlayerPuppet);
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryEndBindCapThrowOnChair(&mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryBindJumpOnChair(mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.BindJump);
+        return;
+    }
+
+    if (rs::isPuppetActionEnd(mPlayerPuppet))
+        al::setNerve(this, &NrvHomeBed.Snooze);
+}
+
+void HomeBed::exeSnooze() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "BedSnooze");
+
+    if (rs::isPuppetMoveStickOn(mPlayerPuppet)) {
+        rs::endBindAndPuppetNull(&mPlayerPuppet);
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryEndBindCapThrowOnChair(&mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryBindJumpOnChair(mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.BindJump);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 180))
+        al::setNerve(this, &NrvHomeBed.SleepStart);
+}
+
+void HomeBed::exeSleepStart() {
+    if (al::updateNerveState(this)) {
+        s32 result = mStateBindSitDown->getResult();
+
+        if (result != 2) {
+            if (result == 1) {
+                al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+                return;
+            }
+
+            al::setNerve(this, &NrvHomeBed.Sleep);
+            return;
+        }
+
+        al::setNerve(this, &NrvHomeBed.BindJump);
+    }
+}
+
+void HomeBed::exeSleep() {
+    IUsePlayerPuppet** playerPuppet = &mPlayerPuppet;
+
+    if (rs::tryEndBindCapThrowOnChair(playerPuppet))
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+    else if (rs::tryBindJumpOnChair(*playerPuppet))
+        al::setNerve(this, &NrvHomeBed.BindJump);
+    else if (rs::tryBindStandUpOnChair(*playerPuppet))
+        al::setNerve(this, &NrvHomeBed.StandUp);
+}
+
+void HomeBed::exeStandUp() {
+    if (al::updateNerveState(this)) {
+        s32 result = mStateBindStandUp->getResult();
+
+        if (result != 2) {
+            if (result == 1) {
+                al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+                return;
+            }
+
+            rs::endBindAndPuppetNull(&mPlayerPuppet);
+            al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+            return;
+        }
+
+        al::setNerve(this, &NrvHomeBed.BindJump);
+    }
+}
+
+void HomeBed::exeBindJump() {
+    rs::startPuppetAction(mPlayerPuppet, "Jump");
+
+    sead::Vector3f endTrans;
+    endTrans.x = 0.0f;
+    endTrans.y = 25.0f;
+    endTrans.z = 0.0f;
+
+    rs::endBindJumpAndPuppetNull(&mPlayerPuppet, endTrans, 0);
+    al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+}
+
+void HomeBed::exeWaitNoSleep() {
+    if (al::isGreaterEqualStep(this, 120))
+        al::setNerve(this, &NrvHomeBed.Wait);
+}
+
+bool HomeBed::tryEndBind() {
+    return false;
+}

--- a/src/MapObj/HomeBed.cpp
+++ b/src/MapObj/HomeBed.cpp
@@ -1,0 +1,191 @@
+#include "MapObj/HomeBed.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/ChairStateBind.h"
+#include "MapObj/FurnitureStateWait.h"
+#include "Util/PlayerPuppetFunction.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(HomeBed, Wait);
+NERVE_IMPL(HomeBed, SleepStart);
+NERVE_IMPL(HomeBed, StandUp);
+NERVE_IMPL(HomeBed, SnoozeStart);
+NERVE_IMPL(HomeBed, WaitNoSleep);
+NERVE_IMPL(HomeBed, BindJump);
+NERVE_IMPL(HomeBed, Snooze);
+NERVE_IMPL(HomeBed, Sleep);
+
+NERVES_MAKE_STRUCT(HomeBed, Wait, SleepStart, StandUp, SnoozeStart, WaitNoSleep, BindJump, Snooze,
+                   Sleep);
+}  // namespace
+
+HomeBed::HomeBed(const char* name) : al::LiveActor(name) {}
+
+void HomeBed::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &NrvHomeBed.Wait, 3);
+
+    mStateWait = new FurnitureStateWait(this, FurnitureType::Bed);
+    al::initNerveState(this, mStateWait, &NrvHomeBed.Wait, "座るまで");
+
+    mStateBindSitDown = new ChairStateBindSitDown(this, &mPlayerPuppet, "BedSleepStart",
+                                                  "BedSleepStart", "BedSleep");
+    al::initNerveState(this, mStateBindSitDown, &NrvHomeBed.SleepStart, "寝るまでの状態");
+    mStateBindSitDown->setEnableStartInterpolation(false);
+
+    mStateBindStandUp = new ChairStateBindStandUp(this, &mPlayerPuppet);
+    al::initNerveState(this, mStateBindStandUp, &NrvHomeBed.StandUp, "立つ");
+
+    makeActorAlive();
+}
+
+bool HomeBed::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    IUsePlayerPuppet** playerPuppet = &mPlayerPuppet;
+
+    if (mPlayerPuppet == nullptr) {
+        if (al::isMsgBindStart(message))
+            return rs::isPlayerNoInput(this);
+
+        if (al::isMsgBindInit(message)) {
+            if (!rs::isPlayerNoInput(this))
+                return false;
+
+            mPlayerPuppet = rs::startPuppet(self, other);
+            mStateBindSitDown->setUseLongStartStep(true);
+            al::setNerve(this, &NrvHomeBed.SnoozeStart);
+            return true;
+        }
+
+        if (*playerPuppet == nullptr)
+            return false;
+    }
+
+    if (rs::tryReceiveBindCancelMsgAndPuppetNull(&mPlayerPuppet, message)) {
+        al::setNerve(this, &NrvHomeBed.Wait);
+        return true;
+    }
+
+    return false;
+}
+
+void HomeBed::exeWait() {
+    al::updateNerveState(this);
+
+    if (mStateWait->isEnableBindRequest())
+        rs::requestBindPlayer(this, al::getHitSensor(this, "Collision"));
+}
+
+void HomeBed::exeSnoozeStart() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "BedSnoozeStart");
+
+    if (rs::isPuppetMoveStickOn(mPlayerPuppet)) {
+        rs::endBindAndPuppetNull(&mPlayerPuppet);
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryEndBindCapThrowOnChair(&mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryBindJumpOnChair(mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.BindJump);
+        return;
+    }
+
+    if (rs::isPuppetActionEnd(mPlayerPuppet))
+        al::setNerve(this, &NrvHomeBed.Snooze);
+}
+
+void HomeBed::exeSnooze() {
+    if (al::isFirstStep(this))
+        rs::startPuppetAction(mPlayerPuppet, "BedSnooze");
+
+    if (rs::isPuppetMoveStickOn(mPlayerPuppet)) {
+        rs::endBindAndPuppetNull(&mPlayerPuppet);
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryEndBindCapThrowOnChair(&mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+        return;
+    }
+
+    if (rs::tryBindJumpOnChair(mPlayerPuppet)) {
+        al::setNerve(this, &NrvHomeBed.BindJump);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 180))
+        al::setNerve(this, &NrvHomeBed.SleepStart);
+}
+
+void HomeBed::exeSleepStart() {
+    if (al::updateNerveState(this)) {
+        switch (mStateBindSitDown->getResult()) {
+        case 1:
+            al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+            return;
+        case 2:
+            al::setNerve(this, &NrvHomeBed.BindJump);
+            return;
+        default:
+            al::setNerve(this, &NrvHomeBed.Sleep);
+            return;
+        }
+    }
+}
+
+void HomeBed::exeSleep() {
+    IUsePlayerPuppet** playerPuppet = &mPlayerPuppet;
+
+    if (rs::tryEndBindCapThrowOnChair(playerPuppet))
+        al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+    else if (rs::tryBindJumpOnChair(*playerPuppet))
+        al::setNerve(this, &NrvHomeBed.BindJump);
+    else if (rs::tryBindStandUpOnChair(*playerPuppet))
+        al::setNerve(this, &NrvHomeBed.StandUp);
+}
+
+void HomeBed::exeStandUp() {
+    if (al::updateNerveState(this)) {
+        switch (mStateBindStandUp->getResult()) {
+        case 1:
+            al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+            return;
+        case 2:
+            al::setNerve(this, &NrvHomeBed.BindJump);
+            return;
+        default:
+            rs::endBindAndPuppetNull(&mPlayerPuppet);
+            al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+            return;
+        }
+    }
+}
+
+void HomeBed::exeBindJump() {
+    rs::startPuppetAction(mPlayerPuppet, "Jump");
+
+    rs::endBindJumpAndPuppetNull(&mPlayerPuppet, {0.0f, 25.0f, 0.0f}, 0);
+    al::setNerve(this, &NrvHomeBed.WaitNoSleep);
+}
+
+void HomeBed::exeWaitNoSleep() {
+    if (al::isGreaterEqualStep(this, 120))
+        al::setNerve(this, &NrvHomeBed.Wait);
+}
+
+bool HomeBed::tryEndBind() {
+    return false;
+}

--- a/src/MapObj/HomeBed.h
+++ b/src/MapObj/HomeBed.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class ChairStateBindSitDown;
+class ChairStateBindStandUp;
+class FurnitureStateWait;
+class IUsePlayerPuppet;
+
+class HomeBed : public al::LiveActor {
+public:
+    HomeBed(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeSnoozeStart();
+    void exeSnooze();
+    void exeSleepStart();
+    void exeSleep();
+    void exeStandUp();
+    void exeBindJump();
+    void exeWaitNoSleep();
+    bool tryEndBind();
+
+private:
+    IUsePlayerPuppet* mPlayerPuppet = nullptr;
+    FurnitureStateWait* mStateWait = nullptr;
+    ChairStateBindSitDown* mStateBindSitDown = nullptr;
+    ChairStateBindStandUp* mStateBindStandUp = nullptr;
+};
+
+static_assert(sizeof(HomeBed) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -84,6 +84,7 @@
 #include "MapObj/FixMapPartsBgmChangeAction.h"
 #include "MapObj/HackFork.h"
 #include "MapObj/HipDropSwitch.h"
+#include "MapObj/HomeBed.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
@@ -359,7 +360,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"HipDropMoveLift", nullptr},
     {"HipDropRepairParts", nullptr},
     {"HipDropTransformPartsWatcher", nullptr},
-    {"HomeBed", nullptr},
+    {"HomeBed", al::createActorFunction<HomeBed>},
     {"HomeChair", nullptr},
     {"HomeInside", nullptr},
     {"HomeShip", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1118)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (774e056 - 55e7b51)

📈 **Matched code**: 14.88% (+0.02%, +2432 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/HomeBed` | `HomeBed::init(al::ActorInitInfo const&)` | +264 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +236 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeSnooze()` | +180 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeSnoozeStart()` | +176 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::HomeBed(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::HomeBed(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeSleep()` | +128 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvSleep::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvSleepStart::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeSleepStart()` | +120 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvStandUp::execute(al::NerveKeeper*) const` | +116 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeStandUp()` | +112 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeBindJump()` | +104 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvBindJump::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvWait::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeWait()` | +80 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvWaitNoSleep::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::exeWaitNoSleep()` | +64 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<HomeBed>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `HomeBed::tryEndBind()` | +8 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvSnoozeStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/HomeBed` | `(anonymous namespace)::HomeBedNrvSnooze::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->