### PR TITLE
MapObj: Implement `YoshiEgg`

### DIFF
--- a/src/MapObj/FukankunZoomCapMessage.h
+++ b/src/MapObj/FukankunZoomCapMessage.h
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+namespace sead {
+template <typename T>
+class BufferedSafeStringBase;
+}  // namespace sead
+
+class FukankunZoomCapMessage {
+public:
+    FukankunZoomCapMessage(const al::LiveActor* actor);
+
+    void init(const al::ActorInitInfo& info, const char* capMessageName,
+              const char* stageMessageName);
+    void initAfterPlacement();
+    void update();
+
+    void setWatchCount(s32 watchCount) { mWatchCount = watchCount; }
+
+    void resetZoomTypes() {
+        mFukankunZoomType = 0;
+        mCapMessageShowType = 0;
+    }
+
+private:
+    const al::LiveActor* mActor = nullptr;
+    s32 mFukankunZoomType = 0;
+    s32 mCapMessageShowType = 1;
+    s32 mWatchCount = 0;
+    bool mIsDisableAfterEnding = false;
+    u8 _15[3] = {};
+    sead::Vector3f mOffset = sead::Vector3f::zero;
+    const char* mTargetJointName = nullptr;
+    bool mIsDisable = false;
+    u8 _31[7] = {};
+    sead::BufferedSafeStringBase<char>* mCapMessageName = nullptr;
+    sead::BufferedSafeStringBase<char>* mStageMessageName = nullptr;
+    bool mIsShown = false;
+    u8 _49[7] = {};
+};
+
+static_assert(sizeof(FukankunZoomCapMessage) == 0x50);

--- a/src/Player/YoshiEgg.cpp
+++ b/src/Player/YoshiEgg.cpp
@@ -1,0 +1,124 @@
+#include "Player/YoshiEgg.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "MapObj/FukankunZoomCapMessage.h"
+#include "MapObj/FukankunZoomTargetFunction.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(YoshiEgg, Wait);
+NERVE_IMPL(YoshiEgg, Appear);
+NERVE_IMPL(YoshiEgg, Break);
+
+NERVES_MAKE_NOSTRUCT(YoshiEgg, Appear);
+
+struct {
+    YoshiEggNrvWait Wait;
+    YoshiEggNrvBreak Break;
+} NrvYoshiEgg;
+}  // namespace
+
+YoshiEgg::YoshiEgg(const al::LiveActor* hostActor, const IUsePlayerCollision* playerCollision)
+    : al::LiveActor("卵"), mHostActor(hostActor), mPlayerCollision(playerCollision) {}
+
+void YoshiEgg::init(const al::ActorInitInfo& info) {
+    al::initChildActorWithArchiveNameNoPlacementInfo(this, info, "YoshiEgg", nullptr);
+    al::initNerve(this, &NrvYoshiEgg.Wait, 0);
+
+    if (al::isPlaced(info)) {
+        bool isFukankunZoomCapMessage = false;
+        if (al::tryGetArg(&isFukankunZoomCapMessage, info, "IsFukankunZoomCapMessage") &&
+            isFukankunZoomCapMessage) {
+            mFukankunZoomCapMessage = new FukankunZoomCapMessage(this);
+            mFukankunZoomCapMessage->init(info, "CapMessage", "FukankunZoomYoshiEgg");
+
+            FukankunZoomCapMessage* capMessage = mFukankunZoomCapMessage;
+            capMessage->setWatchCount(FukankunZoomTargetFunction::getFukankunWatchCountDefault());
+            capMessage->resetZoomTypes();
+        }
+    }
+
+    makeActorDead();
+}
+
+void YoshiEgg::initAfterPlacement() {
+    if (mFukankunZoomCapMessage)
+        mFukankunZoomCapMessage->initAfterPlacement();
+}
+
+void YoshiEgg::initPlacementEgg() {
+    al::copyPose(this, mHostActor);
+    appear();
+    al::setNerve(this, &NrvYoshiEgg.Wait);
+}
+
+void YoshiEgg::appearEgg() {
+    al::copyPose(this, mHostActor);
+    appear();
+    al::invalidateClipping(this);
+    al::setNerve(this, &Appear);
+}
+
+bool YoshiEgg::isEndAppear() const {
+    return !al::isNerve(this, &Appear);
+}
+
+bool YoshiEgg::isBreak() const {
+    return al::isNerve(this, &NrvYoshiEgg.Break);
+}
+
+void YoshiEgg::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+
+    al::copyPose(this, mHostActor);
+
+    if (al::isActionEnd(this)) {
+        al::validateClipping(this);
+        al::setNerve(this, &NrvYoshiEgg.Wait);
+    }
+}
+
+void YoshiEgg::exeWait() {
+    al::tryStartActionIfNotPlaying(this, "Wait");
+    al::copyPose(this, mHostActor);
+
+    if (mFukankunZoomCapMessage)
+        mFukankunZoomCapMessage->update();
+}
+
+void YoshiEgg::exeBreak() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Break");
+
+    if (al::isActionEnd(this))
+        kill();
+}
+
+void YoshiEgg::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorName(self, "Push") && !al::isNerve(this, &NrvYoshiEgg.Break))
+        rs::sendMsgPushToPlayer(other, self);
+}
+
+bool YoshiEgg::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isSensorName(self, "Push"))
+        return al::isMsgPlayerDisregard(message);
+
+    if ((al::isMsgPlayerTrample(message) || rs::isMsgPlayerAndCapObjHipDropReflectAll(message) ||
+         rs::isMsgCapAttack(message) || rs::isMsgThrowObjHitReflect(message) ||
+         rs::isMsgTankBullet(message) || rs::isMsgMotorcycleAttack(message)) &&
+        al::isNerve(this, &NrvYoshiEgg.Wait)) {
+        al::setNerve(this, &NrvYoshiEgg.Break);
+        return true;
+    }
+
+    return false;
+}

--- a/src/Player/YoshiEgg.h
+++ b/src/Player/YoshiEgg.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class FukankunZoomCapMessage;
+class IUsePlayerCollision;
+
+class YoshiEgg : public al::LiveActor {
+public:
+    YoshiEgg(const al::LiveActor* hostActor, const IUsePlayerCollision* playerCollision);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void initPlacementEgg();
+    void appearEgg();
+    bool isEndAppear() const;
+    bool isBreak() const;
+    void exeAppear();
+    void exeWait();
+    void exeBreak();
+
+private:
+    const al::LiveActor* mHostActor = nullptr;
+    const IUsePlayerCollision* mPlayerCollision = nullptr;
+    FukankunZoomCapMessage* mFukankunZoomCapMessage = nullptr;
+};
+
+static_assert(sizeof(YoshiEgg) == 0x120);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1142)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24f5aab - 70399aa)

📈 **Matched code**: 14.56% (+0.01%, +1604 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/YoshiEgg` | `YoshiEgg::init(al::ActorInitInfo const&)` | +244 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +188 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::YoshiEgg(al::LiveActor const*, IUsePlayerCollision const*)` | +156 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::YoshiEgg(al::LiveActor const*, IUsePlayerCollision const*)` | +152 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::attackSensor(al::HitSensor*, al::HitSensor*)` | +112 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvAppear::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeAppear()` | +108 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvBreak::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeBreak()` | +88 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvWait::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::appearEgg()` | +72 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeWait()` | +72 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::initPlacementEgg()` | +64 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::isEndAppear() const` | +36 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::initAfterPlacement()` | +16 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::isBreak() const` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->