### PR TITLE
MapObj: Implement `AppearSwitchFallMapParts`

### DIFF
--- a/src/MapObj/AppearSwitchFallMapParts.cpp
+++ b/src/MapObj/AppearSwitchFallMapParts.cpp
@@ -1,0 +1,159 @@
+#include "MapObj/AppearSwitchFallMapParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+namespace {
+using namespace al;
+
+NERVE_ACTION_IMPL(AppearSwitchFallMapParts, Appear)
+NERVE_ACTION_IMPL(AppearSwitchFallMapParts, Wait)
+NERVE_ACTION_IMPL(AppearSwitchFallMapParts, FallSign)
+NERVE_ACTION_IMPL(AppearSwitchFallMapParts, Fall)
+NERVE_ACTION_IMPL(AppearSwitchFallMapParts, End)
+
+NERVE_ACTIONS_MAKE_STRUCT(AppearSwitchFallMapParts, Appear, Wait, FallSign, Fall, End)
+}  // namespace
+
+AppearSwitchFallMapParts::AppearSwitchFallMapParts(const char* name) : al::LiveActor(name) {}
+
+void AppearSwitchFallMapParts::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "Wait", &NrvAppearSwitchFallMapParts.collector, 0);
+    al::initMapPartsActor(this, info, nullptr);
+    al::registerAreaHostMtx(this, info);
+
+    mPos = al::getTrans(this);
+
+    al::tryGetArg(&mFallTime, info, "FallTime");
+    al::tryGetArg(&mIsInvalidAutoRestart, info, "IsInvalidAutoRestart");
+
+    al::trySyncStageSwitchAppear(this);
+}
+
+bool AppearSwitchFallMapParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                          al::HitSensor* self) {
+    if (al::isMsgFloorTouch(message) &&
+        al::isNerve(this, NrvAppearSwitchFallMapParts.Wait.data())) {
+        al::startNerveAction(this, "FallSign");
+        al::invalidateClipping(this);
+
+        return true;
+    }
+
+    if (al::isMsgShowModel(message)) {
+        if (!al::isNerve(this, NrvAppearSwitchFallMapParts.End.data()))
+            al::showModelIfHide(this);
+
+        return true;
+    }
+
+    if (al::isMsgHideModel(message)) {
+        if (!al::isNerve(this, NrvAppearSwitchFallMapParts.End.data()))
+            al::hideModelIfShow(this);
+
+        return true;
+    }
+
+    if (al::isMsgRestart(message)) {
+        appearAndSetStart();
+
+        return true;
+    }
+
+    return false;
+}
+
+void AppearSwitchFallMapParts::appearAndSetStart() {
+    al::setTrans(this, mPos);
+    al::resetPosition(this);
+    al::showModelIfHide(this);
+    al::startNerveAction(this, "Wait");
+    al::setVelocityZero(this);
+    al::validateCollisionParts(this);
+
+    makeActorAlive();
+}
+
+void AppearSwitchFallMapParts::exeAppear() {
+    if (al::isFirstStep(this)) {
+        al::validateCollisionParts(this);
+        if (!al::tryStartAction(this, "Appear")) {
+            al::startNerveAction(this, "Wait");
+
+            return;
+        }
+    }
+
+    if (!al::isExistAction(this) || al::isActionEnd(this))
+        al::startNerveAction(this, "Wait");
+}
+
+void AppearSwitchFallMapParts::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::tryStartAction(this, "Wait");
+        al::validateClipping(this);
+    }
+}
+
+void AppearSwitchFallMapParts::exeFallSign() {
+    if (al::isFirstStep(this))
+        mIsStartAction = al::tryStartAction(this, "FallSign");
+
+    if (!mIsStartAction) {
+        f32 offset =
+            sead::Mathf::sin(al::calcNerveValue(this, 20, 0.0f, sead::Mathf::pi() * 3)) * 3;
+        al::setTrans(this, offset * sead::Vector3f::ey + mPos);
+    }
+
+    if (isEndFallSign())
+        al::startNerveAction(this, "Fall");
+}
+
+bool AppearSwitchFallMapParts::isEndFallSign() const {
+    return mIsStartAction ? al::isActionEnd(this) : al::isGreaterEqualStep(this, 20);
+}
+
+void AppearSwitchFallMapParts::exeFall() {
+    if (al::isFirstStep(this)) {
+        al::tryStartAction(this, "Fall");
+        al::setTrans(this, mPos);
+    }
+
+    al::addVelocityToGravity(this, 0.3f);
+    al::scaleVelocity(this, 0.9f);
+
+    if (al::isGreaterStep(this, mFallTime))
+        al::startNerveAction(this, "End");
+}
+
+void AppearSwitchFallMapParts::exeEnd() {
+    if (al::isFirstStep(this)) {
+        al::tryStartAction(this, "End");
+        al::hideModelIfShow(this);
+        al::invalidateCollisionParts(this);
+        al::setVelocityZero(this);
+
+        if (mIsInvalidAutoRestart) {
+            kill();
+
+            return;
+        }
+    }
+
+    if (al::isGreaterStep(this, 120)) {
+        al::setTrans(this, mPos);
+        al::resetPosition(this);
+        al::showModelIfHide(this);
+        al::startNerveAction(this, "Appear");
+    }
+}

--- a/src/MapObj/AppearSwitchFallMapParts.h
+++ b/src/MapObj/AppearSwitchFallMapParts.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class AppearSwitchFallMapParts : public al::LiveActor {
+public:
+    AppearSwitchFallMapParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appearAndSetStart();
+    void exeAppear();
+    void exeWait();
+    void exeFallSign();
+    bool isEndFallSign() const;
+    void exeFall();
+    void exeEnd();
+
+private:
+    sead::Vector3f mPos = sead::Vector3f::zero;
+    s32 mFallTime = 75;
+    bool mIsStartAction = false;
+    bool mIsInvalidAutoRestart = false;
+};
+
+static_assert(sizeof(AppearSwitchFallMapParts) == 0x120);

--- a/src/Scene/ProjectAppearSwitchFactory.cpp
+++ b/src/Scene/ProjectAppearSwitchFactory.cpp
@@ -1,7 +1,6 @@
 #include "Scene/ProjectAppearSwitchFactory.h"
 
 #include "Library/LiveActor/CreateActorFunction.h"
-#include "Library/MapObj/FallMapParts.h"
 #include "Library/MapObj/FixMapParts.h"
 #include "Library/MapObj/FloaterMapParts.h"
 #include "Library/MapObj/KeyMoveMapParts.h"
@@ -9,10 +8,12 @@
 #include "Library/MapObj/SeesawMapParts.h"
 #include "Library/MapObj/WobbleMapParts.h"
 
+#include "MapObj/AppearSwitchFallMapParts.h"
+
 // FIXME fill in method references: (1.0) off_7101D89F18
 const al::NameToCreator<al::ActorCreatorFunction> sProjectAppearSwitchFactoryEntries[] = {
     {"FixMapParts", al::createActorFunction<al::FixMapParts>},
-    {"FallMapParts", al::createActorFunction<al::FallMapParts>},
+    {"FallMapParts", al::createActorFunction<AppearSwitchFallMapParts>},
     {"CapHanger", nullptr},
     {"Coin", nullptr},
     {"CoinCollect", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1139)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4706601 - e0d6bd7)

📈 **Matched code**: 14.57% (+0.02%, +2012 bytes)

<details>
<summary>✅ 23 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +292 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::exeFallSign()` | +244 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::exeEnd()` | +176 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::AppearSwitchFallMapParts(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::init(al::ActorInitInfo const&)` | +164 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `_GLOBAL__sub_I_AppearSwitchFallMapParts.cpp` | +164 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::AppearSwitchFallMapParts(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::exeFall()` | +136 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::exeAppear()` | +112 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::appearAndSetStart()` | +96 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvWait::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::exeWait()` | +68 | 0.00% | 100.00% |
| `Scene/ProjectAppearSwitchFactory` | `al::LiveActor* al::createActorFunction<AppearSwitchFallMapParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `AppearSwitchFallMapParts::isEndFallSign() const` | +20 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvAppear::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvFallSign::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvFall::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvEnd::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvAppear::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvFallSign::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/AppearSwitchFallMapParts` | `(anonymous namespace)::AppearSwitchFallMapPartsNrvEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->