### PR TITLE
MapObj: Implement `BlockEmpty`

### DIFF
--- a/src/MapObj/BlockEmpty.cpp
+++ b/src/MapObj/BlockEmpty.cpp
@@ -1,0 +1,112 @@
+#include "MapObj/BlockEmpty.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Shadow/ActorShadowUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BlockEmpty, Wait);
+NERVE_IMPL(BlockEmpty, Reaction);
+NERVE_IMPL(BlockEmpty, ReactionTransparent);
+
+NERVES_MAKE_NOSTRUCT(BlockEmpty, Wait, Reaction, ReactionTransparent);
+}  // namespace
+
+BlockEmpty::BlockEmpty(const char* name, const char* archiveName)
+    : al::LiveActor(name), mArchiveName(archiveName) {}
+
+void BlockEmpty::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, mArchiveName, nullptr);
+    al::initNerve(this, &Wait, 0);
+
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    if (mMtxConnector)
+        al::tryGetArg(&mIsConnectToCollisionBack, info, "IsConnectToCollisionBack");
+
+    makeActorAlive();
+    al::tryAddDisplayOffset(this, info);
+    al::syncSensorScaleY(this);
+    al::invalidateHitSensor(this, "Body");
+}
+
+void BlockEmpty::initAfterPlacement() {
+    if (!mMtxConnector)
+        return;
+
+    if (mIsConnectToCollisionBack) {
+        sead::Vector3f frontDir = {0.0f, 0.0f, 0.0f};
+        al::calcFrontDir(&frontDir, this);
+        al::attachMtxConnectorToCollision(
+            mMtxConnector, this, al::getTrans(this) + 50.0f * frontDir, -400.0f * frontDir);
+    } else {
+        al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
+    }
+}
+
+void BlockEmpty::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void BlockEmpty::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorName(self, "Body"))
+        rs::sendMsgPushToPlayer(other, self);
+}
+
+bool BlockEmpty::receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) {
+    if (rs::isMsgTRexAttackCollideAll(msg)) {
+        al::appearBreakModelRandomRotateY(al::getSubActor(this, "Body"));
+        kill();
+    }
+
+    return al::isMsgPlayerDisregard(msg);
+}
+
+void BlockEmpty::setShadowDropLength(f32 shadowDropLength) {
+    if (al::isNearZero(shadowDropLength, 0.001f)) {
+        al::invalidateShadowMask(this);
+        return;
+    }
+
+    al::setShadowMaskDropLength(this, shadowDropLength, "本体");
+    al::expandClippingRadiusByShadowLength(this, &mShadowDropClippingCenter, shadowDropLength);
+}
+
+void BlockEmpty::startReaction() {
+    al::startAction(this, "Reaction");
+    al::setNerve(this, &Reaction);
+}
+
+void BlockEmpty::startReactionTransparent() {
+    al::startAction(this, "Reaction");
+    al::setNerve(this, &ReactionTransparent);
+    al::validateHitSensor(this, "Body");
+}
+
+void BlockEmpty::exeWait() {}
+
+void BlockEmpty::exeReaction() {
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void BlockEmpty::exeReactionTransparent() {
+    if (al::isActionEnd(this)) {
+        al::setNerve(this, &Wait);
+        al::invalidateHitSensor(this, "Body");
+    }
+}

--- a/src/MapObj/BlockEmpty.h
+++ b/src/MapObj/BlockEmpty.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+
+class BlockEmpty : public al::LiveActor {
+public:
+    BlockEmpty(const char* name, const char* archiveName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* msg, al::HitSensor* other, al::HitSensor* self) override;
+
+    void setShadowDropLength(f32 shadowDropLength);
+    void startReaction();
+    void startReactionTransparent();
+    void exeWait();
+    void exeReaction();
+    void exeReactionTransparent();
+
+private:
+    const char* mArchiveName = nullptr;
+    bool mIsConnectToCollisionBack = false;
+    al::MtxConnector* mMtxConnector = nullptr;
+    sead::Vector3f mShadowDropClippingCenter = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(BlockEmpty) == 0x130);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1144)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (24f5aab - 6ef47a0)

📈 **Matched code**: 14.56% (+0.01%, +1436 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockEmpty` | `BlockEmpty::initAfterPlacement()` | +224 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::init(al::ActorInitInfo const&)` | +184 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::BlockEmpty(char const*, char const*)` | +172 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::BlockEmpty(char const*, char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::setShadowDropLength(float)` | +108 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +84 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `(anonymous namespace)::BlockEmptyNrvReactionTransparent::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::exeReactionTransparent()` | +76 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::attackSensor(al::HitSensor*, al::HitSensor*)` | +72 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::startReactionTransparent()` | +68 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `(anonymous namespace)::BlockEmptyNrvReaction::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::exeReaction()` | +60 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::startReaction()` | +52 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::control()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `BlockEmpty::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/BlockEmpty` | `(anonymous namespace)::BlockEmptyNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->