### PR TITLE
Event: Implement `EventFlowNodeDirectGetLinkShine`

### DIFF
--- a/src/Event/EventFlowNodeDirectGetLinkShine.cpp
+++ b/src/Event/EventFlowNodeDirectGetLinkShine.cpp
@@ -1,0 +1,84 @@
+#include "Event/EventFlowNodeDirectGetLinkShine.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Item/Shine.h"
+#include "Util/ItemUtil.h"
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(EventFlowNodeDirectGetLinkShine, WaitCameraInterpole);
+NERVE_IMPL(EventFlowNodeDirectGetLinkShine, WaitGetDemo);
+NERVES_MAKE_STRUCT(EventFlowNodeDirectGetLinkShine, WaitCameraInterpole, WaitGetDemo);
+}  // namespace
+
+EventFlowNodeDirectGetLinkShine::EventFlowNodeDirectGetLinkShine(const char* name)
+    : al::EventFlowNode(name),
+      mIsTimeBalloon(al::isEqualString(name, "DirectGetLinkShineTimeBalloon")) {}
+
+void EventFlowNodeDirectGetLinkShine::init(const al::EventFlowNodeInitInfo& info) {
+    al::initEventFlowNode(this, info);
+    initNerve(&NrvEventFlowNodeDirectGetLinkShine.WaitCameraInterpole, 0);
+
+    if (mIsTimeBalloon) {
+        mShine = rs::initLinkShopShine(*al::getActorInitInfo(info), "ShineActor");
+        return;
+    }
+
+    bool isMiniGame = false;
+    al::tryGetParamIterKeyBool(&isMiniGame, info, "IsMiniGame");
+
+    const char* linkName = al::tryGetParamIterKeyString(info, "LinkName");
+    if (linkName == nullptr)
+        linkName = "ShineActor";
+
+    mShine = rs::tryInitLinkShine(*al::getActorInitInfo(info), linkName, 0);
+}
+
+void EventFlowNodeDirectGetLinkShine::start() {
+    al::EventFlowNode::start();
+
+    if (!rs::isActiveEventDemo(this))
+        end();
+
+    if (mShine == nullptr) {
+        end();
+        return;
+    }
+
+    if (!rs::isCloseNpcDemoEventTalkMessage(getActor()))
+        rs::startCloseNpcDemoEventTalkMessage(getActor());
+
+    if (al::isActiveCameraInterpole(getActor(), 0)) {
+        al::setNerve(this, &NrvEventFlowNodeDirectGetLinkShine.WaitCameraInterpole);
+        return;
+    }
+
+    al::setNerve(this, &NrvEventFlowNodeDirectGetLinkShine.WaitGetDemo);
+}
+
+void EventFlowNodeDirectGetLinkShine::exeWaitCameraInterpole() {
+    if (!al::isActiveCameraInterpole(getActor(), 0))
+        al::setNerve(this, &NrvEventFlowNodeDirectGetLinkShine.WaitGetDemo);
+}
+
+void EventFlowNodeDirectGetLinkShine::exeWaitGetDemo() {
+    if (rs::isCloseNpcDemoEventTalkMessage(getActor())) {
+        if (al::isFirstStep(this)) {
+            al::resetPosition(mShine, rs::getPlayerHeadPos(mShine));
+            rs::requestEventGetShineDirect(this, mShine);
+        }
+
+        if (rs::checkEndSceneExecuteAndResetRequest(this))
+            end();
+    } else {
+        rs::startCloseNpcDemoEventTalkMessage(getActor());
+        al::setNerve(this, &NrvEventFlowNodeDirectGetLinkShine.WaitGetDemo);
+    }
+}

--- a/src/Event/EventFlowNodeDirectGetLinkShine.h
+++ b/src/Event/EventFlowNodeDirectGetLinkShine.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "Library/Event/EventFlowNode.h"
+
+class Shine;
+
+class EventFlowNodeDirectGetLinkShine : public al::EventFlowNode {
+public:
+    EventFlowNodeDirectGetLinkShine(const char* name);
+
+    void init(const al::EventFlowNodeInitInfo& info) override;
+    void start() override;
+
+    void exeWaitCameraInterpole();
+    void exeWaitGetDemo();
+
+private:
+    Shine* mShine = nullptr;
+    bool mIsTimeBalloon = false;
+};
+
+static_assert(sizeof(EventFlowNodeDirectGetLinkShine) == 0x78);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -5,16 +5,20 @@
 
 namespace al {
 struct ActorInitInfo;
+class EventFlowNode;
 class EventFlowExecutor;
 class LiveActor;
 class MessageTagDataHolder;
 }  // namespace al
+
+class Shine;
 
 namespace rs {
 al::EventFlowExecutor* initEventFlow(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                      const char*);
 al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
                                            const char*, const char*);
+bool isActiveEventDemo(const al::EventFlowNode* node);
 bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
 bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
 void startEventFlow(al::EventFlowExecutor*, const char*);
@@ -26,6 +30,10 @@ void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
+void startCloseNpcDemoEventTalkMessage(al::LiveActor* actor);
+bool isCloseNpcDemoEventTalkMessage(const al::LiveActor* actor);
+void requestEventGetShineDirect(al::EventFlowNode* node, Shine* shine);
+bool checkEndSceneExecuteAndResetRequest(al::EventFlowNode* node);
 void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
 }  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1151)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (30ce81d - c986f3d)

📈 **Matched code**: 14.63% (+0.01%, +800 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventFlowNodeDirectGetLinkShine` | `EventFlowNodeDirectGetLinkShine::init(al::EventFlowNodeInitInfo const&)` | +176 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `EventFlowNodeDirectGetLinkShine::start()` | +172 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `EventFlowNodeDirectGetLinkShine::exeWaitGetDemo()` | +160 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `(anonymous namespace)::EventFlowNodeDirectGetLinkShineNrvWaitCameraInterpole::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `EventFlowNodeDirectGetLinkShine::EventFlowNodeDirectGetLinkShine(char const*)` | +92 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `EventFlowNodeDirectGetLinkShine::exeWaitCameraInterpole()` | +84 | 0.00% | 100.00% |
| `Event/EventFlowNodeDirectGetLinkShine` | `(anonymous namespace)::EventFlowNodeDirectGetLinkShineNrvWaitGetDemo::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->