### PR TITLE
Npc: Implement `AmiiboNpcStateChangeCostume`

### DIFF
--- a/src/Npc/AmiiboNpcStateChangeCostume.cpp
+++ b/src/Npc/AmiiboNpcStateChangeCostume.cpp
@@ -1,0 +1,55 @@
+#include "Npc/AmiiboNpcStateChangeCostume.h"
+
+#include "Library/Camera/CameraUtil.h"
+#include "Library/Event/EventFlowUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/PlayerDemoUtil.h"
+
+AmiiboNpcStateChangeCostume::AmiiboNpcStateChangeCostume(al::LiveActor* actor,
+                                                         const al::PlacementInfo& placementInfo,
+                                                         al::EventFlowExecutor* eventFlowExecutor)
+    : al::ActorStateBase("", actor), mPlacementInfo(&placementInfo),
+      mEventFlowExecutor(eventFlowExecutor) {}
+
+void AmiiboNpcStateChangeCostume::init() {
+    mCameraTicket = al::initEntranceCamera(mActor, *mPlacementInfo, "");
+
+    al::PlacementInfo placementInfo;
+    if (al::tryGetLinksInfo(&placementInfo, *mPlacementInfo, "PlayerRestartPos")) {
+        al::getTrans(&mPlayerRestartTrans, placementInfo);
+        al::getQuat(&mPlayerRestartQuat, placementInfo);
+    }
+}
+
+void AmiiboNpcStateChangeCostume::appear() {
+    al::NerveStateBase::appear();
+
+    if (!al::isActiveCamera(mCameraTicket)) {
+        al::startCamera(mActor, mCameraTicket, -1);
+        al::requestCancelCameraInterpole(mActor, 0);
+    }
+
+    rs::startEventFlow(mEventFlowExecutor, "ChangeCostume");
+}
+
+void AmiiboNpcStateChangeCostume::control() {
+    if (rs::updateEventFlow(mEventFlowExecutor))
+        kill();
+}
+
+bool AmiiboNpcStateChangeCostume::receiveEvent(const al::EventFlowEventData* eventData) {
+    if (al::isEventName(eventData, "AmiiboFirstTalkEnd") ||
+        al::isEventName(eventData, "AmiiboTalkEnd"))
+        return true;
+
+    if (al::isEventName(eventData, "AmiiboPlayerPoseSet")) {
+        rs::replaceDemoPlayer(mActor, mPlayerRestartTrans, mPlayerRestartQuat);
+        return true;
+    }
+
+    return false;
+}

--- a/src/Npc/AmiiboNpcStateChangeCostume.h
+++ b/src/Npc/AmiiboNpcStateChangeCostume.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class CameraTicket;
+class EventFlowEventData;
+class EventFlowExecutor;
+class LiveActor;
+class PlacementInfo;
+}  // namespace al
+
+class AmiiboNpcStateChangeCostume : public al::ActorStateBase {
+public:
+    AmiiboNpcStateChangeCostume(al::LiveActor* actor, const al::PlacementInfo& placementInfo,
+                                al::EventFlowExecutor* eventFlowExecutor);
+
+    void init() override;
+    void appear() override;
+    void control() override;
+    bool receiveEvent(const al::EventFlowEventData* eventData);
+
+private:
+    al::CameraTicket* mCameraTicket = nullptr;
+    const al::PlacementInfo* mPlacementInfo = nullptr;
+    al::EventFlowExecutor* mEventFlowExecutor = nullptr;
+    sead::Vector3f mPlayerRestartTrans = sead::Vector3f::zero;
+    sead::Quatf mPlayerRestartQuat = sead::Quatf::unit;
+};
+
+static_assert(sizeof(AmiiboNpcStateChangeCostume) == 0x58);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1162)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (897b946 - 1f0c04e)

📈 **Matched code**: 14.66% (+0.00%, +588 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::AmiiboNpcStateChangeCostume(al::LiveActor*, al::PlacementInfo const&, al::EventFlowExecutor*)` | +136 | 0.00% | 100.00% |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::init()` | +128 | 0.00% | 100.00% |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::receiveEvent(al::EventFlowEventData const*)` | +120 | 0.00% | 100.00% |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::appear()` | +104 | 0.00% | 100.00% |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::control()` | +64 | 0.00% | 100.00% |
| `Npc/AmiiboNpcStateChangeCostume` | `AmiiboNpcStateChangeCostume::~AmiiboNpcStateChangeCostume()` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->