### PR TITLE
Enemy: Implement `JangoCapSeparateHelpClaimUpdater`

### DIFF
--- a/src/Enemy/Jango/Jango.h
+++ b/src/Enemy/Jango/Jango.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CameraTicket;
+struct ActorInitInfo;
+class HitSensor;
+class JointLookAtController;
+class JointSpringControllerHolder;
+class SensorMsg;
+}  // namespace al
+
+class GoalMark;
+class JangoCap;
+class JangoStateBlowDown;
+class JangoStateCapCatch;
+class JangoStateCapGetDemo;
+class JangoStateWaitTree;
+
+class Jango : public al::LiveActor {
+public:
+    Jango(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+    bool isEnableCap() const;
+    void tryOffCapCatchedSwitch();
+    void exeWaitCapGetDemo();
+    void exeCapGetDemo();
+    void exeEscape();
+    void exeSurprise();
+    void exeBlowDown();
+
+private:
+    JangoStateWaitTree* mStateWaitTree = nullptr;
+    JangoStateCapGetDemo* mStateCapGetDemo = nullptr;
+    JangoStateCapCatch* mStateCapCatch = nullptr;
+    JangoStateBlowDown* mStateBlowDown = nullptr;
+    s32 mDemoType = 0;
+    sead::Vector3f mCapPlaceTrans = sead::Vector3f::zero;
+    sead::Quatf mCapPlaceQuat = sead::Quatf::unit;
+    JangoCap* mCap = nullptr;
+    al::CameraTicket* mDemoCameraTicket = nullptr;
+    al::CameraTicket* mEntranceCameraTicket = nullptr;
+    al::JointLookAtController* mJointLookAtController = nullptr;
+    bool mIsEnableCap = false;
+    al::JointSpringControllerHolder* mJointSpringControllerHolder = nullptr;
+    GoalMark* mGoalMark = nullptr;
+    void* mDemoRequester = nullptr;
+};
+
+static_assert(sizeof(Jango) == 0x188);
+
+namespace JangoFunction {
+void setCapTransOnJoint(al::LiveActor* cap, al::LiveActor* jango);
+void resetCapTransOnJoint(al::LiveActor* cap, al::LiveActor* jango);
+void resetTransJointRoot(al::LiveActor* actor);
+}  // namespace JangoFunction

--- a/src/Enemy/Jango/JangoCap.h
+++ b/src/Enemy/Jango/JangoCap.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Event/IEventFlowEventReceiver.h"
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CameraTicket;
+struct ActorInitInfo;
+class EventFlowEventData;
+class EventFlowExecutor;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BalloonIcon;
+class Jango;
+class JangoCapSeparateHelpClaimUpdater;
+class StateStageTalkDemoCapManHero;
+
+class JangoCap : public al::LiveActor, public al::IEventFlowEventReceiver {
+public:
+    JangoCap(const char* name, s32 demoType, Jango* jango);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    bool receiveEvent(const al::EventFlowEventData* event) override;
+    void control() override;
+    void demoEnd();
+    void hideBalloon();
+    void startBlowDown();
+    void released(const sead::Vector3f& trans, const sead::Quatf& quat);
+    void catched();
+    void directCatched();
+    void startStruggle();
+    void exeCatched();
+    void exeCarried();
+    void exeReleaseDemoWait();
+    void exeFall();
+    void exeWait();
+    void exeTalkDemo();
+
+private:
+    Jango* mJango = nullptr;
+    BalloonIcon* mBalloonIcon = nullptr;
+    sead::Vector3f mReleaseTrans = sead::Vector3f::zero;
+    sead::Quatf mReleaseQuat = sead::Quatf::unit;
+    sead::Vector3f mTalkDemoPlayerTrans = sead::Vector3f::zero;
+    sead::Quatf mTalkDemoPlayerQuat = sead::Quatf::unit;
+    al::EventFlowExecutor* mEventFlowExecutor = nullptr;
+    StateStageTalkDemoCapManHero* mStateTalkDemo = nullptr;
+    JangoCapSeparateHelpClaimUpdater* mSeparateHelpClaimUpdater = nullptr;
+    al::CameraTicket* mEntranceCameraTicket = nullptr;
+    bool mIsBlowDown = false;
+};
+
+static_assert(sizeof(JangoCap) == 0x180);

--- a/src/Enemy/Jango/JangoCapSeparateHelpClaimUpdater.cpp
+++ b/src/Enemy/Jango/JangoCapSeparateHelpClaimUpdater.cpp
@@ -1,0 +1,158 @@
+#include "Enemy/Jango/JangoCapSeparateHelpClaimUpdater.h"
+
+#include "Library/Camera/CameraUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Enemy/Jango/Jango.h"
+#include "Enemy/Jango/JangoCap.h"
+#include "Layout/BalloonIcon.h"
+#include "System/GameDataFunction.h"
+#include "Util/InputInterruptTutorialUtil.h"
+#include "Util/PlayerUtil.h"
+#include "Util/StageInputFunction.h"
+
+namespace {
+NERVE_IMPL(JangoCap, Wait)
+NERVE_IMPL(JangoCap, TalkDemo)
+NERVE_IMPL(JangoCap, Fall)
+NERVE_IMPL(JangoCap, Catched)
+NERVE_IMPL(JangoCap, Carried)
+NERVE_IMPL(JangoCap, ReleaseDemoWait)
+
+NERVES_MAKE_NOSTRUCT(JangoCap, ReleaseDemoWait)
+NERVES_MAKE_STRUCT(JangoCap, Wait, TalkDemo, Fall, Catched, Carried)
+}  // namespace
+
+void JangoCapSeparateHelpClaimUpdater::update() {
+    if (rs::isSeparatePlay(mActor)) {
+        if (rs::isPlayerInputTriggerSeparateCapJangoHelp(mActor)) {
+            al::LiveActor* actor = mActor;
+            if (al::isNerve(actor, &NrvJangoCap.Catched) ||
+                al::isNerve(actor, &NrvJangoCap.Carried)) {
+                if (mHelpReactionCoolTime == 0) {
+                    al::startHitReaction(mActor, "さけぶ");
+                    mHelpReactionCoolTime = 120;
+                }
+            }
+        }
+    } else if (mSinglePlayReactionTimer++ >= 239) {
+        mSinglePlayReactionTimer = 0;
+        al::startHitReaction(mActor, "さけぶ(シングルプレイ)");
+    }
+
+    if (mHelpReactionCoolTime > 0)
+        --mHelpReactionCoolTime;
+}
+
+void JangoCap::demoEnd() {
+    mBalloonIcon->startUpdateDraw();
+}
+
+void JangoCap::hideBalloon() {
+    mBalloonIcon->hideAndStopUpdate();
+}
+
+void JangoCap::startBlowDown() {
+    al::startHitReaction(this, "ヒット");
+    al::startAction(this, "DemoJangoBlowDown");
+    mIsBlowDown = true;
+}
+
+void JangoCap::released(const sead::Vector3f& trans, const sead::Quatf& quat) {
+    mReleaseTrans = trans;
+    mReleaseQuat = quat;
+    al::onCollide(this);
+    al::setNerve(this, &ReleaseDemoWait);
+}
+
+void JangoCap::catched() {
+    mIsBlowDown = false;
+    al::setNerve(this, &NrvJangoCap.Catched);
+}
+
+void JangoCap::directCatched() {
+    BalloonIcon* balloonIcon = mBalloonIcon;
+    mIsBlowDown = false;
+    balloonIcon->startUpdateDraw();
+    al::setNerve(this, &NrvJangoCap.Catched);
+}
+
+void JangoCap::startStruggle() {
+    al::startAction(this, "DemoJangoStruggle");
+}
+
+void JangoCap::exeCatched() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "DemoJangoHunted");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvJangoCap.Carried);
+}
+
+void JangoCap::exeCarried() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "DemoJangoCarried");
+}
+
+void JangoCap::exeReleaseDemoWait() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "DemoJangoLand");
+        al::setQuat(this, mReleaseQuat);
+        al::setVelocityZero(this);
+        al::resetPosition(this, mReleaseTrans);
+    }
+
+    if (al::isActionPlaying(this, "DemoJangoLand") && al::isActionEnd(this))
+        al::startAction(this, "DemoJangoWaitPlayer");
+
+    if (al::isGreaterEqualStep(this, 60))
+        al::setNerve(this, &NrvJangoCap.Fall);
+}
+
+void JangoCap::exeFall() {
+    if (al::isActionPlaying(this, "DemoJangoLand") && al::isActionEnd(this))
+        al::startAction(this, "DemoJangoWaitPlayer");
+
+    al::scaleVelocity(this, 0.95f);
+    al::addVelocityToGravity(this, 2.0f);
+
+    if (al::isOnGround(this, 0))
+        al::setNerve(this, &NrvJangoCap.Wait);
+}
+
+void JangoCap::exeWait() {
+    if (al::isActionPlaying(this, "DemoJangoLand") && al::isActionEnd(this))
+        al::startAction(this, "DemoJangoWaitPlayer");
+
+    al::turnToTarget(this, al::getPlayerPos(this, 0), 1.0f);
+}
+
+void JangoCap::exeTalkDemo() {
+    if (al::isFirstStep(this)) {
+        al::setVelocityZero(this);
+        rs::changeEnableCapTutorial(this);
+    }
+
+    if (al::updateNerveState(this)) {
+        GameDataFunction::disableJangoTrans(this);
+        mJango->tryOffCapCatchedSwitch();
+        al::tryOnStageSwitch(this, "CapGetOn");
+        GameDataFunction::addJangoCount(this);
+
+        if (mEntranceCameraTicket)
+            al::startCamera(this, mEntranceCameraTicket, -1);
+
+        kill();
+    }
+}
+
+JangoCapSeparateHelpClaimUpdater::JangoCapSeparateHelpClaimUpdater(al::LiveActor* actor)
+    : mActor(actor) {}

--- a/src/Enemy/Jango/JangoCapSeparateHelpClaimUpdater.h
+++ b/src/Enemy/Jango/JangoCapSeparateHelpClaimUpdater.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class JangoCapSeparateHelpClaimUpdater {
+public:
+    JangoCapSeparateHelpClaimUpdater(al::LiveActor* actor);
+
+    void update();
+
+private:
+    s32 mHelpReactionCoolTime = 0;
+    al::LiveActor* mActor = nullptr;
+    s32 mSinglePlayReactionTimer = 0;
+};
+
+static_assert(sizeof(JangoCapSeparateHelpClaimUpdater) == 0x18);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1164)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f20b296)

📈 **Matched code**: 14.67% (+0.01%, +1488 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCapSeparateHelpClaimUpdater::update()` | +208 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeReleaseDemoWait()` | +176 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeTalkDemo()` | +148 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeFall()` | +140 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::released(sead::Vector3<float> const&, sead::Quat<float> const&)` | +100 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvWait::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeWait()` | +96 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvCatched::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeCatched()` | +92 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::startBlowDown()` | +64 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvCarried::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::exeCarried()` | +60 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::directCatched()` | +56 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::catched()` | +20 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCapSeparateHelpClaimUpdater::JangoCapSeparateHelpClaimUpdater(al::LiveActor*)` | +16 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::startStruggle()` | +12 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::demoEnd()` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `JangoCap::hideBalloon()` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvTalkDemo::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/JangoCapSeparateHelpClaimUpdater` | `(anonymous namespace)::JangoCapNrvReleaseDemoWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->