### PR TITLE
Library/Movement: Remove `RailMoveMovement::MoveType`

### DIFF
--- a/lib/al/Library/Movement/MoveType.h
+++ b/lib/al/Library/Movement/MoveType.h
@@ -3,7 +3,7 @@
 #include <basis/seadTypes.h>
 
 namespace al {
-enum class MoveType : s32 {
+enum class MoveType : u32 {
     Loop,
     Turn,
     Stop,

--- a/lib/al/Library/Movement/RailMoveMovement.cpp
+++ b/lib/al/Library/Movement/RailMoveMovement.cpp
@@ -19,7 +19,7 @@ RailMoveMovement::RailMoveMovement(LiveActor* host, const ActorInitInfo& info)
     tryGetArg(&mSpeed, info, "Speed");
     tryGetArg((s32*)&mMoveType, info, "MoveType");
 
-    if (mMoveType > MoveType::Ahead)
+    if (mMoveType >= MoveType::Restart)
         mMoveType = MoveType::Loop;
 
     initNerve(&NrvRailMoveMovement.Move, 0);
@@ -36,7 +36,7 @@ void RailMoveMovement::exeMove() {
     case MoveType::Turn:
         moveSyncRailTurn(getHost(), mSpeed);
         break;
-    case MoveType::Ahead:
+    case MoveType::Stop:
         moveSyncRail(getHost(), mSpeed);
         break;
     default:

--- a/lib/al/Library/Movement/RailMoveMovement.h
+++ b/lib/al/Library/Movement/RailMoveMovement.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "Library/Movement/MoveType.h"
 #include "Library/Nerve/NerveStateBase.h"
 
 namespace al {
@@ -12,8 +13,6 @@ public:
     void exeMove();
 
 private:
-    enum class MoveType : u32 { Loop, Turn, Ahead };
-
     f32 mSpeed = 10.0f;
     MoveType mMoveType = MoveType::Loop;
 };


### PR DESCRIPTION
I find it likely that the same type was used here as has been used everywhere else. Note that this is the first time that `</>` comparisons are done on the `MoveType` type, revealing that it should be `u32` instead of `s32`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1121)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0e6a054 - bb7e1b3)

No changes

<!-- decomp.dev report end -->