### PR TITLE
Player: Implement `PlayerInputFunction`

### DIFF
--- a/src/Player/PlayerInputFunction.cpp
+++ b/src/Player/PlayerInputFunction.cpp
@@ -3,8 +3,219 @@
 #include "Library/Controller/InputFunction.h"
 #include "Library/LiveActor/LiveActor.h"
 
+#include "Util/StageInputFunction.h"
+
+namespace {
+constexpr s32 cNoInputJudgeKeyMaskDefault = 0xf1fff;
+constexpr s32 cNoInputJudgeKeyMaskSingleJoy = 0xf7ff7;
+}  // namespace
+
+bool PlayerInputFunction::isSeparatePlaySingleJoy(const al::LiveActor* actor, s32 port) {
+    return rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port);
+}
+
+bool PlayerInputFunction::isTriggerJump(const al::LiveActor* actor, s32 port) {
+    return al::isPadTriggerA(port) || al::isPadTriggerB(port);
+}
+
+bool PlayerInputFunction::isHoldJump(const al::LiveActor* actor, s32 port) {
+    return al::isPadHoldA(port) || al::isPadHoldB(port);
+}
+
+bool PlayerInputFunction::isReleaseJump(const al::LiveActor* actor, s32 port) {
+    return al::isPadReleaseA(port) || al::isPadReleaseB(port);
+}
+
 bool PlayerInputFunction::isTriggerAction(const al::LiveActor* actor, s32 port) {
     if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
         return al::isPadTriggerY(port);
     return al::isPadTriggerX(port) || al::isPadTriggerY(port);
+}
+
+bool PlayerInputFunction::isHoldAction(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadHoldY(port);
+    return al::isPadHoldX(port) || al::isPadHoldY(port);
+}
+
+bool PlayerInputFunction::isReleaseAction(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadReleaseY(port);
+    return al::isPadReleaseX(port) || al::isPadReleaseY(port);
+}
+
+bool PlayerInputFunction::isTriggerSubAction(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadTriggerL(port) || al::isPadTriggerR(port);
+    return al::isPadTriggerZL(port) || al::isPadTriggerZR(port);
+}
+
+bool PlayerInputFunction::isHoldSubAction(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadHoldL(port) || al::isPadHoldR(port);
+    return al::isPadHoldZL(port) || al::isPadHoldZR(port);
+}
+
+bool PlayerInputFunction::isReleaseSubAction(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadReleaseL(port) || al::isPadReleaseR(port);
+    return al::isPadReleaseZL(port) || al::isPadReleaseZR(port);
+}
+
+bool PlayerInputFunction::isHoldBalloonSet(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (al::isPadHoldL(port))
+            return al::isPadHoldR(port);
+    } else if (al::isPadHoldZL(port)) {
+        return al::isPadHoldZR(port);
+    }
+    return false;
+}
+
+bool PlayerInputFunction::isTriggerTalk(const al::LiveActor* actor, s32 port) {
+    return al::isPadTriggerA(port);
+}
+
+bool PlayerInputFunction::isTriggerStartWorldWarp(const al::LiveActor* actor, s32 port) {
+    return al::isPadTriggerA(port);
+}
+
+bool PlayerInputFunction::isTriggerCancelWorldWarp(const al::LiveActor* actor, s32 port) {
+    if (al::isPadTriggerB(port))
+        return true;
+    if (al::isPadTriggerY(port))
+        return true;
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadTriggerX(port);
+}
+
+sead::Vector2f PlayerInputFunction::getMoveInputStick(const al::LiveActor* actor, s32 port,
+                                                      s32 isCameraMove) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+            bool isHoldX = al::isPadHoldX(port);
+            if (isCameraMove != 0)
+                return al::getLeftStick(port);
+            if (!isHoldX)
+                return al::getLeftStick(port);
+            return sead::Vector2f::zero;
+        } else if (al::isPadHoldL(port) || al::isPadHoldR(port)) {
+            return sead::Vector2f::zero;
+        }
+    }
+    return al::getLeftStick(port);
+}
+
+bool PlayerInputFunction::isHoldCameraReset(const al::LiveActor* actor, s32 port,
+                                            s32 isCameraMove) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        bool isHoldX = al::isPadHoldX(port);
+        return (isCameraMove == 0) & isHoldX;
+    }
+    return al::isPadHoldL(port) || al::isPadHoldR(port);
+}
+
+f32 PlayerInputFunction::getRadiconInputSteeringValue(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (al::isPadHoldY(port))
+            return -1.0f;
+        return al::isPadHoldA(port) ? 1.0f : 0.0f;
+    }
+    return al::getRightStick(port).x;
+}
+
+s32 PlayerInputFunction::getNoInputJudgeKeyMask(const al::LiveActor* actor, s32 port) {
+    s32 keyMask = cNoInputJudgeKeyMaskDefault;
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        keyMask = cNoInputJudgeKeyMaskSingleJoy;
+    return keyMask;
+}
+
+bool PlayerInputFunction::isInputLeftStickNoCameraMove(const al::LiveActor* actor, s32 port,
+                                                       f32 threshold) {
+    const sead::Vector2f& leftStick = al::getLeftStick(port);
+    if (leftStick.length() < threshold)
+        return false;
+
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (al::isPadHoldX(port))
+            return false;
+    }
+    return true;
+}
+
+bool PlayerInputFunction::isTriggerCameraReset(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return al::isPadTriggerX(port);
+    return al::isPadTriggerL(port) || al::isPadTriggerR(port);
+}
+
+bool PlayerInputFunction::isTriggerSeparateCameraReset(const al::LiveActor* actor, s32 port,
+                                                       s32 isCameraMove) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (isCameraMove)
+            return al::isPadReleaseX(port);
+        return false;
+    }
+    return al::isPadTriggerL(port) || al::isPadTriggerR(port);
+}
+
+bool PlayerInputFunction::isTriggerCameraSubjective(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadTriggerPressRightStick(port);
+}
+
+bool PlayerInputFunction::isHoldCameraZoom(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadHoldZL(port) || al::isPadHoldZR(port);
+}
+
+bool PlayerInputFunction::isHoldCameraSnapShotZoomIn(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadHoldX(port);
+}
+
+bool PlayerInputFunction::isHoldCameraSnapShotZoomOut(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadHoldA(port);
+}
+
+bool PlayerInputFunction::isHoldCameraSnapShotRollLeft(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadHoldZL(port);
+}
+
+bool PlayerInputFunction::isHoldCameraSnapShotRollRight(const al::LiveActor* actor, s32 port) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port))
+        return false;
+    return al::isPadHoldZR(port);
+}
+
+sead::Vector2f PlayerInputFunction::getCameraMoveInput(const al::LiveActor* actor, s32 port,
+                                                       s32 isCameraMove,
+                                                       bool isValidPressLeftStick) {
+    if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+        if (rs::isSeparatePlay(actor) && al::isPadTypeJoySingle(port)) {
+            s32 isHoldX = al::isPadHoldX(port);
+            if (isCameraMove == 0) {
+                if (isHoldX)
+                    return al::getLeftStick(port);
+            }
+        } else if (al::isPadHoldL(port) || al::isPadHoldR(port)) {
+            return al::getLeftStick(port);
+        }
+
+        if (isValidPressLeftStick && al::isPadHoldPressLeftStick(port)) {
+            const sead::Vector2f& input = al::getLeftStick(port);
+            return sead::Vector2f(input.x, 0);
+        }
+        return sead::Vector2f::zero;
+    }
+    return al::getRightStick(port);
 }

--- a/src/Player/PlayerInputFunction.h
+++ b/src/Player/PlayerInputFunction.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <basis/seadTypes.h>
+#include <math/seadVector.h>
 
 namespace al {
 class LiveActor;
@@ -9,24 +9,43 @@ class IUseSceneObjHolder;
 
 class PlayerInputFunction {
 public:
-    static bool isTriggerAction(const al::LiveActor* actor, s32 port);
-    static bool isHoldAction(const al::LiveActor* actor, s32 port);
-    static bool isReleaseAction(const al::LiveActor* actor, s32 port);
+    static bool isSeparatePlaySingleJoy(const al::LiveActor* actor, s32 port);
 
     static bool isTriggerJump(const al::LiveActor* actor, s32 port);
     static bool isHoldJump(const al::LiveActor* actor, s32 port);
     static bool isReleaseJump(const al::LiveActor* actor, s32 port);
 
+    static bool isTriggerAction(const al::LiveActor* actor, s32 port);
+    static bool isHoldAction(const al::LiveActor* actor, s32 port);
+    static bool isReleaseAction(const al::LiveActor* actor, s32 port);
+
     static bool isTriggerSubAction(const al::LiveActor* actor, s32 port);
     static bool isHoldSubAction(const al::LiveActor* actor, s32 port);
+    static bool isReleaseSubAction(const al::LiveActor* actor, s32 port);
+    static bool isHoldBalloonSet(const al::LiveActor* actor, s32 port);
 
     static bool isTriggerTalk(const al::LiveActor* actor, s32 port);
     static bool isTriggerStartWorldWarp(const al::LiveActor* actor, s32 port);
     static bool isTriggerCancelWorldWarp(const al::LiveActor* actor, s32 port);
+
+    static sead::Vector2f getMoveInputStick(const al::LiveActor* actor, s32 port, s32 isCameraMove);
+    static bool isHoldCameraReset(const al::LiveActor* actor, s32 port, s32 isCameraMove);
+    static f32 getRadiconInputSteeringValue(const al::LiveActor* actor, s32 port);
+    static s32 getNoInputJudgeKeyMask(const al::LiveActor* actor, s32 port);
+    static bool isInputLeftStickNoCameraMove(const al::LiveActor* actor, s32 port, f32 threshold);
+    static bool isTriggerCameraReset(const al::LiveActor* actor, s32 port);
+    static bool isTriggerSeparateCameraReset(const al::LiveActor* actor, s32 port,
+                                             s32 isCameraMove);
+    static bool isTriggerCameraSubjective(const al::LiveActor* actor, s32 port);
+    static bool isHoldCameraZoom(const al::LiveActor* actor, s32 port);
+    static bool isHoldCameraSnapShotZoomIn(const al::LiveActor* actor, s32 port);
+    static bool isHoldCameraSnapShotZoomOut(const al::LiveActor* actor, s32 port);
+    static bool isHoldCameraSnapShotRollLeft(const al::LiveActor* actor, s32 port);
+    static bool isHoldCameraSnapShotRollRight(const al::LiveActor* actor, s32 port);
+    static sead::Vector2f getCameraMoveInput(const al::LiveActor* actor, s32 port, s32 isCameraMove,
+                                             bool isValidPressLeftStick);
 };
 
 namespace rs {
-
-bool isSeparatePlay(const al::IUseSceneObjHolder*);
-
-}
+bool isSeparatePlay(const al::IUseSceneObjHolder* holder);
+}  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1152)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (d6735da - b468665)

📈 **Matched code**: 14.64% (+0.02%, +2684 bytes)

<details>
<summary>✅ 27 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerInputFunction` | `PlayerInputFunction::getCameraMoveInput(al::LiveActor const*, int, int, bool)` | +224 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::getMoveInputStick(al::LiveActor const*, int, int)` | +188 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isInputLeftStickNoCameraMove(al::LiveActor const*, int, float)` | +160 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerCancelWorldWarp(al::LiveActor const*, int)` | +124 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerSeparateCameraReset(al::LiveActor const*, int, int)` | +124 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerSubAction(al::LiveActor const*, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldSubAction(al::LiveActor const*, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isReleaseSubAction(al::LiveActor const*, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldBalloonSet(al::LiveActor const*, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraReset(al::LiveActor const*, int, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::getRadiconInputSteeringValue(al::LiveActor const*, int)` | +120 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerCameraReset(al::LiveActor const*, int)` | +108 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraZoom(al::LiveActor const*, int)` | +100 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldAction(al::LiveActor const*, int)` | +92 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isReleaseAction(al::LiveActor const*, int)` | +92 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::getNoInputJudgeKeyMask(al::LiveActor const*, int)` | +88 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerCameraSubjective(al::LiveActor const*, int)` | +80 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraSnapShotZoomIn(al::LiveActor const*, int)` | +80 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraSnapShotZoomOut(al::LiveActor const*, int)` | +80 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraSnapShotRollLeft(al::LiveActor const*, int)` | +80 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldCameraSnapShotRollRight(al::LiveActor const*, int)` | +80 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isSeparatePlaySingleJoy(al::LiveActor const*, int)` | +68 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerJump(al::LiveActor const*, int)` | +60 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isHoldJump(al::LiveActor const*, int)` | +60 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isReleaseJump(al::LiveActor const*, int)` | +60 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerTalk(al::LiveActor const*, int)` | +8 | 0.00% | 100.00% |
| `Player/PlayerInputFunction` | `PlayerInputFunction::isTriggerStartWorldWarp(al::LiveActor const*, int)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->