### PR TITLE
Camera: Implement `PlayerColliderMatrixCameraTarget`

### DIFF
--- a/src/Camera/PlayerColliderCameraTarget.h
+++ b/src/Camera/PlayerColliderCameraTarget.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/Camera/ActorCameraTarget.h"
+
+class IUsePlayerCollision;
+
+class PlayerColliderCameraTarget : public al::ActorCameraTarget {
+public:
+    PlayerColliderCameraTarget(const al::LiveActor* actor,
+                               const IUsePlayerCollision* playerCollision)
+        : ActorCameraTarget(actor, 0.0f, nullptr), mPlayerCollision(playerCollision) {}
+
+    bool isCollideGround() const override;
+
+private:
+    const IUsePlayerCollision* mPlayerCollision = nullptr;
+};
+
+static_assert(sizeof(PlayerColliderCameraTarget) == 0x30);

--- a/src/Camera/PlayerColliderMatrixCameraTarget.cpp
+++ b/src/Camera/PlayerColliderMatrixCameraTarget.cpp
@@ -1,0 +1,29 @@
+#include "Camera/PlayerColliderMatrixCameraTarget.h"
+
+PlayerColliderMatrixCameraTarget::PlayerColliderMatrixCameraTarget(
+    const al::LiveActor* actor, const IUsePlayerCollision* playerCollision,
+    const sead::Matrix34f* matrix)
+    : PlayerColliderCameraTarget(actor, playerCollision), mMatrix(matrix) {}
+
+void PlayerColliderMatrixCameraTarget::calcTrans(sead::Vector3f* trans) const {
+    mMatrix->getTranslation(*trans);
+}
+
+void PlayerColliderMatrixCameraTarget::calcSide(sead::Vector3f* side) const {
+    mMatrix->getBase(*side, 0);
+    side->normalize();
+}
+
+void PlayerColliderMatrixCameraTarget::calcUp(sead::Vector3f* up) const {
+    mMatrix->getBase(*up, 1);
+    up->normalize();
+}
+
+void PlayerColliderMatrixCameraTarget::calcFront(sead::Vector3f* front) const {
+    mMatrix->getBase(*front, 2);
+    front->normalize();
+}
+
+void PlayerColliderMatrixCameraTarget::calcVelocity(sead::Vector3f* velocity) const {
+    velocity->set(0.0f, 0.0f, 0.0f);
+}

--- a/src/Camera/PlayerColliderMatrixCameraTarget.h
+++ b/src/Camera/PlayerColliderMatrixCameraTarget.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Camera/PlayerColliderCameraTarget.h"
+
+class IUsePlayerCollision;
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerColliderMatrixCameraTarget : public PlayerColliderCameraTarget {
+public:
+    PlayerColliderMatrixCameraTarget(const al::LiveActor* actor,
+                                     const IUsePlayerCollision* playerCollision,
+                                     const sead::Matrix34f* matrix);
+
+    void calcTrans(sead::Vector3f* trans) const override;
+    void calcSide(sead::Vector3f* side) const override;
+    void calcUp(sead::Vector3f* up) const override;
+    void calcFront(sead::Vector3f* front) const override;
+    void calcVelocity(sead::Vector3f* velocity) const override;
+
+private:
+    const sead::Matrix34f* mMatrix = nullptr;
+};
+
+static_assert(sizeof(PlayerColliderMatrixCameraTarget) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1163)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (897b946 - 3602966)

📈 **Matched code**: 14.66% (+0.00%, +576 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::calcSide(sead::Vector3<float>*) const` | +152 | 0.00% | 100.00% |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::calcUp(sead::Vector3<float>*) const` | +152 | 0.00% | 100.00% |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::calcFront(sead::Vector3<float>*) const` | +152 | 0.00% | 100.00% |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::PlayerColliderMatrixCameraTarget(al::LiveActor const*, IUsePlayerCollision const*, sead::Matrix34<float> const*)` | +76 | 0.00% | 100.00% |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::calcTrans(sead::Vector3<float>*) const` | +32 | 0.00% | 100.00% |
| `Camera/PlayerColliderMatrixCameraTarget` | `PlayerColliderMatrixCameraTarget::calcVelocity(sead::Vector3<float>*) const` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->