### PR TITLE
MapObj: Implement `CloudStepKeyMoveComponent`

### DIFF
--- a/src/MapObj/CloudStep.h
+++ b/src/MapObj/CloudStep.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CloudStepKeyMoveComponent;
+
+class CloudStep : public al::LiveActor {
+public:
+    CloudStep(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    void exeWait();
+    void exeWaitOnPlayer();
+    void exeAppear();
+    void endAppear();
+    void exeDisappear();
+    void endDisappear();
+    void exeThrough();
+    void exeLand();
+
+private:
+    s32 _108 = -1;
+    s32 _10c = -1;
+    s32 _110 = -1;
+    bool mIsSteppedOn = false;
+    sead::Vector3f mClippingOffset = sead::Vector3f::zero;
+    sead::Vector3f mThroughEffectPos = sead::Vector3f::zero;
+    CloudStepKeyMoveComponent* mKeyMoveComponent = nullptr;
+};
+
+static_assert(sizeof(CloudStep) == 0x138);

--- a/src/MapObj/CloudStepKeyMoveComponent.cpp
+++ b/src/MapObj/CloudStepKeyMoveComponent.cpp
@@ -1,0 +1,125 @@
+#include "MapObj/CloudStepKeyMoveComponent.h"
+
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "MapObj/CloudStep.h"
+
+namespace {
+NERVE_ACTION_IMPL(CloudStepKeyMoveComponent, Wait)
+NERVE_ACTION_IMPL(CloudStepKeyMoveComponent, StandBy)
+NERVE_ACTION_IMPL(CloudStepKeyMoveComponent, Move)
+NERVE_ACTION_IMPL(CloudStepKeyMoveComponent, Stop)
+
+NERVE_ACTIONS_MAKE_STRUCT(CloudStepKeyMoveComponent, Wait, StandBy, Move, Stop)
+}  // namespace
+
+CloudStepKeyMoveComponent::CloudStepKeyMoveComponent(CloudStep* cloudStep)
+    : al::LiveActor("雲足場キームーブ"), mCloudStep(cloudStep) {}
+
+void CloudStepKeyMoveComponent::init(const al::ActorInitInfo& info) {
+    using CloudStepKeyMoveComponentFunctor =
+        al::FunctorV0M<CloudStepKeyMoveComponent*, void (CloudStepKeyMoveComponent::*)()>;
+
+    al::initNerveAction(this, "Wait", &NrvCloudStepKeyMoveComponent.collector, 0);
+    al::initActorSceneInfo(this, info);
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    al::tryGetArg(&mIsFloorTouchStart, info, "IsFloorTouchStart");
+
+    if (al::getKeyPoseCount(mKeyPoseKeeper) < 2 || mIsFloorTouchStart ||
+        al::listenStageSwitchOnStart(mCloudStep, CloudStepKeyMoveComponentFunctor(
+                                                     this, &CloudStepKeyMoveComponent::start))) {
+        al::startNerveAction(this, "StandBy");
+    }
+
+    al::listenStageSwitchOn(
+        mCloudStep, "SwitchStop",
+        CloudStepKeyMoveComponentFunctor(this, &CloudStepKeyMoveComponent::stop));
+    makeActorAlive();
+}
+
+void CloudStepKeyMoveComponent::start() {
+    if (!al::isNerve(this, NrvCloudStepKeyMoveComponent.StandBy.data()))
+        return;
+
+    if (al::getKeyPoseCount(mKeyPoseKeeper) < 2)
+        return;
+
+    al::startNerveAction(this, "Wait");
+}
+
+void CloudStepKeyMoveComponent::stop() {
+    if (!al::isNerve(this, NrvCloudStepKeyMoveComponent.Stop.data()))
+        al::startNerveAction(this, "Stop");
+}
+
+bool CloudStepKeyMoveComponent::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                           al::HitSensor* self) {
+    if (!mIsFloorTouchStart || !al::isMsgFloorTouch(message))
+        return false;
+
+    if (al::isNerve(this, NrvCloudStepKeyMoveComponent.StandBy.data()) &&
+        al::getKeyPoseCount(mKeyPoseKeeper) >= 2)
+        al::startNerveAction(this, "Wait");
+
+    return true;
+}
+
+void CloudStepKeyMoveComponent::exeWait() {
+    if (al::isFirstStep(this)) {
+        s32 waitTime = al::calcKeyMoveWaitTime(mKeyPoseKeeper);
+        if (waitTime >= 0)
+            mWaitTime = waitTime;
+    }
+
+    if (al::isGreaterEqualStep(this, mWaitTime)) {
+        if (al::isRestart(mKeyPoseKeeper)) {
+            al::restartKeyPose(mKeyPoseKeeper, al::getTransPtr(mCloudStep),
+                               al::getQuatPtr(mCloudStep));
+            al::resetPosition(mCloudStep);
+            al::startNerveAction(this, "Wait");
+        } else {
+            al::startNerveAction(this, "Move");
+        }
+    }
+}
+
+void CloudStepKeyMoveComponent::exeStandBy() {}
+
+void CloudStepKeyMoveComponent::exeMove() {
+    if (al::isFirstStep(this))
+        mMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+
+    f32 rate = al::calcNerveRate(this, mMoveTime);
+    al::calcLerpKeyTrans(al::getTransPtr(mCloudStep), mKeyPoseKeeper, rate);
+    al::calcSlerpKeyQuat(al::getQuatPtr(mCloudStep), mKeyPoseKeeper, rate);
+
+    if (al::isGreaterEqualStep(this, mMoveTime)) {
+        al::nextKeyPose(mKeyPoseKeeper);
+
+        if (al::isStop(mKeyPoseKeeper)) {
+            if (al::isNerve(this, NrvCloudStepKeyMoveComponent.Stop.data()))
+                return;
+
+            al::startNerveAction(this, "Stop");
+        } else {
+            al::startNerveAction(this, "Wait");
+        }
+    }
+}
+
+void CloudStepKeyMoveComponent::exeStop() {
+    if (al::isFirstStep(this) && al::isInvalidClipping(mCloudStep))
+        al::validateClipping(mCloudStep);
+}

--- a/src/MapObj/CloudStepKeyMoveComponent.h
+++ b/src/MapObj/CloudStepKeyMoveComponent.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CloudStep;
+
+namespace al {
+class KeyPoseKeeper;
+}
+
+class CloudStepKeyMoveComponent : public al::LiveActor {
+public:
+    CloudStepKeyMoveComponent(CloudStep* cloudStep);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void start();
+    void stop();
+    void exeWait();
+    void exeStandBy();
+    void exeMove();
+    void exeStop();
+
+private:
+    CloudStep* mCloudStep = nullptr;
+    al::KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    s32 mWaitTime = 30;
+    s32 mMoveTime = 0;
+    bool mIsFloorTouchStart = false;
+};
+
+static_assert(sizeof(CloudStepKeyMoveComponent) == 0x128);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1140)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24f5aab - 3d3b1a7)

📈 **Matched code**: 14.56% (+0.01%, +1740 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::init(al::ActorInitInfo const&)` | +296 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::exeMove()` | +228 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::exeWait()` | +172 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::CloudStepKeyMoveComponent(CloudStep*)` | +160 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::CloudStepKeyMoveComponent(CloudStep*)` | +156 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `_GLOBAL__sub_I_CloudStepKeyMoveComponent.cpp` | +140 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +116 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::start()` | +88 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `al::FunctorV0M<CloudStepKeyMoveComponent*, void (CloudStepKeyMoveComponent::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::stop()` | +72 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvStop::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::exeStop()` | +64 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `al::FunctorV0M<CloudStepKeyMoveComponent*, void (CloudStepKeyMoveComponent::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvStandBy::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvStop::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `CloudStepKeyMoveComponent::exeStandBy()` | +4 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `(anonymous namespace)::CloudStepKeyMoveComponentNrvStandBy::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/CloudStepKeyMoveComponent` | `al::FunctorV0M<CloudStepKeyMoveComponent*, void (CloudStepKeyMoveComponent::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->