### PR TITLE
Scene: Implement `StageSceneStateGetShineMainWithCageShine`

### DIFF
--- a/src/Scene/StageSceneStateBreakCageShine.h
+++ b/src/Scene/StageSceneStateBreakCageShine.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+template <class T>
+class DeriveActorGroup;
+class Scene;
+}  // namespace al
+
+class CageShineWatcher;
+
+class StageSceneStateBreakCageShine : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateBreakCageShine(const char* name, al::Scene* scene,
+                                  al::DeriveActorGroup<CageShineWatcher>* cageShineWatchers);
+
+    void appear() override;
+    void kill() override;
+
+    void exeWait();
+
+    static StageSceneStateBreakCageShine* tryCreate(al::Scene* scene,
+                                                    const al::ActorInitInfo& initInfo);
+
+private:
+    al::DeriveActorGroup<CageShineWatcher>* mCageShineWatchers = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateBreakCageShine) == 0x28);

--- a/src/Scene/StageSceneStateGetShineMain.h
+++ b/src/Scene/StageSceneStateGetShineMain.h
@@ -1,0 +1,80 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class LayoutInitInfo;
+class LiveActor;
+class Scene;
+struct SceneInitInfo;
+class SimpleLayoutAppearWaitEnd;
+class WipeSimple;
+}  // namespace al
+
+class GameDataHolder;
+class QuestInfo;
+class ScenarioStartCameraHolder;
+class Shine;
+class StageSceneLayout;
+class StageSceneStateRecoverLife;
+class StageSceneStateScenarioCamera;
+
+class StageSceneStateGetShineMain : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateGetShineMain(const char* name, al::Scene* scene, StageSceneLayout* layout,
+                                const al::SceneInitInfo& sceneInitInfo,
+                                const al::ActorInitInfo& actorInitInfo,
+                                const al::LayoutInitInfo& layoutInitInfo,
+                                al::LiveActor* playerActor,
+                                ScenarioStartCameraHolder* scenarioStartCameraHolder,
+                                GameDataHolder* gameDataHolder);
+
+    void appear() override;
+    void kill() override;
+
+    void setScenarioCameraState(StageSceneStateScenarioCamera* scenarioCamera);
+    void exeWaitPlayerAnimFirst();
+    void exeDemoGetStart();
+    void exeDemoAppearShineGetLayout();
+    void exeDemoShineCount();
+    void exeDemoWipeClose();
+    void exeDemoWipeWait();
+    void exeDemoLand();
+    void exeDemoOpenDoorSnow();
+    void exeDemoRiseMapParts();
+    void exeDemoScenarioCamera();
+    void exeDemoLifeRecover();
+    void exeDemoEnd();
+    void exeDemoEndCity();
+    void startDemoEnd();
+    bool isDrawChromakey() const;
+    const QuestInfo* getQuestInfo() const;
+
+    void setSkipDemoAfterGet(bool isSkipDemoAfterGet) { mIsSkipDemoAfterGet = isSkipDemoAfterGet; }
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mResultMainGetLayout = nullptr;
+    al::WipeSimple* mWipeResultMainStart = nullptr;
+    al::WipeSimple* mWipeResultMainBack = nullptr;
+    al::WipeSimple* mWipeResultMain = nullptr;
+    al::SimpleLayoutAppearWaitEnd* mResultMainLayout = nullptr;
+    al::CameraTicket* mDemoCameraTicket = nullptr;
+    sead::Matrix34f mDemoCameraMtx;
+    al::LiveActor* mDemoCapManHero = nullptr;
+    al::LiveActor* mPlayerActor = nullptr;
+    al::LiveActor* mDemoGetShineWipeActor = nullptr;
+    al::LiveActor* mStageShineActor = nullptr;
+    StageSceneLayout* mLayout = nullptr;
+    ScenarioStartCameraHolder* mScenarioStartCameraHolder = nullptr;
+    Shine* mShine = nullptr;
+    GameDataHolder* mGameDataHolder = nullptr;
+    StageSceneStateScenarioCamera* mStateScenarioCamera = nullptr;
+    bool mIsSkipDemoAfterGet = false;
+    const QuestInfo* mQuestInfo = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMain) == 0xd8);

--- a/src/Scene/StageSceneStateGetShineMainLast.h
+++ b/src/Scene/StageSceneStateGetShineMainLast.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class CameraTicket;
+class LiveActor;
+class Scene;
+}  // namespace al
+
+class StageSceneStateGetShineMainLast : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateGetShineMainLast(const char* name, al::Scene* scene, al::LiveActor* playerActor,
+                                    al::CameraTicket* demoCameraTicket);
+
+    void appear() override;
+    void kill() override;
+
+    void exeWait();
+
+private:
+    al::LiveActor* mPlayerActor = nullptr;
+    al::CameraTicket* mDemoCameraTicket = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMainLast) == 0x30);

--- a/src/Scene/StageSceneStateGetShineMainWithCageShine.cpp
+++ b/src/Scene/StageSceneStateGetShineMainWithCageShine.cpp
@@ -1,0 +1,102 @@
+#include "Scene/StageSceneStateGetShineMainWithCageShine.h"
+
+#include "Library/Nerve/Nerve.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Scene/StageScene.h"
+#include "Scene/StageSceneStateBreakCageShine.h"
+#include "Scene/StageSceneStateGetShineMain.h"
+#include "Scene/StageSceneStateGetShineMainLast.h"
+#include "Scene/StageSceneStateRecoverLife.h"
+#include "Scene/StageSceneStateScenarioCamera.h"
+#include "Util/PlayerDemoUtil.h"
+
+namespace {
+NERVE_IMPL(StageSceneStateGetShineMainWithCageShine, DemoGetShine);
+NERVE_IMPL(StageSceneStateGetShineMainWithCageShine, DemoBreakCageShine);
+NERVE_IMPL(StageSceneStateGetShineMainWithCageShine, DemoScenarioCamera);
+NERVE_IMPL(StageSceneStateGetShineMainWithCageShine, DemoRecoverLife);
+NERVE_IMPL(StageSceneStateGetShineMainWithCageShine, DemoEnd);
+NERVES_MAKE_NOSTRUCT(StageSceneStateGetShineMainWithCageShine, DemoGetShine, DemoBreakCageShine,
+                     DemoScenarioCamera, DemoRecoverLife, DemoEnd);
+}  // namespace
+
+StageSceneStateGetShineMainWithCageShine*
+StageSceneStateGetShineMainWithCageShine::tryCreate(al::Scene* scene,
+                                                    const al::ActorInitInfo& initInfo) {
+    StageSceneStateBreakCageShine* breakCageShine =
+        StageSceneStateBreakCageShine::tryCreate(scene, initInfo);
+    if (!breakCageShine)
+        return nullptr;
+
+    return new StageSceneStateGetShineMainWithCageShine("メインムーンゲットデモ[ケージシャイン]",
+                                                        scene, breakCageShine);
+}
+
+StageSceneStateGetShineMainWithCageShine::StageSceneStateGetShineMainWithCageShine(
+    const char* name, al::Scene* scene, StageSceneStateBreakCageShine* breakCageShine)
+    : al::HostStateBase<al::Scene>(name, scene), mStateBreakCageShine(breakCageShine) {
+    initNerve(&DemoGetShine, 5);
+    al::initNerveState(this, mStateBreakCageShine, &DemoBreakCageShine, "ケージ壊れる");
+}
+
+void StageSceneStateGetShineMainWithCageShine::init() {}
+
+void StageSceneStateGetShineMainWithCageShine::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &DemoGetShine);
+}
+
+void StageSceneStateGetShineMainWithCageShine::kill() {
+    al::NerveStateBase::kill();
+}
+
+void StageSceneStateGetShineMainWithCageShine::setState(
+    StageSceneStateGetShineMain* getShineMain, StageSceneStateScenarioCamera* scenarioCamera,
+    StageSceneStateRecoverLife* recoverLife, StageSceneStateGetShineMainLast* getShineMainLast) {
+    mStateGetShineMain = getShineMain;
+    getShineMain->setSkipDemoAfterGet(true);
+    al::addNerveState(this, getShineMain, &DemoGetShine, "ムーンゲット");
+
+    mStateScenarioCamera = scenarioCamera;
+    al::addNerveState(this, mStateScenarioCamera, &DemoScenarioCamera, "シナリオ紹介カメラ");
+
+    mStateRecoverLife = recoverLife;
+    al::addNerveState(this, mStateRecoverLife, &DemoRecoverLife, "ライフ回復");
+
+    mStateGetShineMainLast = getShineMainLast;
+    al::addNerveState(this, mStateGetShineMainLast, &DemoEnd, "ムーンゲット最後");
+}
+
+void StageSceneStateGetShineMainWithCageShine::exeDemoGetShine() {
+    if (al::updateNerveState(this))
+        al::setNerve(this, &DemoBreakCageShine);
+}
+
+void StageSceneStateGetShineMainWithCageShine::exeDemoBreakCageShine() {
+    if (!al::updateNerveState(this))
+        return;
+
+    if (mStateScenarioCamera->tryStart()) {
+        rs::forcePutOffMarioHeadCap(rs::getPlayerActor(getHost()));
+        al::setNerve(this, &DemoScenarioCamera);
+    } else {
+        al::setNerve(this, &DemoRecoverLife);
+    }
+}
+
+void StageSceneStateGetShineMainWithCageShine::exeDemoScenarioCamera() {
+    if (al::updateNerveState(this))
+        al::setNerve(this, &DemoRecoverLife);
+}
+
+void StageSceneStateGetShineMainWithCageShine::exeDemoRecoverLife() {
+    if (al::updateNerveState(this))
+        al::setNerve(this, &DemoEnd);
+}
+
+void StageSceneStateGetShineMainWithCageShine::exeDemoEnd() {
+    if (al::updateNerveState(this))
+        kill();
+}

--- a/src/Scene/StageSceneStateGetShineMainWithCageShine.h
+++ b/src/Scene/StageSceneStateGetShineMainWithCageShine.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class Scene;
+}  // namespace al
+
+class StageSceneStateBreakCageShine;
+class StageSceneStateGetShineMain;
+class StageSceneStateGetShineMainLast;
+class StageSceneStateRecoverLife;
+class StageSceneStateScenarioCamera;
+
+class StageSceneStateGetShineMainWithCageShine : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateGetShineMainWithCageShine(const char* name, al::Scene* scene,
+                                             StageSceneStateBreakCageShine* breakCageShine);
+
+    void init() override;
+    void appear() override;
+    void kill() override;
+
+    void setState(StageSceneStateGetShineMain* getShineMain,
+                  StageSceneStateScenarioCamera* scenarioCamera,
+                  StageSceneStateRecoverLife* recoverLife,
+                  StageSceneStateGetShineMainLast* getShineMainLast);
+    void exeDemoGetShine();
+    void exeDemoBreakCageShine();
+    void exeDemoScenarioCamera();
+    void exeDemoRecoverLife();
+    void exeDemoEnd();
+
+    static StageSceneStateGetShineMainWithCageShine* tryCreate(al::Scene* scene,
+                                                               const al::ActorInitInfo& initInfo);
+
+private:
+    StageSceneStateGetShineMain* mStateGetShineMain = nullptr;
+    StageSceneStateScenarioCamera* mStateScenarioCamera = nullptr;
+    StageSceneStateRecoverLife* mStateRecoverLife = nullptr;
+    StageSceneStateGetShineMainLast* mStateGetShineMainLast = nullptr;
+    StageSceneStateBreakCageShine* mStateBreakCageShine = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateGetShineMainWithCageShine) == 0x48);

--- a/src/Scene/StageSceneStateRecoverLife.h
+++ b/src/Scene/StageSceneStateRecoverLife.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class Scene;
+}  // namespace al
+
+class StageScene;
+class StageSceneLayout;
+
+class StageSceneStateRecoverLife : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateRecoverLife(const char* name, StageScene* stageScene, StageSceneLayout* layout);
+
+    void appear() override;
+    void kill() override;
+
+    void exeDemoLifeRecover();
+
+private:
+    StageSceneLayout* mLayout = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateRecoverLife) == 0x28);

--- a/src/Scene/StageSceneStateScenarioCamera.h
+++ b/src/Scene/StageSceneStateScenarioCamera.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+class Scene;
+}  // namespace al
+
+class StageSceneStateSkipDemo;
+
+class StageSceneStateScenarioCamera : public al::HostStateBase<al::Scene> {
+public:
+    StageSceneStateScenarioCamera(const char* name, al::Scene* scene, const char* cameraName,
+                                  s32 scenarioNo, al::LiveActor* playerActor);
+
+    void setStateSkipDemo(StageSceneStateSkipDemo* skipDemo);
+    void appear() override;
+    void kill() override;
+    bool tryStart();
+    bool isExistEnableCamera() const;
+    void exeCamera();
+    void exeSkip();
+
+private:
+    void* _20 = nullptr;
+    void* _28 = nullptr;
+    const char* mCameraName = nullptr;
+    s32 mScenarioNo = 0;
+    al::LiveActor* mPlayerActor = nullptr;
+    StageSceneStateSkipDemo* mStateSkipDemo = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateScenarioCamera) == 0x50);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1148)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d6735da - 03c218d)

📈 **Matched code**: 14.63% (+0.01%, +1252 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::setState(StageSceneStateGetShineMain*, StageSceneStateScenarioCamera*, StageSceneStateRecoverLife*, StageSceneStateGetShineMainLast*)` | +172 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::tryCreate(al::Scene*, al::ActorInitInfo const&)` | +160 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::StageSceneStateGetShineMainWithCageShine(char const*, al::Scene*, StageSceneStateBreakCageShine*)` | +120 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `(anonymous namespace)::StageSceneStateGetShineMainWithCageShineNrvDemoBreakCageShine::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::exeDemoBreakCageShine()` | +104 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `(anonymous namespace)::StageSceneStateGetShineMainWithCageShineNrvDemoGetShine::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `(anonymous namespace)::StageSceneStateGetShineMainWithCageShineNrvDemoScenarioCamera::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `(anonymous namespace)::StageSceneStateGetShineMainWithCageShineNrvDemoRecoverLife::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::exeDemoGetShine()` | +64 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::exeDemoScenarioCamera()` | +64 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::exeDemoRecoverLife()` | +64 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `(anonymous namespace)::StageSceneStateGetShineMainWithCageShineNrvDemoEnd::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::exeDemoEnd()` | +60 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::~StageSceneStateGetShineMainWithCageShine()` | +36 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::appear()` | +16 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::kill()` | +12 | 0.00% | 100.00% |
| `Scene/StageSceneStateGetShineMainWithCageShine` | `StageSceneStateGetShineMainWithCageShine::init()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->