### PR TITLE
Item: Implement `LifeUpItem2D`

### DIFF
--- a/src/Amiibo/HelpAmiiboCountUpCoin.cpp
+++ b/src/Amiibo/HelpAmiiboCountUpCoin.cpp
@@ -42,7 +42,7 @@ void HelpAmiiboCountUpCoin::initAfterPlacement(const al::ActorInitInfo& initInfo
     mLifeUpItem2D = new LifeUpItem2D("ライフアップアイテム2D[amiibo]");
     al::initCreateActorNoPlacementInfo(mLifeUpItem2D, initInfo);
     mLifeUpItem2D->makeActorDead();
-    mLifeUpItem2D->setBool130(true);
+    mLifeUpItem2D->setIsAmiiboTouch(true);
     mCoinBuffer.allocBuffer(3, nullptr);
     mCoin2DBuffer.allocBuffer(3, nullptr);
 

--- a/src/Item/LifeUpItem2D.cpp
+++ b/src/Item/LifeUpItem2D.cpp
@@ -1,0 +1,165 @@
+#include "Item/LifeUpItem2D.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Item/LifeUpItemStateAutoGet.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "Util/ActorDimensionUtil.h"
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(LifeUpItem2D, Wait);
+NERVE_IMPL(LifeUpItem2D, AutoGetDemo);
+NERVE_IMPL(LifeUpItem2D, PopUp);
+NERVE_IMPL(LifeUpItem2D, Get);
+
+NERVES_MAKE_NOSTRUCT(LifeUpItem2D, Get);
+NERVES_MAKE_STRUCT(LifeUpItem2D, Wait, AutoGetDemo, PopUp);
+
+void appearIn2DArea(LifeUpItem2D* actor, ActorDimensionKeeper* dimensionKeeper);
+}  // namespace
+
+LifeUpItem2D::LifeUpItem2D(const char* name) : al::LiveActor(name) {}
+
+void LifeUpItem2D::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "LifeUpItem2D", nullptr);
+    al::initNerve(this, &NrvLifeUpItem2D.Wait, 1);
+    al::offCollide(this);
+    rs::createAndSetFilter2DOnly(this);
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    if (al::isPlaced(info))
+        rs::snap2DParallelizeFront(this, this, 500.0f);
+
+    LifeUpItemStateAutoGet* stateAutoGet = new LifeUpItemStateAutoGet(this, true);
+    mStateAutoGet = stateAutoGet;
+    al::initNerveState(this, stateAutoGet, &NrvLifeUpItem2D.AutoGetDemo, "自動取得");
+    al::startAction(this, "Wait");
+    makeActorAlive();
+}
+
+void LifeUpItem2D::appearPopUp() {
+    al::setNerve(this, &NrvLifeUpItem2D.PopUp);
+    appearIn2DArea(this, mDimensionKeeper);
+    al::startHitReaction(this, "飛出し出現");
+}
+
+namespace {
+void appearIn2DArea(LifeUpItem2D* actor, ActorDimensionKeeper* dimensionKeeper) {
+    rs::updateDimensionKeeper(dimensionKeeper);
+    if (!rs::isIn2DArea(actor))
+        return;
+
+    al::onCollide(actor);
+    rs::snap2DParallelizeFront(actor, actor, 500.0f);
+    al::setVelocity(actor, al::getGravity(actor) * -11.0f);
+    al::showModelIfHide(actor);
+    al::validateHitSensors(actor);
+    al::invalidateClipping(actor);
+    al::startAction(actor, "AppearPopUp");
+    actor->appear();
+}
+}  // namespace
+
+void LifeUpItem2D::appearAmiiboTouch() {
+    al::setNerve(this, &NrvLifeUpItem2D.AutoGetDemo);
+    appearIn2DArea(this, mDimensionKeeper);
+    al::startHitReaction(this, "飛出し出現");
+}
+
+void LifeUpItem2D::get() {
+    if (al::isNerve(this, &Get))
+        return;
+
+    al::setVelocityZero(this);
+    al::startHitReaction(this, "取得");
+    GameDataHolderAccessor accessor(this);
+    if (!GameDataFunction::isPlayerHitPointMax(accessor)) {
+        GameDataFunction::recoveryPlayer(this);
+        kill();
+        return;
+    }
+
+    if (mIsAmiiboTouch) {
+        kill();
+        return;
+    }
+
+    if (!mHitSensor)
+        mHitSensor = al::getHitSensor(this, "Body");
+
+    al::hideModel(this);
+    al::invalidateHitSensors(this);
+    al::invalidateClipping(this);
+    al::setNerve(this, &Get);
+}
+
+void LifeUpItem2D::exePopUp() {
+    al::addVelocityToGravity(this, 0.4f);
+    al::limitVelocitySeparateHV(this, al::getGravity(this), 10.0f, 20.0f);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+    if (!rs::isIn2DArea(this)) {
+        kill();
+        return;
+    }
+
+    rs::snap2DParallelizeFront(this, this, 500.0f);
+    if (al::isOnGround(this, 0)) {
+        al::offCollide(this);
+        al::setVelocityZero(this);
+        al::validateClipping(this);
+        al::setNerve(this, &NrvLifeUpItem2D.Wait);
+    }
+}
+
+void LifeUpItem2D::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void LifeUpItem2D::exeGet() {
+    if (al::isFirstStep(this))
+        mCoinAppearCount = 0;
+
+    if (rs::tryAppearMultiCoinFromObj(this, mHitSensor, al::getNerveStep(this), 150.0f))
+        mCoinAppearCount++;
+
+    if (mCoinAppearCount >= 5)
+        kill();
+}
+
+void LifeUpItem2D::exeAutoGetDemo() {
+    if (al::updateNerveState(this))
+        get();
+}
+
+bool LifeUpItem2D::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                              al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+
+    if (!rs::isMsgItemGet2D(message) || ((al::isNerve(this, &NrvLifeUpItem2D.PopUp) ||
+                                          al::isNerve(this, &NrvLifeUpItem2D.AutoGetDemo)) &&
+                                         al::isLessEqualStep(this, 40))) {
+        return false;
+    }
+
+    mHitSensor = other;
+    get();
+    return true;
+}

--- a/src/Item/LifeUpItem2D.h
+++ b/src/Item/LifeUpItem2D.h
@@ -9,11 +9,11 @@
 namespace al {
 struct ActorInitInfo;
 class HitSensor;
-class NerveStateBase;
 class SensorMsg;
 }  // namespace al
 
 class ActorDimensionKeeper;
+class LifeUpItemStateAutoGet;
 
 class LifeUpItem2D : public al::LiveActor, public IUseDimension {
 public:
@@ -22,7 +22,8 @@ public:
     void init(const al::ActorInitInfo& info) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
                     al::HitSensor* self) override;
-    ActorDimensionKeeper* getActorDimensionKeeper() const override;
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override { return mDimensionKeeper; };
 
     void appearPopUp();
     void appearAmiiboTouch();
@@ -33,12 +34,14 @@ public:
     void exeGet();
     void exeAutoGetDemo();
 
-    void setBool130(bool value) { _130 = value; }
+    void setIsAmiiboTouch(bool value) { mIsAmiiboTouch = value; }
 
 private:
-    al::NerveStateBase* mNerveStateBase = nullptr;
+    LifeUpItemStateAutoGet* mStateAutoGet = nullptr;
     al::HitSensor* mHitSensor = nullptr;
-    s32 _120 = 0;
+    s32 mCoinAppearCount = 0;
     ActorDimensionKeeper* mDimensionKeeper = nullptr;
-    bool _130 = false;
+    bool mIsAmiiboTouch = false;
 };
+
+static_assert(sizeof(LifeUpItem2D) == 0x138);

--- a/src/Item/LifeUpItemStateAutoGet.h
+++ b/src/Item/LifeUpItemStateAutoGet.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class LifeUpItemStateAutoGet : public al::ActorStateBase {
+public:
+    LifeUpItemStateAutoGet(al::LiveActor* actor, bool is2D);
+
+    void appear() override;
+
+    void exePopup();
+
+private:
+    bool mIs2D = false;
+};
+
+static_assert(sizeof(LifeUpItemStateAutoGet) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1132)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - 6e3f568)

📈 **Matched code**: 14.67% (+0.02%, +1968 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/LifeUpItem2D` | `LifeUpItem2D::init(al::ActorInitInfo const&)` | +260 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `(anonymous namespace)::appearIn2DArea(LifeUpItem2D*, ActorDimensionKeeper*)` | +204 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::exePopUp()` | +200 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::get()` | +196 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::LifeUpItem2D(char const*)` | +160 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::LifeUpItem2D(char const*)` | +156 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +148 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `(anonymous namespace)::LifeUpItem2DNrvGet::execute(al::NerveKeeper*) const` | +128 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::exeGet()` | +124 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::appearPopUp()` | +68 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::appearAmiiboTouch()` | +68 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `(anonymous namespace)::LifeUpItem2DNrvWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::exeWait()` | +60 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `(anonymous namespace)::LifeUpItem2DNrvAutoGetDemo::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::exeAutoGetDemo()` | +52 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `LifeUpItem2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `non-virtual thunk to LifeUpItem2D::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `Item/LifeUpItem2D` | `(anonymous namespace)::LifeUpItem2DNrvPopUp::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->