### PR TITLE
Library/Camera: Match `CameraPoser::movement`

### DIFF
--- a/lib/al/Library/Camera/CameraPoser.cpp
+++ b/lib/al/Library/Camera/CameraPoser.cpp
@@ -250,71 +250,170 @@ void CameraPoser::appear(const CameraStartInfo& info) {
         mLookAtInterpole->lookAtPos.set(mTargetTrans);
 }
 
-// TODO: CameraPoser::movement
+void CameraPoser::LookAtInterpole::update(CameraPoser* camera, sead::Vector3f targetTrans) {
+    lerpVec(camera->getTargetTransPtr(), lookAtPos, camera->getTargetTrans(), lookAtDistance);
+    lookAtPos.set(camera->getTargetTrans());
+    camera->addPosition(camera->getTargetTrans() - targetTrans);
+}
 
-inline void CameraPoser::LocalInterpole::interpolate(sead::LookAtCamera* cam) {
-    if (step > -1) {
-        f32 rate = hermiteRate(normalize(step, 0, end), 1.5f, 0.0f);
+void CameraPoser::LookAtInterpole::updateWithGravity(CameraPoser* camera,
+                                                     const sead::Vector3f& targetGravity,
+                                                     sead::Vector3f targetTrans) {
+    sead::Vector3f lookDirection = camera->getTargetTrans() - lookAtPos;
+    sead::Vector3f gravity = {0.0f, 0.0f, 0.0f};
+    parallelizeVec(&gravity, targetGravity, lookDirection);
+    sead::Vector3f dir = lookDirection - gravity;
+    camera->getTargetTransPtr()->set(gravity + lookAtPos + dir * lookAtDistance);
+    lookAtPos.set(camera->getTargetTrans());
+    camera->addPosition(camera->getTargetTrans() - targetTrans);
+}
 
-        sead::Vector3f camPosNext = sead::Vector3f(0, 0, 0);
-        sead::Vector3f lookAtPosNext = sead::Vector3f(0, 0, 0);
-        lerpVec(&camPosNext, prevCameraPos, cam->getPos(), rate);
-        lerpVec(&lookAtPosNext, prevLookAtPos, cam->getAt(), rate);
-
-        cam->setPos(camPosNext);
-        cam->setAt(lookAtPosNext);
+void CameraPoser::LocalInterpole::update(const CameraPoser* camera) {
+    if (alCameraPoserFunction::isChangeTarget(camera)) {
+        step = 0;
+        end = 30;
+        prevCameraPos.set(alCameraPoserFunction::getPreCameraPos(camera));
+        prevLookAtPos.set(alCameraPoserFunction::getPreLookAtPos(camera));
     }
 }
 
-void CameraPoser::makeLookAtCameraPrev(sead::LookAtCamera* cam) const {
-    cam->setPos(mPosition);
-    cam->setAt(mTargetTrans);
-    cam->setUp(mCameraUp);
-    cam->normalizeUp();
+void CameraPoser::movement() {
+    if (mNerveKeeper)
+        mNerveKeeper->update();
+
+    if (mAngleCtrlInfo || mAngleSwingInfo) {
+        sead::Vector2f stick = {0.0f, 0.0f};
+        alCameraPoserFunction::calcCameraRotateStick(&stick, this);
+        if (mAngleCtrlInfo) {
+            bool isTriggerReset = alCameraPoserFunction::isTriggerCameraResetRotate(this);
+            mAngleCtrlInfo->update(stick, alCameraPoserFunction::getStickSensitivityScale(this),
+                                   isTriggerReset);
+            if (alCameraPoserFunction::isSnapShotMode(this) && isTriggerReset) {
+                s32 step = -1;
+                if (mAngleCtrlInfo->isResetStartTiming())
+                    step = mAngleCtrlInfo->getMaxResetStep();
+                alCameraPoserFunction::startResetSnapShotCameraCtrl(this, step);
+            }
+        }
+        if (mAngleSwingInfo)
+            mAngleSwingInfo->update(stick, alCameraPoserFunction::getStickSensitivityScale(this));
+    }
+
+    if (mGyroCtrl && !alCameraPoserFunction::isStopUpdateGyro(this)) {
+        sead::Vector3f side, up, front;
+        alCameraPoserFunction::calcCameraGyroPose(this, &side, &up, &front);
+        mGyroCtrl->setIsValidGyro(alCameraPoserFunction::isValidGyro(this));
+        mGyroCtrl->setSensitivityScale(alCameraPoserFunction::getGyroSensitivityScale(this));
+        mGyroCtrl->update(side, up, front);
+    }
+
+    update();
+
+    if (mLookAtInterpole) {
+        if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb) {
+            sead::Vector3f targetGravity = {0.0f, 0.0f, 0.0f};
+            alCameraPoserFunction::calcTargetGravity(&targetGravity, this);
+            mLookAtInterpole->updateWithGravity(this, targetGravity, mTargetTrans);
+        } else {
+            mLookAtInterpole->update(this, mTargetTrans);
+        }
+    }
 
     if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb)
-        mVerticalAbsorber->makeLookAtCamera(cam);
+        mVerticalAbsorber->update();
+
+    if (alCameraPoserFunction::isSnapShotMode(this) && mSnapShotCtrl)
+        alCameraPoserFunction::updateSnapShotCameraCtrl(this);
+
+    if (mLocalInterpole) {
+        mLocalInterpole->update(this);
+        if (mLocalInterpole->step > -1) {
+            s32 nextStep = mLocalInterpole->step + 1;
+            mLocalInterpole->step = mLocalInterpole->end > nextStep ? nextStep : -1;
+        }
+    }
+
+    if (mArrowCollider && !mPoserFlag->isInvalidCollider) {
+        sead::LookAtCamera camera;
+        makeLookAtCameraPrev(&camera);
+        makeLookAtCamera(&camera);
+
+        if (alCameraPoserFunction::isSnapShotMode(this) && mSnapShotCtrl)
+            mSnapShotCtrl->makeLookAtCameraPost(&camera);
+        if (mParamMoveLimit)
+            mParamMoveLimit->apply(&camera);
+
+        if (alCameraPoserFunction::isSnapShotMode(this) && mSnapShotCtrl)
+            mSnapShotCtrl->makeLookAtCameraLast(&camera);
+        mArrowCollider->update(camera.getPos(), camera.getAt(), camera.getUp());
+    }
+
+    mPoserFlag->isFirstCalc = false;
+}
+
+inline void CameraPoser::LocalInterpole::interpolate(sead::LookAtCamera* camera) {
+    if (step > -1) {
+        f32 rate = hermiteRate(normalize(step, 0, end), 1.5f, 0.0f);
+
+        sead::Vector3f camPosNext = {0.0f, 0.0f, 0.0f};
+        sead::Vector3f lookAtPosNext = {0.0f, 0.0f, 0.0f};
+        lerpVec(&camPosNext, prevCameraPos, camera->getPos(), rate);
+        lerpVec(&lookAtPosNext, prevLookAtPos, camera->getAt(), rate);
+
+        camera->setPos(camPosNext);
+        camera->setAt(lookAtPosNext);
+    }
+}
+
+void CameraPoser::makeLookAtCameraPrev(sead::LookAtCamera* camera) const {
+    camera->setPos(mPosition);
+    camera->setAt(mTargetTrans);
+    camera->setUp(mCameraUp);
+    camera->normalizeUp();
+
+    if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb)
+        mVerticalAbsorber->makeLookAtCamera(camera);
 
     if (mLocalInterpole)
-        mLocalInterpole->interpolate(cam);
+        mLocalInterpole->interpolate(camera);
 
     if (mAngleSwingInfo)
-        mAngleSwingInfo->makeLookAtCamera(cam);
+        mAngleSwingInfo->makeLookAtCamera(camera);
 
     if (mTargetAreaLimitter) {
-        sead::Vector3f camPosNext = cam->getAt();
+        sead::Vector3f camPosNext = camera->getAt();
         if (mTargetAreaLimitter->applyAreaLimit(&camPosNext, camPosNext)) {
-            sead::Vector3f camDiff = camPosNext - cam->getAt();
-            cam->setPos(camDiff + cam->getPos());
-            cam->setAt(camDiff + cam->getAt());
+            sead::Vector3f camDiff = camPosNext - camera->getAt();
+            camera->setPos(camDiff + camera->getPos());
+            camera->setAt(camDiff + camera->getAt());
         }
     }
 }
 
-void CameraPoser::makeLookAtCameraPost(sead::LookAtCamera* cam) const {
+void CameraPoser::makeLookAtCameraPost(sead::LookAtCamera* camera) const {
     if (alCameraPoserFunction::isSnapShotMode(this) && mSnapShotCtrl)
-        mSnapShotCtrl->makeLookAtCameraPost(cam);
+        mSnapShotCtrl->makeLookAtCameraPost(camera);
 
     if (mParamMoveLimit)
-        mParamMoveLimit->apply(cam);
+        mParamMoveLimit->apply(camera);
 }
 
-void CameraPoser::makeLookAtCameraLast(sead::LookAtCamera* cam) const {
+void CameraPoser::makeLookAtCameraLast(sead::LookAtCamera* camera) const {
     if (alCameraPoserFunction::isSnapShotMode(this) && mSnapShotCtrl)
-        mSnapShotCtrl->makeLookAtCameraLast((cam));
+        mSnapShotCtrl->makeLookAtCameraLast(camera);
 }
 
-void CameraPoser::makeLookAtCameraCollide(sead::LookAtCamera* cam) const {
+void CameraPoser::makeLookAtCameraCollide(sead::LookAtCamera* camera) const {
     if (!mPoserFlag->isInvalidCollider && mArrowCollider)
-        mArrowCollider->makeLookAtCamera(cam);
+        mArrowCollider->makeLookAtCamera(camera);
 }
 
-void CameraPoser::calcCameraPose(sead::LookAtCamera* cam) const {
-    makeLookAtCameraPrev(cam);
-    makeLookAtCamera(cam);
-    makeLookAtCameraPost(cam);
-    makeLookAtCameraCollide(cam);
-    makeLookAtCameraLast(cam);
+void CameraPoser::calcCameraPose(sead::LookAtCamera* camera) const {
+    makeLookAtCameraPrev(camera);
+    makeLookAtCamera(camera);
+    makeLookAtCameraPost(camera);
+    makeLookAtCameraCollide(camera);
+    makeLookAtCameraLast(camera);
 }
 
 bool CameraPoser::receiveRequestFromObjectCore(const CameraObjectRequestInfo& info) {

--- a/lib/al/Library/Camera/CameraPoser.cpp
+++ b/lib/al/Library/Camera/CameraPoser.cpp
@@ -253,19 +253,19 @@ void CameraPoser::appear(const CameraStartInfo& info) {
 void CameraPoser::LookAtInterpole::update(CameraPoser* camera, sead::Vector3f targetTrans) {
     lerpVec(camera->getTargetTransPtr(), target, camera->getTargetTrans(), lerp);
     target.set(camera->getTargetTrans());
-    camera->addPosition(camera->getTargetTrans() - targetTrans);
+    camera->addPositionOffset(camera->getTargetTrans() - targetTrans);
 }
 
-void CameraPoser::LookAtInterpole::updateWithGravity(CameraPoser* camera,
-                                                     const sead::Vector3f& targetGravity,
-                                                     sead::Vector3f targetTrans) {
+void CameraPoser::LookAtInterpole::updateWithVerticalAbsorb(CameraPoser* camera,
+                                                            const sead::Vector3f& targetGravity,
+                                                            sead::Vector3f targetTrans) {
     sead::Vector3f camOffset = camera->getTargetTrans() - target;
     sead::Vector3f offsetV = {0.0f, 0.0f, 0.0f};
     parallelizeVec(&offsetV, targetGravity, camOffset);
     sead::Vector3f offsetH = camOffset - offsetV;
-    camera->getTargetTransPtr()->set(offsetV + target + offsetH * lerp);
+    camera->getTargetTransPtr()->set(target + offsetV + offsetH * lerp);
     target.set(camera->getTargetTrans());
-    camera->addPosition(camera->getTargetTrans() - targetTrans);
+    camera->addPositionOffset(camera->getTargetTrans() - targetTrans);
 }
 
 void CameraPoser::LocalInterpole::update(const CameraPoser* camera) {
@@ -313,7 +313,7 @@ void CameraPoser::movement() {
         if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb) {
             sead::Vector3f targetGravity = {0.0f, 0.0f, 0.0f};
             alCameraPoserFunction::calcTargetGravity(&targetGravity, this);
-            mLookAtInterpole->updateWithGravity(this, targetGravity, mTargetTrans);
+            mLookAtInterpole->updateWithVerticalAbsorb(this, targetGravity, mTargetTrans);
         } else {
             mLookAtInterpole->update(this, mTargetTrans);
         }

--- a/lib/al/Library/Camera/CameraPoser.cpp
+++ b/lib/al/Library/Camera/CameraPoser.cpp
@@ -247,24 +247,24 @@ void CameraPoser::appear(const CameraStartInfo& info) {
         mVerticalAbsorber->start(mTargetTrans, info);
 
     if (mLookAtInterpole)
-        mLookAtInterpole->lookAtPos.set(mTargetTrans);
+        mLookAtInterpole->target.set(mTargetTrans);
 }
 
 void CameraPoser::LookAtInterpole::update(CameraPoser* camera, sead::Vector3f targetTrans) {
-    lerpVec(camera->getTargetTransPtr(), lookAtPos, camera->getTargetTrans(), lookAtDistance);
-    lookAtPos.set(camera->getTargetTrans());
+    lerpVec(camera->getTargetTransPtr(), target, camera->getTargetTrans(), lerp);
+    target.set(camera->getTargetTrans());
     camera->addPosition(camera->getTargetTrans() - targetTrans);
 }
 
 void CameraPoser::LookAtInterpole::updateWithGravity(CameraPoser* camera,
                                                      const sead::Vector3f& targetGravity,
                                                      sead::Vector3f targetTrans) {
-    sead::Vector3f lookDirection = camera->getTargetTrans() - lookAtPos;
-    sead::Vector3f gravity = {0.0f, 0.0f, 0.0f};
-    parallelizeVec(&gravity, targetGravity, lookDirection);
-    sead::Vector3f dir = lookDirection - gravity;
-    camera->getTargetTransPtr()->set(gravity + lookAtPos + dir * lookAtDistance);
-    lookAtPos.set(camera->getTargetTrans());
+    sead::Vector3f camOffset = camera->getTargetTrans() - target;
+    sead::Vector3f offsetV = {0.0f, 0.0f, 0.0f};
+    parallelizeVec(&offsetV, targetGravity, camOffset);
+    sead::Vector3f offsetH = camOffset - offsetV;
+    camera->getTargetTransPtr()->set(offsetV + target + offsetH * lerp);
+    target.set(camera->getTargetTrans());
     camera->addPosition(camera->getTargetTrans() - targetTrans);
 }
 

--- a/lib/al/Library/Camera/CameraPoser.cpp
+++ b/lib/al/Library/Camera/CameraPoser.cpp
@@ -244,28 +244,28 @@ void CameraPoser::appear(const CameraStartInfo& info) {
         mArrowCollider->start();
 
     if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb)
-        mVerticalAbsorber->start(mTargetTrans, info);
+        mVerticalAbsorber->start(mAt, info);
 
     if (mLookAtInterpole)
-        mLookAtInterpole->target.set(mTargetTrans);
+        mLookAtInterpole->target.set(mAt);
 }
 
 void CameraPoser::LookAtInterpole::update(CameraPoser* camera, sead::Vector3f targetTrans) {
-    lerpVec(camera->getTargetTransPtr(), target, camera->getTargetTrans(), lerp);
-    target.set(camera->getTargetTrans());
-    camera->addPositionOffset(camera->getTargetTrans() - targetTrans);
+    lerpVec(camera->getAtPtr(), target, camera->getAt(), lerp);
+    target.set(camera->getAt());
+    camera->addEyeOffset(camera->getAt() - targetTrans);
 }
 
 void CameraPoser::LookAtInterpole::updateWithVerticalAbsorb(CameraPoser* camera,
                                                             const sead::Vector3f& targetGravity,
                                                             sead::Vector3f targetTrans) {
-    sead::Vector3f camOffset = camera->getTargetTrans() - target;
+    sead::Vector3f camOffset = camera->getAt() - target;
     sead::Vector3f offsetV = {0.0f, 0.0f, 0.0f};
     parallelizeVec(&offsetV, targetGravity, camOffset);
     sead::Vector3f offsetH = camOffset - offsetV;
-    camera->getTargetTransPtr()->set(target + offsetV + offsetH * lerp);
-    target.set(camera->getTargetTrans());
-    camera->addPositionOffset(camera->getTargetTrans() - targetTrans);
+    camera->getAtPtr()->set(target + offsetV + offsetH * lerp);
+    target.set(camera->getAt());
+    camera->addEyeOffset(camera->getAt() - targetTrans);
 }
 
 void CameraPoser::LocalInterpole::update(const CameraPoser* camera) {
@@ -313,9 +313,9 @@ void CameraPoser::movement() {
         if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb) {
             sead::Vector3f targetGravity = {0.0f, 0.0f, 0.0f};
             alCameraPoserFunction::calcTargetGravity(&targetGravity, this);
-            mLookAtInterpole->updateWithVerticalAbsorb(this, targetGravity, mTargetTrans);
+            mLookAtInterpole->updateWithVerticalAbsorb(this, targetGravity, mAt);
         } else {
-            mLookAtInterpole->update(this, mTargetTrans);
+            mLookAtInterpole->update(this, mAt);
         }
     }
 
@@ -366,9 +366,9 @@ inline void CameraPoser::LocalInterpole::interpolate(sead::LookAtCamera* camera)
 }
 
 void CameraPoser::makeLookAtCameraPrev(sead::LookAtCamera* camera) const {
-    camera->setPos(mPosition);
-    camera->setAt(mTargetTrans);
-    camera->setUp(mCameraUp);
+    camera->setPos(mEye);
+    camera->setAt(mAt);
+    camera->setUp(mUp);
     camera->normalizeUp();
 
     if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb)

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -64,7 +64,8 @@ public:
     };
 
     struct LocalInterpole {
-        inline void interpolate(sead::LookAtCamera* cam);
+        inline void interpolate(sead::LookAtCamera* camera);
+        inline void update(const CameraPoser* camera);
 
         s32 step = -1;
         s32 end = 0;
@@ -75,10 +76,14 @@ public:
     static_assert(sizeof(LocalInterpole) == 0x20);
 
     struct LookAtInterpole {
-        inline LookAtInterpole(f32 v) : _c(v) {}
+        inline LookAtInterpole(f32 distance) : lookAtDistance(distance) {}
+
+        inline void update(CameraPoser* camera, sead::Vector3f targetTrans);
+        inline void updateWithGravity(CameraPoser* camera, const sead::Vector3f& targetGravity,
+                                      sead::Vector3f targetTrans);
 
         sead::Vector3f lookAtPos = {0.0f, 0.0f, 0.0f};
-        f32 _c;
+        f32 lookAtDistance;
     };
 
     static_assert(sizeof(LookAtInterpole) == 0x10);
@@ -133,7 +138,7 @@ public:
 
     virtual void loadParam(const ByamlIter& iter) {}
 
-    virtual void makeLookAtCamera(sead::LookAtCamera* cam) const {}
+    virtual void makeLookAtCamera(sead::LookAtCamera* camera) const {}
 
     virtual bool receiveRequestFromObject(const CameraObjectRequestInfo& info) { return false; }
 
@@ -156,8 +161,8 @@ public:
     RailRider* getRailRider() const override;
 
     virtual void load(const ByamlIter& iter);
-    virtual void movement();  // TODO: implementation missing
-    virtual void calcCameraPose(sead::LookAtCamera* cam) const;
+    virtual void movement();
+    virtual void calcCameraPose(sead::LookAtCamera* camera) const;
 
     virtual bool requestTurnToDirection(const CameraTurnInfo* info) { return false; }
 
@@ -180,10 +185,10 @@ public:
     void tryInitAreaLimitter(const PlacementInfo& info);
     bool tryCalcOrthoProjectionInfo(OrthoProjectionInfo* projectionInfo) const;
 
-    void makeLookAtCameraPrev(sead::LookAtCamera* cam) const;
-    void makeLookAtCameraPost(sead::LookAtCamera* cam) const;
-    void makeLookAtCameraLast(sead::LookAtCamera* cam) const;
-    void makeLookAtCameraCollide(sead::LookAtCamera* cam) const;
+    void makeLookAtCameraPrev(sead::LookAtCamera* camera) const;
+    void makeLookAtCameraPost(sead::LookAtCamera* camera) const;
+    void makeLookAtCameraLast(sead::LookAtCamera* camera) const;
+    void makeLookAtCameraCollide(sead::LookAtCamera* camera) const;
 
     s32 getEndInterpoleStep() const;
     s32 getInterpoleStep() const;
@@ -205,6 +210,8 @@ public:
 
     const sead::Vector3f& getTargetTrans() const { return mTargetTrans; };
 
+    sead::Vector3f* getTargetTransPtr() { return &mTargetTrans; };
+
     const sead::Vector3f& getCameraUp() const { return mCameraUp; };
 
     const sead::Matrix34f& getViewMtx() const { return mViewMtx; };
@@ -214,11 +221,13 @@ public:
     CameraViewInfo* getViewInfo() const { return mViewInfo; }
 
     // set
-    void setPosition(const sead::Vector3f& vec) { mPosition.set(vec); };
+    void setPosition(const sead::Vector3f& pos) { mPosition.set(pos); };
 
-    void setTargetTrans(const sead::Vector3f& vec) { mTargetTrans.set(vec); };
+    void addPosition(const sead::Vector3f& pos) { mPosition.add(pos); };
 
-    void setCameraUp(const sead::Vector3f& vec) { mCameraUp.set(vec); };
+    void setTargetTrans(const sead::Vector3f& trans) { mTargetTrans.set(trans); };
+
+    void setCameraUp(const sead::Vector3f& dir) { mCameraUp.set(dir); };
 
     void setViewMtx(const sead::Matrix34f& mtx) { mViewMtx = mtx; }
 

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -207,13 +207,13 @@ public:
     CameraFlagCtrl* getFlagCtrl() const;
 
     // get
-    const sead::Vector3f& getPosition() const { return mPosition; }
+    const sead::Vector3f& getEye() const { return mEye; }
 
-    const sead::Vector3f& getTargetTrans() const { return mTargetTrans; }
+    const sead::Vector3f& getAt() const { return mAt; }
 
-    sead::Vector3f* getTargetTransPtr() { return &mTargetTrans; }
+    sead::Vector3f* getAtPtr() { return &mAt; }
 
-    const sead::Vector3f& getCameraUp() const { return mCameraUp; }
+    const sead::Vector3f& getUp() const { return mUp; }
 
     const sead::Matrix34f& getViewMtx() const { return mViewMtx; }
 
@@ -222,13 +222,13 @@ public:
     CameraViewInfo* getViewInfo() const { return mViewInfo; }
 
     // set
-    void setPosition(const sead::Vector3f& pos) { mPosition.set(pos); }
+    void setEye(const sead::Vector3f& pos) { mEye.set(pos); }
 
-    void addPositionOffset(const sead::Vector3f& offset) { mPosition.add(offset); }
+    void addEyeOffset(const sead::Vector3f& offset) { mEye.add(offset); }
 
-    void setTargetTrans(const sead::Vector3f& trans) { mTargetTrans.set(trans); }
+    void setAt(const sead::Vector3f& trans) { mAt.set(trans); }
 
-    void setCameraUp(const sead::Vector3f& dir) { mCameraUp.set(dir); }
+    void setCameraUp(const sead::Vector3f& dir) { mUp.set(dir); }
 
     void setViewMtx(const sead::Matrix34f& mtx) { mViewMtx = mtx; }
 
@@ -237,9 +237,9 @@ public:
 protected:
     const char* mPoserName;
     ActiveState mActiveState = ActiveState::Start;
-    sead::Vector3f mPosition = {0.0f, 0.0f, 0.0f};
-    sead::Vector3f mTargetTrans = {0.0f, 0.0f, 500.0f};
-    sead::Vector3f mCameraUp = sead::Vector3f::ey;
+    sead::Vector3f mEye = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mAt = {0.0f, 0.0f, 500.0f};
+    sead::Vector3f mUp = sead::Vector3f::ey;
     f32 mFovyDegree = 35.0f;
     f32 mNearClipDistance = -1.0f;
     sead::Matrix34f mViewMtx = sead::Matrix34f::ident;

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -79,9 +79,8 @@ public:
         inline LookAtInterpole(f32 distance) : lerp(distance) {}
 
         inline void update(CameraPoser* camera, sead::Vector3f targetTrans);
-        inline void updateWithGravity(CameraPoser* camera, const sead::Vector3f& targetGravity,
-                                      sead::Vector3f targetTrans);
-        inline void updateWithVerticalAbsorb(CameraPoser* camera, const sead::Vector3f& target,
+        inline void updateWithVerticalAbsorb(CameraPoser* camera,
+                                             const sead::Vector3f& targetGravity,
                                              sead::Vector3f targetTrans);
 
         sead::Vector3f target = {0.0f, 0.0f, 0.0f};
@@ -225,7 +224,7 @@ public:
     // set
     void setPosition(const sead::Vector3f& pos) { mPosition.set(pos); }
 
-    void addPosition(const sead::Vector3f& offset) { mPosition.add(offset); }
+    void addPositionOffset(const sead::Vector3f& offset) { mPosition.add(offset); }
 
     void setTargetTrans(const sead::Vector3f& trans) { mTargetTrans.set(trans); }
 

--- a/lib/al/Library/Camera/CameraPoser.h
+++ b/lib/al/Library/Camera/CameraPoser.h
@@ -76,14 +76,16 @@ public:
     static_assert(sizeof(LocalInterpole) == 0x20);
 
     struct LookAtInterpole {
-        inline LookAtInterpole(f32 distance) : lookAtDistance(distance) {}
+        inline LookAtInterpole(f32 distance) : lerp(distance) {}
 
         inline void update(CameraPoser* camera, sead::Vector3f targetTrans);
         inline void updateWithGravity(CameraPoser* camera, const sead::Vector3f& targetGravity,
                                       sead::Vector3f targetTrans);
+        inline void updateWithVerticalAbsorb(CameraPoser* camera, const sead::Vector3f& target,
+                                             sead::Vector3f targetTrans);
 
-        sead::Vector3f lookAtPos = {0.0f, 0.0f, 0.0f};
-        f32 lookAtDistance;
+        sead::Vector3f target = {0.0f, 0.0f, 0.0f};
+        f32 lerp;
     };
 
     static_assert(sizeof(LookAtInterpole) == 0x10);
@@ -134,7 +136,7 @@ public:
 
     virtual void update() {}
 
-    virtual void end() { mActiveState = ActiveState::End; };
+    virtual void end() { mActiveState = ActiveState::End; }
 
     virtual void loadParam(const ByamlIter& iter) {}
 
@@ -206,28 +208,28 @@ public:
     CameraFlagCtrl* getFlagCtrl() const;
 
     // get
-    const sead::Vector3f& getPosition() const { return mPosition; };
+    const sead::Vector3f& getPosition() const { return mPosition; }
 
-    const sead::Vector3f& getTargetTrans() const { return mTargetTrans; };
+    const sead::Vector3f& getTargetTrans() const { return mTargetTrans; }
 
-    sead::Vector3f* getTargetTransPtr() { return &mTargetTrans; };
+    sead::Vector3f* getTargetTransPtr() { return &mTargetTrans; }
 
-    const sead::Vector3f& getCameraUp() const { return mCameraUp; };
+    const sead::Vector3f& getCameraUp() const { return mCameraUp; }
 
-    const sead::Matrix34f& getViewMtx() const { return mViewMtx; };
+    const sead::Matrix34f& getViewMtx() const { return mViewMtx; }
 
     bool is_98() const { return _98; }
 
     CameraViewInfo* getViewInfo() const { return mViewInfo; }
 
     // set
-    void setPosition(const sead::Vector3f& pos) { mPosition.set(pos); };
+    void setPosition(const sead::Vector3f& pos) { mPosition.set(pos); }
 
-    void addPosition(const sead::Vector3f& pos) { mPosition.add(pos); };
+    void addPosition(const sead::Vector3f& offset) { mPosition.add(offset); }
 
-    void setTargetTrans(const sead::Vector3f& trans) { mTargetTrans.set(trans); };
+    void setTargetTrans(const sead::Vector3f& trans) { mTargetTrans.set(trans); }
 
-    void setCameraUp(const sead::Vector3f& dir) { mCameraUp.set(dir); };
+    void setCameraUp(const sead::Vector3f& dir) { mCameraUp.set(dir); }
 
     void setViewMtx(const sead::Matrix34f& mtx) { mViewMtx = mtx; }
 

--- a/lib/al/Library/Camera/CameraPoserFix.cpp
+++ b/lib/al/Library/Camera/CameraPoserFix.cpp
@@ -56,10 +56,10 @@ void CameraPoserFix::start(const CameraStartInfo& info) {
 }
 
 void CameraPoserFix::update() {
-    mCameraUp.set(sead::Vector3f::ey);
-    mTargetTrans.set(mLookAtPos);
+    mUp.set(sead::Vector3f::ey);
+    mAt.set(mLookAtPos);
 
-    mTargetTrans *= mViewMtx;
+    mAt *= mViewMtx;
 
     f32 angleH = alCameraPoserFunction::calcZoneRotateAngleH(mAngleH, this);
     f32 x = sinf(sead::Mathf::deg2rad(angleH)) * cosf(sead::Mathf::deg2rad(mAngleV));
@@ -68,12 +68,12 @@ void CameraPoserFix::update() {
     sead::Vector3f viewDir = {x, y, z};
 
     normalize(&viewDir);
-    mPosition.set((mDistance * viewDir) + mTargetTrans);
+    mEye.set((mDistance * viewDir) + mAt);
     if (mIsCalcNearestAtFromPreAt) {
-        sead::Vector3f offset = mPreLookAtPos - mPosition;
+        sead::Vector3f offset = mPreLookAtPos - mEye;
         parallelizeVec(&offset, viewDir, offset);
         if (!isNearZero(offset) && viewDir.dot(offset) < 0.0f)
-            mTargetTrans.set(offset + mPosition);
+            mAt.set(offset + mEye);
     }
 }
 

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -87,7 +87,7 @@ inline void updateAbsorbVec(sead::Vector3f* absorbVec, const CameraPoser* poser,
                             const sead::Vector3f& prevTrans) {
     sead::Vector3f gravity = {0.0f, 0.0f, 0.0f};
     alCameraPoserFunction::calcTargetGravity(&gravity, poser);
-    *absorbVec = poser->getTargetTrans() - prevTrans;
+    *absorbVec = poser->getAt() - prevTrans;
     parallelizeVec(absorbVec, gravity, *absorbVec);
 }
 
@@ -97,9 +97,9 @@ void CameraVerticalAbsorber::update() {
 
     updateAbsorbVec(&mAbsorbVec, mCameraPoser, mPrevTargetTrans);
 
-    mLookAtCamera.setPos(mCameraPoser->getPosition());
-    mLookAtCamera.setAt(mCameraPoser->getTargetTrans());
-    mLookAtCamera.setUp(mCameraPoser->getCameraUp());
+    mLookAtCamera.setPos(mCameraPoser->getEye());
+    mLookAtCamera.setAt(mCameraPoser->getAt());
+    mLookAtCamera.setUp(mCameraPoser->getUp());
     mLookAtCamera.normalizeUp();
 
     makeLookAtCamera(&mLookAtCamera);
@@ -130,7 +130,7 @@ void CameraVerticalAbsorber::update() {
                                                                         mKeepInFrameOffsetDown);
         mAbsorbVec -= offset;
     }
-    mPrevTargetTrans.set(mCameraPoser->getTargetTrans() - mAbsorbVec);
+    mPrevTargetTrans.set(mCameraPoser->getAt() - mAbsorbVec);
     mPrevTargetFront.set(mTargetFront);
 }
 


### PR DESCRIPTION
It took 3 persons to do this implementation. Moddimation who did the initial implementation, Fuzzy who helped find the match and I found the complete match. This function is 11 months old.

I also changed some names due conflicting with myself.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1158)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f980b6 - 1b00d2d)

📈 **Matched code**: 15.20% (+0.01%, +1096 bytes)

<details>
<summary>✅ 1 new match</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Camera/CameraPoser` | `al::CameraPoser::movement()` | +1096 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->