### PR TITLE
Event: Implement `EventActorStateGiveShine`

### DIFF
--- a/src/Event/EventActorStateGiveShine.cpp
+++ b/src/Event/EventActorStateGiveShine.cpp
@@ -1,0 +1,45 @@
+#include "Event/EventActorStateGiveShine.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/ItemUtil.h"
+
+namespace {
+NERVE_IMPL(EventActorStateGiveShine, Start);
+NERVE_IMPL(EventActorStateGiveShine, Wait);
+
+NERVES_MAKE_STRUCT(EventActorStateGiveShine, Start, Wait);
+}  // namespace
+
+EventActorStateGiveShine::EventActorStateGiveShine(al::LiveActor* actor)
+    : al::ActorStateBase("シャイン放出状態", actor) {
+    initNerve(&NrvEventActorStateGiveShine.Start, 0);
+}
+
+void EventActorStateGiveShine::start(Shine* shine, const sead::Vector3f& trans,
+                                     const char* actionName) {
+    mShine = shine;
+    mShineAppearTrans.set(trans);
+
+    if (actionName) {
+        al::startAction(mActor, actionName);
+        al::setNerve(this, &NrvEventActorStateGiveShine.Start);
+    } else {
+        al::setNerve(this, &NrvEventActorStateGiveShine.Wait);
+    }
+}
+
+void EventActorStateGiveShine::exeStart() {
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &NrvEventActorStateGiveShine.Wait);
+}
+
+void EventActorStateGiveShine::exeWait() {
+    if (al::isFirstStep(this))
+        rs::appearPopupShineWithoutDemo(mShine, mShineAppearTrans);
+
+    if (rs::isEndAppearShine(mShine))
+        kill();
+}

--- a/src/Event/EventActorStateGiveShine.h
+++ b/src/Event/EventActorStateGiveShine.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class Shine;
+
+namespace al {
+class LiveActor;
+}
+
+class EventActorStateGiveShine : public al::ActorStateBase {
+public:
+    EventActorStateGiveShine(al::LiveActor* actor);
+
+    void start(Shine* shine, const sead::Vector3f& trans, const char* actionName);
+    void exeStart();
+    void exeWait();
+
+private:
+    Shine* mShine = nullptr;
+    sead::Vector3f mShineAppearTrans = {0.0f, 0.0f, 0.0f};
+};
+
+static_assert(sizeof(EventActorStateGiveShine) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1149)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c181dd4 - e44bf55)

📈 **Matched code**: 14.66% (+0.00%, +524 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventActorStateGiveShine` | `EventActorStateGiveShine::start(Shine*, sead::Vector3<float> const&, char const*)` | +92 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `EventActorStateGiveShine::EventActorStateGiveShine(al::LiveActor*)` | +88 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `(anonymous namespace)::EventActorStateGiveShineNrvWait::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `EventActorStateGiveShine::exeWait()` | +84 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `EventActorStateGiveShine::exeStart()` | +68 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `(anonymous namespace)::EventActorStateGiveShineNrvStart::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Event/EventActorStateGiveShine` | `EventActorStateGiveShine::~EventActorStateGiveShine()` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->