### PR TITLE
Player: Implement `PlayerStateAbyss`

### DIFF
--- a/lib/al/Library/Audio/System/AudioKeeperFunction.h
+++ b/lib/al/Library/Audio/System/AudioKeeperFunction.h
@@ -26,6 +26,12 @@ class PadRumbleDirector;
 class Resource;
 class SeadAudioPlayer;
 class SeDataBase;
+class IUseAudioKeeper;
+
+void activateAudioEventController(const IUseAudioKeeper* user);
+void deactivateAudioEventController(const IUseAudioKeeper* user);
+void banAudioEventActivation(const IUseAudioKeeper* user);
+void allowAudioEventActivation(const IUseAudioKeeper* user);
 }  // namespace al
 
 namespace alAudioSystemFunction {

--- a/lib/al/Library/Se/SeFunction.h
+++ b/lib/al/Library/Se/SeFunction.h
@@ -65,4 +65,5 @@ namespace alSeFunction {
 void stopAllSe(const al::AudioDirector*, u32);
 void startListenerPoser(const al::IUseAudioKeeper*, const char*, s32);
 void endListenerPoser(const al::IUseAudioKeeper*, const char*, s32);
+void startSeFromUpperLayerSeKeeper(const al::IUseAudioKeeper* user, const char* soundEffect);
 }  // namespace alSeFunction

--- a/src/Player/PlayerStateAbyss.cpp
+++ b/src/Player/PlayerStateAbyss.cpp
@@ -25,13 +25,12 @@ NERVES_MAKE_NOSTRUCT(PlayerStateAbyss, Fall, Recovery)
 PlayerStateAbyss::PlayerStateAbyss(al::LiveActor* player, const PlayerConst* playerConst,
                                    PlayerRecoverySafetyPoint* recoverySafetyPoint,
                                    PlayerColliderHakoniwa* playerCollider,
-                                   PlayerAnimator* playerAnimator, al::LiveActor* playerModelHolder)
+                                   PlayerAnimator* playerAnimator, al::LiveActor* player2dModel)
     : al::ActorStateBase("奈落死", player), mConst(playerConst),
       mRecoverySafetyPoint(recoverySafetyPoint), mAnimator(playerAnimator) {
     initNerve(&Fall, 1);
-    mStateRecoveryDead =
-        new PlayerStateRecoveryDead(player, recoverySafetyPoint, playerCollider, playerAnimator,
-                                    playerConst, playerModelHolder);
+    mStateRecoveryDead = new PlayerStateRecoveryDead(player, recoverySafetyPoint, playerCollider,
+                                                     playerAnimator, playerConst, player2dModel);
     al::initNerveState(this, mStateRecoveryDead, &Recovery, "奈落復帰");
 }
 

--- a/src/Player/PlayerStateAbyss.cpp
+++ b/src/Player/PlayerStateAbyss.cpp
@@ -1,0 +1,102 @@
+#include "Player/PlayerStateAbyss.h"
+
+#include "Library/Audio/System/AudioKeeperFunction.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerRecoverySafetyPoint.h"
+#include "Player/PlayerStateRecoveryDead.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(PlayerStateAbyss, Fall)
+NERVE_IMPL(PlayerStateAbyss, Recovery)
+NERVES_MAKE_NOSTRUCT(PlayerStateAbyss, Fall, Recovery)
+}  // namespace
+
+PlayerStateAbyss::PlayerStateAbyss(al::LiveActor* player, const PlayerConst* playerConst,
+                                   PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                                   PlayerColliderHakoniwa* playerCollider,
+                                   PlayerAnimator* playerAnimator, al::LiveActor* playerModelHolder)
+    : al::ActorStateBase("奈落死", player), mPlayerConst(playerConst),
+      mPlayerRecoverySafetyPoint(recoverySafetyPoint), mPlayerAnimator(playerAnimator) {
+    initNerve(&Fall, 1);
+    mPlayerStateRecoveryDead =
+        new PlayerStateRecoveryDead(player, recoverySafetyPoint, playerCollider, playerAnimator,
+                                    playerConst, playerModelHolder);
+    al::initNerveState(this, mPlayerStateRecoveryDead, &Recovery, "奈落復帰");
+}
+
+void PlayerStateAbyss::appear() {
+    al::NerveStateBase::appear();
+    if (mPlayerRecoverySafetyPoint->isValid()) {
+        al::offAreaTarget(mActor);
+        al::setNerve(this, &Recovery);
+        return;
+    }
+
+    if (rs::isPlayer2D(mActor))
+        mPlayerAnimator->startAnim("Fall");
+
+    al::offAreaTarget(mActor);
+    al::setNerve(this, &Fall);
+}
+
+void PlayerStateAbyss::kill() {
+    al::onAreaTarget(mActor);
+    al::setNerve(this, &Fall);
+    al::NerveStateBase::kill();
+}
+
+void PlayerStateAbyss::exeFall() {
+    if (al::isFirstStep(this)) {
+        if (rs::isPlayer3D(mActor)) {
+            if (mPlayerAnimator->isSubAnimPlaying())
+                mPlayerAnimator->endSubAnim();
+            mPlayerAnimator->startAnim("DeadFall");
+            al::startSe(mActor, "FallDown");
+            al::startSe(mActor, "vDeadFallDown");
+        } else {
+            alSeFunction::startSeFromUpperLayerSeKeeper(mActor, "FallDown2D");
+        }
+    }
+
+    al::addVelocityToGravityLimit(mActor, mPlayerConst->getGravityAir(),
+                                  mPlayerConst->getFallSpeedMax());
+}
+
+void PlayerStateAbyss::exeRecovery() {
+    if (al::isFirstStep(this)) {
+        al::deactivateAudioEventController(mActor);
+        al::banAudioEventActivation(mActor);
+    }
+
+    if (al::updateNerveState(this)) {
+        al::allowAudioEventActivation(mActor);
+        al::activateAudioEventController(mActor);
+        al::startAndStopBgmInCurPosition(mActor, false);
+        kill();
+    }
+}
+
+bool PlayerStateAbyss::isRecovery() const {
+    return al::isNerve(this, &Recovery);
+}
+
+bool PlayerStateAbyss::isRecoveryLandFall() const {
+    if (!isDead() && al::isNerve(this, &Recovery))
+        return mPlayerStateRecoveryDead->isLandFall();
+    return false;
+}
+
+void PlayerStateAbyss::prepareRecovery() {
+    al::setNerve(this, &Recovery);
+}

--- a/src/Player/PlayerStateAbyss.cpp
+++ b/src/Player/PlayerStateAbyss.cpp
@@ -26,25 +26,25 @@ PlayerStateAbyss::PlayerStateAbyss(al::LiveActor* player, const PlayerConst* pla
                                    PlayerRecoverySafetyPoint* recoverySafetyPoint,
                                    PlayerColliderHakoniwa* playerCollider,
                                    PlayerAnimator* playerAnimator, al::LiveActor* playerModelHolder)
-    : al::ActorStateBase("奈落死", player), mPlayerConst(playerConst),
-      mPlayerRecoverySafetyPoint(recoverySafetyPoint), mPlayerAnimator(playerAnimator) {
+    : al::ActorStateBase("奈落死", player), mConst(playerConst),
+      mRecoverySafetyPoint(recoverySafetyPoint), mAnimator(playerAnimator) {
     initNerve(&Fall, 1);
-    mPlayerStateRecoveryDead =
+    mStateRecoveryDead =
         new PlayerStateRecoveryDead(player, recoverySafetyPoint, playerCollider, playerAnimator,
                                     playerConst, playerModelHolder);
-    al::initNerveState(this, mPlayerStateRecoveryDead, &Recovery, "奈落復帰");
+    al::initNerveState(this, mStateRecoveryDead, &Recovery, "奈落復帰");
 }
 
 void PlayerStateAbyss::appear() {
-    al::NerveStateBase::appear();
-    if (mPlayerRecoverySafetyPoint->isValid()) {
+    al::ActorStateBase::appear();
+    if (mRecoverySafetyPoint->isValid()) {
         al::offAreaTarget(mActor);
-        al::setNerve(this, &Recovery);
+        prepareRecovery();
         return;
     }
 
     if (rs::isPlayer2D(mActor))
-        mPlayerAnimator->startAnim("Fall");
+        mAnimator->startAnim("Fall");
 
     al::offAreaTarget(mActor);
     al::setNerve(this, &Fall);
@@ -53,15 +53,15 @@ void PlayerStateAbyss::appear() {
 void PlayerStateAbyss::kill() {
     al::onAreaTarget(mActor);
     al::setNerve(this, &Fall);
-    al::NerveStateBase::kill();
+    al::ActorStateBase::kill();
 }
 
 void PlayerStateAbyss::exeFall() {
     if (al::isFirstStep(this)) {
         if (rs::isPlayer3D(mActor)) {
-            if (mPlayerAnimator->isSubAnimPlaying())
-                mPlayerAnimator->endSubAnim();
-            mPlayerAnimator->startAnim("DeadFall");
+            if (mAnimator->isSubAnimPlaying())
+                mAnimator->endSubAnim();
+            mAnimator->startAnim("DeadFall");
             al::startSe(mActor, "FallDown");
             al::startSe(mActor, "vDeadFallDown");
         } else {
@@ -69,8 +69,7 @@ void PlayerStateAbyss::exeFall() {
         }
     }
 
-    al::addVelocityToGravityLimit(mActor, mPlayerConst->getGravityAir(),
-                                  mPlayerConst->getFallSpeedMax());
+    al::addVelocityToGravityLimit(mActor, mConst->getGravityAir(), mConst->getFallSpeedMax());
 }
 
 void PlayerStateAbyss::exeRecovery() {
@@ -92,9 +91,7 @@ bool PlayerStateAbyss::isRecovery() const {
 }
 
 bool PlayerStateAbyss::isRecoveryLandFall() const {
-    if (!isDead() && al::isNerve(this, &Recovery))
-        return mPlayerStateRecoveryDead->isLandFall();
-    return false;
+    return !isDead() && al::isNerve(this, &Recovery) && mStateRecoveryDead->isLandFall();
 }
 
 void PlayerStateAbyss::prepareRecovery() {

--- a/src/Player/PlayerStateAbyss.cpp
+++ b/src/Player/PlayerStateAbyss.cpp
@@ -90,7 +90,7 @@ bool PlayerStateAbyss::isRecovery() const {
 }
 
 bool PlayerStateAbyss::isRecoveryLandFall() const {
-    return !isDead() && al::isNerve(this, &Recovery) && mStateRecoveryDead->isLandFall();
+    return !isDead() && isRecovery() && mStateRecoveryDead->isLandFall();
 }
 
 void PlayerStateAbyss::prepareRecovery() {

--- a/src/Player/PlayerStateAbyss.h
+++ b/src/Player/PlayerStateAbyss.h
@@ -17,7 +17,7 @@ public:
     PlayerStateAbyss(al::LiveActor* player, const PlayerConst* playerConst,
                      PlayerRecoverySafetyPoint* recoverySafetyPoint,
                      PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
-                     al::LiveActor* anotherActor);
+                     al::LiveActor* player2dModel);
 
     void appear() override;
     void kill() override;
@@ -29,10 +29,10 @@ public:
     void prepareRecovery();
 
 private:
-    const PlayerConst* mPlayerConst = nullptr;
-    PlayerRecoverySafetyPoint* mPlayerRecoverySafetyPoint = nullptr;
-    PlayerAnimator* mPlayerAnimator = nullptr;
-    PlayerStateRecoveryDead* mPlayerStateRecoveryDead = nullptr;
+    const PlayerConst* mConst = nullptr;
+    PlayerRecoverySafetyPoint* mRecoverySafetyPoint = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    PlayerStateRecoveryDead* mStateRecoveryDead = nullptr;
 };
 
 static_assert(sizeof(PlayerStateAbyss) == 0x40);

--- a/src/Player/PlayerStateAbyss.h
+++ b/src/Player/PlayerStateAbyss.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerConst;
+class PlayerRecoverySafetyPoint;
+class PlayerColliderHakoniwa;
+class PlayerAnimator;
+class PlayerStateRecoveryDead;
+
+class PlayerStateAbyss : public al::ActorStateBase {
+public:
+    PlayerStateAbyss(al::LiveActor* player, const PlayerConst* playerConst,
+                     PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                     PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
+                     al::LiveActor* anotherActor);
+
+    ~PlayerStateAbyss() override;
+    void appear() override;
+    void kill() override;
+
+    void exeFall();
+    void exeRecovery();
+    bool isRecovery() const;
+    bool isRecoveryLandFall() const;
+    void prepareRecovery();
+
+private:
+    const PlayerConst* mPlayerConst = nullptr;
+    PlayerRecoverySafetyPoint* mPlayerRecoverySafetyPoint = nullptr;
+    PlayerAnimator* mPlayerAnimator = nullptr;
+    PlayerStateRecoveryDead* mPlayerStateRecoveryDead = nullptr;
+};
+
+static_assert(sizeof(PlayerStateAbyss) == 0x40);

--- a/src/Player/PlayerStateAbyss.h
+++ b/src/Player/PlayerStateAbyss.h
@@ -19,7 +19,6 @@ public:
                      PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
                      al::LiveActor* anotherActor);
 
-    ~PlayerStateAbyss() override;
     void appear() override;
     void kill() override;
 

--- a/src/Player/PlayerStateRecoveryDead.h
+++ b/src/Player/PlayerStateRecoveryDead.h
@@ -20,7 +20,6 @@ public:
                             PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
                             const PlayerConst* playerConst, al::LiveActor* playerModelHolder);
 
-    ~PlayerStateRecoveryDead() override;
     void appear() override;
     void kill() override;
 

--- a/src/Player/PlayerStateRecoveryDead.h
+++ b/src/Player/PlayerStateRecoveryDead.h
@@ -1,0 +1,54 @@
+#pragma once
+
+#include <math/seadQuat.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerRecoverySafetyPoint;
+class PlayerColliderHakoniwa;
+class PlayerAnimator;
+class PlayerConst;
+class ActorDimensionKeeper;
+
+class PlayerStateRecoveryDead : public al::ActorStateBase {
+public:
+    PlayerStateRecoveryDead(al::LiveActor* player, PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                            PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
+                            const PlayerConst* playerConst, al::LiveActor* playerModelHolder);
+
+    ~PlayerStateRecoveryDead() override;
+    void appear() override;
+    void kill() override;
+
+    void exeFall();
+    void exeRecovery();
+    void exeStart();
+    bool isLandFall() const;
+
+private:
+    PlayerRecoverySafetyPoint* mPlayerRecoverySafetyPoint;
+    PlayerColliderHakoniwa* mPlayerColliderHakoniwa;
+    PlayerAnimator* mPlayerAnimator;
+    const PlayerConst* mPlayerConst;
+    al::LiveActor* mPlayerModelHolder;
+    f32 _48;
+    f32 _4c;
+    sead::Vector3f mTrans;
+    sead::Vector3f mNegativeGravity;
+    sead::Vector3f _68;
+    s32 _74;
+    s32 _78;
+    f32 _7c;
+    sead::Quatf _80;
+    sead::Vector3f _90;
+    sead::Vector3f _9c;
+    ActorDimensionKeeper* mDimensionKeeper;
+    sead::Vector3f _b0;
+    sead::Vector3f _bc;
+};
+
+static_assert(sizeof(PlayerStateRecoveryDead) == 0xc8);

--- a/src/Player/PlayerStateRecoveryDead.h
+++ b/src/Player/PlayerStateRecoveryDead.h
@@ -18,7 +18,7 @@ class PlayerStateRecoveryDead : public al::ActorStateBase {
 public:
     PlayerStateRecoveryDead(al::LiveActor* player, PlayerRecoverySafetyPoint* recoverySafetyPoint,
                             PlayerColliderHakoniwa* playerCollider, PlayerAnimator* playerAnimator,
-                            const PlayerConst* playerConst, al::LiveActor* playerModelHolder);
+                            const PlayerConst* playerConst, al::LiveActor* player2dModel);
 
     void appear() override;
     void kill() override;
@@ -29,11 +29,11 @@ public:
     bool isLandFall() const;
 
 private:
-    PlayerRecoverySafetyPoint* mPlayerRecoverySafetyPoint;
-    PlayerColliderHakoniwa* mPlayerColliderHakoniwa;
-    PlayerAnimator* mPlayerAnimator;
-    const PlayerConst* mPlayerConst;
-    al::LiveActor* mPlayerModelHolder;
+    PlayerRecoverySafetyPoint* mRecoverySafetyPoint;
+    PlayerColliderHakoniwa* mColliderHakoniwa;
+    PlayerAnimator* mAnimator;
+    const PlayerConst* mConst;
+    al::LiveActor* mModelHolder;
     f32 _48;
     f32 _4c;
     sead::Vector3f mTrans;


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1123)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (2da9983 - 15744d2)

📈 **Matched code**: 14.77% (+0.01%, +1052 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::exeFall()` | +272 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::PlayerStateAbyss(al::LiveActor*, PlayerConst const*, PlayerRecoverySafetyPoint*, PlayerColliderHakoniwa*, PlayerAnimator*, al::LiveActor*)` | +212 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::exeRecovery()` | +176 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::appear()` | +168 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::isRecoveryLandFall() const` | +80 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::kill()` | +60 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::~PlayerStateAbyss()` | +36 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::prepareRecovery()` | +16 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::isRecovery() const` | +16 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `(anonymous namespace)::PlayerStateAbyssNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `(anonymous namespace)::PlayerStateAbyssNrvRecovery::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->