### PR TITLE
Enemy: Implement `GamaneBullet`

### DIFF
--- a/src/Enemy/GamaneBullet.cpp
+++ b/src/Enemy/GamaneBullet.cpp
@@ -1,0 +1,160 @@
+#include "Enemy/GamaneBullet.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(GamaneBullet, Straight)
+NERVE_IMPL(GamaneBullet, Hit)
+NERVE_IMPL(GamaneBullet, Brake)
+NERVE_IMPL(GamaneBullet, Fall)
+
+NERVES_MAKE_NOSTRUCT(GamaneBullet, Straight, Hit, Brake, Fall)
+}  // namespace
+
+GamaneBullet::GamaneBullet(const char* name, const al::LiveActor* parent) : al::LiveActor(name) {
+    mParentActor = parent;
+}
+
+void GamaneBullet::init(const al::ActorInitInfo& info) {
+    al::initNerve(this, &Straight, 0);
+    al::initActorWithArchiveName(this, info, "GamaneBullet", nullptr);
+    makeActorDead();
+}
+
+void GamaneBullet::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &Hit))
+        return;
+
+    if (al::isSensorMapObj(other)) {
+        if (rs::sendMsgGamaneBullet(other, self)) {
+            al::startHitReaction(this, "オブジェヒット");
+            al::setNerve(this, &Hit);
+            return;
+        }
+
+        if (rs::sendMsgWeaponItemGet(other, self))
+            return;
+    }
+
+    if (rs::sendMsgGamaneBulletThrough(other, self)) {
+        al::startHitReaction(this, "オブジェヒット");
+        return;
+    }
+
+    if (rs::sendMsgGamaneBulletForCoinFlower(other, self)) {
+        al::startHitReaction(this, "コインで伸びる草ヒット");
+        kill();
+        return;
+    }
+
+    if (rs::sendMsgGamaneBullet(other, self) || rs::sendMsgBreakPartsBreak(other, self)) {
+        al::startHitReaction(this, "オブジェヒット");
+        al::setNerve(this, &Hit);
+    }
+}
+
+bool GamaneBullet::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                              al::HitSensor* self) {
+    if (al::isNerve(this, &Hit))
+        return false;
+
+    if (al::isMsgPlayerDisregard(message) || rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+
+    return rs::isMsgPlayerDisregardTargetMarker(message);
+}
+
+void GamaneBullet::appear() {
+    al::LiveActor::appear();
+    al::setNerve(this, &Straight);
+}
+
+void GamaneBullet::control() {
+    if (al::isNerve(this, &Hit))
+        return;
+
+    if (al::isInDeathArea(this) || al::isCollidedFloorCode(this, "DamageFire") ||
+        al::isCollidedFloorCode(this, "Needle") || al::isCollidedFloorCode(this, "Poison")) {
+        al::startHitReaction(this, "消滅");
+        kill();
+        return;
+    }
+
+    if (al::isCollided(this)) {
+        al::HitSensor* collidedSensor = al::tryGetCollidedSensor(this);
+        if (collidedSensor) {
+            if (rs::sendMsgHackAttack(collidedSensor, al::getHitSensor(this, "Body")) ||
+                rs::sendMsgGamaneBullet(collidedSensor, al::getHitSensor(this, "Body"))) {
+                al::startHitReaction(this, "オブジェヒット");
+            }
+        }
+
+        if (al::isCollided(this))
+            al::setNerve(this, &Hit);
+    }
+}
+
+void GamaneBullet::shoot(f32 speed, const sead::Vector3f& direction) {
+    sead::Vector3f velocity;
+    velocity.x = direction.x * speed + 0.0f;
+    velocity.y = direction.y * speed + 0.0f;
+    velocity.z = direction.z * speed + 0.0f;
+    al::setVelocity(this, velocity);
+    al::invalidateClipping(this);
+    al::makeQuatFrontUp(al::getQuatPtr(this), sead::Vector3f::ey, direction);
+    mRotateDegree = 60.0f;
+    appear();
+}
+
+void GamaneBullet::rotate(f32 degree) {
+    sead::Vector3f up = sead::Vector3f::ez;
+    al::calcUpDir(&up, this);
+    al::rotateVectorDegreeY(&up, mRotateDegree);
+    al::makeQuatFrontUp(al::getQuatPtr(this), sead::Vector3f::ey, up);
+    mRotateDegree = sead::Mathf::clampMin(mRotateDegree - degree, 0);
+}
+
+void GamaneBullet::exeStraight() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+
+    rotate(0.5f);
+
+    if (al::isGreaterEqualStep(this, 15))
+        al::setNerve(this, &Brake);
+}
+
+void GamaneBullet::exeBrake() {
+    rotate(2.5f);
+    al::scaleVelocityHV(this, 0.98f, 0.96f);
+
+    if (al::isGreaterEqualStep(this, 10))
+        al::setNerve(this, &Fall);
+}
+
+void GamaneBullet::exeFall() {
+    rotate(2.5f);
+    al::addVelocityY(this, -0.7f);
+
+    if (al::isGreaterEqualStep(this, 300))
+        kill();
+}
+
+void GamaneBullet::exeHit() {
+    al::startHitReaction(this, "命中");
+    kill();
+}

--- a/src/Enemy/GamaneBullet.h
+++ b/src/Enemy/GamaneBullet.h
@@ -14,6 +14,7 @@ class SensorMsg;
 class GamaneBullet : public al::LiveActor {
 public:
     GamaneBullet(const char* name, const al::LiveActor* parent);
+
     void init(const al::ActorInitInfo& info) override;
     void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
@@ -21,17 +22,19 @@ public:
     void appear() override;
     void control() override;
 
-    void shoot(f32, const sead::Vector3f&);
-    void rotate(f32);
+    void shoot(f32 speed, const sead::Vector3f& direction);
+    void rotate(f32 degree);
 
     void exeStraight();
     void exeBrake();
     void exeFall();
     void exeHit();
 
-    al::LiveActor* getParent() { return mParentActor; }
+    const al::LiveActor* getParent() const { return mParentActor; }
 
 private:
-    f32 _108;
-    al::LiveActor* mParentActor;
+    f32 mRotateDegree = 60.0f;
+    const al::LiveActor* mParentActor = nullptr;
 };
+
+static_assert(sizeof(GamaneBullet) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1157)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (30ce81d - 4c667ff)

📈 **Matched code**: 14.64% (+0.02%, +2120 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/GamaneBullet` | `GamaneBullet::control()` | +300 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::attackSensor(al::HitSensor*, al::HitSensor*)` | +284 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::exeStraight()` | +188 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::exeBrake()` | +188 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::exeFall()` | +180 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::shoot(float, sead::Vector3<float> const&)` | +156 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::GamaneBullet(char const*, al::LiveActor const*)` | +148 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::GamaneBullet(char const*, al::LiveActor const*)` | +144 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::rotate(float)` | +140 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::init(al::ActorInitInfo const&)` | +120 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +96 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `(anonymous namespace)::GamaneBulletNrvHit::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::exeHit()` | +52 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `GamaneBullet::appear()` | +44 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `(anonymous namespace)::GamaneBulletNrvStraight::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `(anonymous namespace)::GamaneBulletNrvBrake::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/GamaneBullet` | `(anonymous namespace)::GamaneBulletNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->