### PR TITLE
MapObj: Implement `SwitchKeyMoveMapParts`

### DIFF
--- a/src/MapObj/SwitchKeyMoveMapParts.cpp
+++ b/src/MapObj/SwitchKeyMoveMapParts.cpp
@@ -1,0 +1,186 @@
+#include "MapObj/SwitchKeyMoveMapParts.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+using al::SwitchKeyMoveMapParts;
+
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, StandBy)
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, Wait)
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, MoveSign)
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, Move)
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, StopSign)
+NERVE_ACTION_IMPL(SwitchKeyMoveMapParts, Stop)
+
+NERVE_ACTIONS_MAKE_STRUCT(SwitchKeyMoveMapParts, StandBy, Wait, MoveSign, Move, StopSign, Stop)
+}  // namespace
+
+namespace al {
+SwitchKeyMoveMapParts::SwitchKeyMoveMapParts(const char* name) : LiveActor(name) {}
+
+void SwitchKeyMoveMapParts::init(const ActorInitInfo& info) {
+    using SwitchKeyMoveMapPartsFunctor =
+        FunctorV0M<SwitchKeyMoveMapParts*, void (SwitchKeyMoveMapParts::*)()>;
+
+    initNerveAction(this, "StandBy", &NrvSwitchKeyMoveMapParts.collector, 0);
+    initMapPartsActor(this, info, nullptr);
+    tryGetQuatPtr(this);
+    mKeyPoseKeeper = createKeyPoseKeeper(info);
+    mKeyPoseKeeper->setMoveTypeStop();
+    setKeyMoveClippingInfo(this, &mClippingOffset, mKeyPoseKeeper);
+    registActorToDemoInfo(this, info);
+    listenStageSwitchOnOffStart(this,
+                                SwitchKeyMoveMapPartsFunctor(this, &SwitchKeyMoveMapParts::on),
+                                SwitchKeyMoveMapPartsFunctor(this, &SwitchKeyMoveMapParts::off));
+    makeActorAlive();
+}
+
+void SwitchKeyMoveMapParts::on() {
+    if (mIsReverse) {
+        reverse();
+        return;
+    }
+
+    if (isNerve(this, NrvSwitchKeyMoveMapParts.StandBy.data())) {
+        if (isExistAction(this, "Start"))
+            startAction(this, "Start");
+
+        startNerveAction(this, "Wait");
+    }
+}
+
+void SwitchKeyMoveMapParts::off() {
+    if (!mIsReverse) {
+        reverse();
+        return;
+    }
+
+    if (isNerve(this, NrvSwitchKeyMoveMapParts.Stop.data())) {
+        if (isExistAction(this, "Start"))
+            startAction(this, "Start");
+
+        startNerveAction(this, "Wait");
+    }
+}
+
+void SwitchKeyMoveMapParts::reverse() {
+    if (isNerve(this, NrvSwitchKeyMoveMapParts.Wait.data()) ||
+        isNerve(this, NrvSwitchKeyMoveMapParts.MoveSign.data())) {
+        startNerveAction(this, "Stop");
+    } else if (isNerve(this, NrvSwitchKeyMoveMapParts.Move.data())) {
+        nextKeyPose(mKeyPoseKeeper);
+        reverseKeyPose(mKeyPoseKeeper);
+
+        mMoveRate = 1.0f - sead::Mathf::clamp(
+                               (f32)getNerveStep(this) / mKeyMoveMoveTime + mMoveRate, 0.0f, 1.0f);
+
+        startNerveAction(this, "Move");
+    } else if (isNerve(this, NrvSwitchKeyMoveMapParts.StopSign.data()) ||
+               isNerve(this, NrvSwitchKeyMoveMapParts.Stop.data()) ||
+               isNerve(this, NrvSwitchKeyMoveMapParts.StandBy.data())) {
+        reverseKeyPose(mKeyPoseKeeper);
+        if (isExistAction(this, "Start"))
+            startAction(this, "Start");
+
+        startNerveAction(this, "Wait");
+    }
+
+    mIsReverse = !mIsReverse;
+}
+
+void SwitchKeyMoveMapParts::stop() {
+    if (isNerve(this, NrvSwitchKeyMoveMapParts.StopSign.data()) ||
+        isNerve(this, NrvSwitchKeyMoveMapParts.Stop.data()))
+        return;
+
+    if (isExistAction(this, "StopSign"))
+        startNerveAction(this, "StopSign");
+    else
+        startNerveAction(this, "Stop");
+
+    tryStartSe(this, "MoveEnd");
+}
+
+void SwitchKeyMoveMapParts::exeStandBy() {}
+
+void SwitchKeyMoveMapParts::exeWait() {
+    if (isFirstStep(this)) {
+        s32 keyMoveWaitTime = calcKeyMoveWaitTime(mKeyPoseKeeper);
+        if (keyMoveWaitTime >= 0)
+            mKeyMoveWaitTime = keyMoveWaitTime;
+    }
+
+    if (isGreaterEqualStep(this, mKeyMoveWaitTime)) {
+        if (isMoveSignKey(mKeyPoseKeeper) && isExistAction(this, "MoveKeySign")) {
+            startNerveAction(this, "MoveSign");
+        } else {
+            mKeyMoveMoveTime = calcKeyMoveMoveTime(mKeyPoseKeeper);
+            startNerveAction(this, "Move");
+        }
+    }
+}
+
+void SwitchKeyMoveMapParts::exeMoveSign() {
+    if (isFirstStep(this))
+        startAction(this, "MoveKeySign");
+
+    if (isActionEnd(this)) {
+        mKeyMoveMoveTime = calcKeyMoveMoveTime(mKeyPoseKeeper);
+        startNerveAction(this, "Move");
+    }
+}
+
+void SwitchKeyMoveMapParts::exeMove() {
+    if (isFirstStep(this) && isExistAction(this, "MoveLoop"))
+        tryStartActionIfNotPlaying(this, "MoveLoop");
+
+    f32 rate =
+        sead::Mathf::clamp((f32)getNerveStep(this) / mKeyMoveMoveTime + mMoveRate, 0.0f, 1.0f);
+
+    calcLerpKeyTrans(getTransPtr(this), mKeyPoseKeeper, rate);
+    calcSlerpKeyQuat(getQuatPtr(this), mKeyPoseKeeper, rate);
+
+    if (rate >= 1.0f) {
+        KeyPoseKeeper* keyPoseKeeper = mKeyPoseKeeper;
+        mMoveRate = 0.0f;
+        nextKeyPose(keyPoseKeeper);
+
+        if (!isStop(mKeyPoseKeeper)) {
+            startNerveAction(this, "Wait");
+            tryStartSe(this, "MoveEnd");
+        } else if (!isNerve(this, NrvSwitchKeyMoveMapParts.StopSign.data()) &&
+                   !isNerve(this, NrvSwitchKeyMoveMapParts.Stop.data())) {
+            if (isExistAction(this, "StopSign"))
+                startNerveAction(this, "StopSign");
+            else
+                startNerveAction(this, "Stop");
+
+            tryStartSe(this, "MoveEnd");
+        }
+    }
+}
+
+void SwitchKeyMoveMapParts::exeStopSign() {
+    if (isFirstStep(this))
+        startAction(this, "StopSign");
+
+    if (isActionEnd(this))
+        startNerveAction(this, "Stop");
+}
+
+void SwitchKeyMoveMapParts::exeStop() {
+    if (isFirstStep(this) && isExistAction(this, "Stop"))
+        tryStartAction(this, "Stop");
+}
+}  // namespace al

--- a/src/MapObj/SwitchKeyMoveMapParts.h
+++ b/src/MapObj/SwitchKeyMoveMapParts.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class KeyPoseKeeper;
+}
+
+namespace al {
+class SwitchKeyMoveMapParts : public LiveActor {
+public:
+    SwitchKeyMoveMapParts(const char* name);
+
+    void init(const ActorInitInfo& info) override;
+
+    void on();
+    void off();
+    void reverse();
+    void stop();
+
+    void exeStandBy();
+    void exeWait();
+    void exeMoveSign();
+    void exeMove();
+    void exeStopSign();
+    void exeStop();
+
+private:
+    KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    sead::Vector3f mClippingOffset = sead::Vector3f::zero;
+    s32 mKeyMoveWaitTime = 30;
+    s32 mKeyMoveMoveTime = 0;
+    f32 mMoveRate = 0.0f;
+    bool mIsReverse = false;
+};
+
+static_assert(sizeof(SwitchKeyMoveMapParts) == 0x130);
+}  // namespace al

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -108,6 +108,7 @@
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
+#include "MapObj/SwitchKeyMoveMapParts.h"
 #include "MapObj/TalkPoint.h"
 #include "MapObj/TrampleBush.h"
 #include "MapObj/TrampleSwitch.h"
@@ -584,7 +585,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"StatueSnapMark", nullptr},
     {"SubActorLodFixPartsScenarioAction", nullptr},
     {"SwitchAnd", nullptr},
-    {"SwitchKeyMoveMapParts", nullptr},
+    {"SwitchKeyMoveMapParts", al::createActorFunction<al::SwitchKeyMoveMapParts>},
     {"TalkMessageInfoPoint", nullptr},
     {"TalkMessageInfoPointSaveObj", nullptr},
     {"TalkNpc", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1147)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d6735da - 43d4c17)

📈 **Matched code**: 14.64% (+0.02%, +2812 bytes)

<details>
<summary>✅ 30 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeMove()` | +368 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::reverse()` | +320 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::init(al::ActorInitInfo const&)` | +216 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `_GLOBAL__sub_I_SwitchKeyMoveMapParts.cpp` | +188 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::SwitchKeyMoveMapParts(char const*)` | +176 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::SwitchKeyMoveMapParts(char const*)` | +164 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::stop()` | +160 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeWait()` | +148 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::off()` | +136 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::on()` | +132 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvMoveSign::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeMoveSign()` | +100 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStopSign::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeStopSign()` | +88 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStop::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeStop()` | +80 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::FunctorV0M<al::SwitchKeyMoveMapParts*, void (al::SwitchKeyMoveMapParts::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<al::SwitchKeyMoveMapParts>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::FunctorV0M<al::SwitchKeyMoveMapParts*, void (al::SwitchKeyMoveMapParts::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStandBy::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvMoveSign::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStopSign::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStop::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::SwitchKeyMoveMapParts::exeStandBy()` | +4 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `(anonymous namespace)::SwitchKeyMoveMapPartsNrvStandBy::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/SwitchKeyMoveMapParts` | `al::FunctorV0M<al::SwitchKeyMoveMapParts*, void (al::SwitchKeyMoveMapParts::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->