### PR TITLE
Sequence: Implement `HakoniwaStateDemoOpening`

### DIFF
--- a/lib/al/Library/Play/Layout/WipeHolder.h
+++ b/lib/al/Library/Play/Layout/WipeHolder.h
@@ -24,12 +24,15 @@ public:
     bool isOpenEnd() const;
     bool isCloseWipe(const char* name) const;
 
+    bool isClose() const { return mIsClose; }
+
 private:
     s32 mMaxWipeCount;
     s32 mWipeCount;
     void* _8;
     WipeSimple** mWipes;
-    void* filler[4];
+    bool mIsClose;
+    u8 _19[0x1f];
 };
 }  // namespace al
 

--- a/lib/al/Library/Scene/Scene.h
+++ b/lib/al/Library/Scene/Scene.h
@@ -67,6 +67,8 @@ public:
 
     StageResourceKeeper* getStageResourceKeeper() const { return mStageResourceKeeper; }
 
+    bool isAlive() const { return mIsAlive; }
+
     LiveActorKit* getLiveActorKit() const { return mLiveActorKit; }
 
     LayoutKit* getLayoutKit() const { return mLayoutKit; }

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -32,6 +32,8 @@ public:
 
     virtual Scene* getCurrentScene() const { return nullptr; }
 
+    void setNextScene(Scene* scene) { mNextScene = scene; }
+
     SceneCreator* getSceneCreator() const override { return mSceneCreator; }
 
     void setSceneCreator(SceneCreator* sceneCreator) override { mSceneCreator = sceneCreator; }
@@ -40,6 +42,8 @@ public:
     void initAudioKeeper(const char*);
     void initDrawSystemInfo(const SequenceInitInfo&);
     AudioSystemInfo* getAudioSystemInfo();
+
+    AudioDirector* getAudioDirector() const { return mAudioDirector; }
 
     DrawSystemInfo* getDrawInfo() const { return mDrawSystemInfo; }
 

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,10 +1,20 @@
 #pragma once
 
+#include <heap/seadHeap.h>
+#include <heap/seadHeapMgr.h>
+
 namespace al {
 
-class SceneHeapSetter {
+class SceneHeapSetter : public sead::ScopedCurrentHeapSetter {
 public:
     SceneHeapSetter();
+
+    sead::Heap* getSceneHeap() const { return mSceneHeap; }
+
+private:
+    sead::Heap* mSceneHeap = nullptr;
 };
 
 }  // namespace al
+
+static_assert(sizeof(al::SceneHeapSetter) == 0x10);

--- a/lib/al/Project/Scene/SceneCreator.h
+++ b/lib/al/Project/Scene/SceneCreator.h
@@ -12,6 +12,8 @@ class GameDataHolderBase;
 class ScreenCaptureExecutor;
 class InitializeThread;
 class AudioDirector;
+class IUseSceneCreator;
+class Sequence;
 class Scene;
 
 class SceneCreator {
@@ -32,5 +34,12 @@ private:
     InitializeThread* mInitializeThread;
     AudioDirector* mAudioDirector;
 };
+
+void setSceneAndUseInitThread(IUseSceneCreator* sceneCreatorUser, Scene* scene, s32 priority,
+                              const char* stageName, s32 scenarioNo, const char* sequenceName,
+                              sead::Heap* heap);
+bool tryEndSceneInitThread(IUseSceneCreator* sceneCreatorUser);
+void setSequenceAudioKeeperToSceneSeDirector(Sequence* sequence, Scene* scene);
+void setSequenceNameForActorPickTool(Sequence* sequence, Scene* scene);
 
 }  // namespace al

--- a/src/Scene/DemoScene.h
+++ b/src/Scene/DemoScene.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+struct ActorInitInfo;
+class LayoutInitInfo;
+class StageInfo;
+class WipeHolder;
+}  // namespace al
+
+class DemoScene : public al::Scene {
+public:
+    DemoScene(al::WipeHolder* wipeHolder);
+    ~DemoScene() override;
+
+    void init(const al::SceneInitInfo& info) override;
+    void appear() override;
+    void control() override;
+    void kill() override;
+    void drawMain() const override;
+
+    virtual void exePlay();
+    virtual void initLayout(const al::LayoutInitInfo& layoutInitInfo);
+
+    void initPlacement(const al::ActorInitInfo& actorInitInfo);
+    bool isLoadEnd() const;
+    void exeSkipProc();
+    void initPlacementSky(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    void initPlacementDemo(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    void initPlacementObject(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo,
+                             const char* suffix);
+
+    void setLoadEnd() { mIsLoadEnd = true; }
+
+private:
+    sead::FixedSafeString<64> mStageName;
+    void* _130 = nullptr;
+    void* _138 = nullptr;
+    bool mIsLoadEnd = false;
+    void* _148 = nullptr;
+    s32 _150 = 1;
+    s32 _154 = 0;
+    void* _158 = nullptr;
+    void* _160 = nullptr;
+    void* _168 = nullptr;
+    void* _170 = nullptr;
+    s32 _178 = 0;
+    s32 _17c = 0;
+    al::WipeHolder* mWipeHolder = nullptr;
+    void* _188 = nullptr;
+    void* _190 = nullptr;
+};
+
+static_assert(sizeof(DemoScene) == 0x198);

--- a/src/Scene/DemoSceneWithCinemaCaption.h
+++ b/src/Scene/DemoSceneWithCinemaCaption.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Scene/DemoScene.h"
+
+class CaptionInfoHolder;
+class CinemaCaption;
+
+namespace al {
+class LayoutInitInfo;
+class WipeHolder;
+}  // namespace al
+
+class DemoSceneWithCinemaCaption : public DemoScene {
+public:
+    DemoSceneWithCinemaCaption(al::WipeHolder* wipeHolder);
+
+    void init(const al::SceneInitInfo& info) override;
+    void exePlay() override;
+    void initLayout(const al::LayoutInitInfo& layoutInitInfo) override;
+
+private:
+    CinemaCaption* mCinemaCaption = nullptr;
+    CaptionInfoHolder* mCaptionInfoHolder = nullptr;
+};
+
+static_assert(sizeof(DemoSceneWithCinemaCaption) == 0x1a8);

--- a/src/Sequence/HakoniwaStateDeleteScene.h
+++ b/src/Sequence/HakoniwaStateDeleteScene.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Sequence/Sequence.h"
+
+class WorldResourceLoader;
+class Scene;
+
+namespace al {
+class AsyncFunctorThread;
+}  // namespace al
+
+class HakoniwaStateDeleteScene : public al::HostStateBase<al::Sequence> {
+public:
+    HakoniwaStateDeleteScene(al::Sequence* sequence, WorldResourceLoader* resourceLoader);
+
+    void appear() override;
+    void kill() override;
+
+    void deleteScene();
+    void start(al::Scene* scene, bool destroyResource, bool finalizeAudio, s32 stopSeFadeFrames);
+    void exePrepare();
+    void exeFinalizeAudio();
+    void exeDeleteScene();
+
+private:
+    al::Scene* mScene = nullptr;
+    al::AsyncFunctorThread* mDeleteThread = nullptr;
+    bool mIsDestroyResource = false;
+    bool mIsFinalizeAudio = false;
+    s32 mStopSeFadeFrames = 0;
+    WorldResourceLoader* mResourceLoader = nullptr;
+};
+
+static_assert(sizeof(HakoniwaStateDeleteScene) == 0x40);

--- a/src/Sequence/HakoniwaStateDemoOpening.cpp
+++ b/src/Sequence/HakoniwaStateDemoOpening.cpp
@@ -1,0 +1,251 @@
+#include "Sequence/HakoniwaStateDemoOpening.h"
+
+#include <heap/seadHeap.h>
+#include <thread/seadThread.h>
+
+#include "Library/Audio/System/AudioKeeperFunction.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+#include "Library/Play/Layout/WipeHolder.h"
+#include "Library/Screen/ScreenFunction.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Thread/AsyncFunctorThread.h"
+#include "Project/Memory/SceneHeapSetter.h"
+#include "Project/Scene/SceneCreator.h"
+
+#include "Layout/BootLayout.h"
+#include "Layout/LoadLayoutCtrl.h"
+#include "Scene/DemoSceneWithCinemaCaption.h"
+#include "Scene/FirstSequenceScene.h"
+#include "Sequence/HakoniwaSequence.h"
+#include "Sequence/HakoniwaStateDeleteScene.h"
+#include "Sequence/WorldResourceLoader.h"
+
+namespace {
+struct SceneThreadInfo {
+    s32 priority;
+    s32 defaultPriority;
+    f32 unused;
+    s32 coreId;
+};
+
+const SceneThreadInfo sSceneThreadInfo = {
+    sead::Thread::cDefaultPriority + 3,
+    sead::Thread::cDefaultPriority,
+    -100.0f,
+    0,
+};
+
+NERVE_IMPL(HakoniwaStateDemoOpening, Boot);
+NERVE_IMPL(HakoniwaStateDemoOpening, DestroyFirstSequence);
+NERVE_IMPL(HakoniwaStateDemoOpening, End);
+NERVE_IMPL(HakoniwaStateDemoOpening, LoadFirstSequence);
+NERVE_IMPL(HakoniwaStateDemoOpening, FirstSequence);
+NERVE_IMPL(HakoniwaStateDemoOpening, Load);
+NERVE_IMPL(HakoniwaStateDemoOpening, FadeToText);
+NERVE_IMPL(HakoniwaStateDemoOpening, TextAppear);
+NERVE_IMPL(HakoniwaStateDemoOpening, Text);
+NERVE_IMPL(HakoniwaStateDemoOpening, FadeToDemo);
+NERVE_IMPL(HakoniwaStateDemoOpening, DemoOpening);
+
+NERVES_MAKE_NOSTRUCT(HakoniwaStateDemoOpening, LoadFirstSequence, FirstSequence, TextAppear, Text,
+                     FadeToDemo, DemoOpening);
+NERVES_MAKE_STRUCT(HakoniwaStateDemoOpening, Boot, DestroyFirstSequence, End, Load, FadeToText);
+}  // namespace
+
+HakoniwaStateDemoOpening::HakoniwaStateDemoOpening(
+    HakoniwaSequence* sequence, al::WipeHolder* wipeHolder,
+    al::ScreenCaptureExecutor* screenCaptureExecutor, WorldResourceLoader* resourceLoader,
+    BootLayout* bootLayout, const al::LayoutInitInfo& layoutInitInfo,
+    HakoniwaStateDeleteScene* stateDeleteScene, al::AsyncFunctorThread* initThread,
+    LoadLayoutCtrl* loadLayoutCtrl)
+    : al::HostStateBase<HakoniwaSequence>("オープニングデモ", sequence), mWipeHolder(wipeHolder),
+      mBootLayout(bootLayout), mScreenCaptureExecutor(screenCaptureExecutor),
+      mResourceLoader(resourceLoader), mStateDeleteScene(stateDeleteScene), mInitThread(initThread),
+      mLoadLayoutCtrl(loadLayoutCtrl) {
+    mStartOpeningDemo = new al::SimpleLayoutAppearWaitEnd(
+        "オープニングテキスト", "StartOpeningDemo", layoutInitInfo, nullptr, false);
+    al::killLayoutIfActive(mStartOpeningDemo);
+}
+
+HakoniwaStateDemoOpening::~HakoniwaStateDemoOpening() {
+    delete mDemoScene;
+    mDemoScene = nullptr;
+}
+
+void HakoniwaStateDemoOpening::init() {
+    initNerve(&NrvHakoniwaStateDemoOpening.Boot, 2);
+    al::addNerveState(this, mStateDeleteScene, &NrvHakoniwaStateDemoOpening.DestroyFirstSequence,
+                      "シーン破棄[初回シーケンス]");
+    al::addNerveState(this, mStateDeleteScene, &NrvHakoniwaStateDemoOpening.End,
+                      "シーン破棄[オープニング]");
+}
+
+void HakoniwaStateDemoOpening::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &NrvHakoniwaStateDemoOpening.Boot);
+}
+
+void HakoniwaStateDemoOpening::startSecond() {
+    mIsSecond = true;
+}
+
+void HakoniwaStateDemoOpening::exeBoot() {
+    if (al::isFirstStep(this)) {
+        al::createSceneHeap(nullptr, true);
+        al::SceneHeapSetter heapSetter;
+        mFirstSequenceScene = new FirstSequenceScene();
+        alAudioSystemFunction::resetDataDependedStage(getHost()->getAudioDirector(), nullptr, 1);
+        al::setSceneAndUseInitThread(getHost(), mFirstSequenceScene, sSceneThreadInfo.priority,
+                                     nullptr, 1, "Sequence=ProductSequence", nullptr);
+        mInitThread->start();
+    }
+
+    if (mIsSecond || al::isGreaterEqualStep(this, 60))
+        al::setNerve(this, &LoadFirstSequence);
+}
+
+void HakoniwaStateDemoOpening::exeLoadFirstSequence() {
+    getHost()->updatePadSystem();
+
+    if (al::isFirstStep(this) && !mIsSecond)
+        mBootLayout->appear();
+
+    if (!al::tryEndSceneInitThread(getHost()) || !mInitThread->isDone() ||
+        (!mIsSecond && al::isLessEqualStep(this, 540)))
+        return;
+
+    al::setSequenceAudioKeeperToSceneSeDirector(getHost(), mFirstSequenceScene);
+    mFirstSequenceScene->appear();
+    getHost()->setNextScene(mFirstSequenceScene);
+    al::setSequenceNameForActorPickTool(getHost(), mFirstSequenceScene);
+    al::setNerve(this, &FirstSequence);
+}
+
+void HakoniwaStateDemoOpening::exeFirstSequence() {
+    getHost()->updatePadSystem();
+
+    if (al::isFirstStep(this)) {
+        mBootLayout->kill();
+        mScreenCaptureExecutor->offDraw();
+        if (mWipeHolder->isClose()) {
+            mFirstSequenceScene->setNoWipe();
+            mWipeHolder->startOpen(-1);
+        }
+    }
+
+    if (mFirstSequenceScene->isAlive())
+        return;
+
+    mScreenCaptureExecutor->requestCapture(true, 0);
+    al::setNerve(this, &NrvHakoniwaStateDemoOpening.DestroyFirstSequence);
+}
+
+void HakoniwaStateDemoOpening::exeDestroyFirstSequence() {
+    if (al::isFirstStep(this)) {
+        mStateDeleteScene->start(mFirstSequenceScene, true, false, 0);
+        mWipeHolder->startClose("FadeBlack", 150);
+        al::stopBgm(getHost(), "Stage", 300);
+        return;
+    }
+
+    if (al::updateNerveState(this)) {
+        mFirstSequenceScene = nullptr;
+        al::setNerve(this, &NrvHakoniwaStateDemoOpening.Load);
+    }
+}
+
+void HakoniwaStateDemoOpening::exeLoad() {
+    if (!mInitThread->isDone()) {
+        al::setNerve(this, &NrvHakoniwaStateDemoOpening.Load);
+        return;
+    }
+
+    if (al::isFirstStep(this)) {
+        const char* stageName = "DemoOpeningStage";
+        al::createSceneHeap(stageName, true);
+        al::SceneHeapSetter heapSetter;
+        mDemoScene = new DemoSceneWithCinemaCaption(mWipeHolder);
+        alAudioSystemFunction::resetDataDependedStage(getHost()->getAudioDirector(), stageName, 1);
+        al::setSceneAndUseInitThread(getHost(), mDemoScene, sSceneThreadInfo.priority, stageName, 1,
+                                     "Sequence=ProductSequence", nullptr);
+    }
+
+    al::setNerve(this, &NrvHakoniwaStateDemoOpening.FadeToText);
+}
+
+void HakoniwaStateDemoOpening::exeFadeToText() {
+    if (!mWipeHolder->isCloseEnd())
+        return;
+
+    mStartOpeningDemo->appear();
+    mBootLayout->kill();
+    al::setNerve(this, &TextAppear);
+    al::startSe(getHost(), "AmbBeforeOP");
+}
+
+void HakoniwaStateDemoOpening::exeTextAppear() {
+    if (mStartOpeningDemo->isWait())
+        al::setNerve(this, &Text);
+}
+
+void HakoniwaStateDemoOpening::exeText() {
+    if (al::isGreaterEqualStep(this, 100)) {
+        mStartOpeningDemo->end();
+        al::setNerve(this, &FadeToDemo);
+    }
+}
+
+void HakoniwaStateDemoOpening::exeFadeToDemo() {
+    if (!al::isDead(mStartOpeningDemo) || !al::tryEndSceneInitThread(getHost()))
+        return;
+
+    al::setSequenceAudioKeeperToSceneSeDirector(getHost(), mDemoScene);
+    al::getSceneHeap()->adjust();
+    al::setSequenceNameForActorPickTool(getHost(), mDemoScene);
+    mScreenCaptureExecutor->offDraw();
+    mDemoScene->setLoadEnd();
+    mDemoScene->appear();
+    getHost()->setNextScene(mDemoScene);
+    mWipeHolder->startOpen(150);
+    al::setNerve(this, &DemoOpening);
+}
+
+void HakoniwaStateDemoOpening::exeDemoOpening() {
+    getHost()->updatePadSystem();
+
+    if (al::isFirstStep(this)) {
+        mResourceLoader->requestLoadWorldHomeStageResource(0, 1);
+        al::tryStopSe(getHost(), "AmbBeforeOP", -1, nullptr);
+    }
+
+    if (mDemoScene->isAlive())
+        return;
+
+    mLoadLayoutCtrl->startWaitLoad();
+    mScreenCaptureExecutor->requestCapture(true, 0);
+    if (!mWipeHolder->isClose())
+        mWipeHolder->startClose("FadeBlack", -1);
+    al::setNerve(this, &NrvHakoniwaStateDemoOpening.End);
+}
+
+void HakoniwaStateDemoOpening::exeEnd() {
+    if (al::isFirstStep(this)) {
+        if (mResourceLoader->isEndLoadWorldResource()) {
+            mStateDeleteScene->start(mDemoScene, true, false, 0);
+            al::stopBgm(getHost(), "Stage", 300);
+            return;
+        }
+        al::setNerve(this, &NrvHakoniwaStateDemoOpening.End);
+        return;
+    }
+
+    if (al::updateNerveState(this)) {
+        mDemoScene = nullptr;
+        kill();
+    }
+}

--- a/src/Sequence/HakoniwaStateDemoOpening.h
+++ b/src/Sequence/HakoniwaStateDemoOpening.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class BootLayout;
+class DemoSceneWithCinemaCaption;
+class FirstSequenceScene;
+class HakoniwaSequence;
+class HakoniwaStateDeleteScene;
+class LoadLayoutCtrl;
+class WorldResourceLoader;
+
+namespace al {
+class AsyncFunctorThread;
+class LayoutInitInfo;
+class ScreenCaptureExecutor;
+class SimpleLayoutAppearWaitEnd;
+class WipeHolder;
+}  // namespace al
+
+class HakoniwaStateDemoOpening : public al::HostStateBase<HakoniwaSequence> {
+public:
+    HakoniwaStateDemoOpening(HakoniwaSequence* sequence, al::WipeHolder* wipeHolder,
+                             al::ScreenCaptureExecutor* screenCaptureExecutor,
+                             WorldResourceLoader* resourceLoader, BootLayout* bootLayout,
+                             const al::LayoutInitInfo& layoutInitInfo,
+                             HakoniwaStateDeleteScene* stateDeleteScene,
+                             al::AsyncFunctorThread* initThread, LoadLayoutCtrl* loadLayoutCtrl);
+    ~HakoniwaStateDemoOpening() override;
+
+    void init() override;
+    void appear() override;
+
+    void startSecond();
+    void exeBoot();
+    void exeLoadFirstSequence();
+    void exeFirstSequence();
+    void exeDestroyFirstSequence();
+    void exeLoad();
+    void exeFadeToText();
+    void exeTextAppear();
+    void exeText();
+    void exeFadeToDemo();
+    void exeDemoOpening();
+    void exeEnd();
+
+private:
+    FirstSequenceScene* mFirstSequenceScene = nullptr;
+    DemoSceneWithCinemaCaption* mDemoScene = nullptr;
+    al::WipeHolder* mWipeHolder;
+    BootLayout* mBootLayout;
+    al::SimpleLayoutAppearWaitEnd* mStartOpeningDemo = nullptr;
+    al::ScreenCaptureExecutor* mScreenCaptureExecutor;
+    WorldResourceLoader* mResourceLoader;
+    bool mIsSecond = false;
+    HakoniwaStateDeleteScene* mStateDeleteScene;
+    al::AsyncFunctorThread* mInitThread;
+    LoadLayoutCtrl* mLoadLayoutCtrl;
+};
+
+static_assert(sizeof(HakoniwaStateDemoOpening) == 0x78);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1154)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (30ce81d - 80d195b)

📈 **Matched code**: 14.64% (+0.02%, +2756 bytes)

<details>
<summary>✅ 29 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeLoad()` | +276 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeBoot()` | +228 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeDemoOpening()` | +216 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::HakoniwaStateDemoOpening(HakoniwaSequence*, al::WipeHolder*, al::ScreenCaptureExecutor*, WorldResourceLoader*, BootLayout*, al::LayoutInitInfo const&, HakoniwaStateDeleteScene*, al::AsyncFunctorThread*, LoadLayoutCtrl*)` | +200 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeLoadFirstSequence()` | +196 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeFadeToDemo()` | +188 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeEnd()` | +180 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeDestroyFirstSequence()` | +164 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeFirstSequence()` | +160 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeFadeToText()` | +148 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvFadeToText::execute(al::NerveKeeper*) const` | +148 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::init()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::~HakoniwaStateDemoOpening()` | +80 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvText::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::~HakoniwaStateDemoOpening()` | +72 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeText()` | +72 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::exeTextAppear()` | +64 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvTextAppear::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `_GLOBAL__sub_I_HakoniwaStateDemoOpening.cpp` | +40 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::appear()` | +16 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `HakoniwaStateDemoOpening::startSecond()` | +12 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvBoot::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvDestroyFirstSequence::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvLoadFirstSequence::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvFirstSequence::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvLoad::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvFadeToDemo::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoOpening` | `(anonymous namespace)::HakoniwaStateDemoOpeningNrvDemoOpening::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->