### PR TITLE
MapObj: Implement `CapAppearTarget`

### DIFF
--- a/src/MapObj/CapAppearMapParts.h
+++ b/src/MapObj/CapAppearMapParts.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CapAppearTarget;
+
+class CapAppearMapParts : public al::LiveActor {
+public:
+    CapAppearMapParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    void listenAppear();
+    void startWait();
+    void killAll();
+
+    void exeAppear();
+    void exeAppearEnd();
+    void exeWait();
+    void exeReaction();
+    void exeWaitForever();
+    void exeDisappear();
+
+private:
+    CapAppearTarget* mTarget = nullptr;
+    s32 mAppearTime = 0;
+    sead::Vector3f mTargetTrans = sead::Vector3f::zero;
+    f32 mDisappearDistance = 0.0f;
+    bool mHasDisappearSign = false;
+    sead::Vector3f mSensorPos = sead::Vector3f::zero;
+    bool mIsUseShadowMask = false;
+};
+
+static_assert(sizeof(CapAppearMapParts) == 0x138);

--- a/src/MapObj/CapAppearTarget.cpp
+++ b/src/MapObj/CapAppearTarget.cpp
@@ -1,0 +1,116 @@
+#include "MapObj/CapAppearTarget.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "MapObj/CapAppearMapParts.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(CapAppearTarget, Wait);
+NERVE_IMPL(CapAppearTarget, Appear);
+NERVE_IMPL(CapAppearTarget, Disappear);
+NERVE_IMPL(CapAppearTarget, Reaction);
+NERVE_IMPL(CapAppearTarget, Dead);
+
+NERVES_MAKE_NOSTRUCT(CapAppearTarget, Appear, Dead);
+
+struct {
+    CapAppearTargetNrvWait Wait;
+    CapAppearTargetNrvReaction Reaction;
+    CapAppearTargetNrvDisappear Disappear;
+} NrvCapAppearTarget;
+}  // namespace
+
+CapAppearTarget::CapAppearTarget(const char* name, CapAppearMapParts* mapParts)
+    : al::LiveActor(name), mMapParts(mapParts) {}
+
+void CapAppearTarget::init(const al::ActorInitInfo& info) {
+    al::initChildActorWithArchiveNameNoPlacementInfo(this, info, "CapAppearTarget", nullptr);
+    al::initNerve(this, &NrvCapAppearTarget.Wait, 0);
+
+    if (al::isValidStageSwitch(mMapParts, "SwitchAppear"))
+        makeActorDead();
+    else
+        makeActorAlive();
+}
+
+void CapAppearTarget::appear() {
+    al::LiveActor::appear();
+    al::startAction(this, "Appear");
+    calcAnim();
+    al::startHitReactionHitEffect(this, "出現", al::getTrans(this));
+    al::invalidateClipping(this);
+    al::setNerve(this, &Appear);
+}
+
+void CapAppearTarget::switchAppear() {
+    al::LiveActor::appear();
+    al::startAction(this, "Appear");
+    al::setNerve(this, &Appear);
+}
+
+bool CapAppearTarget::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                 al::HitSensor* self) {
+    if (rs::isMsgCapAttack(message) && (al::isNerve(this, &NrvCapAppearTarget.Wait) ||
+                                        al::isNerve(this, &NrvCapAppearTarget.Disappear))) {
+        al::startHitReactionHitEffect(this, "攻撃された時", al::getTrans(this));
+        mMapParts->appear();
+        al::setNerve(this, &NrvCapAppearTarget.Reaction);
+        return true;
+    }
+
+    if ((al::isMsgPlayerObjTouch(message) || al::isMsgKickStoneAttack(message)) &&
+        mIsValidTouchReaction && al::isNerve(this, &NrvCapAppearTarget.Wait)) {
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvCapAppearTarget.Disappear);
+        return true;
+    }
+
+    return false;
+}
+
+void CapAppearTarget::exeWait() {
+    if (al::isFirstStep(this)) {
+        al::validateClipping(this);
+        al::startAction(this, "Wait");
+    }
+
+    if (!mIsValidTouchReaction && !al::isNearPlayer(this, 300.0f))
+        mIsValidTouchReaction = true;
+}
+
+void CapAppearTarget::exeReaction() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Reaction");
+
+    if (al::isActionEnd(this)) {
+        al::setNerve(this, &NrvCapAppearTarget.Wait);
+        mIsValidTouchReaction = false;
+    }
+}
+
+void CapAppearTarget::exeAppear() {
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvCapAppearTarget.Wait);
+}
+
+void CapAppearTarget::exeDisappear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "DisAppear");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Dead);
+}
+
+void CapAppearTarget::exeDead() {
+    if (al::isFirstStep(this))
+        kill();
+}

--- a/src/MapObj/CapAppearTarget.h
+++ b/src/MapObj/CapAppearTarget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CapAppearMapParts;
+
+class CapAppearTarget : public al::LiveActor {
+public:
+    CapAppearTarget(const char* name, CapAppearMapParts* mapParts);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void switchAppear();
+
+    void exeWait();
+    void exeReaction();
+    void exeAppear();
+    void exeDisappear();
+    void exeDead();
+
+private:
+    CapAppearMapParts* mMapParts = nullptr;
+    bool mIsValidTouchReaction = true;
+};
+
+static_assert(sizeof(CapAppearTarget) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1141)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24f5aab - 7a1a314)

📈 **Matched code**: 14.56% (+0.01%, +1644 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CapAppearTarget` | `CapAppearTarget::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +232 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::init(al::ActorInitInfo const&)` | +152 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::CapAppearTarget(char const*, CapAppearMapParts*)` | +148 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::CapAppearTarget(char const*, CapAppearMapParts*)` | +144 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::appear()` | +112 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `(anonymous namespace)::CapAppearTargetNrvWait::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::exeWait()` | +96 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `(anonymous namespace)::CapAppearTargetNrvDisappear::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::exeDisappear()` | +88 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `(anonymous namespace)::CapAppearTargetNrvReaction::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::exeReaction()` | +84 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `(anonymous namespace)::CapAppearTargetNrvAppear::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `(anonymous namespace)::CapAppearTargetNrvDead::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::switchAppear()` | +60 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::exeAppear()` | +60 | 0.00% | 100.00% |
| `MapObj/CapAppearTarget` | `CapAppearTarget::exeDead()` | +60 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->