### PR TITLE
Library/Anim: Implement `AnimInfo`

### DIFF
--- a/lib/al/Project/Action/InitResourceDataActionAnim.cpp
+++ b/lib/al/Project/Action/InitResourceDataActionAnim.cpp
@@ -123,17 +123,16 @@ const al::AnimInfoTable* createAnimInfoTableIfNeed(const al::AnimInfoTable* tabl
     if (table1 == table2 || !table2)
         return table1;
 
-    al::AnimInfoTable* newTable =
-        new al::AnimInfoTable(table1->getInfoCount() + table2->getInfoCount());
+    al::AnimInfoTable* newTable = new al::AnimInfoTable(table1->getSize() + table2->getSize());
 
-    for (s32 i = 0; i < table1->getInfoCount(); i++) {
-        const al::AnimResInfo& entry = table1->getResInfo(i);
-        newTable->add(entry.name, entry.resMaterialAnim, entry.frameMax, entry.isLoop);
+    for (s32 i = 0; i < table1->getSize(); i++) {
+        const al::AnimResInfo& entry = table1->getAnimInfo(i);
+        newTable->add(entry.name, entry.buffer, entry.frameMax, entry.isLooping);
     }
 
-    for (s32 i = 0; i < table2->getInfoCount(); i++) {
-        const al::AnimResInfo& entry = table2->getResInfo(i);
-        newTable->add(entry.name, entry.resMaterialAnim, entry.frameMax, entry.isLoop);
+    for (s32 i = 0; i < table2->getSize(); i++) {
+        const al::AnimResInfo& entry = table2->getAnimInfo(i);
+        newTable->add(entry.name, entry.buffer, entry.frameMax, entry.isLooping);
     }
 
     newTable->sort();

--- a/lib/al/Project/Anim/AnimInfo.cpp
+++ b/lib/al/Project/Anim/AnimInfo.cpp
@@ -1,0 +1,121 @@
+#include "Project/Anim/AnimInfo.h"
+
+#include "Library/Base/StringUtil.h"
+
+namespace al {
+
+AnimResInfo::AnimResInfo() = default;
+
+s32 AnimResInfo::getFrameMax() const {
+    return static_cast<s32>(frameMax);
+}
+
+bool AnimResInfo::isLoop() const {
+    return isLooping;
+}
+
+AnimInfoTable::AnimInfoTable(s32 capacity) {
+    mInfoEntries = new AnimResInfo[capacity];
+}
+
+void AnimInfoTable::add(const char* name, void* buffer, f32 frameMax, bool isLoop) {
+    // BUG: Is sorted flag is not cleared and no bounds check
+    AnimResInfo* info = &mInfoEntries[mSize];
+    info->name = createStringIfInStack(name);
+    info->buffer = buffer;
+    info->frameMax = frameMax;
+    info->isLooping = isLoop;
+    mSize++;
+}
+
+AnimResInfo* AnimInfoTable::findAnimInfo(const char* name) const {
+    if (mIsSorted) {
+        s32 low = 0;
+        s32 high = mSize;
+        while (low < high) {
+            s32 mid = (high + low - 1) >> 1;
+            AnimResInfo* info = &mInfoEntries[mid];
+            s32 cmp = strcmp(info->name, name);
+
+            if (cmp > 0) {
+                high = mid;
+                continue;
+            }
+
+            if (cmp == 0)
+                return info;
+
+            low = mid + 1;
+        }
+        return nullptr;
+    }
+
+    for (s32 i = 0; i < mSize; i++) {
+        AnimResInfo* info = &mInfoEntries[i];
+        if (isEqualString(info->name, name))
+            return info;
+    }
+    return nullptr;
+}
+
+// NON-MATCHING: Different register somehow https://decomp.me/scratch/ZxdNk
+AnimResInfo* AnimInfoTable::tryFindAnimInfo(const char* name) const {
+    return findAnimInfo(name);
+}
+
+inline void heapify(AnimResInfo* entries, s32 n, const AnimResInfo& temp, s32 parent) {
+    s32 child = parent * 2;
+    while (child <= n) {
+        if (child < n && strcmp(entries[child - 1].name, entries[child].name) < 0)
+            child++;
+
+        if (strcmp(temp.name, entries[child - 1].name) >= 0)
+            break;
+
+        entries[parent - 1] = entries[child - 1];
+        parent = child;
+        child = parent * 2;
+    }
+    entries[parent - 1] = temp;
+}
+
+void AnimInfoTable::sort() {
+    s32 n = mSize;
+    AnimResInfo* entries = mInfoEntries;
+
+    if (n < 2 || !entries) {
+        mIsSorted = true;
+        return;
+    }
+
+    AnimResInfo temp;
+
+    for (s32 i = n / 2; i >= 1; i--) {
+        temp = entries[i - 1];
+        heapify(entries, n, temp, i);
+    }
+
+    // TODO: Figure out how to apply heapify here as well
+    for (s32 i = n; i >= 2; i--) {
+        temp = entries[i - 1];
+        entries[i - 1] = entries[0];
+        s32 parent = 1;
+        s32 child = parent * 2;
+        while (child < i) {
+            if (child < i - 1 && strcmp(entries[child - 1].name, entries[child].name) < 0)
+                child++;
+
+            if (strcmp(temp.name, entries[child - 1].name) >= 0)
+                break;
+
+            entries[parent - 1] = entries[child - 1];
+            parent = child;
+            child = parent * 2;
+        }
+        entries[parent - 1] = temp;
+    }
+
+    mIsSorted = true;
+}
+
+}  // namespace al

--- a/lib/al/Project/Anim/AnimInfo.h
+++ b/lib/al/Project/Anim/AnimInfo.h
@@ -2,31 +2,36 @@
 
 #include <basis/seadTypes.h>
 
-namespace nn::g3d {
-class ResMaterialAnim;
-}  // namespace nn::g3d
-
 namespace al {
+
 struct AnimResInfo {
-    const char* name;
-    const nn::g3d::ResMaterialAnim* resMaterialAnim;
-    s32 frameMax;
-    bool isLoop;
+    AnimResInfo();
+
+    s32 getFrameMax() const;
+    bool isLoop() const;
+
+    const char* name = nullptr;
+    void* buffer = nullptr;
+    f32 frameMax = 0.0f;
+    bool isLooping = false;
 };
+
+static_assert(sizeof(AnimResInfo) == 0x18);
 
 class AnimInfoTable {
 public:
-    AnimInfoTable(u32);
-
-    AnimResInfo* findAnimInfo(const char* name);
-    bool tryFindAnimInfo(const char* name);
-
-    void add(const char* name, void*, f32 frameMax, bool isLoop);
+    AnimInfoTable(s32 capacity);
+    void add(const char* name, void* buffer, f32 frameMax, bool isLoop);
+    AnimResInfo* findAnimInfo(const char* name) const;
+    AnimResInfo* tryFindAnimInfo(const char* name) const;
     void sort();
 
 private:
-    u32 mInfoCount;
-    AnimResInfo* mResInfos;
-    bool mIsSorted;
+    s32 mSize = 0;
+    AnimResInfo* mInfoEntries = nullptr;
+    bool mIsSorted = false;
 };
+
+static_assert(sizeof(AnimInfoTable) == 0x18);
+
 }  // namespace al

--- a/lib/al/Project/Anim/AnimInfo.h
+++ b/lib/al/Project/Anim/AnimInfo.h
@@ -3,30 +3,40 @@
 #include <basis/seadTypes.h>
 
 namespace al {
+
 struct AnimResInfo {
-    const char* name;
-    void* resMaterialAnim;
-    f32 frameMax;
-    bool isLoop;
+    AnimResInfo();
+
+    s32 getFrameMax() const;
+    bool isLoop() const;
+
+    const char* name = nullptr;
+    void* buffer = nullptr;
+    f32 frameMax = 0.0f;
+    bool isLooping = false;
 };
+
+static_assert(sizeof(AnimResInfo) == 0x18);
 
 class AnimInfoTable {
 public:
-    AnimInfoTable(s32);
+    AnimInfoTable(s32 capacity);
 
-    const AnimResInfo& findAnimInfo(const char* name) const;
-    bool tryFindAnimInfo(const char* name) const;
-
-    void add(const char* name, void*, f32 frameMax, bool isLoop);
+    void add(const char* name, void* buffer, f32 frameMax, bool isLoop);
+    AnimResInfo* findAnimInfo(const char* name) const;
+    AnimResInfo* tryFindAnimInfo(const char* name) const;
     void sort();
 
-    s32 getInfoCount() const { return mInfoCount; }
+    s32 getSize() const { return mSize; }
 
-    const AnimResInfo& getResInfo(s32 index) const { return mResInfos[index]; }
+    const AnimResInfo& getAnimInfo(s32 index) const { return mInfoEntries[index]; }
 
 private:
-    s32 mInfoCount;
-    AnimResInfo* mResInfos;
-    bool mIsSorted;
+    s32 mSize = 0;
+    AnimResInfo* mInfoEntries = nullptr;
+    bool mIsSorted = false;
 };
+
+static_assert(sizeof(AnimInfoTable) == 0x18);
+
 }  // namespace al


### PR DESCRIPTION
AnimInfo uses binary search and heap sort to speed up lookup times. However there are some clues to inline code here. For starters heap sort is almost identical to PtrArray heap sort. Binary search uses both `strcmp` and `isEqualString` which probably means mInfoEntries is a sead object.

Similarly to PtrArray  implementations. I wasn't able to fully clean the code.  But I did manage to get the proper for loops for this one.

Finaly `tryFindAnimInfo` and `findAnimInfo` generate different assembly code. No idea on how to match that. _ZNK2al13AnimInfoTable15tryFindAnimInfoEPKc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1127)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0412c1e - f470901)

📈 **Matched code**: 15.61% (+0.01%, +1052 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Anim/AnimInfo` | `al::AnimInfoTable::sort()` | +564 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimInfoTable::findAnimInfo(char const*) const` | +224 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimInfoTable::AnimInfoTable(int)` | +116 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimInfoTable::add(char const*, void*, float, bool)` | +116 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimResInfo::AnimResInfo()` | +12 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimResInfo::getFrameMax() const` | +12 | 0.00% | 100.00% |
| `Project/Anim/AnimInfo` | `al::AnimResInfo::isLoop() const` | +8 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Anim/AnimInfo` | `al::AnimInfoTable::tryFindAnimInfo(char const*) const` | +56 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->