### PR TITLE
workflow: add labels to PRs via self-service

### DIFF
--- a/.github/workflows/selfservice-labels.yml
+++ b/.github/workflows/selfservice-labels.yml
@@ -1,0 +1,73 @@
+name: Assign or unassign self-managed labels on PRs
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  issues: write
+  repository-projects: read
+  pull-requests: read
+
+jobs:
+  selfservice_labels:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != null
+    steps:
+      - name: Check comment and label accordingly
+        uses: actions/github-script@v7
+        with:
+          script: |
+            # command: label (+ = add, - = remove)
+            const labels = {
+              "ai": "+ai",
+              "no-ai": "-ai",
+              "human": "-ai",
+
+              "priority": "+priority",
+              "high-priority": "+priority",
+              "no-priority": "-priority",
+              "low-priority": "-priority",
+            };
+
+            const comment = context.payload.comment.body.trim().toLowerCase();
+            const commentId = context.payload.comment.id;
+            const issueNumber = context.payload.issue.number;
+
+            async function deleteComment() {
+              await github.rest.issues.deleteComment({
+                ...context.repo,
+                comment_id: commentId
+              });
+              console.log(`Deleted comment ID ${commentId}`);
+            }
+
+            for (const [command, label] of Object.entries(labels)) {
+              if (comment.startsWith(`/${command}`) || comment.startsWith(`/${command.replace(/-/g, "")}`)) {
+                if (label.startsWith("+")) {
+                  await github.rest.issues.addLabels({
+                    ...context.repo,
+                    issue_number: issueNumber,
+                    labels: [label.substring(1)]
+                  });
+                  console.log(`Added '${label.substring(1)}' label to PR #${issueNumber}`);
+                } else if (label.startsWith("-")) {
+                  try {
+                    await github.rest.issues.removeLabel({
+                      ...context.repo,
+                      issue_number: issueNumber,
+                      name: label.substring(1)
+                    });
+                    console.log(`Removed '${label.substring(1)}' label from PR #${issueNumber}`);
+                  } catch (error) {
+                    if (error.status === 404) {
+                      console.log(`Label not found on PR #${issueNumber}`);
+                    } else {
+                      throw error;
+                    }
+                  }
+                }
+                await deleteComment();
+                return; // Exit after processing the first matching command
+              }
+            }

--- a/.github/workflows/selfservice-labels.yml
+++ b/.github/workflows/selfservice-labels.yml
@@ -43,14 +43,14 @@ jobs:
             }
 
             for (const [command, label] of Object.entries(labels)) {
-              if (comment.startsWith(`/${command}`) || comment.startsWith(`/${command.replace(/-/g, "")}`)) {
+              if (comment.startsWith(`/${command}`) || comment.startsWith(`/${command.replaceAll("-", "")}`)) {
                 if (label.startsWith("+")) {
                   await github.rest.issues.addLabels({
                     ...context.repo,
                     issue_number: issueNumber,
                     labels: [label.substring(1)]
                   });
-                  console.log(`Added '${label.substring(1)}' label to PR #${issueNumber}`);
+                  console.log(`Added '${label.substring(1)}' label to PR ${issueNumber}`);
                 } else if (label.startsWith("-")) {
                   try {
                     await github.rest.issues.removeLabel({
@@ -58,10 +58,10 @@ jobs:
                       issue_number: issueNumber,
                       name: label.substring(1)
                     });
-                    console.log(`Removed '${label.substring(1)}' label from PR #${issueNumber}`);
+                    console.log(`Removed '${label.substring(1)}' label from PR ${issueNumber}`);
                   } catch (error) {
                     if (error.status === 404) {
-                      console.log(`Label not found on PR #${issueNumber}`);
+                      console.log(`Label not found on PR ${issueNumber}`);
                     } else {
                       throw error;
                     }


### PR DESCRIPTION
According to the recent poll:
https://discord.com/channels/774687602996936747/1496575225213747403/1496575335993446590

AI-based PRs should be handled with a lower priority. Therefore, they should be tagged with an `ai` label which looks like this:
https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai

Additionally, a https://github.com/MonsterDruide1/OdysseyDecomp/labels/priority tag should symbolize that a particular PR is of higher relevance than others and should be prioritized in reviews to get merged more quickly. This can be used on both AI and non-AI PRs, resulting in a total priority ranking like this:
1. https://github.com/MonsterDruide1/OdysseyDecomp/labels/priority
2. https://github.com/MonsterDruide1/OdysseyDecomp/labels/priority + https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai
3. none (no-AI, non-prioritized)
4. https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai

These labels and potentially more can be handled via self-service by commenting on the PR, similar to the workflow on the tracker repo. For now, the commands are like this:
`/ai`: adds https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai
`/noai`, `/no-ai`, `/human`: removes https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai
`/priority`, `/high-priority`, `/highpriority`: adds https://github.com/MonsterDruide1/OdysseyDecomp/labels/priority
`/no-priority`, `/nopriority`, `/low-priority`, `/lowpriority`: removes https://github.com/MonsterDruide1/OdysseyDecomp/labels/priority

Note: This workflow/code has not been tested.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1160)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (da1cefa - 8b45e52)

No changes

<!-- decomp.dev report end -->