### PR TITLE
Boss/Koopa: Implement `KoopaCapOnlyWeapon`

### DIFF
--- a/src/Boss/Koopa/KoopaCapOnlyWeapon.cpp
+++ b/src/Boss/Koopa/KoopaCapOnlyWeapon.cpp
@@ -1,0 +1,173 @@
+#include "Boss/Koopa/KoopaCapOnlyWeapon.h"
+
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/Koopa/KoopaCapScaleAnimator.h"
+#include "Boss/Koopa/KoopaCapStateSpinThrow.h"
+#include "Boss/Koopa/KoopaFunction.h"
+#include "Boss/Koopa/KoopaItemHolder.h"
+#include "Player/PlayerPushReceiver.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(KoopaCapOnlyWeapon, SpinThrow)
+
+NERVE_IMPL(KoopaCapOnlyWeapon, WaitHoverDelay)
+NERVE_IMPL(KoopaCapOnlyWeapon, WaitHoverStart)
+NERVE_IMPL(KoopaCapOnlyWeapon, WaitHover)
+
+NERVES_MAKE_NOSTRUCT(KoopaCapOnlyWeapon, SpinThrow)
+NERVES_MAKE_STRUCT(KoopaCapOnlyWeapon, WaitHoverDelay, WaitHoverStart, WaitHover)
+}  // namespace
+
+KoopaCapOnlyWeapon::KoopaCapOnlyWeapon(const char* name) : al::LiveActor(name) {}
+
+void KoopaCapOnlyWeapon::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "KoopaCapDummy", nullptr);
+    al::initNerve(this, &SpinThrow, 1);
+    al::createAndSetColliderSpecialPurpose(this, "MoveLimit");
+
+    mStateSpinThrow = new KoopaCapStateSpinThrow(this);
+    al::initNerveState(this, mStateSpinThrow, &SpinThrow, "スピン投げ");
+    al::initJointControllerKeeper(this, 1);
+    KoopaFunction::initCapJointSideRotator(this, &mCapSideRotator);
+
+    mScaleAnimator = new KoopaCapScaleAnimator(this);
+    mPlayerPushReceiver = new PlayerPushReceiver(this);
+    makeActorDead();
+}
+
+void KoopaCapOnlyWeapon::appear() {
+    al::LiveActor::appear();
+    al::startHitReaction(this, "出現");
+    mCapSideRotator = 0.0f;
+}
+
+void KoopaCapOnlyWeapon::kill() {
+    al::LiveActor::kill();
+    mPlayerPushReceiver->clear();
+    mScaleAnimator->reset();
+}
+
+void KoopaCapOnlyWeapon::disappear() {
+    al::startHitReaction(this, "間接消滅");
+    kill();
+}
+
+void KoopaCapOnlyWeapon::control() {
+    mScaleAnimator->update(this);
+}
+
+void KoopaCapOnlyWeapon::updateCollider() {
+    sead::Vector3f pushedVelocity = {0.0f, 0.0f, 0.0f};
+    mPlayerPushReceiver->calcPushedVelocity(&pushedVelocity, al::getVelocity(this));
+
+    sead::Vector3f velocity = al::getVelocity(this);
+    al::setVelocity(this, pushedVelocity);
+    al::LiveActor::updateCollider();
+    al::setVelocity(this, velocity);
+    mPlayerPushReceiver->clear();
+}
+
+void KoopaCapOnlyWeapon::startWaitHover(s32 delay) {
+    if (al::isDead(this))
+        appear();
+
+    al::hideModelIfShow(this);
+
+    if (delay >= 1) {
+        mWaitHoverDelay = delay;
+        al::setNerve(this, &NrvKoopaCapOnlyWeapon.WaitHoverDelay);
+        return;
+    }
+
+    al::setNerve(this, &NrvKoopaCapOnlyWeapon.WaitHoverStart);
+}
+
+void KoopaCapOnlyWeapon::startSpinThrowChase(const sead::Vector3f* targetTrans, f32 degree) {
+    if (al::isDead(this))
+        appear();
+
+    al::invalidateClipping(this);
+    mStateSpinThrow->startSpinThrowChase(targetTrans, degree, false);
+    al::setNerve(this, &SpinThrow);
+}
+
+bool KoopaCapOnlyWeapon::isEndWaitHoverStart() const {
+    return !al::isNerve(this, &NrvKoopaCapOnlyWeapon.WaitHoverDelay) &&
+           !al::isNerve(this, &NrvKoopaCapOnlyWeapon.WaitHoverStart);
+}
+
+bool KoopaCapOnlyWeapon::isWaitHover() const {
+    return !isEndWaitHoverStart() || al::isNerve(this, &NrvKoopaCapOnlyWeapon.WaitHover);
+}
+
+void KoopaCapOnlyWeapon::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorEnemyAttack(self)) {
+        if (isWaitHover())
+            al::sendMsgEnemyAttack(other, self);
+        else
+            rs::sendMsgKoopaCapSpinAttack(other, self);
+    }
+}
+
+bool KoopaCapOnlyWeapon::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                    al::HitSensor* self) {
+    if (al::isSensorEnemyBody(self)) {
+        if (isWaitHover()) {
+            if (rs::isMsgCapReflect(message)) {
+                rs::requestHitReactionToAttacker(message, self, other);
+                mScaleAnimator->startWaitHoverScaling();
+                return true;
+            }
+        } else if (rs::isMsgCapAttack(message)) {
+            if (mItemHolder)
+                mItemHolder->tryGenerateLifeUpItem(this);
+
+            rs::requestHitReactionToAttacker(message, self, other);
+            al::startHitReaction(this, "消滅");
+            kill();
+            return true;
+        }
+    }
+
+    return false;
+}
+
+void KoopaCapOnlyWeapon::exeWaitHoverDelay() {
+    al::setNerveAtGreaterEqualStep(this, &NrvKoopaCapOnlyWeapon.WaitHoverStart, mWaitHoverDelay);
+}
+
+void KoopaCapOnlyWeapon::exeWaitHoverStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "WaitHoverStart");
+        al::showModelIfHide(this);
+    }
+
+    al::setNerveAtActionEnd(this, &NrvKoopaCapOnlyWeapon.WaitHover);
+}
+
+void KoopaCapOnlyWeapon::exeWaitHover() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "WaitHover");
+}
+
+void KoopaCapOnlyWeapon::exeSpinThrow() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Spin");
+
+    if (al::updateNerveState(this)) {
+        al::startHitReaction(this, "間接消滅");
+        kill();
+    }
+}

--- a/src/Boss/Koopa/KoopaCapOnlyWeapon.h
+++ b/src/Boss/Koopa/KoopaCapOnlyWeapon.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class KoopaCapScaleAnimator;
+class KoopaCapStateSpinThrow;
+class KoopaItemHolder;
+class PlayerPushReceiver;
+
+class KoopaCapOnlyWeapon : public al::LiveActor {
+public:
+    KoopaCapOnlyWeapon(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    void kill() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+    void updateCollider() override;
+
+    void disappear();
+    void startWaitHover(s32 delay);
+    void startSpinThrowChase(const sead::Vector3f* targetTrans, f32 degree);
+    bool isEndWaitHoverStart() const;
+    bool isWaitHover() const;
+
+    void exeWaitHoverDelay();
+    void exeWaitHoverStart();
+    void exeWaitHover();
+    void exeSpinThrow();
+
+private:
+    KoopaCapStateSpinThrow* mStateSpinThrow = nullptr;
+    KoopaCapScaleAnimator* mScaleAnimator = nullptr;
+    KoopaItemHolder* mItemHolder = nullptr;
+    PlayerPushReceiver* mPlayerPushReceiver = nullptr;
+    f32 mCapSideRotator = 0.0f;
+    s32 mWaitHoverDelay = 0;
+};
+
+static_assert(sizeof(KoopaCapOnlyWeapon) == 0x130);

--- a/src/Boss/Koopa/KoopaCapScaleAnimator.h
+++ b/src/Boss/Koopa/KoopaCapScaleAnimator.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class KoopaCapScaleAnimator : public al::NerveExecutor {
+public:
+    KoopaCapScaleAnimator(al::LiveActor* actor);
+
+    void update(al::LiveActor* actor);
+    f32 getScale() const;
+    void startWaitHoverScaling();
+    void reset();
+    void exeStop();
+    void exeWaitHoverScaling();
+};
+
+static_assert(sizeof(KoopaCapScaleAnimator) == 0x10);

--- a/src/Boss/Koopa/KoopaCapStateSpinThrow.h
+++ b/src/Boss/Koopa/KoopaCapStateSpinThrow.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class KoopaCapStateSpinThrow : public al::ActorStateBase {
+public:
+    KoopaCapStateSpinThrow(al::LiveActor* actor);
+    ~KoopaCapStateSpinThrow() override;
+
+    void startSpinThrowChase(const sead::Vector3f* targetTrans, f32 degree, bool isStartSpin);
+    void exeSpinStart();
+    void exeSpin();
+
+private:
+    sead::Vector3f mSpinDir = sead::Vector3f::zero;
+    f32 mSpinDegree = 0.0f;
+    const sead::Vector3f* mTargetTrans = nullptr;
+    s32 mSpinStep = 0;
+};
+
+static_assert(sizeof(KoopaCapStateSpinThrow) == 0x40);

--- a/src/Boss/Koopa/KoopaItemHolder.h
+++ b/src/Boss/Koopa/KoopaItemHolder.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class KoopaItemHolder {
+public:
+    KoopaItemHolder();
+
+    bool tryGenerateLifeUpItem(al::LiveActor* actor);
+
+private:
+    al::LiveActor* mLifeUpItem = nullptr;
+    s32 mGenerateDelay = 0;
+    s32 mGenerateCount = 1;
+    bool mIsEnableGenerate = false;
+};
+
+static_assert(sizeof(KoopaItemHolder) == 0x18);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1156)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (30ce81d - 3e75c80)

📈 **Matched code**: 14.64% (+0.02%, +2156 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::init(al::ActorInitInfo const&)` | +260 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +252 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::attackSensor(al::HitSensor*, al::HitSensor*)` | +160 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::KoopaCapOnlyWeapon(char const*)` | +144 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::KoopaCapOnlyWeapon(char const*)` | +132 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::updateCollider()` | +132 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::startSpinThrowChase(sead::Vector3<float> const*, float)` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `(anonymous namespace)::KoopaCapOnlyWeaponNrvSpinThrow::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::startWaitHover(int)` | +104 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::exeSpinThrow()` | +104 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::isWaitHover() const` | +88 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `(anonymous namespace)::KoopaCapOnlyWeaponNrvWaitHoverStart::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::isEndWaitHoverStart() const` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::exeWaitHoverStart()` | +76 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `(anonymous namespace)::KoopaCapOnlyWeaponNrvWaitHover::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::exeWaitHover()` | +60 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::appear()` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::disappear()` | +52 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::kill()` | +44 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `(anonymous namespace)::KoopaCapOnlyWeaponNrvWaitHoverDelay::execute(al::NerveKeeper*) const` | +24 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::exeWaitHoverDelay()` | +20 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaCapOnlyWeapon` | `KoopaCapOnlyWeapon::control()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->