### PR TITLE
Library/Camera: Implement `CameraPoserFactory`

### DIFF
--- a/lib/al/Library/Camera/CameraPoserFactory.cpp
+++ b/lib/al/Library/Camera/CameraPoserFactory.cpp
@@ -1,0 +1,50 @@
+#include "Library/Camera/CameraPoserFactory.h"
+
+#include "Library/Play/Camera/CameraPoserEntrance.h"
+#include "Library/Play/Camera/SimpleCameraPoserFactory.h"
+
+namespace al {
+CameraPoserFactory::CameraPoserFactory(const char* factoryName) : Factory(factoryName) {}
+
+CameraPoserEntrance* CameraPoserFactory::createEntranceCameraPoser() const {
+    return new CameraPoserEntrance("スタート");
+}
+}  // namespace al
+
+namespace alCameraPoserFactoryFunction {
+void initAndCreateTableFromOtherTable2(
+    al::CameraPoserFactory* factory,
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* table1, s32 table1Count,
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* table2, s32 table2Count) {
+    s32 tableCount = table1Count + table2Count;
+    al::NameToCreator<al::CameraPoserCreatorFunction>* table =
+        new al::NameToCreator<al::CameraPoserCreatorFunction>[tableCount];
+
+    for (s32 i = 0; i < table1Count; i++) {
+        table[i].name = table1[i].name;
+        table[i].creationFunction = table1[i].creationFunction;
+    }
+
+    for (s32 i = 0; i < table2Count; i++) {
+        table[table1Count + i].name = table2[i].name;
+        table[table1Count + i].creationFunction = table2[i].creationFunction;
+    }
+
+    factory->initFactory(table, tableCount);
+}
+
+// NON_MATCHING
+void initAndCreateTableWithAnotherFactory(
+    al::CameraPoserFactory* factory, const al::CameraPoserFactory* otherFactory,
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* table, s32 tableCount) {
+    initAndCreateTableFromOtherTable2(factory, table, tableCount, otherFactory->getFactoryEntries(),
+                                      otherFactory->getNumFactoryEntries());
+}
+
+void initAndCreateTableWithPresetPosers(
+    al::CameraPoserFactory* factory, const al::NameToCreator<al::CameraPoserCreatorFunction>* table,
+    s32 tableCount) {
+    al::SimpleCameraPoserFactory simpleFactory = {"シンプルカメラ生成"};
+    initAndCreateTableWithAnotherFactory(factory, &simpleFactory, table, tableCount);
+}
+}  // namespace alCameraPoserFactoryFunction

--- a/lib/al/Library/Camera/CameraPoserFactory.cpp
+++ b/lib/al/Library/Camera/CameraPoserFactory.cpp
@@ -37,8 +37,8 @@ void initAndCreateTableFromOtherTable2(
 void initAndCreateTableWithAnotherFactory(
     al::CameraPoserFactory* factory, const al::CameraPoserFactory* otherFactory,
     const al::NameToCreator<al::CameraPoserCreatorFunction>* table, s32 tableCount) {
-    initAndCreateTableFromOtherTable2(factory, table, tableCount, otherFactory->getFactoryEntries(),
-                                      otherFactory->getNumFactoryEntries());
+    initAndCreateTableFromOtherTable2(factory, otherFactory->getFactoryEntries(),
+                                      otherFactory->getNumFactoryEntries(), table, tableCount);
 }
 
 void initAndCreateTableWithPresetPosers(

--- a/lib/al/Library/Camera/CameraPoserFactory.cpp
+++ b/lib/al/Library/Camera/CameraPoserFactory.cpp
@@ -33,12 +33,28 @@ void initAndCreateTableFromOtherTable2(
     factory->initFactory(table, tableCount);
 }
 
-// NON_MATCHING
 void initAndCreateTableWithAnotherFactory(
     al::CameraPoserFactory* factory, const al::CameraPoserFactory* otherFactory,
     const al::NameToCreator<al::CameraPoserCreatorFunction>* table, s32 tableCount) {
-    initAndCreateTableFromOtherTable2(factory, otherFactory->getFactoryEntries(),
-                                      otherFactory->getNumFactoryEntries(), table, tableCount);
+    s32 otherCount = otherFactory->getNumFactoryEntries();
+
+    al::NameToCreator<al::CameraPoserCreatorFunction>* newTable =
+        new al::NameToCreator<al::CameraPoserCreatorFunction>[otherCount + tableCount];
+
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* otherTable =
+        otherFactory->getFactoryEntries();
+
+    for (s32 i = 0; i < otherFactory->getNumFactoryEntries(); i++) {
+        newTable[i].name = otherTable[i].name;
+        newTable[i].creationFunction = otherTable[i].creationFunction;
+    }
+
+    for (s32 i = 0; i < tableCount; i++) {
+        newTable[otherCount + i].name = table[i].name;
+        newTable[otherCount + i].creationFunction = table[i].creationFunction;
+    }
+
+    factory->initFactory(newTable, otherCount + tableCount);
 }
 
 void initAndCreateTableWithPresetPosers(

--- a/lib/al/Library/Camera/CameraPoserFactory.h
+++ b/lib/al/Library/Camera/CameraPoserFactory.h
@@ -14,8 +14,6 @@ public:
 
     virtual CameraPoserEntrance* createEntranceCameraPoser() const;
 
-    s32 get_1c() const { return _1c; }
-
 private:
     s32 _1c = 0;
 };

--- a/lib/al/Library/Camera/CameraPoserFactory.h
+++ b/lib/al/Library/Camera/CameraPoserFactory.h
@@ -13,19 +13,24 @@ public:
     CameraPoserFactory(const char* factoryName);
 
     virtual CameraPoserEntrance* createEntranceCameraPoser() const;
+
+    s32 get_1c() const { return _1c; }
+
+private:
+    s32 _1c = 0;
 };
 }  // namespace al
 
 namespace alCameraPoserFactoryFunction {
 void initAndCreateTableFromOtherTable2(
-    al::CameraPoserFactory* out, const al::NameToCreator<al::CameraPoserCreatorFunction>* table1,
-    s32 table1Count, const al::NameToCreator<al::CameraPoserCreatorFunction>* table2,
-    s32 table2Count);
+    al::CameraPoserFactory* factory,
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* table1, s32 table1Count,
+    const al::NameToCreator<al::CameraPoserCreatorFunction>* table2, s32 table2Count);
 void initAndCreateTableWithAnotherFactory(
-    al::CameraPoserFactory* out, const al::CameraPoserFactory* factory,
+    al::CameraPoserFactory* factory, const al::CameraPoserFactory* otherFactory,
     const al::NameToCreator<al::CameraPoserCreatorFunction>* table, s32 tableCount);
 void initAndCreateTableWithPresetPosers(
-    al::CameraPoserFactory* out, const al::NameToCreator<al::CameraPoserCreatorFunction>* table,
+    al::CameraPoserFactory* factory, const al::NameToCreator<al::CameraPoserCreatorFunction>* table,
     s32 tableCount);
 
 template <s32 N1, s32 N2>

--- a/lib/al/Library/Factory/Factory.h
+++ b/lib/al/Library/Factory/Factory.h
@@ -25,13 +25,19 @@ public:
 
     template <s32 N>
     inline void initFactory(const NameToCreator<T> (&entries)[N]) {
+        initFactory(entries, N);
+    }
+
+    inline void initFactory(const NameToCreator<T>* entries, s32 numFactoryEntries) {
         mFactoryEntries = entries;
-        mNumFactoryEntries = N;
+        mNumFactoryEntries = numFactoryEntries;
     }
 
     virtual const char* convertName(const char* name) const { return name; }
 
     s32 getNumFactoryEntries() const { return mNumFactoryEntries; }
+
+    const NameToCreator<T>* getFactoryEntries() const { return mFactoryEntries; }
 
     s32 getEntryIndex(T* creationPtr, const char* entryName) const {
         const char* name = convertName(entryName);

--- a/lib/al/Library/Play/Camera/SimpleCameraPoserFactory.h
+++ b/lib/al/Library/Play/Camera/SimpleCameraPoserFactory.h
@@ -3,14 +3,8 @@
 #include "Library/Camera/CameraPoserFactory.h"
 
 namespace al {
-class CameraPoser;
-class CameraPoserParallelSimple;
-class CameraPoserFollowSimple;
-class CameraPoserQuickTurn;
-
 class SimpleCameraPoserFactory : public CameraPoserFactory {
 public:
-    SimpleCameraPoserFactory(const char*);
+    SimpleCameraPoserFactory(const char* factoryName);
 };
-
 }  // namespace al


### PR DESCRIPTION
This PR add `CameraPoserFactory` implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1161)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (897b946 - daf38d0)

📈 **Matched code**: 14.66% (+0.01%, +676 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Camera/CameraPoserFactory` | `alCameraPoserFactoryFunction::initAndCreateTableWithPresetPosers(al::CameraPoserFactory*, al::NameToCreator<al::CameraPoser* (*)(char const*)> const*, int)` | +212 | 0.00% | 100.00% |
| `Library/Camera/CameraPoserFactory` | `alCameraPoserFactoryFunction::initAndCreateTableWithAnotherFactory(al::CameraPoserFactory*, al::CameraPoserFactory const*, al::NameToCreator<al::CameraPoser* (*)(char const*)> const*, int)` | +196 | 0.00% | 100.00% |
| `Library/Camera/CameraPoserFactory` | `alCameraPoserFactoryFunction::initAndCreateTableFromOtherTable2(al::CameraPoserFactory*, al::NameToCreator<al::CameraPoser* (*)(char const*)> const*, int, al::NameToCreator<al::CameraPoser* (*)(char const*)> const*, int)` | +188 | 0.00% | 100.00% |
| `Library/Camera/CameraPoserFactory` | `al::CameraPoserFactory::createEntranceCameraPoser() const` | +52 | 0.00% | 100.00% |
| `Library/Camera/CameraPoserFactory` | `al::CameraPoserFactory::CameraPoserFactory(char const*)` | +28 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->