### PR TITLE
MapObj: Implement `MoonBasementGate`, `MoonBasementFinalGate` and `MoonBasementGateParts`

### DIFF
--- a/src/MapObj/CollisionAnimCtrl.h
+++ b/src/MapObj/CollisionAnimCtrl.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+struct ActorInitInfo;
+class CollisionObj;
+class LiveActor;
+}  // namespace al
+
+class CollisionAnimCtrl {
+public:
+    CollisionAnimCtrl(const al::LiveActor* actor, const al::ActorInitInfo& info,
+                      const char** collisionNames, s32 collisionNum);
+
+    void startBreak(const char* collisionName);
+    void killAll();
+
+private:
+    al::CollisionObj** mCollisionObjs = nullptr;
+    s32 mCollisionNum = 0;
+};
+
+static_assert(sizeof(CollisionAnimCtrl) == 0x10);

--- a/src/MapObj/MoonBasementFinalGate.cpp
+++ b/src/MapObj/MoonBasementFinalGate.cpp
@@ -1,0 +1,222 @@
+#include "MapObj/MoonBasementFinalGate.h"
+
+#include "Library/Camera/CameraUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/BreakModel.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "MapObj/CollisionAnimCtrl.h"
+#include "Npc/PeachOnKoopaAnimRequester.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(MoonBasementFinalGate, BreakPillar)
+NERVE_IMPL(MoonBasementFinalGate, Wait)
+NERVE_IMPL(MoonBasementFinalGate, BreakLastAfter)
+NERVE_IMPL(MoonBasementFinalGate, Break)
+NERVE_IMPL(MoonBasementFinalGate, BreakLast)
+
+NERVES_MAKE_NOSTRUCT(MoonBasementFinalGate, BreakPillar)
+NERVES_MAKE_STRUCT(MoonBasementFinalGate, Wait, BreakLastAfter, Break, BreakLast)
+
+const char* sBreakPillarActions[] = {"WaitInit", "BreakPillar1", "BreakPillar2", "BreakPillar3",
+                                     "BreakPillar4"};
+const char* sBreakLastAfterActions[] = {"BreakLastAfter1", "BreakLastAfter2", "BreakLastAfter3",
+                                        "BreakLastAfter4", "BreakLastAfter5", "BreakLastAfter6",
+                                        "BreakLastAfter7", "BreakLastAfter8", "BreakLastAfter9",
+                                        "BreakLastAfter9", "BreakLastAfter9", "BreakLastAfter9"};
+const char* sBreakAfterActions[] = {"BreakAfter1", "BreakAfter2", "BreakAfter3", "BreakAfter4",
+                                    "BreakAfter5"};
+const char* sBreakPillarAfterActions[] = {"WaitInit", "BreakPillarAfter1", "BreakPillarAfter2",
+                                          "BreakPillarAfter3", "BreakPillarAfter4"};
+const char* sBreakPillarReactions[] = {"WaitInit", "柱ヒット1", "柱ヒット2", "柱ヒット3",
+                                       "柱ヒット4"};
+const char* sBreakActions[] = {"Break1", "Break2", "Break3", "Break4", "Break5"};
+const char* sBreakReactions[] = {"ひび割れ1", "ひび割れ2", "ひび割れ3", "ひび割れ4", "ひび割れ5"};
+const char* sBreakLastActions[] = {"BreakLast1", "BreakLast2", "BreakLast3", "BreakLast4",
+                                   "BreakLast5", "BreakLast6", "BreakLast7", "BreakLast8",
+                                   "BreakLast9", "BreakLast9", "BreakLast9", "BreakLastFinal"};
+const char* sBreakLastReactions[] = {"ひび割れラスト1",   "ひび割れラスト2",   "ひび割れラスト3",
+                                     "ひび割れラスト4",   "ひび割れラスト5",   "ひび割れラスト6",
+                                     "ひび割れラスト7",   "ひび割れラスト8",   "ひび割れラスト9",
+                                     "ひび割れラスト9-2", "ひび割れラスト9-3", "とどめ開始"};
+const char* sCollisionNames[] = {"BreakPillar1", "BreakPillar2", "BreakPillar3",
+                                 "BreakPillar4", "Break1",       "Break2",
+                                 "Break3",       "Break4",       "Break5"};
+}  // namespace
+
+MoonBasementFinalGate::MoonBasementFinalGate(const char* name) : al::LiveActor(name) {}
+
+void MoonBasementFinalGate::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &NrvMoonBasementFinalGate.Wait, 0);
+
+    mBreakModel = al::createBreakModel(this, info, "崩落ステージの最後の岩壊れモデル",
+                                       "MoonBasementFinalGateBreak", nullptr, nullptr, "Break");
+
+    mCollisionAnimCtrl = new CollisionAnimCtrl(this, info, sCollisionNames, 9);
+
+    if (al::tryGetBoolArgOrFalse(info, "IsValidBreakLastObjectCamera"))
+        mBreakLastCameraTicket = al::initObjectCamera(this, info, "BreakLast", nullptr);
+
+    al::invalidateHitSensor(this, "AttackBreak");
+    makeActorAlive();
+}
+
+void MoonBasementFinalGate::kill() {
+    al::tryOnSwitchDeadOn(this);
+    mBreakModel->appear();
+    al::LiveActor::kill();
+    mCollisionAnimCtrl->killAll();
+}
+
+void MoonBasementFinalGate::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorPlayerAttack(self))
+        rs::sendMsgMoonBasementBreakShockwaveMeteor(other, self);
+}
+
+bool MoonBasementFinalGate::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                       al::HitSensor* self) {
+    if (al::isNerve(this, &NrvMoonBasementFinalGate.BreakLastAfter))
+        return false;
+
+    if (!rs::isMsgKoopaHackPunchCollide(message) && !al::isMsgExplosionCollide(message))
+        return false;
+
+    if (mBreakPillarIndex < 4)
+        return false;
+
+    s32 breakAfterIndex = mBreakAfterIndex + 1;
+    if (breakAfterIndex <= 4) {
+        mBreakAfterIndex = breakAfterIndex;
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvMoonBasementFinalGate.Break);
+        return true;
+    }
+
+    s32 breakLastIndex = mBreakLastIndex + 1;
+    if (breakLastIndex <= 11) {
+        mBreakLastIndex = breakLastIndex;
+        al::invalidateClipping(this);
+        al::setNerve(this, &NrvMoonBasementFinalGate.BreakLast);
+        return true;
+    }
+
+    return false;
+}
+
+void MoonBasementFinalGate::startBreakPillar(s32 breakPillarIndex) {
+    if (breakPillarIndex >= 2)
+        for (s32 i = 1; i < breakPillarIndex; i++)
+            mCollisionAnimCtrl->startBreak(sBreakPillarActions[i]);
+
+    mBreakPillarIndex = breakPillarIndex;
+    al::invalidateClipping(this);
+    al::setNerve(this, &BreakPillar);
+}
+
+void MoonBasementFinalGate::exeWait() {
+    if (!al::isFirstStep(this))
+        return;
+
+    const char* actionName = "WaitInit";
+    if ((u32)mBreakLastIndex <= 11)
+        actionName = sBreakLastAfterActions[mBreakLastIndex];
+    else if ((u32)mBreakAfterIndex <= 4)
+        actionName = sBreakAfterActions[mBreakAfterIndex];
+    else if ((u32)(mBreakPillarIndex - 1) <= 3)
+        actionName = sBreakPillarAfterActions[mBreakPillarIndex];
+
+    al::startAction(this, actionName);
+    al::validateClipping(this);
+}
+
+void MoonBasementFinalGate::exeBreakPillar() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, sBreakPillarActions[mBreakPillarIndex]);
+        al::startHitReaction(this, sBreakPillarReactions[mBreakPillarIndex]);
+    }
+
+    if (al::isActionEnd(this)) {
+        mCollisionAnimCtrl->startBreak(sBreakPillarActions[mBreakPillarIndex]);
+        al::setNerve(this, &NrvMoonBasementFinalGate.Wait);
+    }
+}
+
+void MoonBasementFinalGate::exeBreak() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, sBreakActions[mBreakAfterIndex]);
+        al::startHitReaction(this, sBreakReactions[mBreakAfterIndex]);
+    }
+
+    if (al::isActionEnd(this)) {
+        if (mBreakAfterIndex >= 4)
+            al::tryOnStageSwitch(this, "SwitchBreakEndOn");
+
+        mCollisionAnimCtrl->startBreak(sBreakActions[mBreakAfterIndex]);
+        al::setNerve(this, &NrvMoonBasementFinalGate.Wait);
+    }
+}
+
+void MoonBasementFinalGate::exeBreakLast() {
+    s32 breakLastIndex = mBreakLastIndex;
+
+    do {
+        if (al::isFirstStep(this)) {
+            al::startAction(this, sBreakLastActions[mBreakLastIndex]);
+            al::startHitReaction(this, sBreakLastReactions[mBreakLastIndex]);
+
+            if (breakLastIndex > 10 || (al::isStep(this, 2), false))
+                al::validateHitSensor(this, "AttackBreak");
+            else
+                break;
+        }
+
+        s32 isBreakStep = al::isStep(this, 2);
+        if (breakLastIndex >= 11) {
+            if (isBreakStep)
+                al::invalidateHitSensor(this, "AttackBreak");
+        }
+    } while (false);
+
+    if (!al::isActionEnd(this))
+        return;
+
+    if (breakLastIndex >= 11) {
+        al::startHitReaction(this, "とどめ終了");
+        rs::requestStartPeachOnKoopaHitReactionBreakGateFinal(this);
+        al::tryOnStageSwitch(this, "SwitchBreakFinalOn");
+
+        if (mBreakLastCameraTicket != nullptr) {
+            al::hideModelIfShow(this);
+            al::invalidateCollisionParts(this);
+            al::setNerve(this, &NrvMoonBasementFinalGate.BreakLastAfter);
+            return;
+        }
+
+        kill();
+        return;
+    }
+
+    al::setNerve(this, &NrvMoonBasementFinalGate.Wait);
+}
+
+void MoonBasementFinalGate::exeBreakLastAfter() {
+    if (al::isFirstStep(this))
+        al::startCamera(this, mBreakLastCameraTicket, -1);
+
+    if (al::isGreaterEqualStep(this, 150)) {
+        rs::requestStartPeachOnKoopaAnimSuccess(this);
+        al::endCamera(this, mBreakLastCameraTicket, -1, false);
+        kill();
+    }
+}

--- a/src/MapObj/MoonBasementFinalGate.h
+++ b/src/MapObj/MoonBasementFinalGate.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CollisionAnimCtrl;
+
+namespace al {
+class BreakModel;
+class CameraTicket;
+}  // namespace al
+
+class MoonBasementFinalGate : public al::LiveActor {
+public:
+    MoonBasementFinalGate(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void kill() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void startBreakPillar(s32 breakPillarIndex);
+
+    void exeWait();
+    void exeBreakPillar();
+    void exeBreak();
+    void exeBreakLast();
+    void exeBreakLastAfter();
+
+private:
+    CollisionAnimCtrl* mCollisionAnimCtrl = nullptr;
+    al::BreakModel* mBreakModel = nullptr;
+    al::CameraTicket* mBreakLastCameraTicket = nullptr;
+    s32 mBreakPillarIndex = 0;
+    s32 mBreakAfterIndex = -1;
+    s32 mBreakLastIndex = -1;
+};
+
+static_assert(sizeof(MoonBasementFinalGate) == 0x130);

--- a/src/MapObj/MoonBasementGate.cpp
+++ b/src/MapObj/MoonBasementGate.cpp
@@ -1,0 +1,272 @@
+#include "MapObj/MoonBasementGate.h"
+
+#include <math/seadMatrix.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/BreakModel.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Boss/Koopa/KoopaHackStopCtrl.h"
+#include "Npc/PeachOnKoopaAnimRequester.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace alSeFunction {
+void startSituation(const al::IUseAudioKeeper* user, const char* situationName, s32 fadeFrames);
+void endSituation(const al::IUseAudioKeeper* user, const char* situationName, s32 fadeFrames);
+}  // namespace alSeFunction
+
+namespace {
+NERVE_IMPL(MoonBasementGate, Invalid)
+NERVE_IMPL(MoonBasementGate, BreakAfter)
+NERVE_IMPL(MoonBasementGate, Wait)
+NERVE_IMPL(MoonBasementGate, Break)
+NERVE_IMPL(MoonBasementGate, ClimaxCamera)
+
+NERVES_MAKE_NOSTRUCT(MoonBasementGate, Invalid, BreakAfter)
+NERVES_MAKE_STRUCT(MoonBasementGate, Wait, Break, ClimaxCamera)
+
+const char sPartsSuffixCBA[] = {'C', 'B', 'A', '\0'};
+const char sPartsSuffixCB[] = {'C', 'B', '\0'};
+const char* sPartsSuffixes[] = {sPartsSuffixCBA, sPartsSuffixCB, "C", "", "D"};
+const char* sBreakActions[] = {"Break1", "Break2", "Break3", "Break4", "Break5"};
+const char* sBreakReactions[] = {"ひび割れ1", "ひび割れ2", "ひび割れ3", "ひび割れ4", "ひび割れ5"};
+
+void moveSlideToTarget(al::LiveActor* actor, const sead::Vector3f& targetTrans) {
+    sead::Vector3f direction = targetTrans - al::getTrans(actor);
+    al::verticalizeVec(&direction, al::getFront(actor), direction);
+
+    sead::Vector3f nextTrans = al::getTrans(actor) + direction;
+    al::resetPosition(actor, nextTrans);
+}
+}  // namespace
+
+MoonBasementGate::MoonBasementGate(const char* name) : al::LiveActor(name) {}
+
+void MoonBasementGate::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    al::initNerve(this, &Invalid, 0);
+    al::initActorBgmKeeper(this, info, nullptr);
+    al::invalidateHitSensorPlayerAll(this);
+
+    sead::Matrix34f* matrix = new sead::Matrix34f;
+    al::makeMtxSRT(matrix, this);
+
+    const char* modelName = al::getModelName(this);
+    al::HitSensor* collisionSensor = al::getHitSensor(this, "Collision");
+    mCollisionObj =
+        al::createCollisionObjMtx(this, info, modelName, collisionSensor, matrix, nullptr);
+    mCollisionObj->makeActorAlive();
+
+    if (al::isEqualString(al::getModelName(this), "MoonBasementGate")) {
+        mBreakModel = al::createBreakModel(this, info, "崩落ステージのゲート壊れモデル",
+                                           "MoonBasementGateBreak", nullptr, nullptr, "Break");
+    } else if (al::isEqualString(al::getModelName(this), "MoonBasementGateHard")) {
+        mBreakModel = al::createBreakModel(this, info, "崩落ステージのゲート壊れモデル",
+                                           "MoonBasementGateHardBreak", nullptr, nullptr, "Break");
+    }
+
+    al::initSubActorKeeperNoFile(this, info, 5);
+    mParts = new MoonBasementGateParts*[5];
+
+    IMoonBasementGateParts* firstPrevParts = this;
+    s32 prevIndex = -1;
+    const char* breakModelFormat = "MoonBasementGateParts%sBreak";
+    for (s32 i = 0; i < 5; i++) {
+        s32 next = i + 1;
+        sead::Vector3f partsTrans(0.0f, 0.0f, 0.0f);
+        sead::Vector3f localTrans(0.0f, 0.0f, next * 400.0f);
+        al::multVecPose(&partsTrans, this, localTrans);
+
+        mParts[i] = new MoonBasementGateParts("");
+
+        const char* suffix = sPartsSuffixes[i];
+        MoonBasementGateParts* parts = mParts[i];
+        al::StringTmp<64> model("MoonBasementGateParts%s", suffix);
+        const char* partsModelName = model.cstr();
+        al::StringTmp<64> breakModel(breakModelFormat, suffix);
+
+        parts->initParts(info, partsModelName, breakModel.cstr(), partsTrans, next < 5);
+
+        MoonBasementGateParts* currentParts = mParts[i];
+        IMoonBasementGateParts* prevParts;
+        if (i < 1) {
+            prevParts = firstPrevParts;
+        } else {
+            MoonBasementGateParts* prevActor = mParts[prevIndex];
+            prevParts = prevActor != nullptr ? prevActor : nullptr;
+        }
+        currentParts->setPrevParts(prevParts);
+
+        al::registerSubActorSyncClipping(this, mParts[i]);
+        prevIndex++;
+    }
+
+    if (al::isExistLinkChild(info, "ClimaxEventKeyMoveCamera", 0)) {
+        mClimaxCameraTicket = al::initAnimCamera(this, info, "Anim");
+        al::tryGetLinksQT(&mClimaxAfterKoopaQuat, &mClimaxAfterKoopaTrans, info,
+                          "ClimaxAfterKoopaPosture");
+    }
+
+    makeActorAlive();
+}
+
+void MoonBasementGate::kill() {
+    al::LiveActor::kill();
+    mCollisionObj->kill();
+
+    for (s32 i = 0; i < 5; i++)
+        if (al::isAlive(mParts[i]))
+            mParts[i]->kill();
+
+    al::tryOnSwitchDeadOn(this);
+    al::tryOffStageSwitch(this, "SwitchAllRockBreakOn");
+}
+
+void MoonBasementGate::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorPlayerAttack(self))
+        rs::sendMsgMoonBasementBreakShockwaveMeteor(other, self);
+}
+
+bool MoonBasementGate::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self) {
+    if (rs::isMsgKoopaInvalidHackPunchFaceToCollision(message))
+        return true;
+
+    bool canReceive = al::isNerve(this, &NrvMoonBasementGate.Wait);
+    if (!canReceive && al::isNerve(this, &NrvMoonBasementGate.Break))
+        canReceive = al::isGreaterStep(this, 12);
+
+    if (!canReceive)
+        return false;
+
+    bool isPunchCollide = rs::isMsgKoopaHackPunchCollide(message);
+    if (!isPunchCollide) {
+        if (al::isEqualString(al::getModelName(this), "MoonBasementGateHard"))
+            return false;
+        if (!al::isMsgExplosionCollide(message))
+            return false;
+    }
+
+    if (mBreakCount <= 5 && al::isExistAction(this, sBreakActions[mBreakCount])) {
+        al::setNerve(this, &NrvMoonBasementGate.Break);
+        return true;
+    }
+
+    al::startHitReaction(this, "破壊");
+
+    if (mBreakModel != nullptr)
+        mBreakModel->appear();
+
+    if (mClimaxCameraTicket == nullptr) {
+        rs::requestStartPeachOnKoopaAnimSuccess(this);
+        kill();
+    } else {
+        al::tryOnStageSwitch(this, "SwitchClimaxCameraStartOn");
+        al::setNerve(this, &NrvMoonBasementGate.ClimaxCamera);
+    }
+
+    return true;
+}
+
+void MoonBasementGate::validate() {
+    al::setNerve(this, &NrvMoonBasementGate.Wait);
+}
+
+void MoonBasementGate::moveSlideToTarget(const sead::Vector3f& targetTrans) {
+    if (al::isEqualString(al::getModelName(this), "MoonBasementGateHard")) {
+        al::tryOnStageSwitch(this, "SwitchAllRockBreakOn");
+        return;
+    }
+
+    ::moveSlideToTarget(this, targetTrans);
+}
+
+void MoonBasementGate::exeInvalid() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MoonBasementGate::exeWait() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(this, "Wait");
+}
+
+void MoonBasementGate::exeBreak() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, sBreakActions[mBreakCount]);
+
+        if (al::isEqualString(al::getModelName(this), "MoonBasementGateHard"))
+            rs::requestStartPeachOnKoopaHitReactionCrackGateHard(this);
+
+        mBreakCount++;
+    }
+
+    if (al::isGreaterEqualStep(this, 1)) {
+        if (al::isStep(this, 1))
+            al::startHitReaction(this, sBreakReactions[mBreakCount - 1]);
+
+        al::setNerveAtActionEnd(this, &NrvMoonBasementGate.Wait);
+    }
+}
+
+void MoonBasementGate::exeBreakAfter() {
+    if (al::isFirstStep(this)) {
+        KoopaHackFunction::startStopKoopaHack(this);
+        KoopaHackFunction::setStatusDemoForSceneKoopaHack(this);
+        rs::requestStartPeachOnKoopaHitReactionBreakGateHard(this);
+        al::hideModelIfShow(this);
+        al::validateHitSensor(this, "Shockwave");
+        al::stopAllBgm(this, -1);
+        alSeFunction::startSituation(this, "崩落ステージ地球デモ", -1);
+    }
+
+    if (al::isGreaterEqualStep(this, 60)) {
+        al::invalidateHitSensor(this, "Shockwave");
+        al::setNerve(this, &BreakAfter);
+    }
+}
+
+void MoonBasementGate::exeClimaxCamera() {
+    if (al::isFirstStep(this)) {
+        al::invalidateClipping(this);
+        al::startAnimCamera(this, mClimaxCameraTicket, "ClimaxCamera", 0);
+    }
+
+    if (al::isStep(this, 1))
+        KoopaHackFunction::resetPostureKoopaHack(this, mClimaxAfterKoopaQuat,
+                                                 mClimaxAfterKoopaTrans);
+
+    if (al::isStep(this, 170))
+        al::startBgm(this, "Climax", -1, 0);
+
+    if (al::isStep(this, 168))
+        al::startHitReaction(this, "クライマックスブラー");
+
+    if (al::isEndAnimCamera(mClimaxCameraTicket)) {
+        al::endCamera(this, mClimaxCameraTicket, -1, false);
+        al::validateClipping(this);
+        KoopaHackFunction::endStopKoopaHack(this);
+        KoopaHackFunction::resetStatusDemoForSceneKoopaHack(this);
+        rs::requestStartPeachOnKoopaAnimSuccess(this);
+        alSeFunction::endSituation(this, "崩落ステージ地球デモ", -1);
+        kill();
+    }
+}

--- a/src/MapObj/MoonBasementGate.h
+++ b/src/MapObj/MoonBasementGate.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "MapObj/MoonBasementGateParts.h"
+
+namespace al {
+class BreakModel;
+class CameraTicket;
+class CollisionObj;
+}  // namespace al
+
+class MoonBasementGate : public al::LiveActor, public IMoonBasementGateParts {
+public:
+    MoonBasementGate(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void kill() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void validate() override;
+    void moveSlideToTarget(const sead::Vector3f& targetTrans) override;
+
+    void exeInvalid();
+    void exeWait();
+    void exeBreak();
+    void exeBreakAfter();
+    void exeClimaxCamera();
+
+private:
+    s32 mBreakCount = 0;
+    al::BreakModel* mBreakModel = nullptr;
+    al::CollisionObj* mCollisionObj = nullptr;
+    MoonBasementGateParts** mParts = nullptr;
+    al::CameraTicket* mClimaxCameraTicket = nullptr;
+    sead::Quatf mClimaxAfterKoopaQuat = sead::Quatf::unit;
+    sead::Vector3f mClimaxAfterKoopaTrans = {0.0f, 0.0f, 0.0f};
+};
+
+static_assert(sizeof(MoonBasementGate) == 0x158);

--- a/src/MapObj/MoonBasementGateParts.cpp
+++ b/src/MapObj/MoonBasementGateParts.cpp
@@ -1,0 +1,108 @@
+#include "MapObj/MoonBasementGateParts.h"
+
+#include <math/seadMatrix.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/BreakModel.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Obj/PartsFunction.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(MoonBasementGateParts, Wait)
+NERVE_IMPL(MoonBasementGateParts, Invalid)
+NERVE_IMPL(MoonBasementGateParts, BreakDelay)
+
+NERVES_MAKE_STRUCT(MoonBasementGateParts, Wait, Invalid, BreakDelay)
+}  // namespace
+
+MoonBasementGateParts::MoonBasementGateParts(const char* name) : al::LiveActor(name) {}
+
+void MoonBasementGateParts::initParts(const al::ActorInitInfo& info, const char* modelName,
+                                      const char* breakModelName, const sead::Vector3f& trans,
+                                      bool isStartInvalid) {
+    al::initActorWithArchiveName(this, info, modelName, nullptr);
+    al::initNerve(this, &NrvMoonBasementGateParts.Wait, 0);
+    al::setTrans(this, trans);
+
+    sead::Matrix34f* matrix = new sead::Matrix34f;
+    al::makeMtxSRT(matrix, this);
+
+    al::HitSensor* collisionSensor = al::getHitSensor(this, "Collision");
+    mCollisionObj =
+        al::createCollisionObjMtx(this, info, modelName, collisionSensor, matrix, nullptr);
+    mCollisionObj->makeActorAlive();
+
+    mBreakModel = al::createBreakModel(this, info, "崩落ステージのゲートパーツ壊れモデル",
+                                       breakModelName, nullptr, nullptr, "Break");
+
+    if (isStartInvalid)
+        al::setNerve(this, &NrvMoonBasementGateParts.Invalid);
+
+    makeActorAlive();
+}
+
+void MoonBasementGateParts::kill() {
+    al::LiveActor::kill();
+    mCollisionObj->kill();
+
+    if (mPrevParts != nullptr)
+        mPrevParts->validate();
+}
+
+bool MoonBasementGateParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                       al::HitSensor* self) {
+    if (!al::isNerve(this, &NrvMoonBasementGateParts.Wait))
+        return false;
+
+    if (!rs::isMsgKoopaHackPunchCollide(message) && !al::isMsgExplosionCollide(message))
+        return false;
+
+    if (mPrevParts != nullptr)
+        mPrevParts->moveSlideToTarget(al::getActorTrans(other));
+
+    al::hideModelIfShow(this);
+    mBreakModel->appear();
+    al::startHitReaction(this, "破壊");
+    al::setNerve(this, &NrvMoonBasementGateParts.BreakDelay);
+    return true;
+}
+
+void MoonBasementGateParts::validate() {
+    al::setNerve(this, &NrvMoonBasementGateParts.Wait);
+}
+
+void MoonBasementGateParts::moveSlideToTarget(const sead::Vector3f& targetTrans) {
+    sead::Vector3f direction = targetTrans - al::getTrans(this);
+    al::verticalizeVec(&direction, al::getFront(this), direction);
+
+    sead::Vector3f nextTrans = al::getTrans(this) + direction;
+    al::resetPosition(this, nextTrans);
+}
+
+void MoonBasementGateParts::exeInvalid() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void MoonBasementGateParts::exeWait() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(this, "Wait");
+}
+
+void MoonBasementGateParts::exeBreakDelay() {
+    if (al::isGreaterEqualStep(this, 5)) {
+        al::LiveActor* actor = this;
+        actor->kill();
+    }
+}

--- a/src/MapObj/MoonBasementGateParts.h
+++ b/src/MapObj/MoonBasementGateParts.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class BreakModel;
+class CollisionObj;
+}  // namespace al
+
+class IMoonBasementGateParts {
+public:
+    virtual void validate() = 0;
+    virtual void moveSlideToTarget(const sead::Vector3f& targetTrans) = 0;
+};
+
+class MoonBasementGateParts : public al::LiveActor, public IMoonBasementGateParts {
+public:
+    MoonBasementGateParts(const char* name);
+
+    void initParts(const al::ActorInitInfo& info, const char* modelName, const char* breakModelName,
+                   const sead::Vector3f& trans, bool isStartInvalid);
+
+    void kill() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void validate() override;
+    void moveSlideToTarget(const sead::Vector3f& targetTrans) override;
+
+    void setPrevParts(IMoonBasementGateParts* prevParts) { mPrevParts = prevParts; }
+
+    void exeInvalid();
+    void exeWait();
+    void exeBreakDelay();
+
+private:
+    al::CollisionObj* mCollisionObj = nullptr;
+    al::BreakModel* mBreakModel = nullptr;
+    IMoonBasementGateParts* mPrevParts = nullptr;
+};
+
+static_assert(sizeof(MoonBasementGateParts) == 0x128);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -93,7 +93,9 @@
 #include "MapObj/LavaPan.h"
 #include "MapObj/MeganeMapParts.h"
 #include "MapObj/MoonBasementBreakParts.h"
+#include "MapObj/MoonBasementFinalGate.h"
 #include "MapObj/MoonBasementFloor.h"
+#include "MapObj/MoonBasementGate.h"
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/PeachWorldTree.h"
@@ -419,10 +421,10 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"MoonBasementBreakParts", al::createActorFunction<MoonBasementBreakParts>},
     {"MoonBasementClimaxWatcher", nullptr},
     {"MoonBasementFallObj", nullptr},
-    {"MoonBasementFinalGate", nullptr},
+    {"MoonBasementFinalGate", al::createActorFunction<MoonBasementFinalGate>},
     {"MoonBasementFallObjDecoration", nullptr},
     {"MoonBasementFloor", al::createActorFunction<MoonBasementFloor>},
-    {"MoonBasementGate", nullptr},
+    {"MoonBasementGate", al::createActorFunction<MoonBasementGate>},
     {"MoonBasementMeteorAreaObj", nullptr},
     {"MoonBasementPillar", nullptr},
     {"MoonBasementRock", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1143)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24f5aab - 1cfc376)

📈 **Matched code**: 14.60% (+0.05%, +6816 bytes)

<details>
<summary>✅ 54 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoonBasementGate` | `MoonBasementGate::init(al::ActorInitInfo const&)` | +760 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +328 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::exeBreakLast()` | +316 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::initParts(al::ActorInitInfo const&, char const*, char const*, sead::Vector3<float> const&, bool)` | +300 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::exeClimaxCamera()` | +284 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::kill()` | +252 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::init(al::ActorInitInfo const&)` | +228 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::moveSlideToTarget(sead::Vector3<float> const&)` | +212 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +196 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::MoonBasementGate(char const*)` | +192 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::exeBreakAfter()` | +192 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::MoonBasementGate(char const*)` | +188 | 0.00% | 100.00% |
| `MapObj/MoonBasementGate` | `MoonBasementGate::exeBreak()` | +188 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +184 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::exeBreak()` | +172 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `non-virtual thunk to MoonBasementGateParts::moveSlideToTarget(sead::Vector3<float> const&)` | +164 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::moveSlideToTarget(sead::Vector3<float> const&)` | +160 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::MoonBasementFinalGate(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `(anonymous namespace)::MoonBasementFinalGateNrvWait::execute(al::NerveKeeper*) const` | +152 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::exeWait()` | +148 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::MoonBasementGateParts(char const*)` | +148 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::MoonBasementFinalGate(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::exeBreakPillar()` | +144 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::MoonBasementGateParts(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `(anonymous namespace)::MoonBasementFinalGateNrvBreakLastAfter::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::exeBreakLastAfter()` | +120 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::startBreakPillar(int)` | +108 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `MoonBasementGateParts::kill()` | +76 | 0.00% | 100.00% |
| `MapObj/MoonBasementGateParts` | `(anonymous namespace)::MoonBasementGatePartsNrvBreakDelay::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/MoonBasementFinalGate` | `MoonBasementFinalGate::kill()` | +64 | 0.00% | 100.00% |

...and 24 more new matches
</details>


<!-- decomp.dev report end -->