### PR TITLE
Event: Implement `EventActorStateDemoTalk`

### DIFF
--- a/src/Event/EventActorStateDemoTalk.cpp
+++ b/src/Event/EventActorStateDemoTalk.cpp
@@ -1,0 +1,96 @@
+#include "Event/EventActorStateDemoTalk.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/NpcEventFlowUtil.h"
+
+namespace {
+
+NERVE_IMPL(EventActorStateDemoTalk, Wait);
+NERVE_IMPL(EventActorStateDemoTalk, Talk);
+NERVE_IMPL(EventActorStateDemoTalk, TalkAfter);
+
+NERVES_MAKE_NOSTRUCT(EventActorStateDemoTalk, Wait, Talk, TalkAfter);
+
+}  // namespace
+
+EventActorStateDemoTalk::EventActorStateDemoTalk(al::LiveActor* actor)
+    : al::ActorStateBase("イベントデモ中の会話", actor) {
+    mMessageName = "Talk";
+    initNerve(&Wait, 0);
+}
+
+void EventActorStateDemoTalk::appear() {
+    al::NerveStateBase::appear();
+    al::startAction(mActor, mMessageName);
+
+    if (rs::isPlayingTextPaneAnimEventTalkMessage(mActor)) {
+        al::setSklAnimBlendWeightDouble(mActor, 0.0f, 1.0f);
+        al::setNerve(this, &Talk);
+    } else {
+        al::setSklAnimBlendWeightDouble(mActor, 1.0f, 0.0f);
+        al::setNerve(this, &Wait);
+    }
+}
+
+void EventActorStateDemoTalk::exeWait() {
+    al::LiveActor* actor = mActor;
+    f32 blendWeight = al::getSklAnimBlendWeight(actor, 0);
+    blendWeight += 0.125f;
+    if (blendWeight > 1.0f)
+        blendWeight = 1.0f;
+    al::setSklAnimBlendWeightDouble(actor, blendWeight, 1.0f - blendWeight);
+
+    if (rs::isPlayingTextPaneAnimEventTalkMessage(mActor))
+        al::setNerve(this, &Talk);
+}
+
+void EventActorStateDemoTalk::exeTalk() {
+    al::LiveActor* actor = mActor;
+    f32 blendWeight = al::getSklAnimBlendWeight(actor, 1);
+    blendWeight += 0.125f;
+    f32 one = 1.0f;
+    if (blendWeight > 1.0f)
+        blendWeight = 1.0f;
+    al::setSklAnimBlendWeightDouble(actor, one - blendWeight, blendWeight);
+
+    if (!rs::isPlayingTextPaneAnimEventTalkMessage(mActor))
+        al::setNerve(this, &TalkAfter);
+}
+
+void EventActorStateDemoTalk::exeTalkAfter() {
+    al::LiveActor* actor = mActor;
+    f32 blendWeight = al::getSklAnimBlendWeight(actor, 1);
+    blendWeight += 0.125f;
+    f32 one = 1.0f;
+    if (blendWeight > 1.0f)
+        blendWeight = 1.0f;
+    al::setSklAnimBlendWeightDouble(actor, one - blendWeight, blendWeight);
+
+    if (al::isGreaterEqualStep(this, 45)) {
+        if (mIsInitialized) {
+            al::LiveActor* actor2 = mActor;
+            const char* actionName = al::getActionName(actor2);
+            f32 frameMax = al::getActionFrameMax(actor2, actionName);
+            f32 frame = al::getActionFrame(mActor);
+
+            if (frameMax <= frame + one)
+                al::setSklAnimBlendWeightDouble(mActor, 1.0f);
+            else
+                return;
+        }
+        al::setNerve(this, &Wait);
+    }
+}
+
+ParamEventActorStateDemoTalkGK::ParamEventActorStateDemoTalkGK() {
+    mParam1 = 0.125f;
+    mParam2 = 0;
+}
+
+ParamEventActorStateDemoTalkGK::ParamEventActorStateDemoTalkGK(f32 param1, s32 param2)
+    : mParam1(param1), mParam2(param2) {}

--- a/src/Event/EventActorStateDemoTalk.h
+++ b/src/Event/EventActorStateDemoTalk.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class EventActorStateDemoTalk : public al::ActorStateBase {
+public:
+    EventActorStateDemoTalk(al::LiveActor* actor);
+
+    void appear() override;
+    void exeWait();
+    void exeTalk();
+    void exeTalkAfter();
+
+private:
+    const char* mMessageName;
+    bool mIsInitialized = false;
+};
+
+static_assert(sizeof(EventActorStateDemoTalk) == 0x30);
+
+class ParamEventActorStateDemoTalkGK {
+public:
+    ParamEventActorStateDemoTalkGK();
+    ParamEventActorStateDemoTalkGK(f32 param1, s32 param2);
+
+    f32 mParam1 = 0.125f;
+    s32 mParam2 = 0;
+};
+
+static_assert(sizeof(ParamEventActorStateDemoTalkGK) == 0x8);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -15,6 +15,7 @@ al::EventFlowExecutor* initEventFlow(al::LiveActor*, const al::ActorInitInfo&, c
 al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                            const char*, const char*);
 bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
+bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor* actor);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1125)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (7b334ed - 9a401fc)

📈 **Matched code**: 14.53% (+0.01%, +908 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::exeTalkAfter()` | +192 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::appear()` | +112 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::exeWait()` | +112 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `(anonymous namespace)::EventActorStateDemoTalkNrvWait::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::exeTalk()` | +108 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `(anonymous namespace)::EventActorStateDemoTalkNrvTalk::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::EventActorStateDemoTalk(al::LiveActor*)` | +96 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `EventActorStateDemoTalk::~EventActorStateDemoTalk()` | +36 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `ParamEventActorStateDemoTalkGK::ParamEventActorStateDemoTalkGK()` | +12 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `ParamEventActorStateDemoTalkGK::ParamEventActorStateDemoTalkGK(float, int)` | +12 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalk` | `(anonymous namespace)::EventActorStateDemoTalkNrvTalkAfter::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->