### PR TITLE
MapObj: Implement `Special2KeyMoveLift`

### DIFF
--- a/src/MapObj/Special2KeyMoveLift.cpp
+++ b/src/MapObj/Special2KeyMoveLift.cpp
@@ -1,0 +1,127 @@
+#include "MapObj/Special2KeyMoveLift.h"
+
+#include <math/seadVector.h>
+
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+#include "Project/Joint/KeyPose.h"
+
+namespace {
+NERVE_ACTION_IMPL(Special2KeyMoveParts, StandBy)
+NERVE_ACTION_IMPL(Special2KeyMoveParts, Delay)
+NERVE_ACTION_IMPL(Special2KeyMoveParts, MoveSign)
+NERVE_ACTION_IMPL(Special2KeyMoveParts, Move)
+NERVE_ACTION_IMPL(Special2KeyMoveParts, Stop)
+NERVE_ACTION_IMPL(Special2KeyMoveParts, Reset)
+
+NERVE_ACTIONS_MAKE_STRUCT(Special2KeyMoveParts, StandBy, Delay, MoveSign, Move, Stop, Reset)
+}  // namespace
+
+Special2KeyMoveParts::Special2KeyMoveParts(const char* name) : al::LiveActor(name) {}
+
+// NOTE: declares 1 state, but never adds it
+void Special2KeyMoveParts::init(const al::ActorInitInfo& info) {
+    using Special2KeyMovePartsFunctor =
+        al::FunctorV0M<Special2KeyMoveParts*, void (Special2KeyMoveParts::*)()>;
+
+    al::initNerveAction(this, "StandBy", &NrvSpecial2KeyMoveParts.collector, 1);
+    al::initActor(this, info);
+
+    al::listenStageSwitchOnStart(this,
+                                 Special2KeyMovePartsFunctor(this, &Special2KeyMoveParts::start));
+    al::listenStageSwitchOn(this, "SwitchReset",
+                            Special2KeyMovePartsFunctor(this, &Special2KeyMoveParts::reset));
+
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    al::getArg(&mDelayTime, info, "DelayTime");
+
+    makeActorAlive();
+}
+
+void Special2KeyMoveParts::start() {
+    al::invalidateClipping(this);
+
+    if (mDelayTime > 0)
+        al::startNerveAction(this, "Delay");
+    else
+        al::startNerveAction(this, "MoveSign");
+}
+
+void Special2KeyMoveParts::reset() {
+    al::invalidateClipping(this);
+    al::startNerveAction(this, "Reset");
+}
+
+void Special2KeyMoveParts::exeStandBy() {
+    if (al::isFirstStep(this))
+        al::validateClipping(this);
+}
+
+void Special2KeyMoveParts::exeDelay() {
+    if (al::isGreaterEqualStep(this, mDelayTime))
+        al::startNerveAction(this, "MoveSign");
+}
+
+void Special2KeyMoveParts::exeMoveSign() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "MoveKeySign");
+
+    if (al::isActionEnd(this))
+        al::startNerveAction(this, "Move");
+}
+
+void Special2KeyMoveParts::exeMove() {
+    if (al::isFirstStep(this))
+        mMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+
+    f32 rate = al::calcNerveRate(this, mMoveTime);
+
+    al::calcLerpKeyTrans(al::getTransPtr(this), mKeyPoseKeeper, rate);
+
+    if (al::isGreaterEqualStep(this, mMoveTime))
+        al::startNerveAction(this, "Stop");
+}
+
+void Special2KeyMoveParts::exeStop() {}
+
+void Special2KeyMoveParts::exeReset() {
+    if (al::isFirstStep(this)) {
+    }
+
+    const sead::Vector3f& keyTrans = mKeyPoseKeeper->getKeyPose(0).getTrans();
+    const sead::Vector3f& trans = al::getTrans(this);
+
+    sead::Vector3f moveDir = keyTrans - trans;
+    al::tryNormalizeOrZero(&moveDir, moveDir);
+
+    al::setTrans(this, trans + moveDir * 10.0f);
+
+    if (moveDir.dot(keyTrans - trans) < 0.0f) {
+        al::setTrans(this, keyTrans);
+        al::startNerveAction(this, "StandBy");
+        mKeyPoseKeeper->reset();
+    }
+}
+
+Special2KeyMoveLift::Special2KeyMoveLift(const char* name) : al::KeyMoveMapParts(name) {}
+
+void Special2KeyMoveLift::exeStandBy() {
+    if (al::isFirstStep(this)) {
+        if (mIsFirstStandBy)
+            mIsFirstStandBy = false;
+        else
+            al::startHitReaction(this, "出現");
+    }
+
+    al::KeyMoveMapParts::exeStandBy();
+}

--- a/src/MapObj/Special2KeyMoveLift.h
+++ b/src/MapObj/Special2KeyMoveLift.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/MapObj/KeyMoveMapParts.h"
+
+namespace al {
+class KeyPoseKeeper;
+}  // namespace al
+
+class Special2KeyMoveParts : public al::LiveActor {
+public:
+    Special2KeyMoveParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void start();
+    void reset();
+    void exeStandBy();
+    void exeDelay();
+    void exeMoveSign();
+    void exeMove();
+    void exeStop();
+    void exeReset();
+
+private:
+    al::KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    s32 mDelayTime = 0;
+    s32 mMoveTime = 0;
+};
+
+static_assert(sizeof(Special2KeyMoveParts) == 0x118);
+
+class Special2KeyMoveLift : public al::KeyMoveMapParts {
+public:
+    Special2KeyMoveLift(const char* name);
+
+    void exeStandBy() override;
+
+private:
+    bool mIsFirstStandBy = true;
+};
+
+static_assert(sizeof(Special2KeyMoveLift) == 0x158);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -107,6 +107,7 @@
 #include "MapObj/SignBoard.h"
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
+#include "MapObj/Special2KeyMoveLift.h"
 #include "MapObj/StageSwitchSelector.h"
 #include "MapObj/TalkPoint.h"
 #include "MapObj/TrampleBush.h"
@@ -567,8 +568,8 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"SnowVolumeEraser", nullptr},
     {"Souvenir", al::createActorFunction<Souvenir>},
     {"SouvenirDirector", nullptr},
-    {"Special2KeyMoveLift", nullptr},
-    {"Special2KeyMoveParts", nullptr},
+    {"Special2KeyMoveLift", al::createActorFunction<Special2KeyMoveLift>},
+    {"Special2KeyMoveParts", al::createActorFunction<Special2KeyMoveParts>},
     {"SphinxQuiz", nullptr},
     {"SphinxRide", nullptr},
     {"SphinxTaxiWatcher", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1131)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - b382bb2)

📈 **Matched code**: 14.67% (+0.02%, +2288 bytes)

<details>
<summary>✅ 32 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeReset()` | +292 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::init(al::ActorInitInfo const&)` | +224 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `_GLOBAL__sub_I_Special2KeyMoveLift.cpp` | +188 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeMove()` | +144 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveLift::Special2KeyMoveLift(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::Special2KeyMoveParts(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveLift::Special2KeyMoveLift(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::Special2KeyMoveParts(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvMoveSign::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeMoveSign()` | +88 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `al::FunctorV0M<Special2KeyMoveParts*, void (Special2KeyMoveParts::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveLift::exeStandBy()` | +72 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::start()` | +68 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvDelay::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeDelay()` | +64 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvStandBy::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeStandBy()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Special2KeyMoveLift>(char const*)` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<Special2KeyMoveParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::reset()` | +44 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `al::FunctorV0M<Special2KeyMoveParts*, void (Special2KeyMoveParts::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvStandBy::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvDelay::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvMoveSign::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvStop::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvReset::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `(anonymous namespace)::Special2KeyMovePartsNrvReset::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/Special2KeyMoveLift` | `Special2KeyMoveParts::exeStop()` | +4 | 0.00% | 100.00% |

...and 2 more new matches
</details>


<!-- decomp.dev report end -->