### PR TITLE
Util: Implement `NpcEventFlowUtil`

### DIFF
--- a/lib/al/Library/Audio/IUseAudioKeeper.h
+++ b/lib/al/Library/Audio/IUseAudioKeeper.h
@@ -7,4 +7,6 @@ class IUseAudioKeeper {
 public:
     virtual AudioKeeper* getAudioKeeper() const = 0;
 };
+
+void notifyDemoSkipToDemoSyncedProc(const IUseAudioKeeper* user);
 }  // namespace al

--- a/lib/al/Library/Event/BalloonOrderGroupHolder.h
+++ b/lib/al/Library/Event/BalloonOrderGroupHolder.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class BalloonOrderGroup;
+class PlacementInfo;
+
+class BalloonOrderGroupHolder {
+public:
+    BalloonOrderGroupHolder();
+
+    BalloonOrderGroup* tryFindGroup(const PlacementInfo& placementInfo) const;
+    void registerGroup(BalloonOrderGroup* group);
+    void updateAll(const sead::Vector3f& position);
+    void resetInsideTerritoryAll();
+
+private:
+    s32 mGroupCount;
+    BalloonOrderGroup** mGroups;
+};
+
+static_assert(sizeof(BalloonOrderGroupHolder) == 0x10);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowChart.h
+++ b/lib/al/Library/Event/EventFlowChart.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class EventFlowChartInitInfo;
+class EventFlowNode;
+
+class EventFlowChart {
+public:
+    EventFlowChart();
+
+    void init(const EventFlowChartInitInfo& info);
+    void initAfterPlacement();
+    EventFlowNode* findEntryNode(const char* entryName) const;
+    EventFlowNode* findNodeById(s32 id) const;
+    bool isExistEntry(const char* entryName) const;
+
+private:
+    s32 mNodeNum;
+    EventFlowNode** mNodes;
+    void* mEntryNodeTable;
+};
+
+static_assert(sizeof(EventFlowChart) == 0x18);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowChartInitInfo.h
+++ b/lib/al/Library/Event/EventFlowChartInitInfo.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "Library/Placement/PlacementId.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowDataHolder;
+class EventFlowNodeFactory;
+class LiveActor;
+class MessageSystem;
+class SceneEventFlowMsg;
+
+class EventFlowChartInitInfo {
+public:
+    EventFlowChartInitInfo(LiveActor* actor, EventFlowDataHolder* dataHolder,
+                           const ActorInitInfo& actorInitInfo, const char* eventFileName,
+                           const char* eventObjName, const char* eventFlowName,
+                           const EventFlowNodeFactory& nodeFactory, SceneEventFlowMsg* sceneMsg,
+                           const char* stageName);
+
+private:
+    LiveActor* mActor;
+    EventFlowDataHolder* mDataHolder;
+    const ActorInitInfo* mActorInitInfo;
+    const char* mEventFileName;
+    const char* mEventObjName;
+    const char* mEventFlowName;
+    PlacementId mPlacementId;
+    const EventFlowNodeFactory* mNodeFactory;
+    SceneEventFlowMsg* mSceneMsg;
+    const MessageSystem* mMessageSystem;
+    const char* mStageName;
+};
+
+static_assert(sizeof(EventFlowChartInitInfo) == 0x70);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowChoiceInfo.h
+++ b/lib/al/Library/Event/EventFlowChoiceInfo.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class EventFlowChoiceInfo {
+public:
+    EventFlowChoiceInfo(s32 choiceNum);
+
+    void registerChoiceMessage(const char16* message);
+
+private:
+    s32 mSelectedIndex;
+    s32 mCancelIndex;
+    s32 mChoiceMessageNum;
+    s32 mChoiceMessageCapacity;
+    const char16** mChoiceMessages;
+    void* _18;
+    bool mIsEnableCancel;
+};
+
+static_assert(sizeof(EventFlowChoiceInfo) == 0x28);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowDataHolder.h
+++ b/lib/al/Library/Event/EventFlowDataHolder.h
@@ -5,13 +5,16 @@
 #include <prim/seadSafeString.h>
 
 namespace al {
-class CameraTicket;
-class LiveActor;
-class EventFlowEventData;
-class IUseCamera;
-class EventFlowRequestInfo;
-class EventFlowScareCtrlBase;
 class BalloonOrderGroup;
+class CameraTicket;
+class EventFlowEventData;
+class EventFlowScareCtrlBase;
+class IEventFlowActionNameConverter;
+class IEventFlowQueryJudge;
+class IUseCamera;
+class LiveActor;
+class MessageTagDataHolder;
+class EventFlowRequestInfo;
 
 class EventFlowDataHolder {
 public:
@@ -41,17 +44,59 @@ public:
     bool isEndInterpoleCamera(const IUseCamera*, const char*) const;
     bool isPlayingEventAnimCamera(const char*) const;
 
+    EventFlowRequestInfo* getRequestInfo() const { return mRequestInfo; }
+
+    void setEventFlowActorParam(const void* actorParam) { mEventFlowActorParam = actorParam; }
+
+    void setEventFlowActor(const LiveActor* actor) { mEventFlowActor = actor; }
+
+    void setEventQueryJudge(const IEventFlowQueryJudge* queryJudge) {
+        mEventQueryJudge = queryJudge;
+    }
+
+    void setEventActionNameConverter(const IEventFlowActionNameConverter* converter) {
+        mEventActionNameConverter = converter;
+    }
+
+    void setMessageTagDataHolder(const MessageTagDataHolder* messageTagDataHolder) {
+        mMessageTagDataHolder = messageTagDataHolder;
+    }
+
+    const MessageTagDataHolder* getMessageTagDataHolder() const { return mMessageTagDataHolder; }
+
+    void setBalloonOrderGroup(BalloonOrderGroup* group) { mBalloonOrderGroup = group; }
+
+    void swapCharacterName(const sead::WBufferedSafeString* name) { mSwappedCharacterName = name; }
+
+    void resetCharacterName() { mSwappedCharacterName = nullptr; }
+
+    const char* getTalkSubActorName() const { return mTalkSubActorName; }
+
+    s32 getItemTypeCount() const { return mItemTypeCount; }
+
+    const char* getItemType(s64 index) const { return mItemTypes[index]; }
+
 private:
     EventFlowRequestInfo* mRequestInfo;
-    void* filler_8[10];
+    void* _8;
+    void* _10;
+    const void* mEventFlowActorParam;
+    const LiveActor* mEventFlowActor;
+    void* _28;
+    void* _30;
+    void* _38;
+    void* _40;
+    void* _48;
+    void* _50;
     void* _58;
-    void* filler_60[1];
+    void* _60;
     EventFlowScareCtrlBase* mScareCtrl;
-    void* _70;
-    void* filler_78[2];
+    const IEventFlowQueryJudge* mEventQueryJudge;
+    const IEventFlowActionNameConverter* mEventActionNameConverter;
+    const MessageTagDataHolder* mMessageTagDataHolder;
     BalloonOrderGroup* mBalloonOrderGroup;
     sead::WFixedSafeString<32> _90;
-    void* filler_e8[1];
+    const sead::WBufferedSafeString* mSwappedCharacterName;
     const char* mTalkSubActorName;
     s32 mItemTypeCapacity;
     s32 mItemTypeCount;
@@ -59,5 +104,4 @@ private:
 };
 
 static_assert(sizeof(EventFlowDataHolder) == 0x108);
-
 }  // namespace al

--- a/lib/al/Library/Event/EventFlowExecutor.h
+++ b/lib/al/Library/Event/EventFlowExecutor.h
@@ -31,6 +31,13 @@ public:
 
     LiveActor* getActor() const { return mActor; }
 
+    bool isEnd() const { return mName == nullptr || mEventFlowNode == nullptr; }
+
+    void clearCurrentNodeAndName() {
+        mEventFlowNode = nullptr;
+        mName = nullptr;
+    }
+
 private:
     LiveActor* mActor;
     EventFlowChart* mEventFlowChart;

--- a/lib/al/Library/Event/EventFlowExecutorHolder.h
+++ b/lib/al/Library/Event/EventFlowExecutorHolder.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class EventFlowExecutor;
+
+class EventFlowExecutorHolder {
+public:
+    EventFlowExecutorHolder(s32 capacity);
+
+    void registerExecutor(EventFlowExecutor* executor);
+    void initAfterPlacement();
+
+private:
+    s32 mCapacity;
+    s32 mCount;
+    EventFlowExecutor** mExecutors;
+};
+
+static_assert(sizeof(EventFlowExecutorHolder) == 0x10);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowMovement.h
+++ b/lib/al/Library/Event/EventFlowMovement.h
@@ -1,0 +1,110 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Event/IUseEventFlowData.h"
+#include "Library/Nerve/IUseNerve.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+class Nerve;
+
+class EventFlowMovement : public IUseEventFlowData, public IUseNerve {
+public:
+    EventFlowMovement(const char* name, LiveActor* actor);
+
+    EventFlowDataHolder* getEventFlowDataHolder() const override;
+
+    virtual void init(const ActorInitInfo& info) {}
+
+    virtual void appear();
+    virtual void kill();
+    virtual void control();
+    NerveKeeper* getNerveKeeper() const override;
+    virtual bool isTurnMovement() const;
+    virtual bool isWaitAtPointMovement() const;
+
+    void movement();
+    void initNerve(const Nerve* nerve, s32 maxStates);
+
+    void setEventFlowDataHolder(EventFlowDataHolder* dataHolder) {
+        mEventFlowDataHolder = dataHolder;
+    }
+
+private:
+    const char* mName;
+    LiveActor* mActor;
+    NerveKeeper* mNerveKeeper;
+    EventFlowDataHolder* mEventFlowDataHolder;
+};
+
+class EventFlowMovementRail : public EventFlowMovement {
+public:
+    EventFlowMovementRail(LiveActor* actor);
+
+    void init(const ActorInitInfo& info) override;
+    void appear() override;
+    void exeMove();
+};
+
+class EventFlowMovementTurnSeparate : public EventFlowMovement {
+public:
+    EventFlowMovementTurnSeparate(LiveActor* actor);
+
+    void init(const ActorInitInfo& info) override;
+    void appear() override;
+    void exeWaitFar();
+    void exeWaitNear();
+    void exeTurn();
+    bool isTurnMovement() const override;
+    bool isWaitAtPointMovement() const override;
+
+private:
+    void* _30 = nullptr;
+    void* _38 = nullptr;
+    void* _40 = nullptr;
+    void* _48 = nullptr;
+    void* _50 = nullptr;
+    s32 _58 = 0;
+};
+
+class EventFlowMovementWait : public EventFlowMovement {
+public:
+    EventFlowMovementWait(LiveActor* actor);
+
+    void appear() override;
+    bool isWaitAtPointMovement() const override;
+
+private:
+    bool _30 = true;
+};
+
+class EventFlowMovementWander : public EventFlowMovement {
+public:
+    EventFlowMovementWander(LiveActor* actor);
+
+    void init(const ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+    void exeWait();
+    void exeTurnOneTime();
+    void exeTurnLoop();
+    void exeWalk();
+
+private:
+    void* _30 = nullptr;
+    void* _38 = nullptr;
+    void* _40 = nullptr;
+    void* _48 = nullptr;
+    void* _50 = nullptr;
+    void* _58 = nullptr;
+    f32 _60 = 500.0f;
+};
+
+static_assert(sizeof(EventFlowMovement) == 0x30);
+static_assert(sizeof(EventFlowMovementRail) == 0x30);
+static_assert(sizeof(EventFlowMovementTurnSeparate) == 0x60);
+static_assert(sizeof(EventFlowMovementWait) == 0x38);
+static_assert(sizeof(EventFlowMovementWander) == 0x68);
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowUtil.h
+++ b/lib/al/Library/Event/EventFlowUtil.h
@@ -16,9 +16,41 @@ class EventFlowRequestInfo {
 public:
     EventFlowRequestInfo();
     void reset();
-    void requestDemoAction(const char*);
-    void requestDemoCamera(const char*);
+    void requestDemoAction(const char* actionName);
+    void requestDemoCamera(const char* cameraName);
+
+    const char* getRequestedDemoPlayerActionName() const { return mDemoPlayerActionName; }
+
+    void clearRequestedDemoPlayerActionName() { mDemoPlayerActionName = nullptr; }
+
+    bool isDemoPlayerHidden() const { return mIsDemoPlayerHidden; }
+
+    void setDemoPlayerHidden(bool isHidden) { mIsDemoPlayerHidden = isHidden; }
+
+    bool isRequestHideDemoPlayer() const { return mIsRequestHideDemoPlayer; }
+
+    void resetRequestHideDemoPlayer() { mIsRequestHideDemoPlayer = false; }
+
+    bool isRequestShowDemoPlayer() const { return mIsRequestShowDemoPlayer; }
+
+    void resetRequestShowDemoPlayer() { mIsRequestShowDemoPlayer = false; }
+
+private:
+    bool _0 = false;
+    bool _1 = false;
+    char _2[6] = {};
+    const char* mDemoActionName = nullptr;
+    const char* _10 = nullptr;
+    const char* mDemoPlayerActionName = nullptr;
+    const char* mDemoCameraName = nullptr;
+    void* _28 = nullptr;
+    bool mIsDemoPlayerHidden = false;
+    bool mIsRequestHideDemoPlayer = false;
+    bool mIsRequestShowDemoPlayer = false;
+    char _33[5] = {};
 };
+
+static_assert(sizeof(EventFlowRequestInfo) == 0x38);
 
 bool isNodeName(const EventFlowNode*, const char*);
 const char16* getScareMessage(const EventFlowNode*);
@@ -90,7 +122,7 @@ bool isExistEventEntry(const EventFlowExecutor*, const char*);
 bool isCurrentEventEntry(const EventFlowExecutor*, const char*);
 bool isEventName(const EventFlowEventData*, const char*, ...);
 const char* getEventName(const EventFlowEventData*);
-bool getEventDataParamString(const EventFlowEventData*, const char*);
+const char* getEventDataParamString(const EventFlowEventData*, const char*);
 bool isEventDataParamBool(const EventFlowEventData*, const char*);
 }  // namespace al
 

--- a/lib/al/Library/Event/EventFlowWatchParam.h
+++ b/lib/al/Library/Event/EventFlowWatchParam.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class ByamlIter;
+class HitSensor;
+class LiveActor;
+
+class EventFlowWatchParam {
+public:
+    EventFlowWatchParam();
+
+    void load(const ByamlIter& iter);
+    bool isWatchSensor(const HitSensor* sensor) const;
+    void calcWatchTrans(sead::Vector3f* out, const LiveActor* actor) const;
+};
+}  // namespace al

--- a/lib/al/Library/Event/IEventFlowActionNameConverter.h
+++ b/lib/al/Library/Event/IEventFlowActionNameConverter.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <prim/seadSafeString.h>
+
+namespace al {
+class IEventFlowActionNameConverter {
+public:
+    virtual void convertActionName(sead::BufferedSafeString* out, const char* actionName) const = 0;
+};
+}  // namespace al

--- a/lib/al/Library/Event/IEventFlowQueryJudge.h
+++ b/lib/al/Library/Event/IEventFlowQueryJudge.h
@@ -1,0 +1,8 @@
+#pragma once
+
+namespace al {
+class IEventFlowQueryJudge {
+public:
+    virtual const char* judgeQuery(const char* queryName) const = 0;
+};
+}  // namespace al

--- a/lib/al/Library/Play/Camera/CameraPoserLookBoard.h
+++ b/lib/al/Library/Play/Camera/CameraPoserLookBoard.h
@@ -12,8 +12,12 @@ public:
     void loadParam(const ByamlIter& iter) override;
     void start(const CameraStartInfo& info) override;
 
+    void setLookAtOffset(const sead::Vector3f& offset) { mLookAtOffset = offset; }
+
 private:
-    s8 filler[0x150 - sizeof(CameraPoser)];
+    s8 filler[0x140 - sizeof(CameraPoser)];
+    sead::Vector3f mLookAtOffset;
+    s32 _14c = 0;
 };
 
 }  // namespace al

--- a/src/Event/CostumePatternChecker.h
+++ b/src/Event/CostumePatternChecker.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class CostumePatternChecker {
+public:
+    CostumePatternChecker();
+
+    u32 checkMatchCostume(bool* isCapMatch, bool* isClothMatch, const char* currentCap,
+                          const char* currentCloth, const char* pattern) const;
+    void* tryFindPattern(const char* pattern) const;
+    bool checkMatchCostumePair(const char* currentCap, const char* currentCloth,
+                               const char* pattern) const;
+
+private:
+    void* mPatterns;
+    s32 mPatternNum;
+};
+
+static_assert(sizeof(CostumePatternChecker) == 0x10);

--- a/src/Event/EventDemoCtrl.h
+++ b/src/Event/EventDemoCtrl.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+namespace al {
+class LiveActor;
+}
+
+class EventDemoCtrl : public al::ISceneObj {
+public:
+    EventDemoCtrl();
+
+    bool isSuccessLockTalkDemo(const al::LiveActor* actor);
+    bool tryLockStartTalkDemo(al::LiveActor* actor);
+    bool tryLockStartTalkDemoWithoutBalloon(al::LiveActor* actor);
+    bool tryStartTalkDemo(al::LiveActor* actor);
+    bool tryStartTalkOnlyRequesterDemo(al::LiveActor* actor);
+    bool tryStartTalkKeepHackDemo(al::LiveActor* actor);
+    bool tryStartTalkUseCoinDemo(al::LiveActor* actor);
+    bool tryStartNormalDemo(al::LiveActor* actor);
+    bool tryStartKeepBindDemo(al::LiveActor* actor);
+    bool tryStartCutSceneDemo(al::LiveActor* actor);
+    bool tryStartCutSceneKeepHackDemo(al::LiveActor* actor);
+    bool tryStartCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor);
+    void requestEndDemo(al::LiveActor* actor);
+    void endCutSceneDemo(al::LiveActor* actor);
+    void endCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor);
+    void endCutSceneDemoBySkip(al::LiveActor* actor);
+    bool isActiveDemo() const;
+    bool isActiveDemoWithPlayer() const;
+    bool isRequestEndDemo() const;
+    al::LiveActor* getDemoStartActor() const;
+    void endDemo();
+    bool isDemoStartActor(const al::LiveActor* actor) const;
+    void notifyStartDemoSkipFromScene();
+    bool isDemoSkipStart() const;
+    const char* getSceneObjName() const override;
+
+private:
+    void* mInfo;
+};
+
+static_assert(sizeof(EventDemoCtrl) == 0x10);

--- a/src/Event/EventFlowScareCtrl.h
+++ b/src/Event/EventFlowScareCtrl.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Event/IUseEventFlowData.h"
+#include "Library/Nerve/IUseNerve.h"
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowDataHolder;
+class HitSensor;
+
+class EventFlowScareCtrlBase {
+public:
+    virtual bool isScare() const = 0;
+    virtual bool tryGetScareEnemyPos(sead::Vector3f* out) const = 0;
+    virtual const char16* getScareMessage() const = 0;
+    virtual void update() = 0;
+    virtual void attackSensor(HitSensor* self, HitSensor* other) = 0;
+};
+class LiveActor;
+}  // namespace al
+
+class EventFlowScareCtrl : public al::EventFlowScareCtrlBase,
+                           public al::IUseEventFlowData,
+                           public al::IUseNerve {
+public:
+    EventFlowScareCtrl();
+
+    void init(al::LiveActor* actor, const al::ActorInitInfo& info,
+              al::EventFlowDataHolder* dataHolder, const char* eventName);
+
+    bool isScare() const override;
+    bool tryGetScareEnemyPos(sead::Vector3f* out) const override;
+    const char16* getScareMessage() const override;
+    void update() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    al::EventFlowDataHolder* getEventFlowDataHolder() const override;
+    al::NerveKeeper* getNerveKeeper() const override;
+
+    void exeWait();
+    void exeScare();
+    void exeScareAfter();
+
+    void disableRunAway() { mIsInvalidRunAway = true; }
+
+private:
+    al::LiveActor* mActor = nullptr;
+    al::NerveKeeper* mNerveKeeper = nullptr;
+    al::EventFlowDataHolder* mEventFlowDataHolder = nullptr;
+    void* mScareAreaGroup = nullptr;
+    s32 mHackType = -1;
+    bool _3c = false;
+    void* _40 = nullptr;
+    void* _48 = nullptr;
+    bool _50 = false;
+    char _51[0x3] = {};
+    void* _54 = nullptr;
+    bool mIsInvalidRunAway = false;
+    char _61[0x7] = {};
+};
+
+static_assert(sizeof(EventFlowScareCtrl) == 0x68);

--- a/src/Event/EventFlowSceneExecuteCtrl.h
+++ b/src/Event/EventFlowSceneExecuteCtrl.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+class Scene;
+}  // namespace al
+class Shine;
+
+class EventFlowSceneExecuteCtrl : public al::NerveExecutor {
+public:
+    EventFlowSceneExecuteCtrl();
+
+    void requestEventGetShineDirect(const al::LiveActor* actor, Shine* shine);
+    void requestEventOpenBgmList(const al::LiveActor* actor);
+    void requestEventOpenShineList(const al::LiveActor* actor);
+    void requestEventGetAchievement(const al::LiveActor* actor, const char* achievementName);
+    bool isExistRequestGetShineDirect() const;
+    bool isExistRequestOpenBgmList() const;
+    bool isExistRequestOpenShineList() const;
+    bool isExistRequestGetAchievement() const;
+    Shine* getShine() const;
+    const char* getAchievementName() const;
+    void startSceneExecute(const al::Scene* scene);
+    void endSceneExecute(const al::Scene* scene);
+    bool isExecuteScene() const;
+    bool checkEndSceneExecuteAndReset(const al::LiveActor* actor);
+
+private:
+    void* mRequestActor = nullptr;
+    void* mRequestArg = nullptr;
+};
+
+static_assert(sizeof(EventFlowSceneExecuteCtrl) == 0x20);

--- a/src/Npc/NpcEventBalloonInfo.h
+++ b/src/Npc/NpcEventBalloonInfo.h
@@ -1,0 +1,86 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+#include <prim/seadSafeString.h>
+
+namespace al {
+class IUseMessageSystem;
+class LiveActor;
+class MessageTagDataHolder;
+}  // namespace al
+
+struct NpcEventBalloonRequestInfo {
+    s32 priority = 0;
+    sead::Vector3f localOffset = sead::Vector3f::zero;
+    f32 scale = 1.0f;
+    f32 collisionCheckOffsetRadius = 0.0f;
+    bool isInvalidUiCollisionCheck = false;
+};
+
+class NpcEventBalloonInfo {
+public:
+    NpcEventBalloonInfo();
+
+    void setupForMessageBalloon(const al::LiveActor* actor, const char16* message,
+                                const al::MessageTagDataHolder* tagDataHolder);
+    void reset();
+    void setupForEmotionIconBalloon(const al::LiveActor* actor, const char* iconName);
+    void setupForTalkIconBalloon(const al::LiveActor* actor, const char* iconName,
+                                 bool isEnableButtonA);
+    void setCommonParam(const NpcEventBalloonRequestInfo& requestInfo);
+
+    void setInvalidUiCollisionCheck() { mIsInvalidUiCollisionCheck = true; }
+
+    void setEntranceCamera() { mIsEntranceCamera = true; }
+
+    void makeTextW(sead::WBufferedSafeString* out,
+                   const al::IUseMessageSystem* messageSystem) const;
+    bool isTypeMessage() const;
+    bool isTypeEmotionIcon() const;
+    bool isTypeTalkIcon() const;
+
+private:
+    const al::LiveActor* mActor;
+    const char16* mMessage;
+    s32 mType;
+    const char* mIconName;
+    sead::Vector3f mLocalOffset;
+    f32 mScale;
+    f32 mCollisionCheckOffsetRadius;
+    s32 mPriority;
+    bool mIsInvalidUiCollisionCheck;
+    void* _40;
+    bool mIsEnableButtonA;
+    bool mIsEntranceCamera;
+};
+
+class NpcEventTalkInfo {
+public:
+    NpcEventTalkInfo();
+    NpcEventTalkInfo(const al::LiveActor* actor, const char16* message,
+                     const al::MessageTagDataHolder* tagDataHolder);
+
+    void reset();
+
+    void setEnableButtonA() { mIsEnableButtonA = true; }
+
+    void setSystemMessage(s32 style) {
+        mIsSystemMessage = true;
+        mMessageStyle = style;
+    }
+
+private:
+    const char16* mMessage;
+    void* _8;
+    const al::MessageTagDataHolder* mTagDataHolder;
+    const al::LiveActor* mActor;
+    bool mIsEnableButtonA = false;
+    bool mIsSystemMessage = false;
+    char _22[2] = {};
+    s32 mMessageStyle = -1;
+};
+
+static_assert(sizeof(NpcEventBalloonRequestInfo) == 0x1c);
+static_assert(sizeof(NpcEventBalloonInfo) == 0x50);
+static_assert(sizeof(NpcEventTalkInfo) == 0x28);

--- a/src/Npc/NpcEventCtrlInfo.h
+++ b/src/Npc/NpcEventCtrlInfo.h
@@ -1,0 +1,195 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+namespace al {
+class BalloonOrderGroupHolder;
+class EventFlowChoiceInfo;
+class EventFlowExecutorHolder;
+class EventFlowNode;
+class LiveActor;
+class SceneEventFlowMsg;
+}  // namespace al
+class CostumePatternChecker;
+class EventFlowSceneExecuteCtrl;
+class NpcEventBalloonInfo;
+class NpcEventSceneConstData;
+class NpcEventTalkInfo;
+
+class NpcEventSceneInfo {
+public:
+    const al::LiveActor* getBalloonActor() const { return mBalloonActor; }
+
+    bool isPlayingBalloonMessageVoice() const { return mIsPlayingBalloonMessageVoice; }
+
+    bool isOpenWaitTalkMessage() const { return mIsOpenWaitTalkMessage; }
+
+    bool isPlayingTextPaneAnim() const { return !mIsEndTextPaneAnim; }
+
+    bool isTalkMessageClosed() const { return mTalkMessageInfo->isClosed(); }
+
+    bool isCloseWipeFadeBlack() const { return mWipeFadeBlackState == 1; }
+
+    bool isOpenWipeFadeBlack() const { return mWipeFadeBlackState == -1; }
+
+    bool isExistNpcLookPos() const { return mIsExistNpcLookPos; }
+
+    const sead::Vector3f& getNpcLookPos() const { return mNpcLookPos; }
+
+    bool isPlayerInWater() const { return mIsPlayerInWater == 1; }
+
+private:
+    struct TalkMessageInfo {
+        bool isClosed() const { return message == nullptr; }
+
+        const char16* message = nullptr;
+    };
+
+    const al::LiveActor* mBalloonActor = nullptr;
+    TalkMessageInfo* mTalkMessageInfo = nullptr;
+    bool mIsPlayingBalloonMessageVoice = false;
+    bool mIsOpenWaitTalkMessage = false;
+    bool _12 = false;
+    bool mIsEndTextPaneAnim = false;
+    bool mIsExistNpcLookPos = false;
+    char _15[0x3] = {};
+    s32 mWipeFadeBlackState = 0;
+    sead::Vector3f mNpcLookPos = sead::Vector3f::zero;
+    char _28[0xc] = {};
+    s32 mIsPlayerInWater = 0;
+};
+
+class NpcEventMessageStyleInfo {
+public:
+    virtual void clear();
+    virtual void copy(const NpcEventMessageStyleInfo&);
+    virtual void _10();
+    virtual void update();
+
+    s64 getStyle() const { return mStyle; }
+
+private:
+    s64 mStyle = 0;
+};
+
+class NpcEventSceneConstData {
+public:
+    s64 getEventTalkWindowMessageStyle() const {
+        NpcEventMessageStyleInfo* info = &mMessageStyleInfo;
+        info->update();
+        return info->getStyle();
+    }
+
+private:
+    char _0[0x38] = {};
+    mutable NpcEventMessageStyleInfo mMessageStyleInfo;
+};
+
+class NpcEventCtrlInfo : public al::ISceneObj {
+public:
+    NpcEventCtrlInfo(const NpcEventSceneInfo& sceneInfo, const NpcEventSceneConstData& constData,
+                     EventFlowSceneExecuteCtrl* sceneExecuteCtrl);
+
+    bool isCloseTalk() const;
+    void popBalloonInfo(NpcEventBalloonInfo* info);
+    void popTalkInfo(NpcEventTalkInfo* info);
+    void requestShowBalloonMessage(const NpcEventBalloonInfo& info);
+    void requestShowTalkMessage(const al::EventFlowNode* node, const NpcEventTalkInfo& info);
+    void requestCloseTalkMessage(const al::LiveActor* actor);
+    void requestCloseWipeFadeBlack(al::EventFlowNode* node, s32 step);
+    void requestOpenWipeFadeBlack(al::EventFlowNode* node, s32 step);
+    void setBalloonFilterOnlyMiniGame(const al::LiveActor* actor);
+    void resetBalloonFilter(const al::LiveActor* actor);
+    void startChoice(const al::EventFlowNode* node, al::EventFlowChoiceInfo* choiceInfo);
+    s32 getChoiceMessageNum() const;
+    const char16* getChoiceMessage(s32 index) const;
+    s32 getChoiceCancelIndex() const;
+    const char16* tryGetChoiceTalkMessage() const;
+    void endChoice(s32 index);
+    bool isEnableCancelChoice() const;
+    const char* getSceneObjName() const override;
+
+    const al::LiveActor* getCurrentBalloonActor() const { return mBalloonActor; }
+
+    al::SceneEventFlowMsg* getSceneEventFlowMsg() const { return mSceneEventFlowMsg; }
+
+    al::EventFlowExecutorHolder* getEventFlowExecutorHolder() const {
+        return mEventFlowExecutorHolder;
+    }
+
+    al::BalloonOrderGroupHolder* getBalloonOrderGroupHolder() const {
+        return mBalloonOrderGroupHolder;
+    }
+
+    CostumePatternChecker* getCostumePatternChecker() const { return mCostumePatternChecker; }
+
+    EventFlowSceneExecuteCtrl* getSceneExecuteCtrl() const { return mSceneExecuteCtrl; }
+
+    bool isSuccessBalloonMessage(const al::LiveActor* actor) const {
+        return mSceneInfo->getBalloonActor() == actor;
+    }
+
+    bool isPlayingBalloonMessageVoice() const { return mSceneInfo->isPlayingBalloonMessageVoice(); }
+
+    bool isOpenWaitTalkMessage() const { return mSceneInfo->isOpenWaitTalkMessage(); }
+
+    bool isPlayingTextPaneAnim() const { return mSceneInfo->isPlayingTextPaneAnim(); }
+
+    bool isCloseWipeFadeBlack() const { return mSceneInfo->isCloseWipeFadeBlack(); }
+
+    bool isOpenWipeFadeBlack() const { return mSceneInfo->isOpenWipeFadeBlack(); }
+
+    bool isTalkMessageClosed() const { return mSceneInfo->isTalkMessageClosed(); }
+
+    bool isTalkMessageRequestEnd() const { return _90 == nullptr; }
+
+    bool isEndTalkMessage() const { return isTalkMessageClosed() && isTalkMessageRequestEnd(); }
+
+    s64 getEventTalkWindowMessageStyle() const {
+        return mSceneConstData->getEventTalkWindowMessageStyle();
+    }
+
+    bool isExistNpcLookPos() const { return mSceneInfo->isExistNpcLookPos(); }
+
+    const sead::Vector3f& getNpcLookPos() const { return mSceneInfo->getNpcLookPos(); }
+
+    bool isPlayerInWater() const { return mSceneInfo->isPlayerInWater(); }
+
+private:
+    const NpcEventSceneInfo* mSceneInfo;
+    const NpcEventSceneConstData* mSceneConstData;
+    al::SceneEventFlowMsg* mSceneEventFlowMsg;
+    EventFlowSceneExecuteCtrl* mSceneExecuteCtrl;
+    al::EventFlowExecutorHolder* mEventFlowExecutorHolder;
+    al::BalloonOrderGroupHolder* mBalloonOrderGroupHolder;
+    void* _38 = nullptr;
+    void* _40 = nullptr;
+    s32 _48 = -1;
+    void* _50 = nullptr;
+    void* _58 = nullptr;
+    s32 _60 = 0;
+    f32 _64 = 1.0f;
+    s32 _68 = 0;
+    s32 _6c = -1;
+    bool _70 = false;
+    char _71[0x7] = {};
+    void* _78 = nullptr;
+    char16 _80[4] = {};
+    const al::LiveActor* mBalloonActor = nullptr;
+    void* _90 = nullptr;
+    void* _98 = nullptr;
+    void* _a0 = nullptr;
+    void* _a8 = nullptr;
+    s32 _b0 = 0;
+    s32 _b4 = -1;
+    void* _b8 = nullptr;
+    CostumePatternChecker* mCostumePatternChecker = nullptr;
+    char16 _c8[2] = {};
+    s32 _cc = -1;
+    s32 _d0 = -1;
+};
+
+static_assert(sizeof(NpcEventCtrlInfo) == 0xd8);

--- a/src/Npc/TalkNpcActionAnimInfo.h
+++ b/src/Npc/TalkNpcActionAnimInfo.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Event/IEventFlowActionNameConverter.h"
+#include "Library/HostIO/HioNode.h"
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+class TalkNpcParam;
+
+class TalkNpcActionAnimInfo : public al::HioNode, public al::IEventFlowActionNameConverter {
+public:
+    TalkNpcActionAnimInfo();
+
+    const char* getArgWaitActionName(const al::ActorInitInfo& info);
+    void initWaitActionNameFromPlacementInfo(const al::LiveActor* actor,
+                                             const al::ActorInitInfo& info, bool isHack);
+    void initWaitActionNameDirect(const al::LiveActor* actor, const char* actionName, bool isHack);
+    void init(const al::LiveActor* actor, const al::ActorInitInfo& info, const TalkNpcParam* param,
+              const char* suffix);
+    const char* getWaitActionName() const;
+    const char* tryGetActorParamSuffix() const;
+    bool tryApplyVisAnim(al::LiveActor* actor) const;
+    void convertActionName(sead::BufferedSafeString* out, const char* actionName) const override;
+    void changeWaitActionName(const char* actionName, const TalkNpcParam* param);
+    void changeHackWaitActionName(const char* actionName, const TalkNpcParam* param);
+    void onHackWaitActionName(const TalkNpcParam* param);
+    void offHackWaitActionName(const TalkNpcParam* param);
+    void changeWaitActionNameBySwitch(const char* actionName, const TalkNpcParam* param);
+    void resetWaitActionNameBySwitch(const TalkNpcParam* param);
+    bool isSelectedInitWaitAction() const;
+    const char* getAnyRandomActionName() const;
+
+private:
+    void* _8 = nullptr;
+    void* _10 = nullptr;
+    void* _18 = nullptr;
+    void* _20 = nullptr;
+    const char* mDefaultActionName = "Surprise";
+    bool _30 = false;
+    char _31[0x7] = {};
+    void* _38 = nullptr;
+    void* _40 = nullptr;
+    void* _48 = nullptr;
+    s32 _50 = 0;
+    void* _58 = nullptr;
+    u16 _60 = 0x101;
+};
+
+static_assert(sizeof(TalkNpcActionAnimInfo) == 0x68);

--- a/src/Npc/TalkNpcParam.h
+++ b/src/Npc/TalkNpcParam.h
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct ActorInitInfo;
+class EventFlowWatchParam;
+class HitSensor;
+class IUseNerve;
+class LiveActor;
+}  // namespace al
+
+class TalkNpcParam {
+public:
+    TalkNpcParam();
+
+    void init(const al::LiveActor* actor, const char* suffix);
+    bool isEqualModelName(const al::LiveActor* actor) const;
+    bool isEqualSuffixName(const char* suffix) const;
+    void* createAndAppendJointLookAtController(al::LiveActor* actor) const;
+    void* createJointGroundSmoothController(al::LiveActor* actor) const;
+    bool applyMaterialAnimPreset(al::LiveActor* actor, const char* suffix) const;
+    const void* getEventFlowActorParam() const;
+    const void* findEventFlowActorSuffixParam(const char* suffix) const;
+    bool tryInitPartialSklAnim(al::LiveActor* actor) const;
+    bool isValidFacialAnim() const;
+    void updateFacialAnim(al::LiveActor* actor) const;
+    const char* tryGetByeByeBaseJointName(const al::LiveActor* actor) const;
+    void getByeByeLocalAxisFront(sead::Vector3f* out) const;
+    void calcBirdGlideMtx(sead::Matrix34f* out, const al::LiveActor* actor) const;
+    bool isInvalidJointLookSklAnim(const char* animName) const;
+    bool isInvalidChangeAllAnimFromWait(const char* animName) const;
+    bool isInvalidChangeTurnAnimFromWait(const char* animName) const;
+    bool isPlayerWatchDisregard(const al::HitSensor* sensor) const;
+    void calcPlayerWatchTrans(sead::Vector3f* out, const al::LiveActor* actor) const;
+    bool isInvalidTrampleSensor(const al::HitSensor* sensor) const;
+    bool isEnableReactionRestartEvent(const al::IUseNerve* user) const;
+    void manualInitLookAtJoint(const char* jointName, const char* baseJointName,
+                               const al::LiveActor* actor, const char* suffix);
+
+    const al::LiveActor* getActor() const { return mActor; }
+
+    const al::LiveActor* getEventFlowActor() const {
+        return static_cast<const al::LiveActor*>(mEventFlowActor);
+    }
+
+    const al::EventFlowWatchParam* getEventFlowWatchParam() const {
+        return static_cast<const al::EventFlowWatchParam*>(mEventFlowActor);
+    }
+
+private:
+    const al::LiveActor* mActor = nullptr;
+    const char* mModelName = nullptr;
+    const char* mSuffixName = nullptr;
+    const void* mEventFlowActor = nullptr;
+    void* _20 = nullptr;
+    s32 _28 = 0;
+    s32 _2c = -1;
+    void* _30 = nullptr;
+    void* _38 = nullptr;
+    void* _40 = nullptr;
+    s32 _48 = 0;
+    void* _50 = nullptr;
+    void* _58 = nullptr;
+    void* _60 = nullptr;
+    s32 _68 = 0;
+    void* _70 = nullptr;
+    void* _78 = nullptr;
+    void* _80 = nullptr;
+};
+
+static_assert(sizeof(TalkNpcParam) == 0x88);

--- a/src/Npc/TalkNpcSceneEventSwitcher.h
+++ b/src/Npc/TalkNpcSceneEventSwitcher.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+class TalkNpcSceneEventSwitcher : public al::HioNode, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_TalkNpcSceneEventSwitcher;
+
+    TalkNpcSceneEventSwitcher();
+
+    const char* getSceneObjName() const override;
+
+    void requestAfterDoorSnow(s32 eventId) { mAfterDoorSnowEventId = eventId; }
+
+    void requestVolleyBall(const char* entryName) { mVolleyBallEntryName = entryName; }
+
+    void requestJumpingRope(const char* entryName) { mJumpingRopeEntryName = entryName; }
+
+    void requestRadicon(const char* entryName) { mRadiconEntryName = entryName; }
+
+    s32 getAfterDoorSnowEventId() const { return mAfterDoorSnowEventId; }
+
+    const char* getVolleyBallEntryName() const { return mVolleyBallEntryName; }
+
+    const char* getJumpingRopeEntryName() const { return mJumpingRopeEntryName; }
+
+    const char* getRadiconEntryName() const { return mRadiconEntryName; }
+
+private:
+    s32 mAfterDoorSnowEventId = 0;
+    s32 _c = 0;
+    const char* mVolleyBallEntryName = nullptr;
+    const char* mJumpingRopeEntryName = nullptr;
+    const char* mRadiconEntryName = nullptr;
+};
+
+static_assert(sizeof(TalkNpcSceneEventSwitcher) == 0x28);

--- a/src/Util/NpcEventFlowUtil.cpp
+++ b/src/Util/NpcEventFlowUtil.cpp
@@ -1,16 +1,399 @@
 #include "Util/NpcEventFlowUtil.h"
 
+#include "Library/Area/TrafficAreaDirector.h"
+#include "Library/Audio/IUseAudioKeeper.h"
 #include "Library/Base/StringUtil.h"
 #include "Library/Camera/CameraPoser.h"
 #include "Library/Camera/CameraPoserFix.h"
 #include "Library/Camera/CameraPoserFunction.h"
 #include "Library/Camera/CameraTicket.h"
 #include "Library/Camera/CameraUtil.h"
+#include "Library/Event/BalloonOrderGroup.h"
+#include "Library/Event/BalloonOrderGroupHolder.h"
+#include "Library/Event/EventFlowChart.h"
+#include "Library/Event/EventFlowChartInitInfo.h"
+#include "Library/Event/EventFlowChoiceInfo.h"
 #include "Library/Event/EventFlowDataHolder.h"
 #include "Library/Event/EventFlowExecutor.h"
+#include "Library/Event/EventFlowExecutorHolder.h"
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/Event/EventFlowMovement.h"
+#include "Library/Event/EventFlowNode.h"
+#include "Library/Event/EventFlowUtil.h"
+#include "Library/Event/EventFlowWatchParam.h"
+#include "Library/Item/ItemUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
 #include "Library/LiveActor/LiveActor.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Message/IUseMessageSystem.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Play/Camera/CameraPoserLookBoard.h"
+#include "Library/Play/Camera/CameraPoserTalk.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Event/CostumePatternChecker.h"
+#include "Event/EventDemoCtrl.h"
+#include "Event/EventFlowScareCtrl.h"
+#include "Event/EventFlowSceneExecuteCtrl.h"
+#include "Npc/NpcEventBalloonInfo.h"
+#include "Npc/NpcEventCtrlInfo.h"
+#include "Npc/TalkNpcActionAnimInfo.h"
+#include "Npc/TalkNpcParam.h"
+#include "Npc/TalkNpcSceneEventSwitcher.h"
+#include "Scene/ProjectEventFlowNodeFactory.h"
+#include "Scene/SceneObjFactory.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "Util/DemoUtil.h"
+#include "Util/PlayerDemoUtil.h"
+#include "Util/PlayerUtil.h"
+#include "Util/StageInputFunction.h"
+
+namespace {
+
+static const sead::Vector3f CameraOffsetZero = {0.0f, 0.0f, 0.0f};
+
+class MessageSystemAccessor : public al::IUseMessageSystem {
+public:
+    MessageSystemAccessor() {}
+
+    const al::MessageSystem* getMessageSystem() const override;
+
+    void setMessageSystem(const al::MessageSystem* messageSystem) {
+        mMessageSystem = messageSystem;
+    }
+
+private:
+    const al::MessageSystem* mMessageSystem;
+};
+
+const al::IUseSceneObjHolder* getSceneObjHolder(const al::LiveActor* actor) {
+    return actor;
+}
+
+al::IUseCamera* getCameraUser(al::LiveActor* actor) {
+    return actor;
+}
+
+const al::IUseAudioKeeper* getAudioUser(const al::LiveActor* actor) {
+    return actor;
+}
+
+NpcEventCtrlInfo* getNpcEventCtrlInfo(const al::LiveActor* actor) {
+    return static_cast<NpcEventCtrlInfo*>(
+        al::getSceneObj(getSceneObjHolder(actor), SceneObjID_NpcEventCtrlInfo));
+}
+
+NpcEventCtrlInfo* getNpcEventCtrlInfo(const al::EventFlowNode* node) {
+    return getNpcEventCtrlInfo(node->getActor());
+}
+
+EventDemoCtrl* getEventDemoCtrl(const al::LiveActor* actor) {
+    return static_cast<EventDemoCtrl*>(
+        al::getSceneObj(getSceneObjHolder(actor), SceneObjID_EventDemoCtrl));
+}
+
+EventDemoCtrl* getEventDemoCtrl(const al::EventFlowNode* node) {
+    return getEventDemoCtrl(node->getActor());
+}
+
+TalkNpcSceneEventSwitcher* getTalkNpcSceneEventSwitcher(const al::LiveActor* actor) {
+    return static_cast<TalkNpcSceneEventSwitcher*>(
+        al::getSceneObj(getSceneObjHolder(actor), SceneObjID_TalkNpcSceneEventSwitcher));
+}
+
+TalkNpcSceneEventSwitcher* getTalkNpcSceneEventSwitcher(const al::EventFlowNode* node) {
+    return getTalkNpcSceneEventSwitcher(node->getActor());
+}
+
+EventFlowSceneExecuteCtrl* getSceneExecuteCtrl(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->getSceneExecuteCtrl();
+}
+
+EventFlowSceneExecuteCtrl* getSceneExecuteCtrl(const al::EventFlowNode* node) {
+    return getSceneExecuteCtrl(node->getActor());
+}
+
+al::TrafficAreaDirector* tryGetTrafficAreaDirector(const al::LiveActor* actor) {
+    return static_cast<al::TrafficAreaDirector*>(
+        al::tryGetSceneObj(getSceneObjHolder(actor), SceneObjID_alTrafficAreaDirector));
+}
+
+void setInvalidUiCollisionCheckIfRequested(NpcEventBalloonInfo* balloonInfo,
+                                           const al::IUseEventFlowData* user) {
+    if (al::isInvalidUiCollisionCheck(user))
+        balloonInfo->setInvalidUiCollisionCheck();
+}
+
+void requestShowBalloonMessage(al::EventFlowNode* node, const NpcEventBalloonInfo& info) {
+    getNpcEventCtrlInfo(node)->requestShowBalloonMessage(info);
+}
+
+al::LiveActor* getTalkMessageActor(al::EventFlowNode* node) {
+    const char* subActorName = node->getEventFlowDataHolder()->getTalkSubActorName();
+    al::LiveActor* actor = node->getActor();
+    if (subActorName != nullptr)
+        return al::getSubActor(actor, node->getEventFlowDataHolder()->getTalkSubActorName());
+    return actor;
+}
+
+void startOpenTalkMessage(al::EventFlowNode* node, const char16* message, bool isEnableButtonA,
+                          bool isSystemMessage, s32 messageStyle) {
+    NpcEventTalkInfo info(getTalkMessageActor(node), message,
+                          node->getEventFlowDataHolder()->getMessageTagDataHolder());
+    if (isEnableButtonA)
+        info.setEnableButtonA();
+    if (isSystemMessage)
+        info.setSystemMessage(messageStyle);
+    getNpcEventCtrlInfo(node)->requestShowTalkMessage(node, info);
+}
+
+void initEventMovementCommon(al::EventFlowExecutor* executor, al::EventFlowMovement* movement,
+                             const al::ActorInitInfo& initInfo) {
+    movement->setEventFlowDataHolder(executor->getEventFlowDataHolder());
+    movement->init(initInfo);
+    executor->initMovement(movement);
+}
+
+al::EventFlowExecutor* initEventFlowImpl(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                         const char* eventFileName, const char* eventObjName,
+                                         const char* eventFlowName, bool isInitScareCtrl,
+                                         bool isEnableRunAway) {
+    const char* objectName = eventObjName;
+    if (objectName == nullptr)
+        al::getObjectName(&objectName, initInfo);
+    const char* flowName = eventFlowName == nullptr ? objectName : eventFlowName;
+
+    al::EventFlowDataHolder* dataHolder = new al::EventFlowDataHolder();
+    ProjectEventFlowNodeFactory nodeFactory;
+    const char* chartObjectName = objectName;
+    const al::IUseSceneObjHolder* sceneObjHolder = getSceneObjHolder(actor);
+    al::SceneEventFlowMsg* sceneMsg = getNpcEventCtrlInfo(actor)->getSceneEventFlowMsg();
+
+    al::EventFlowChartInitInfo chartInitInfo(
+        actor, dataHolder, initInfo, eventFileName, chartObjectName, flowName, nodeFactory,
+        sceneMsg, GameDataFunction::getCurrentStageName(GameDataHolderAccessor(sceneObjHolder)));
+    al::EventFlowChart* chart = new al::EventFlowChart();
+    chart->init(chartInitInfo);
+
+    al::EventFlowExecutor* executor = new al::EventFlowExecutor();
+    executor->init(actor, chart, dataHolder);
+
+    if (isInitScareCtrl) {
+        EventFlowScareCtrl* scareCtrl = new EventFlowScareCtrl();
+        scareCtrl->init(actor, initInfo, dataHolder, objectName);
+        executor->initScareCtrl(scareCtrl);
+        if (!isEnableRunAway)
+            scareCtrl->disableRunAway();
+    }
+
+    al::PlacementInfo placementInfo;
+    if (al::tryGetLinksInfo(&placementInfo, initInfo, "BalloonOrderGroup")) {
+        al::BalloonOrderGroup* group =
+            getNpcEventCtrlInfo(actor)->getBalloonOrderGroupHolder()->tryFindGroup(placementInfo);
+        if (group == nullptr) {
+            group = new al::BalloonOrderGroup(placementInfo);
+            getNpcEventCtrlInfo(actor)->getBalloonOrderGroupHolder()->registerGroup(group);
+        }
+        group->registerRequester(actor, executor, initInfo);
+        dataHolder->setBalloonOrderGroup(group);
+    }
+
+    getNpcEventCtrlInfo(actor)->getEventFlowExecutorHolder()->registerExecutor(executor);
+    return executor;
+}
+
+bool isFixCameraForNearestAt(al::CameraTicket* cameraTicket) {
+    return al::isEqualString(cameraTicket->getPoser()->getName(), "固定") ||
+           al::isEqualString(cameraTicket->getPoser()->getName(), "完全固定") ||
+           al::isEqualString(cameraTicket->getPoser()->getName(), "出入口専用固定");
+}
+
+void setupFixCameraForNearestAt(al::CameraTicket* cameraTicket) {
+    if (isFixCameraForNearestAt(cameraTicket)) {
+        al::CameraPoserFix* poser = static_cast<al::CameraPoserFix*>(cameraTicket->getPoser());
+        poser->setIsCalcNearestAtFromPreAt(true);
+        alCameraPoserFunction::invalidateKeepDistanceNextCameraIfNoCollide(poser);
+    }
+}
+
+s32 getBindPriority(const al::HitSensor* sensor) {
+    if (sensor == nullptr)
+        return -1;
+    if (al::isSensorBindableGoal(sensor))
+        return 7;
+    if (al::isSensorBindableAllPlayer(sensor))
+        return 6;
+    if (al::isSensorBindableBubbleOutScreen(sensor))
+        return 5;
+    if (al::isSensorBindableKoura(sensor))
+        return 4;
+    if (al::isSensorBindableRouteDokan(sensor))
+        return 3;
+    if (al::isSensorBindableBubblePadInput(sensor))
+        return 2;
+    if (al::isSensorBindable(sensor))
+        return 1;
+    return -1;
+}
+
+}  // namespace
 
 namespace rs {
+
+al::EventFlowExecutor* initEventFlow(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                     const char* eventObjName, const char* eventFlowName) {
+    return initEventFlowImpl(actor, initInfo, nullptr, eventObjName, eventFlowName, true, true);
+}
+
+al::EventFlowExecutor* initEventFlowForRunAwayNpc(al::LiveActor* actor,
+                                                  const al::ActorInitInfo& initInfo,
+                                                  const char* eventObjName,
+                                                  const char* eventFlowName) {
+    return initEventFlowImpl(actor, initInfo, nullptr, eventObjName, eventFlowName, true, false);
+}
+
+al::EventFlowExecutor* initEventFlowForSystem(al::LiveActor* actor,
+                                              const al::ActorInitInfo& initInfo,
+                                              const char* eventFileName, const char* eventObjName,
+                                              const char* eventFlowName) {
+    return initEventFlowImpl(actor, initInfo, eventFileName, eventObjName, eventFlowName, false,
+                             true);
+}
+
+al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                           const char* eventFileName, const char* eventObjName,
+                                           const char* eventFlowName) {
+    return initEventFlowImpl(actor, initInfo, eventFileName, eventObjName, eventFlowName, true,
+                             true);
+}
+
+al::EventFlowExecutor* initEventFlowFromPlacementInfo(al::LiveActor* actor,
+                                                      const al::ActorInitInfo& initInfo,
+                                                      const char* eventObjName) {
+    const char* eventName = al::getStringArg(initInfo, "EventName");
+    return initEventFlowImpl(actor, initInfo, nullptr, eventObjName, eventName, true, true);
+}
+
+al::EventFlowExecutor* initCommonEventFlow(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                           const char* eventFlowName) {
+    return initEventFlowImpl(actor, initInfo, nullptr, "Common", eventFlowName, true, true);
+}
+
+al::EventFlowExecutor* createCommonEventFlowFromPlacementInfo(al::LiveActor* actor,
+                                                              const al::ActorInitInfo& initInfo) {
+    const char* eventName = "None";
+    al::tryGetStringArg(&eventName, initInfo, "EventName");
+    return initEventFlowImpl(actor, initInfo, nullptr, "Common", eventName, true, true);
+}
+
+void initEventCharacterName(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                            const char* name) {
+    MessageSystemAccessor accessor;
+    const al::LayoutInitInfo& layoutInfo = al::getLayoutInitInfo(initInfo);
+    accessor.setMessageSystem(layoutInfo.getMessageSystem());
+    if (al::isExistLabelInSystemMessage(&accessor, "CharacterName", name)) {
+        const char16* message = al::getSystemMessageString(&accessor, "CharacterName", name);
+        executor->getEventFlowDataHolder()->initCharacterName(message);
+    }
+}
+
+void makeEventCharacterName(sead::WBufferedSafeString* out, const al::ActorInitInfo& initInfo,
+                            const char* name) {
+    MessageSystemAccessor accessor;
+    const al::LayoutInitInfo& layoutInfo = al::getLayoutInitInfo(initInfo);
+    accessor.setMessageSystem(layoutInfo.getMessageSystem());
+    const char16* message = al::getSystemMessageString(&accessor, "CharacterName", name);
+    al::copyMessageWithTag(out->getBuffer(), out->getBufferSize(), message);
+}
+
+void initEventParam(al::EventFlowExecutor* executor, const TalkNpcParam* param,
+                    const char* suffix) {
+    al::EventFlowDataHolder* dataHolder = executor->getEventFlowDataHolder();
+    const void* actorParam = suffix != nullptr ? param->findEventFlowActorSuffixParam(suffix) :
+                                                 param->getEventFlowActorParam();
+    dataHolder->setEventFlowActorParam(actorParam);
+    executor->getEventFlowDataHolder()->setEventFlowActor(param->getEventFlowActor());
+}
+
+bool tryInitItemKeeperByEvent(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                              const al::EventFlowExecutor* executor) {
+    if (executor->getEventFlowDataHolder()->getItemTypeCount() < 1)
+        return false;
+    actor->initItemKeeper(executor->getEventFlowDataHolder()->getItemTypeCount());
+    for (s64 i = 0; i < executor->getEventFlowDataHolder()->getItemTypeCount(); i++) {
+        const char* itemType = executor->getEventFlowDataHolder()->getItemType(i);
+        al::addItem(actor, initInfo, itemType, itemType, nullptr, -1, false);
+    }
+    return true;
+}
+
+void startEventFlow(al::EventFlowExecutor* executor, const char* entryName) {
+    executor->start(entryName);
+}
+
+bool updateEventFlow(al::EventFlowExecutor* executor) {
+    executor->execute();
+    return executor->isEnd();
+}
+
+void stopEventFlow(al::EventFlowExecutor* executor) {
+    executor->stopMovement();
+}
+
+void restartEventFlow(al::EventFlowExecutor* executor) {
+    executor->restartMovement();
+}
+
+void initEventMovementRail(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo) {
+    initEventMovementCommon(executor, new al::EventFlowMovementRail(executor->getActor()),
+                            initInfo);
+}
+
+void initEventMovement(al::EventFlowExecutor* executor, al::EventFlowMovement* movement,
+                       const al::ActorInitInfo& initInfo) {
+    initEventMovementCommon(executor, movement, initInfo);
+}
+
+void initEventMovementTurnSeparate(al::EventFlowExecutor* executor,
+                                   const al::ActorInitInfo& initInfo) {
+    initEventMovementCommon(executor, new al::EventFlowMovementTurnSeparate(executor->getActor()),
+                            initInfo);
+}
+
+void initEventMovementWait(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo) {
+    initEventMovementCommon(executor, new al::EventFlowMovementWait(executor->getActor()),
+                            initInfo);
+}
+
+void initEventMovementWander(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo) {
+    initEventMovementCommon(executor, new al::EventFlowMovementWander(executor->getActor()),
+                            initInfo);
+}
+
+bool isDefinedEventCamera(const al::EventFlowExecutor* executor, const char* name) {
+    return executor->getEventFlowDataHolder()->isExistCameraInfo(name);
+}
+
+void initEventActionNameConverter(al::EventFlowExecutor* executor,
+                                  const al::IEventFlowActionNameConverter* converter) {
+    executor->getEventFlowDataHolder()->setEventActionNameConverter(converter);
+}
+
+void initEventQueryJudge(al::EventFlowExecutor* executor,
+                         const al::IEventFlowQueryJudge* queryJudge) {
+    executor->getEventFlowDataHolder()->setEventQueryJudge(queryJudge);
+}
+
+void initEventMessageTagDataHolder(al::EventFlowExecutor* executor,
+                                   const al::MessageTagDataHolder* messageTagDataHolder) {
+    executor->getEventFlowDataHolder()->setMessageTagDataHolder(messageTagDataHolder);
+}
 
 void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
                            const char* name) {
@@ -29,6 +412,621 @@ void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorI
     }
 
     flowExecutor->getEventFlowDataHolder()->initCamera(name, cameraTicket);
+}
+
+void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* executor,
+                                        const al::ActorInitInfo& initInfo, const char* name) {
+    al::CameraTicket* cameraTicket =
+        al::initObjectCamera(getCameraUser(executor->getActor()), initInfo, name, "会話用2点間");
+    alCameraFunction::initPriorityDemoTalk(cameraTicket);
+    alCameraFunction::validateCameraInterpoleEaseOut(cameraTicket);
+    setupFixCameraForNearestAt(cameraTicket);
+    executor->getEventFlowDataHolder()->initCamera(name, cameraTicket);
+}
+
+void initEventCameraTalk(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                         const char* name, f32 minDistance) {
+    al::LiveActor* actor = executor->getActor();
+    al::CameraPoserTalk* poser = new al::CameraPoserTalk("会話用2点間");
+    if (minDistance > 0.0f)
+        poser->setMinDistance(minDistance);
+    al::CameraTicket* ticket =
+        alCameraFunction::initCamera(poser, getCameraUser(actor), initInfo, name, 10);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraTalk2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                          const char* name) {
+    al::LiveActor* actor = executor->getActor();
+    al::CameraPoserTalk* poser = new al::CameraPoserTalk("会話用2点間");
+    al::CameraTicket* ticket =
+        alCameraFunction::initCamera(poser, getCameraUser(actor), initInfo, name, 10);
+    alCameraFunction::initPriorityDemo(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraLookBoard(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                              const sead::Vector3f& offset, const char* name) {
+    al::CameraPoserLookBoard* poser = new al::CameraPoserLookBoard("看板");
+    poser->setLookAtOffset(offset);
+    al::CameraTicket* ticket = alCameraFunction::initCamera(
+        poser, getCameraUser(executor->getActor()), initInfo, name, 10);
+    alCameraFunction::validateKeepPreSelfPoseNextCamera(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraAnim(al::EventFlowExecutor* executor, const al::LiveActor* actor,
+                         const al::ActorInitInfo& initInfo, const char* name) {
+    al::CameraTicket* ticket = al::initDemoAnimCamera(actor, initInfo, name);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraFixActor(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                             const char* name, const al::LiveActor* target,
+                             const sead::Vector3f* offset, f32 distance, f32 angleH, f32 angleV) {
+    const al::LiveActor* executorActor = executor->getActor();
+    const sead::Vector3f* defaultOffset = &CameraOffsetZero;
+    al::CameraTicket* ticket =
+        al::initFixActorCamera(target == nullptr ? executorActor : target, initInfo, name,
+                               *(offset == nullptr ? defaultOffset : offset),
+                               distance < 0.0f ? 500.0f : distance, angleH, angleV, false);
+    alCameraFunction::initPriorityDemoTalk(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraFixActor2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                              const char* name, const al::LiveActor* target,
+                              const sead::Vector3f* offset, f32 distance, f32 angleH, f32 angleV,
+                              bool isUseDistance) {
+    const al::LiveActor* executorActor = executor->getActor();
+    const sead::Vector3f* defaultOffset = &CameraOffsetZero;
+    al::CameraTicket* ticket =
+        al::initFixActorCamera(target == nullptr ? executorActor : target, initInfo, name,
+                               *(offset == nullptr ? defaultOffset : offset),
+                               distance < 0.0f ? 500.0f : distance, angleH, angleV, isUseDistance);
+    alCameraFunction::initPriorityDemo(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraFixActorAutoAroundFront(al::EventFlowExecutor* executor,
+                                            const al::ActorInitInfo& initInfo, const char* name,
+                                            const al::LiveActor* target,
+                                            const sead::Vector3f* offset, f32 distance, f32 angleH,
+                                            f32 angleV, bool isUseDistance) {
+    const al::LiveActor* executorActor = executor->getActor();
+    const sead::Vector3f* defaultOffset = &CameraOffsetZero;
+    al::CameraTicket* ticket =
+        al::initFixTalkCamera(target == nullptr ? executorActor : target, initInfo, name,
+                              *(offset == nullptr ? defaultOffset : offset),
+                              distance < 0.0f ? 500.0f : distance, angleH, angleV, isUseDistance);
+    alCameraFunction::initPriorityDemoTalk(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+void initEventCameraFixActorAutoAroundFront2(al::EventFlowExecutor* executor,
+                                             const al::ActorInitInfo& initInfo, const char* name,
+                                             const al::LiveActor* target,
+                                             const sead::Vector3f* offset, f32 distance, f32 angleH,
+                                             f32 angleV) {
+    const al::LiveActor* executorActor = executor->getActor();
+    const sead::Vector3f* defaultOffset = &CameraOffsetZero;
+    al::CameraTicket* ticket =
+        al::initFixTalkCamera(target == nullptr ? executorActor : target, initInfo, name,
+                              *(offset == nullptr ? defaultOffset : offset),
+                              distance < 0.0f ? 500.0f : distance, angleH, angleV, false);
+    alCameraFunction::initPriorityDemo(ticket);
+    alCameraFunction::validateCameraInterpoleEaseOut(ticket);
+    executor->getEventFlowDataHolder()->initCamera(name, ticket);
+}
+
+u32 checkMatchPatternCurrentCostume(bool* isCapMatch, bool* isClothMatch,
+                                    const al::LiveActor* actor, const char* pattern) {
+    CostumePatternChecker* checker = getNpcEventCtrlInfo(actor)->getCostumePatternChecker();
+    GameDataHolderAccessor capAccessor(getSceneObjHolder(actor));
+    const char* capName = GameDataFunction::getCurrentCapTypeName(capAccessor);
+    GameDataHolderAccessor costumeAccessor(getSceneObjHolder(actor));
+    const char* costumeName = GameDataFunction::getCurrentCostumeTypeName(costumeAccessor);
+    return checker->checkMatchCostume(isCapMatch, isClothMatch, capName, costumeName, pattern);
+}
+
+bool checkMatchPatternCurrentCostumePair(const al::LiveActor* actor, const char* pattern) {
+    CostumePatternChecker* checker = getNpcEventCtrlInfo(actor)->getCostumePatternChecker();
+    GameDataHolderAccessor capAccessor(getSceneObjHolder(actor));
+    const char* capName = GameDataFunction::getCurrentCapTypeName(capAccessor);
+    GameDataHolderAccessor costumeAccessor(getSceneObjHolder(actor));
+    const char* costumeName = GameDataFunction::getCurrentCostumeTypeName(costumeAccessor);
+    return checker->checkMatchCostumePair(capName, costumeName, pattern);
+}
+
+bool isSuccessNpcEventBalloonMessage(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isSuccessBalloonMessage(actor);
+}
+
+bool isPlayingNpcEventBalloonMessageVoice(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isPlayingBalloonMessageVoice();
+}
+
+void requestNpcEventBalloonMessage(al::EventFlowNode* node, const char16* message,
+                                   const NpcEventBalloonRequestInfo& requestInfo) {
+    NpcEventBalloonInfo info;
+    info.setupForMessageBalloon(node->getActor(), message,
+                                node->getEventFlowDataHolder()->getMessageTagDataHolder());
+    info.setCommonParam(requestInfo);
+    setInvalidUiCollisionCheckIfRequested(&info, node);
+    requestShowBalloonMessage(node, info);
+}
+
+void requestNpcEventTalkBalloonMessage(al::EventFlowNode* node, const char* iconName,
+                                       const NpcEventBalloonRequestInfo& requestInfo) {
+    if (al::isEqualString(iconName, "Action"))
+        return;
+    NpcEventBalloonInfo info;
+    info.setupForEmotionIconBalloon(node->getActor(), iconName);
+    info.setCommonParam(requestInfo);
+    setInvalidUiCollisionCheckIfRequested(&info, node);
+    requestShowBalloonMessage(node, info);
+}
+
+void requestNpcEventTalkBalloonMessageEntranceCamera(
+    al::EventFlowNode* node, const char* iconName, const NpcEventBalloonRequestInfo& requestInfo) {
+    NpcEventBalloonInfo info;
+    info.setupForEmotionIconBalloon(node->getActor(), iconName);
+    info.setCommonParam(requestInfo);
+    setInvalidUiCollisionCheckIfRequested(&info, node);
+    info.setEntranceCamera();
+    requestShowBalloonMessage(node, info);
+}
+
+void requestNpcEventTalkBalloonMessageWithEnableButtonA(
+    al::EventFlowNode* node, const char* iconName, const NpcEventBalloonRequestInfo& requestInfo) {
+    NpcEventBalloonInfo info;
+    info.setupForTalkIconBalloon(node->getActor(), iconName, true);
+    info.setCommonParam(requestInfo);
+    setInvalidUiCollisionCheckIfRequested(&info, node);
+    requestShowBalloonMessage(node, info);
+}
+
+void requestNpcEventTalkBalloonMessageWithDisableButtonA(
+    al::EventFlowNode* node, const char* iconName, const NpcEventBalloonRequestInfo& requestInfo) {
+    NpcEventBalloonInfo info;
+    info.setupForTalkIconBalloon(node->getActor(), iconName, false);
+    info.setCommonParam(requestInfo);
+    setInvalidUiCollisionCheckIfRequested(&info, node);
+    requestShowBalloonMessage(node, info);
+}
+
+void requestNpcEventActionBalloonMessage(al::LiveActor* actor, bool isEnableButtonA,
+                                         const NpcEventBalloonRequestInfo& requestInfo) {
+    NpcEventBalloonInfo info;
+    info.setupForTalkIconBalloon(actor, "Action", isEnableButtonA);
+    info.setCommonParam(requestInfo);
+    getNpcEventCtrlInfo(actor)->requestShowBalloonMessage(info);
+}
+
+void setEventBalloonFilterOnlyMiniGame(const al::LiveActor* actor) {
+    getNpcEventCtrlInfo(actor)->setBalloonFilterOnlyMiniGame(actor);
+}
+
+void resetEventBalloonFilter(const al::LiveActor* actor) {
+    getNpcEventCtrlInfo(actor)->resetBalloonFilter(actor);
+}
+
+void startChoiceEvent(al::EventFlowNode* node, al::EventFlowChoiceInfo* choiceInfo) {
+    getNpcEventCtrlInfo(node)->startChoice(node, choiceInfo);
+}
+
+bool isSuccessLockEventTalkDemo(const al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->isSuccessLockTalkDemo(node->getActor());
+}
+
+bool tryLockStartEventTalkDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryLockStartTalkDemo(node->getActor());
+}
+
+bool tryLockStartEventTalkDemoWithoutBalloon(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryLockStartTalkDemoWithoutBalloon(node->getActor());
+}
+
+bool tryStartEventTalkDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryStartTalkDemo(node->getActor());
+}
+
+bool tryStartEventTalkOnlyRequesterDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryStartTalkOnlyRequesterDemo(node->getActor());
+}
+
+bool tryStartEventTalkKeepHackDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryStartTalkKeepHackDemo(node->getActor());
+}
+
+bool tryStartEventTalkUseCoinDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryStartTalkUseCoinDemo(node->getActor());
+}
+
+bool tryStartEventNormalDemo(al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->tryStartNormalDemo(node->getActor());
+}
+
+bool tryStartEventKeepBindDemo(al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->tryStartKeepBindDemo(actor);
+}
+
+bool tryStartEventCutSceneDemo(al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->tryStartCutSceneDemo(actor);
+}
+
+bool tryStartEventCutSceneKeepHackDemo(al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->tryStartCutSceneKeepHackDemo(actor);
+}
+
+bool tryStartEventCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->tryStartCutSceneTalkOnlyRequesterDemo(actor);
+}
+
+void endEventCutSceneDemo(al::LiveActor* actor) {
+    getEventDemoCtrl(actor)->endCutSceneDemo(actor);
+}
+
+void endEventCutSceneTalkOnlyRequeterDemo(al::LiveActor* actor) {
+    getEventDemoCtrl(actor)->endCutSceneTalkOnlyRequesterDemo(actor);
+}
+
+void endEventCutSceneDemoBySkip(al::LiveActor* actor) {
+    getEventDemoCtrl(actor)->endCutSceneDemoBySkip(actor);
+}
+
+void endEventCutSceneDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor* actor) {
+    if (isWaitDemoSkipEnd(actor))
+        endEventCutSceneDemoBySkip(actor);
+    else
+        endEventCutSceneDemo(actor);
+}
+
+void endEventCutSceneTalkOnlyRequeterDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor* actor) {
+    if (isWaitDemoSkipEnd(actor))
+        endEventCutSceneDemoBySkip(actor);
+    else
+        endEventCutSceneTalkOnlyRequeterDemo(actor);
+}
+
+void requestEndEventDemo(al::LiveActor* actor) {
+    getEventDemoCtrl(actor)->requestEndDemo(actor);
+}
+
+void requestEndEventDemo(al::EventFlowNode* node) {
+    getEventDemoCtrl(node)->requestEndDemo(node->getActor());
+}
+
+bool isActiveEventDemo(const al::EventFlowNode* node) {
+    return getEventDemoCtrl(node)->isActiveDemo();
+}
+
+bool isActiveEventDemo(const al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->isActiveDemo();
+}
+
+bool isEqualEventDemoStartActor(const al::LiveActor* actor) {
+    return getEventDemoCtrl(actor)->isDemoStartActor(actor);
+}
+
+bool tryHideDemoPlayerIfRequested(al::LiveActor* actor, al::EventFlowExecutor* executor) {
+    if (!executor->getEventFlowDataHolder()->getRequestInfo()->isRequestHideDemoPlayer())
+        return false;
+    executor->getEventFlowDataHolder()->getRequestInfo()->resetRequestHideDemoPlayer();
+    if (executor->getEventFlowDataHolder()->getRequestInfo()->isDemoPlayerHidden())
+        return false;
+    hideDemoPlayer(actor);
+    startActionDemoPlayer(actor, "Wait");
+    executor->getEventFlowDataHolder()->getRequestInfo()->setDemoPlayerHidden(true);
+    return true;
+}
+
+bool tryShowDemoPlayerIfRequested(al::LiveActor* actor, al::EventFlowExecutor* executor) {
+    if (!executor->getEventFlowDataHolder()->getRequestInfo()->isRequestShowDemoPlayer())
+        return false;
+    executor->getEventFlowDataHolder()->getRequestInfo()->resetRequestShowDemoPlayer();
+    if (!executor->getEventFlowDataHolder()->getRequestInfo()->isDemoPlayerHidden())
+        return false;
+    showDemoPlayer(actor);
+    executor->getEventFlowDataHolder()->getRequestInfo()->setDemoPlayerHidden(false);
+    return true;
+}
+
+bool tryStartDemoPlayerActionIfRequested(al::LiveActor* actor, al::EventFlowExecutor* executor) {
+    if (executor->getEventFlowDataHolder()->getRequestInfo()->getRequestedDemoPlayerActionName() ==
+        nullptr)
+        return false;
+    startActionDemoPlayer(
+        actor,
+        executor->getEventFlowDataHolder()->getRequestInfo()->getRequestedDemoPlayerActionName());
+    executor->getEventFlowDataHolder()->getRequestInfo()->clearRequestedDemoPlayerActionName();
+    return true;
+}
+
+void swapEventCharacterName(al::EventFlowExecutor* executor,
+                            const sead::WBufferedSafeString* name) {
+    executor->getEventFlowDataHolder()->swapCharacterName(name);
+}
+
+void resetEventCharacterName(al::EventFlowExecutor* executor) {
+    executor->getEventFlowDataHolder()->resetCharacterName();
+}
+
+void startOpenNpcDemoEventTalkMessage(al::EventFlowNode* node, const char16* message) {
+    startOpenTalkMessage(node, message, false, false, 0);
+}
+
+void startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode* node, const char16* message) {
+    startOpenTalkMessage(node, message, true, false, 0);
+}
+
+void startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode* node, const char16* message,
+                                                   s32 messageStyle) {
+    startOpenTalkMessage(node, message, true, true, messageStyle);
+}
+
+void startCloseNpcDemoEventTalkMessage(al::LiveActor* actor) {
+    getNpcEventCtrlInfo(actor)->requestCloseTalkMessage(actor);
+}
+
+bool isOpenWaitNpcDemoEventTalkMessage(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isOpenWaitTalkMessage();
+}
+
+bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isPlayingTextPaneAnim();
+}
+
+bool isEndNpcDemoEventTalkMessage(const al::EventFlowNode* node) {
+    if (!getNpcEventCtrlInfo(node)->isTalkMessageClosed())
+        return false;
+    return getNpcEventCtrlInfo(node)->isTalkMessageRequestEnd();
+}
+
+bool isCloseNpcDemoEventTalkMessage(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isCloseTalk();
+}
+
+s64 getEventTalkWindowMessageStyle(const al::EventFlowNode* node) {
+    return getNpcEventCtrlInfo(node)->getEventTalkWindowMessageStyle();
+}
+
+bool isCloseEventWipeFadeBlack(const al::EventFlowNode* node) {
+    return getNpcEventCtrlInfo(node)->isCloseWipeFadeBlack();
+}
+
+bool isOpenEventWipeFadeBlack(const al::EventFlowNode* node) {
+    return getNpcEventCtrlInfo(node)->isOpenWipeFadeBlack();
+}
+
+void requestCloseEventWipeFadeBlack(al::EventFlowNode* node, s32 step) {
+    getNpcEventCtrlInfo(node)->requestCloseWipeFadeBlack(node, step);
+}
+
+void requestOpenEventWipeFadeBlack(al::EventFlowNode* node, s32 step) {
+    getNpcEventCtrlInfo(node)->requestOpenWipeFadeBlack(node, step);
+}
+
+void calcPlayerWatchTrans(sead::Vector3f* out, const al::LiveActor* actor,
+                          const TalkNpcParam* param) {
+    const al::EventFlowWatchParam* watchParam = param->getEventFlowWatchParam();
+    if (watchParam != nullptr) {
+        watchParam->calcWatchTrans(out, actor);
+        return;
+    }
+    const sead::Vector3f& trans = al::getTrans(actor);
+    out->set(trans);
+}
+
+bool isPlayerInWater(const al::EventFlowNode* node) {
+    return getNpcEventCtrlInfo(node)->isPlayerInWater();
+}
+
+bool isNpcScareTiming(const al::EventFlowExecutor* executor) {
+    return al::isScare(executor);
+}
+
+bool isExistNpcLookPos(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->isExistNpcLookPos();
+}
+
+bool isExistNpcLookPos(const al::EventFlowExecutor* executor) {
+    return getNpcEventCtrlInfo(executor->getActor())->isExistNpcLookPos();
+}
+
+const sead::Vector3f& getNpcLookPos(const al::LiveActor* actor) {
+    return getNpcEventCtrlInfo(actor)->getNpcLookPos();
+}
+
+const sead::Vector3f& getNpcLookPos(const al::EventFlowExecutor* executor) {
+    return getNpcEventCtrlInfo(executor->getActor())->getNpcLookPos();
+}
+
+bool isExistTrafficAreaDirector(const al::LiveActor* actor) {
+    return tryGetTrafficAreaDirector(actor) != nullptr;
+}
+
+bool tryPermitEnterTrafficNpcAndSyncDrawClipping(al::LiveActor* actor) {
+    al::TrafficAreaDirector* director = tryGetTrafficAreaDirector(actor);
+    if (director == nullptr)
+        return true;
+    return director->tryPermitEnterNpcAndSyncDrawClipping(actor);
+}
+
+bool tryPermitEnterTrafficCar(const al::LiveActor* actor, const sead::Vector3f& position) {
+    al::TrafficAreaDirector* director = tryGetTrafficAreaDirector(actor);
+    if (director == nullptr)
+        return true;
+    return director->tryPermitEnterCar(position);
+}
+
+void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 eventId) {
+    switch (eventId) {
+    case 1:
+        getTalkNpcSceneEventSwitcher(actor)->requestAfterDoorSnow(1);
+        break;
+    case 2:
+        getTalkNpcSceneEventSwitcher(actor)->requestAfterDoorSnow(2);
+        break;
+    case 3:
+        getTalkNpcSceneEventSwitcher(actor)->requestAfterDoorSnow(3);
+        break;
+    case 4:
+        getTalkNpcSceneEventSwitcher(actor)->requestAfterDoorSnow(4);
+        break;
+    }
+}
+
+void requestSwitchTalkNpcEventVolleyBall(al::LiveActor* actor, s32 shineIndex) {
+    if (shineIndex == 1)
+        getTalkNpcSceneEventSwitcher(actor)->requestVolleyBall("VolleyBallAppearShine1");
+    else if (shineIndex == 2)
+        getTalkNpcSceneEventSwitcher(actor)->requestVolleyBall("VolleyBallAppearShine2");
+}
+
+void requestSwitchTalkNpcEventJumpingRope(al::LiveActor* actor, s32 shineIndex) {
+    if (shineIndex == 1)
+        getTalkNpcSceneEventSwitcher(actor)->requestJumpingRope("JumpingRopeAppearShine1");
+    else if (shineIndex == 2)
+        getTalkNpcSceneEventSwitcher(actor)->requestJumpingRope("JumpingRopeAppearShine2");
+}
+
+void requestSwitchTalkNpcEventRadicon(al::LiveActor* actor, s32 shineIndex) {
+    if (shineIndex == 1)
+        getTalkNpcSceneEventSwitcher(actor)->requestRadicon("RadiconAppearShine1");
+    else if (shineIndex == 2)
+        getTalkNpcSceneEventSwitcher(actor)->requestRadicon("RadiconAppearShine2");
+}
+
+bool isEventAfterDoorSnow1(const al::EventFlowNode* node) {
+    return getTalkNpcSceneEventSwitcher(node)->getAfterDoorSnowEventId() == 1;
+}
+
+bool isEventAfterDoorSnow2(const al::EventFlowNode* node) {
+    return getTalkNpcSceneEventSwitcher(node)->getAfterDoorSnowEventId() == 2;
+}
+
+bool isEventAfterDoorSnow3(const al::EventFlowNode* node) {
+    return getTalkNpcSceneEventSwitcher(node)->getAfterDoorSnowEventId() == 3;
+}
+
+bool isEventAfterDoorSnow4(const al::EventFlowNode* node) {
+    return getTalkNpcSceneEventSwitcher(node)->getAfterDoorSnowEventId() == 4;
+}
+
+const char* tryGetTalkNpcVolleyBallEntryName(const al::LiveActor* actor) {
+    return getTalkNpcSceneEventSwitcher(actor)->getVolleyBallEntryName();
+}
+
+const char* tryGetTalkNpcJumpingRopeEntryName(const al::LiveActor* actor) {
+    return getTalkNpcSceneEventSwitcher(actor)->getJumpingRopeEntryName();
+}
+
+const char* tryGetTalkNpcRadiconEntryName(const al::LiveActor* actor) {
+    return getTalkNpcSceneEventSwitcher(actor)->getRadiconEntryName();
+}
+
+void requestEventGetShineDirect(al::EventFlowNode* node, Shine* shine) {
+    getSceneExecuteCtrl(node)->requestEventGetShineDirect(node->getActor(), shine);
+}
+
+void requestEventOpenBgmList(al::EventFlowNode* node) {
+    getSceneExecuteCtrl(node)->requestEventOpenBgmList(node->getActor());
+}
+
+void requestEventOpenShineList(al::LiveActor* actor) {
+    getSceneExecuteCtrl(actor)->requestEventOpenShineList(actor);
+}
+
+void requestEventGetAchievement(al::LiveActor* actor, const char* achievementName) {
+    getSceneExecuteCtrl(actor)->requestEventGetAchievement(actor, achievementName);
+}
+
+bool checkEndSceneExecuteAndResetRequest(al::EventFlowNode* node) {
+    return getSceneExecuteCtrl(node)->checkEndSceneExecuteAndReset(node->getActor());
+}
+
+bool checkEndSceneExecuteAndResetRequest(al::LiveActor* actor) {
+    return getSceneExecuteCtrl(actor)->checkEndSceneExecuteAndReset(actor);
+}
+
+bool isExecuteSceneEvent(const al::LiveActor* actor) {
+    return getSceneExecuteCtrl(actor)->isExecuteScene();
+}
+
+bool checkTriggerDecideWithRequestIcon(al::LiveActor* actor, const sead::Vector3f& offset,
+                                       f32 distance) {
+    NpcEventBalloonRequestInfo requestInfo;
+    requestInfo.localOffset.set(offset);
+    if (distance > 0.0f)
+        requestInfo.collisionCheckOffsetRadius = distance;
+
+    bool result = false;
+    if (isPlayerEnableTalkGround(actor)) {
+        requestNpcEventActionBalloonMessage(actor, true, requestInfo);
+        if (isTriggerUiDecide(getSceneObjHolder(actor)) &&
+            getNpcEventCtrlInfo(actor)->isSuccessBalloonMessage(actor)) {
+            return true;
+        }
+    }
+    return result;
+}
+
+void skipEventDemo(al::EventFlowExecutor* executor) {
+    if (al::isHideDemoPlayer(executor))
+        showDemoPlayer(executor->getActor());
+    if (!getNpcEventCtrlInfo(executor->getActor())->isCloseTalk()) {
+        al::LiveActor* actor = executor->getActor();
+        getNpcEventCtrlInfo(actor)->requestCloseTalkMessage(actor);
+    }
+    executor->getEventFlowDataHolder()->endAllEventCamera(getCameraUser(executor->getActor()));
+    executor->clearCurrentNodeAndName();
+    al::notifyDemoSkipToDemoSyncedProc(getAudioUser(executor->getActor()));
+}
+
+}  // namespace rs
+
+namespace TalkNpcFunction {
+
+bool receiveEventChangeWaitAction(TalkNpcActionAnimInfo* actionAnimInfo,
+                                  const al::EventFlowEventData* eventData,
+                                  const TalkNpcParam* param) {
+    if (!al::isEventName(eventData, "ChangeWaitAction"))
+        return false;
+    const char* actionName = al::getEventDataParamString(eventData, "ActionName");
+    actionAnimInfo->changeWaitActionName(actionName, param);
+    return true;
+}
+
+}  // namespace TalkNpcFunction
+
+namespace {
+
+const al::MessageSystem* MessageSystemAccessor::getMessageSystem() const {
+    return mMessageSystem;
+}
+
+}  // namespace
+
+namespace rs {
+
+bool isGreaterBindPriority(const al::HitSensor* lhs, const al::HitSensor* rhs) {
+    if (lhs == rhs)
+        return false;
+    if (rhs == nullptr)
+        return true;
+    if (al::isSensorBindable(lhs) && al::isSensorBindable(rhs))
+        return false;
+    if (al::isSensorBindableAllPlayer(lhs) && al::isSensorBindableAllPlayer(rhs))
+        return false;
+    return getBindPriority(rhs) <= getBindPriority(lhs);
 }
 
 }  // namespace rs

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -2,29 +2,170 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+#include <prim/seadSafeString.h>
 
 namespace al {
 struct ActorInitInfo;
+class EventFlowChoiceInfo;
+class EventFlowEventData;
 class EventFlowExecutor;
+class EventFlowMovement;
+class EventFlowNode;
+class HitSensor;
+class IEventFlowActionNameConverter;
+class IEventFlowQueryJudge;
 class LiveActor;
 class MessageTagDataHolder;
 }  // namespace al
+struct NpcEventBalloonRequestInfo;
+class Shine;
+class TalkNpcActionAnimInfo;
+class TalkNpcParam;
 
 namespace rs {
 al::EventFlowExecutor* initEventFlow(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                      const char*);
+al::EventFlowExecutor* initEventFlowForRunAwayNpc(al::LiveActor*, const al::ActorInitInfo&,
+                                                  const char*, const char*);
+al::EventFlowExecutor* initEventFlowForSystem(al::LiveActor*, const al::ActorInitInfo&, const char*,
+                                              const char*, const char*);
 al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                            const char*, const char*);
-bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
-bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
+al::EventFlowExecutor* initEventFlowFromPlacementInfo(al::LiveActor*, const al::ActorInitInfo&,
+                                                      const char*);
+al::EventFlowExecutor* initCommonEventFlow(al::LiveActor*, const al::ActorInitInfo&, const char*);
+al::EventFlowExecutor* createCommonEventFlowFromPlacementInfo(al::LiveActor*,
+                                                              const al::ActorInitInfo&);
+void initEventCharacterName(al::EventFlowExecutor*, const al::ActorInitInfo&, const char*);
+void makeEventCharacterName(sead::WBufferedSafeString*, const al::ActorInitInfo&, const char*);
+void initEventParam(al::EventFlowExecutor*, const TalkNpcParam*, const char*);
+bool tryInitItemKeeperByEvent(al::LiveActor*, const al::ActorInitInfo&,
+                              const al::EventFlowExecutor*);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
+void stopEventFlow(al::EventFlowExecutor*);
+void restartEventFlow(al::EventFlowExecutor*);
+void initEventMovementRail(al::EventFlowExecutor*, const al::ActorInitInfo&);
+void initEventMovement(al::EventFlowExecutor*, al::EventFlowMovement*, const al::ActorInitInfo&);
+void initEventMovementTurnSeparate(al::EventFlowExecutor*, const al::ActorInitInfo&);
+void initEventMovementWait(al::EventFlowExecutor*, const al::ActorInitInfo&);
+void initEventMovementWander(al::EventFlowExecutor*, const al::ActorInitInfo&);
+bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
+void initEventActionNameConverter(al::EventFlowExecutor*, const al::IEventFlowActionNameConverter*);
+void initEventQueryJudge(al::EventFlowExecutor*, const al::IEventFlowQueryJudge*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);
 void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
                            const char* name);
 void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
+void initEventCameraTalk(al::EventFlowExecutor*, const al::ActorInitInfo&, const char*, f32);
+void initEventCameraTalk2(al::EventFlowExecutor*, const al::ActorInitInfo&, const char*);
+void initEventCameraLookBoard(al::EventFlowExecutor*, const al::ActorInitInfo&,
+                              const sead::Vector3f&, const char*);
+void initEventCameraAnim(al::EventFlowExecutor*, const al::LiveActor*, const al::ActorInitInfo&,
+                         const char*);
+void initEventCameraFixActor(al::EventFlowExecutor*, const al::ActorInitInfo&, const char*,
+                             const al::LiveActor*, const sead::Vector3f*, f32, f32, f32);
+void initEventCameraFixActor2(al::EventFlowExecutor*, const al::ActorInitInfo&, const char*,
+                              const al::LiveActor*, const sead::Vector3f*, f32, f32, f32, bool);
+void initEventCameraFixActorAutoAroundFront(al::EventFlowExecutor*, const al::ActorInitInfo&,
+                                            const char*, const al::LiveActor*,
+                                            const sead::Vector3f*, f32, f32, f32, bool);
+void initEventCameraFixActorAutoAroundFront2(al::EventFlowExecutor*, const al::ActorInitInfo&,
+                                             const char*, const al::LiveActor*,
+                                             const sead::Vector3f*, f32, f32, f32);
+u32 checkMatchPatternCurrentCostume(bool*, bool*, const al::LiveActor*, const char*);
+bool checkMatchPatternCurrentCostumePair(const al::LiveActor*, const char*);
+bool isSuccessNpcEventBalloonMessage(const al::LiveActor*);
+bool isPlayingNpcEventBalloonMessageVoice(const al::LiveActor*);
+void requestNpcEventBalloonMessage(al::EventFlowNode*, const char16*,
+                                   const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessage(al::EventFlowNode*, const char*,
+                                       const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageEntranceCamera(al::EventFlowNode*, const char*,
+                                                     const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageWithEnableButtonA(al::EventFlowNode*, const char*,
+                                                        const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageWithDisableButtonA(al::EventFlowNode*, const char*,
+                                                         const NpcEventBalloonRequestInfo&);
+void requestNpcEventActionBalloonMessage(al::LiveActor*, bool, const NpcEventBalloonRequestInfo&);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
+void startChoiceEvent(al::EventFlowNode*, al::EventFlowChoiceInfo*);
+bool isSuccessLockEventTalkDemo(const al::EventFlowNode*);
+bool tryLockStartEventTalkDemo(al::EventFlowNode*);
+bool tryLockStartEventTalkDemoWithoutBalloon(al::EventFlowNode*);
+bool tryStartEventTalkDemo(al::EventFlowNode*);
+bool tryStartEventTalkOnlyRequesterDemo(al::EventFlowNode*);
+bool tryStartEventTalkKeepHackDemo(al::EventFlowNode*);
+bool tryStartEventTalkUseCoinDemo(al::EventFlowNode*);
+bool tryStartEventNormalDemo(al::EventFlowNode*);
+bool tryStartEventKeepBindDemo(al::LiveActor*);
+bool tryStartEventCutSceneDemo(al::LiveActor*);
+bool tryStartEventCutSceneKeepHackDemo(al::LiveActor*);
+bool tryStartEventCutSceneTalkOnlyRequesterDemo(al::LiveActor*);
+void endEventCutSceneDemo(al::LiveActor*);
+void endEventCutSceneTalkOnlyRequeterDemo(al::LiveActor*);
+void endEventCutSceneDemoBySkip(al::LiveActor*);
+void endEventCutSceneDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor*);
+void endEventCutSceneTalkOnlyRequeterDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor*);
+void requestEndEventDemo(al::LiveActor*);
+void requestEndEventDemo(al::EventFlowNode*);
+bool isActiveEventDemo(const al::EventFlowNode*);
+bool isActiveEventDemo(const al::LiveActor*);
+bool isEqualEventDemoStartActor(const al::LiveActor*);
+bool tryHideDemoPlayerIfRequested(al::LiveActor*, al::EventFlowExecutor*);
+bool tryShowDemoPlayerIfRequested(al::LiveActor*, al::EventFlowExecutor*);
+bool tryStartDemoPlayerActionIfRequested(al::LiveActor*, al::EventFlowExecutor*);
+void swapEventCharacterName(al::EventFlowExecutor*, const sead::WBufferedSafeString*);
+void resetEventCharacterName(al::EventFlowExecutor*);
+void startOpenNpcDemoEventTalkMessage(al::EventFlowNode*, const char16*);
+void startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode*, const char16*);
+void startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode*, const char16*, s32);
+void startCloseNpcDemoEventTalkMessage(al::LiveActor*);
+bool isOpenWaitNpcDemoEventTalkMessage(const al::LiveActor*);
+bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor*);
+bool isEndNpcDemoEventTalkMessage(const al::EventFlowNode*);
+bool isCloseNpcDemoEventTalkMessage(const al::LiveActor*);
+s64 getEventTalkWindowMessageStyle(const al::EventFlowNode*);
+bool isCloseEventWipeFadeBlack(const al::EventFlowNode*);
+bool isOpenEventWipeFadeBlack(const al::EventFlowNode*);
+void requestCloseEventWipeFadeBlack(al::EventFlowNode*, s32);
+void requestOpenEventWipeFadeBlack(al::EventFlowNode*, s32);
+void calcPlayerWatchTrans(sead::Vector3f*, const al::LiveActor*, const TalkNpcParam*);
+bool isPlayerInWater(const al::EventFlowNode*);
+bool isNpcScareTiming(const al::EventFlowExecutor*);
+bool isExistNpcLookPos(const al::LiveActor*);
+bool isExistNpcLookPos(const al::EventFlowExecutor*);
+const sead::Vector3f& getNpcLookPos(const al::LiveActor*);
+const sead::Vector3f& getNpcLookPos(const al::EventFlowExecutor*);
+bool isExistTrafficAreaDirector(const al::LiveActor*);
+bool tryPermitEnterTrafficNpcAndSyncDrawClipping(al::LiveActor*);
+bool tryPermitEnterTrafficCar(const al::LiveActor*, const sead::Vector3f&);
+void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor*, s32);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
+void requestSwitchTalkNpcEventJumpingRope(al::LiveActor*, s32);
+void requestSwitchTalkNpcEventRadicon(al::LiveActor*, s32);
+bool isEventAfterDoorSnow1(const al::EventFlowNode*);
+bool isEventAfterDoorSnow2(const al::EventFlowNode*);
+bool isEventAfterDoorSnow3(const al::EventFlowNode*);
+bool isEventAfterDoorSnow4(const al::EventFlowNode*);
+const char* tryGetTalkNpcVolleyBallEntryName(const al::LiveActor*);
+const char* tryGetTalkNpcJumpingRopeEntryName(const al::LiveActor*);
+const char* tryGetTalkNpcRadiconEntryName(const al::LiveActor*);
+void requestEventGetShineDirect(al::EventFlowNode*, Shine*);
+void requestEventOpenBgmList(al::EventFlowNode*);
+void requestEventOpenShineList(al::LiveActor*);
+void requestEventGetAchievement(al::LiveActor*, const char*);
+bool checkEndSceneExecuteAndResetRequest(al::EventFlowNode*);
+bool checkEndSceneExecuteAndResetRequest(al::LiveActor*);
+bool isExecuteSceneEvent(const al::LiveActor*);
+bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
+void skipEventDemo(al::EventFlowExecutor*);
+bool isGreaterBindPriority(const al::HitSensor*, const al::HitSensor*);
 }  // namespace rs
+
+namespace TalkNpcFunction {
+bool receiveEventChangeWaitAction(TalkNpcActionAnimInfo*, const al::EventFlowEventData*,
+                                  const TalkNpcParam*);
+}  // namespace TalkNpcFunction


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1138)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4706601 - 1705cc8)

📈 **Matched code**: 14.63% (+0.08%, +10588 bytes)

<details>
<summary>✅ 121 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/NpcEventFlowUtil` | `(anonymous namespace)::initEventFlowImpl(al::LiveActor*, al::ActorInitInfo const&, char const*, char const*, char const*, bool, bool)` | +532 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::tryInitItemKeeperByEvent(al::LiveActor*, al::ActorInitInfo const&, al::EventFlowExecutor const*)` | +240 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraObjectAfterKeepPose(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*)` | +220 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::checkTriggerDecideWithRequestIcon(al::LiveActor*, sead::Vector3<float> const&, float)` | +220 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode*, char16_t const*, int)` | +196 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode*, char16_t const*)` | +184 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraLookBoard(al::EventFlowExecutor*, al::ActorInitInfo const&, sead::Vector3<float> const&, char const*)` | +180 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::tryHideDemoPlayerIfRequested(al::LiveActor*, al::EventFlowExecutor*)` | +180 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `(anonymous namespace)::getBindPriority(al::HitSensor const*)` | +180 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraTalk(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*, float)` | +176 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::startOpenNpcDemoEventTalkMessage(al::EventFlowNode*, char16_t const*)` | +176 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::skipEventDemo(al::EventFlowExecutor*)` | +168 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestNpcEventBalloonMessage(al::EventFlowNode*, char16_t const*, NpcEventBalloonRequestInfo const&)` | +164 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::tryShowDemoPlayerIfRequested(al::LiveActor*, al::EventFlowExecutor*)` | +164 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::checkMatchPatternCurrentCostume(bool*, bool*, al::LiveActor const*, char const*)` | +160 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestNpcEventTalkBalloonMessage(al::EventFlowNode*, char const*, NpcEventBalloonRequestInfo const&)` | +160 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor*, int)` | +160 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraTalk2(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*)` | +152 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestNpcEventTalkBalloonMessageEntranceCamera(al::EventFlowNode*, char const*, NpcEventBalloonRequestInfo const&)` | +148 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCharacterName(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*)` | +144 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestNpcEventTalkBalloonMessageWithEnableButtonA(al::EventFlowNode*, char const*, NpcEventBalloonRequestInfo const&)` | +144 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::requestNpcEventTalkBalloonMessageWithDisableButtonA(al::EventFlowNode*, char const*, NpcEventBalloonRequestInfo const&)` | +144 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::isGreaterBindPriority(al::HitSensor const*, al::HitSensor const*)` | +144 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::checkMatchPatternCurrentCostumePair(al::LiveActor const*, char const*)` | +140 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraFixActor(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*, al::LiveActor const*, sead::Vector3<float> const*, float, float, float)` | +132 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraFixActor2(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*, al::LiveActor const*, sead::Vector3<float> const*, float, float, float, bool)` | +132 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraFixActorAutoAroundFront(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*, al::LiveActor const*, sead::Vector3<float> const*, float, float, float, bool)` | +132 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::initEventCameraFixActorAutoAroundFront2(al::EventFlowExecutor*, al::ActorInitInfo const&, char const*, al::LiveActor const*, sead::Vector3<float> const*, float, float, float)` | +132 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::makeEventCharacterName(sead::BufferedSafeStringBase<char16_t>*, al::ActorInitInfo const&, char const*)` | +128 | 0.00% | 100.00% |
| `Util/NpcEventFlowUtil` | `rs::tryStartDemoPlayerActionIfRequested(al::LiveActor*, al::EventFlowExecutor*)` | +128 | 0.00% | 100.00% |

...and 91 more new matches
</details>


<!-- decomp.dev report end -->