### PR TITLE
Npc: Implement `SessionMusicianManager`

### DIFF
--- a/src/Npc/SessionMayorNpc.h
+++ b/src/Npc/SessionMayorNpc.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+#include "Library/Event/IEventFlowEventReceiver.h"
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowEventData;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SessionMusicianNpc;
+
+class SessionMayorNpc : public al::LiveActor, public al::IEventFlowEventReceiver {
+public:
+    void init(const al::ActorInitInfo& info) override;
+    void movement() override;
+    void initIntroductionCamera(const al::ActorInitInfo& info,
+                                sead::PtrArray<SessionMusicianNpc>* musicians);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    bool receiveEvent(const al::EventFlowEventData* data) override;
+    bool judgeQuery(const char* query) const;
+    void control() override;
+    void startReaction();
+    void startReactionOnlyTurn();
+    void startReactionOnlyFlower();
+    bool tryStartReaction();
+    bool tryAppearMemberMusicians();
+    bool tryStartDance();
+    void exeWait();
+    void exeReaction();
+    void exeDance();
+    void exeDemo();
+
+private:
+    u8 _168[0x60];
+};
+
+static_assert(sizeof(SessionMayorNpc) == 0x170);

--- a/src/Npc/SessionMusicianBgmController.h
+++ b/src/Npc/SessionMusicianBgmController.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class SessionMusicianBgmController : public al::NerveExecutor {
+public:
+    SessionMusicianBgmController(al::LiveActor* actor, const al::ActorInitInfo& info,
+                                 bool isIndoor);
+
+    void exeWait();
+    bool tryStartBgmSituation();
+    void exeInArea();
+    void exeOutArea();
+
+private:
+    u8 _10[0x30];
+};
+
+static_assert(sizeof(SessionMusicianBgmController) == 0x40);

--- a/src/Npc/SessionMusicianLocalFunction.h
+++ b/src/Npc/SessionMusicianLocalFunction.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Npc/SessionMusicianType.h"
+
+namespace al {
+class IUseSceneObjHolder;
+class LiveActor;
+}  // namespace al
+
+class SessionMusicianNpc;
+
+namespace SessionMusicianLocalFunction {
+SessionMusicianType getMusicianType(const al::LiveActor* actor);
+bool isMusicianType(const al::LiveActor* actor, SessionMusicianType type);
+bool isSubscribed(const al::LiveActor* actor, SessionMusicianType type);
+bool isAlreadySessionMember(const SessionMusicianNpc* musician);
+void entryMusicianToManager(SessionMusicianNpc* musician);
+s32 getMemberMusicianNum(const al::LiveActor* actor);
+bool isSessionFullMember(const al::LiveActor* actor);
+void startPlayingTheBa(const al::LiveActor* actor);
+void startPlayingTheDs(const al::LiveActor* actor);
+void startPlayingTheGt(const al::LiveActor* actor);
+void startPlayingTheTp(const al::LiveActor* actor);
+void endPlayingTheBa(const al::LiveActor* actor);
+void endPlayingTheDs(const al::LiveActor* actor);
+void endPlayingTheGt(const al::LiveActor* actor);
+void endPlayingTheTp(const al::LiveActor* actor);
+}  // namespace SessionMusicianLocalFunction

--- a/src/Npc/SessionMusicianManager.cpp
+++ b/src/Npc/SessionMusicianManager.cpp
@@ -1,0 +1,355 @@
+#include "Npc/SessionMusicianManager.h"
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Npc/SessionEventProgress.h"
+#include "Npc/SessionMayorNpc.h"
+#include "Npc/SessionMusicianBgmController.h"
+#include "Npc/SessionMusicianLocalFunction.h"
+#include "Npc/SessionMusicianNpc.h"
+#include "Npc/SessionMusicianWarpAgent.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "Util/DemoUtil.h"
+
+namespace {
+NERVE_IMPL(SessionMusicianManager, Wait);
+NERVE_IMPL(SessionMusicianManager, Complete);
+
+NERVES_MAKE_NOSTRUCT(SessionMusicianManager, Wait, Complete);
+}  // namespace
+
+SessionMusicianManager::SessionMusicianManager(const char* name) : al::LiveActor(name) {
+    mMusicians.allocBuffer(7, nullptr);
+}
+
+void SessionMusicianManager::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initActorWithArchiveName(this, info, "SessionMusicianManager", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::initActorSeKeeperWithout3D(this, info, "SessionMusicianManager");
+
+    if (mMayor != nullptr) {
+        mMayor->initIntroductionCamera(info, &mMusicians);
+        mBgmController = new SessionMusicianBgmController(this, info, false);
+    }
+
+    makeActorAlive();
+}
+
+void SessionMusicianManager::entryMusician(SessionMusicianNpc* musician) {
+    mMusicians.pushBack(musician);
+}
+
+bool SessionMusicianManager::isJoinedMusician() const {
+    if (mMusicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        if ((*musician++)->isJoined())
+            return true;
+
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+
+    return false;
+}
+
+SessionMusicianNpc* SessionMusicianManager::getJoinedMusician() const {
+    if (mMusicians.size() == 0)
+        return nullptr;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        if ((*musician)->isJoined())
+            return *musician;
+
+        musician++;
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+
+    return nullptr;
+}
+
+bool SessionMusicianManager::isSubscribed(SessionMusicianType type) const {
+    if (mMusicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        if (SessionMusicianLocalFunction::isMusicianType(*musician, type) &&
+            SessionMusicianLocalFunction::isAlreadySessionMember(*musician))
+            return true;
+
+        musician++;
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+
+    return false;
+}
+
+bool SessionMusicianManager::tryAppearPowerPlant() {
+    SessionMusicianNpc* powerPlant = findPowerPlant();
+    if (powerPlant == nullptr || al::isAlive(powerPlant))
+        return false;
+
+    if (GameDataFunction::getSessionEventProgress(this).value() <
+        SessionEventProgress::WaitThePowerPlantWorks)
+        return false;
+
+    powerPlant->appear();
+    return true;
+}
+
+SessionMusicianNpc* SessionMusicianManager::findPowerPlant() const {
+    if (mMusicians.size() == 0)
+        return nullptr;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        if (SessionMusicianLocalFunction::getMusicianType(*musician) == SessionMusicianType::Vocal)
+            return *musician;
+
+        musician++;
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+
+    return nullptr;
+}
+
+bool SessionMusicianManager::tryStartWarp(al::PlacementInfo* placementInfo) {
+    if (mMusicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        if ((*musician)->isStateWarp()) {
+            SessionMusicianWarpAgent* warpAgent = (*musician)->getWarpAgent();
+            if (warpAgent->tryGetWarpTargetInfo(placementInfo) && warpAgent->tryStartWarp()) {
+                (*musician)->doneWarp();
+                al::invalidateClipping(mMayor);
+                return true;
+            }
+        }
+
+        musician++;
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+
+    return false;
+}
+
+void SessionMusicianManager::addDemoAllMusicians() {
+    if (mMusicians.size() == 0)
+        return;
+
+    SessionMusicianNpc** musician = mMusicians.data();
+    while (true) {
+        rs::addDemoActor(*musician++, true);
+
+        if (musician == &mMusicians.data()[mMusicians.size()])
+            break;
+    }
+}
+
+void SessionMusicianManager::exeWait() {
+    if (mBgmController != nullptr)
+        mBgmController->updateNerve();
+
+    if (!(SessionMusicianLocalFunction::getMemberMusicianNum(this) < 5)) {
+        al::setNerve(this, &Complete);
+        return;
+    }
+
+    tryAppearPowerPlant();
+}
+
+void SessionMusicianManager::exeComplete() {
+    if (mBgmController != nullptr)
+        mBgmController->updateNerve();
+}
+
+namespace SessionMusicianLocalFunction {
+
+void tryCreateSessionMusicianManager(const al::IUseSceneObjHolder* holder) {
+    if (isExistSessionMusicianManager(holder))
+        return;
+
+    al::setSceneObj(holder, new SessionMusicianManager("セッション[マネージャー]"));
+}
+
+SessionMusicianManager* getSessionMusicianManager(const al::IUseSceneObjHolder* holder) {
+    return al::tryGetSceneObj<SessionMusicianManager>(holder);
+}
+
+bool isExistSessionMusicianManager(const al::IUseSceneObjHolder* holder) {
+    return al::isExistSceneObj(holder, SceneObjID_SessionMusicianManager);
+}
+
+bool tryStartWarpToSessionMayor(const al::IUseSceneObjHolder* holder,
+                                al::PlacementInfo* placementInfo) {
+    if (!isExistSessionMusicianManager(holder))
+        return false;
+
+    return getSessionMusicianManager(holder)->tryStartWarp(placementInfo);
+}
+
+void entrySessionMayorToManager(SessionMayorNpc* mayor) {
+    return getSessionMusicianManager(mayor)->setSessionMayor(mayor);
+}
+
+bool isJoinedSessionMusician(const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = getSessionMusicianManager(holder);
+    if (manager == nullptr)
+        return false;
+
+    return manager->isJoinedMusician();
+}
+
+SessionMusicianNpc* tryGetJoinedSessionMusicanActor(const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = getSessionMusicianManager(holder);
+    if (manager == nullptr)
+        return nullptr;
+
+    return manager->getJoinedMusician();
+}
+
+bool tryAddJoinedSessionMusicianDemoActor(const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = al::tryGetSceneObj<SessionMusicianManager>(holder);
+    bool result = false;
+    if (manager == nullptr)
+        return result;
+
+    const sead::PtrArray<SessionMusicianNpc>& musicians = manager->getMusicians();
+    if (musicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musicianPtr = musicians.data();
+    while (true) {
+        if ((*musicianPtr)->isJoined())
+            break;
+
+        musicianPtr++;
+        if (musicianPtr == &musicians.data()[musicians.size()])
+            return false;
+    }
+
+    SessionMusicianNpc* musician = *musicianPtr;
+    if (musician == nullptr)
+        return false;
+
+    rs::addDemoActor(musician, true);
+    result = true;
+    if (musician->getDemoActorNum() < 1)
+        return result;
+
+    s64 demoActorIndex = 0;
+    result = true;
+    do {
+        rs::addDemoActor(musician->tryGetDemoActor(demoActorIndex), true);
+        demoActorIndex++;
+    } while (demoActorIndex < musician->getDemoActorNum());
+
+    return result;
+}
+
+bool tryGetSessionMoonGetDemoPlayerPos(sead::Vector3f* out, const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = al::tryGetSceneObj<SessionMusicianManager>(holder);
+    if (manager == nullptr)
+        return false;
+
+    const sead::PtrArray<SessionMusicianNpc>& musicians = manager->getMusicians();
+    if (musicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musicianPtr = musicians.data();
+    while (true) {
+        if ((*musicianPtr)->isJoined())
+            break;
+
+        musicianPtr++;
+        if (musicianPtr == &musicians.data()[musicians.size()])
+            return false;
+    }
+
+    SessionMusicianNpc* musician = *musicianPtr;
+    if (musician == nullptr)
+        return false;
+
+    new (out) sead::Vector3f(musician->getMoonGetDemoPlayerPos());
+    return true;
+}
+
+bool tryGetSessionMoonGetDemoPlayerPose(sead::Quatf* out, const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = al::tryGetSceneObj<SessionMusicianManager>(holder);
+    if (manager == nullptr)
+        return false;
+
+    const sead::PtrArray<SessionMusicianNpc>& musicians = manager->getMusicians();
+    if (musicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musicianPtr = musicians.data();
+    while (true) {
+        if ((*musicianPtr)->isJoined())
+            break;
+
+        musicianPtr++;
+        if (musicianPtr == &musicians.data()[musicians.size()])
+            return false;
+    }
+
+    SessionMusicianNpc* musician = *musicianPtr;
+    if (musician == nullptr)
+        return false;
+
+    new (out) sead::Quatf(musician->getMoonGetDemoPlayerPose());
+    return true;
+}
+
+bool trySetJoinedSessionMusicianTransformForMoonGetDemo(const al::IUseSceneObjHolder* holder) {
+    SessionMusicianManager* manager = al::tryGetSceneObj<SessionMusicianManager>(holder);
+    if (manager == nullptr)
+        return false;
+
+    const sead::PtrArray<SessionMusicianNpc>& musicians = manager->getMusicians();
+    if (musicians.size() == 0)
+        return false;
+
+    SessionMusicianNpc** musicianPtr = musicians.data();
+    while (true) {
+        if ((*musicianPtr)->isJoined())
+            break;
+
+        musicianPtr++;
+        if (musicianPtr == &musicians.data()[musicians.size()])
+            return false;
+    }
+
+    SessionMusicianNpc* musician = *musicianPtr;
+    if (musician == nullptr)
+        return false;
+
+    sead::Vector3f pos = musician->getMoonGetDemoPlayerPos();
+    al::faceToTarget(musician, pos);
+    return true;
+}
+
+void addDemoAllMusicians(const al::IUseSceneObjHolder* holder) {
+    getSessionMusicianManager(holder)->addDemoAllMusicians();
+}
+
+}  // namespace SessionMusicianLocalFunction

--- a/src/Npc/SessionMusicianManager.h
+++ b/src/Npc/SessionMusicianManager.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Npc/SessionMusicianType.h"
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+class PlacementInfo;
+}  // namespace al
+
+class SessionMayorNpc;
+class SessionMusicianBgmController;
+class SessionMusicianNpc;
+
+class SessionMusicianManager : public al::LiveActor, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_SessionMusicianManager;
+
+    SessionMusicianManager(const char* name);
+
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+    void entryMusician(SessionMusicianNpc* musician);
+    bool isJoinedMusician() const;
+    SessionMusicianNpc* getJoinedMusician() const;
+    bool isSubscribed(SessionMusicianType type) const;
+    bool tryAppearPowerPlant();
+    SessionMusicianNpc* findPowerPlant() const;
+    bool tryStartWarp(al::PlacementInfo* placementInfo);
+    void addDemoAllMusicians();
+    void exeWait();
+    void exeComplete();
+
+    const sead::PtrArray<SessionMusicianNpc>& getMusicians() const { return mMusicians; }
+
+    void setSessionMayor(SessionMayorNpc* mayor) { mMayor = mayor; }
+
+private:
+    sead::PtrArray<SessionMusicianNpc> mMusicians;
+    SessionMusicianBgmController* mBgmController = nullptr;
+    SessionMayorNpc* mMayor = nullptr;
+};
+
+static_assert(sizeof(SessionMusicianManager) == 0x130);
+
+namespace SessionMusicianLocalFunction {
+void tryCreateSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+SessionMusicianManager* getSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+bool isExistSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+bool tryStartWarpToSessionMayor(const al::IUseSceneObjHolder* holder,
+                                al::PlacementInfo* placementInfo);
+void entrySessionMayorToManager(SessionMayorNpc* mayor);
+bool isJoinedSessionMusician(const al::IUseSceneObjHolder* holder);
+SessionMusicianNpc* tryGetJoinedSessionMusicanActor(const al::IUseSceneObjHolder* holder);
+bool tryAddJoinedSessionMusicianDemoActor(const al::IUseSceneObjHolder* holder);
+bool tryGetSessionMoonGetDemoPlayerPos(sead::Vector3f* out, const al::IUseSceneObjHolder* holder);
+bool tryGetSessionMoonGetDemoPlayerPose(sead::Quatf* out, const al::IUseSceneObjHolder* holder);
+bool trySetJoinedSessionMusicianTransformForMoonGetDemo(const al::IUseSceneObjHolder* holder);
+void addDemoAllMusicians(const al::IUseSceneObjHolder* holder);
+}  // namespace SessionMusicianLocalFunction

--- a/src/Npc/SessionMusicianNpc.h
+++ b/src/Npc/SessionMusicianNpc.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowEventData;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class SessionMusicianWarpAgent;
+
+class SessionMusicianNpc : public al::LiveActor {
+public:
+    void init(const al::ActorInitInfo& info) override;
+    void startEvent();
+    void appear() override;
+    void kill() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    bool receiveEvent(const al::EventFlowEventData* data);
+    bool judgeQuery(const char* query) const;
+    void endClipped() override;
+    void control() override;
+    void forceControlForDance();
+    void controlForDance();
+    bool isJoined() const;
+    bool isStateWarp() const;
+    void doneWarp();
+    bool isEnableMuteBgmTrack() const;
+    void exeWaitNoEventFlowSabi();
+    void exeWaitNoEventFlow();
+    void exeWait();
+    void exeWarpStart();
+    void exeWarp();
+    void exeWarpEnd();
+    void exeReaction();
+    void endReaction();
+
+    SessionMusicianWarpAgent* getWarpAgent() const { return mWarpAgent; }
+
+    s32 getDemoActorNum() const { return mDemoActors.size(); }
+
+    u32 getDemoActorNumU() const { return mDemoActors.size(); }
+
+    al::LiveActor* tryGetDemoActor(u64 index) const {
+        if (getDemoActorNumU() <= index)
+            return nullptr;
+
+        return mDemoActors.data()[index];
+    }
+
+    const sead::Vector3f& getMoonGetDemoPlayerPos() const { return mMoonGetDemoPlayerPos; }
+
+    const sead::Quatf& getMoonGetDemoPlayerPose() const { return mMoonGetDemoPlayerPose; }
+
+private:
+    u8 _108[0x28];
+    sead::PtrArray<al::LiveActor> mDemoActors;
+    SessionMusicianWarpAgent* mWarpAgent = nullptr;
+    u8 _148[0x20];
+    sead::Vector3f mMoonGetDemoPlayerPos;
+    sead::Quatf mMoonGetDemoPlayerPose;
+};

--- a/src/Npc/SessionMusicianWarpAgent.h
+++ b/src/Npc/SessionMusicianWarpAgent.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+class PlacementInfo;
+}  // namespace al
+
+class SessionMusicianWarpAgent {
+public:
+    SessionMusicianWarpAgent(al::LiveActor* actor, const al::ActorInitInfo& info);
+
+    bool tryGetWarpTargetInfo(al::PlacementInfo* placementInfo);
+    bool tryStartWarp();
+
+private:
+    u8 _0[0x20];
+};
+
+static_assert(sizeof(SessionMusicianWarpAgent) == 0x20);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1130)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d6735da - 350ebe3)

📈 **Matched code**: 14.64% (+0.03%, +3160 bytes)

<details>
<summary>✅ 30 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryCreateSessionMusicianManager(al::IUseSceneObjHolder const*)` | +232 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryAddJoinedSessionMusicianDemoActor(al::IUseSceneObjHolder const*)` | +220 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::exeWait()` | +216 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +200 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryStartWarpToSessionMayor(al::IUseSceneObjHolder const*, al::PlacementInfo*)` | +188 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::tryAppearPowerPlant()` | +184 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::SessionMusicianManager(char const*)` | +168 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryGetSessionMoonGetDemoPlayerPose(sead::Quat<float>*, al::IUseSceneObjHolder const*)` | +168 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::SessionMusicianManager(char const*)` | +164 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryGetSessionMoonGetDemoPlayerPos(sead::Vector3<float>*, al::IUseSceneObjHolder const*)` | +160 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::tryStartWarp(al::PlacementInfo*)` | +152 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::trySetJoinedSessionMusicianTransformForMoonGetDemo(al::IUseSceneObjHolder const*)` | +152 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::isSubscribed(SessionMusicianType) const` | +116 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::tryGetJoinedSessionMusicanActor(al::IUseSceneObjHolder const*)` | +112 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::isJoinedSessionMusician(al::IUseSceneObjHolder const*)` | +108 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::findPowerPlant() const` | +92 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::getJoinedMusician() const` | +88 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::addDemoAllMusicians(al::IUseSceneObjHolder const*)` | +88 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::isJoinedMusician() const` | +84 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::addDemoAllMusicians()` | +72 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::entrySessionMayorToManager(SessionMayorNpc*)` | +64 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::entryMusician(SessionMusicianNpc*)` | +44 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::getSessionMusicianManager(al::IUseSceneObjHolder const*)` | +36 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::exeComplete()` | +16 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `non-virtual thunk to SessionMusicianManager::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +8 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianLocalFunction::isExistSessionMusicianManager(al::IUseSceneObjHolder const*)` | +8 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `non-virtual thunk to SessionMusicianManager::~SessionMusicianManager()` | +8 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::~SessionMusicianManager()` | +4 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `SessionMusicianManager::~SessionMusicianManager()` | +4 | 0.00% | 100.00% |
| `Npc/SessionMusicianManager` | `non-virtual thunk to SessionMusicianManager::~SessionMusicianManager()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->