### PR TITLE
Demo: Implement `DemoStateHackFirst`

### DIFF
--- a/src/Demo/DemoHackFirstDirector.h
+++ b/src/Demo/DemoHackFirstDirector.h
@@ -1,0 +1,43 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class IUsePlayerHack;
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class LiveActor;
+}  // namespace al
+
+class DemoHackFirstDirector : public al::LiveActor {
+public:
+    DemoHackFirstDirector(s32 demoType);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void appear() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+
+    void registRequestActor(al::LiveActor* actor);
+    s32 getDemoStartWaitFrame() const;
+    void setHackFirstDemo(al::LiveActor* actor, IUsePlayerHack* playerHack);
+    void setHackFirstDemoCore(al::LiveActor* actor, IUsePlayerHack* playerHack);
+    void noticeDemoStartToDemoHackFirstDirector();
+    void skipDemo();
+    void endDemo();
+    void updateOnlyDemoGraphics();
+    bool tryEndDemo();
+    bool isEndHackFirstDemo() const;
+    void exeWatch();
+    void exeDemo();
+    void exeShowMessage();
+    void startShowMessageFrog();
+    void exeEnd();
+
+private:
+    u8 _108[0x178 - sizeof(al::LiveActor)];
+};
+
+static_assert(sizeof(DemoHackFirstDirector) == 0x178);

--- a/src/Demo/DemoStateHackFirst.cpp
+++ b/src/Demo/DemoStateHackFirst.cpp
@@ -1,0 +1,180 @@
+#include "Demo/DemoStateHackFirst.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Demo/DemoHackFirstDirector.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "Util/DemoUtil.h"
+#include "Util/Hack.h"
+#include "Util/InputInterruptTutorialUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(DemoStateHackFirst, Demo);
+NERVE_IMPL(DemoStateHackFirst, End);
+
+NERVES_MAKE_NOSTRUCT(DemoStateHackFirst, Demo, End);
+}  // namespace
+
+DemoStateHackFirst::DemoStateHackFirst(al::LiveActor* actor, const al::ActorInitInfo& initInfo)
+    : al::ActorStateBase("初回憑依デモ", actor) {
+    if (al::isObjectName(initInfo, "Frog")) {
+        mDemoType = 1;
+    } else {
+        if (!al::isObjectNameSubStr(initInfo, "Koopa"))
+            return;
+        mDemoType = 2;
+    }
+
+    if (al::isExistLinkChild(initInfo, "LinkDemoHackDirector", 0))
+        mDemoHackFirstDirector = rs::tryCreateDemoHackFirstDirector(mActor, mDemoType, initInfo);
+
+    initNerve(&Demo, 0);
+}
+
+void DemoStateHackFirst::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Demo);
+    mDemoHackFirstDirector->setHackFirstDemo(mActor, mPlayerHack);
+    al::tryOnStageSwitch(mActor, "SwitchActiveDemoHackFirstOnOff");
+    rs::requestValidateDemoSkip(this, mActor);
+}
+
+void DemoStateHackFirst::kill() {
+    al::NerveStateBase::kill();
+}
+
+bool DemoStateHackFirst::isFirstDemo() const {
+    if (mDemoType == 1)
+        return true;
+
+    if (mDemoType == 2) {
+        if (GameDataFunction::isExistInHackDictionary(GameDataHolderAccessor(mActor), "Koopa"))
+            return false;
+    }
+
+    return true;
+}
+
+bool DemoStateHackFirst::isEnableSkipDemo() const {
+    return true;
+}
+
+void DemoStateHackFirst::skipDemo() {
+    mDemoHackFirstDirector->skipDemo();
+    endDemo();
+}
+
+void DemoStateHackFirst::endDemo() {
+    al::setNerve(this, &End);
+
+    if (mDemoType == 1)
+        rs::appearFirstHackTutorialFrog(mActor);
+    else if (mDemoType == 2)
+        rs::appearFirstHackTutorialKoopa(mActor);
+
+    al::tryOnStageSwitch(mActor, "SwitchHackFirstEndOn");
+    al::tryOffStageSwitch(mActor, "SwitchActiveDemoHackFirstOnOff");
+    rs::endHackStartDemo(mPlayerHack, mActor);
+    kill();
+}
+
+void DemoStateHackFirst::updateOnlyDemoGraphics() {
+    if (mDemoHackFirstDirector)
+        mDemoHackFirstDirector->updateOnlyDemoGraphics();
+}
+
+bool DemoStateHackFirst::tryHackFirstDemoWait(const al::SensorMsg* message) {
+    if (!mDemoHackFirstDirector)
+        return false;
+    if (!isEnableShowHackDemo())
+        return false;
+    if (!rs::isMsgStartHack(message))
+        return false;
+
+    s32 demoStartWaitFrame = mDemoStartWaitFrame;
+    if (demoStartWaitFrame == mDemoHackFirstDirector->getDemoStartWaitFrame())
+        return false;
+
+    demoStartWaitFrame = mDemoStartWaitFrame;
+    if (demoStartWaitFrame == 0) {
+        al::startHitReaction(mActor, "[初キャプチャーデモ用]帽子ヒット");
+        mDemoHackFirstDirector->appear();
+        demoStartWaitFrame = mDemoStartWaitFrame;
+    }
+
+    mDemoStartWaitFrame = demoStartWaitFrame + 1;
+    return true;
+}
+
+bool DemoStateHackFirst::isEnableShowHackDemo() const {
+    s32 demoType = mDemoType;
+    if (demoType == 1) {
+        if (GameDataFunction::getCurrentWorldId(GameDataHolderAccessor(mActor)) != 0)
+            return false;
+        demoType = mDemoType;
+    }
+
+    if (demoType == 2) {
+        s32 worldId = GameDataFunction::getCurrentWorldId(GameDataHolderAccessor(mActor));
+        if (worldId != GameDataFunction::getWorldIndexMoon())
+            return false;
+        demoType = mDemoType;
+    }
+
+    if (demoType == 1) {
+        if (GameDataFunction::isExistInHackDictionary(GameDataHolderAccessor(mActor), "Frog"))
+            return false;
+    }
+
+    return true;
+}
+
+bool DemoStateHackFirst::tryHackFirst(IUsePlayerHack** playerHack, const al::SensorMsg* message,
+                                      al::HitSensor* other, al::HitSensor* self) {
+    if (!rs::isMsgStartHack(message))
+        return false;
+    if (!mDemoHackFirstDirector)
+        return false;
+
+    if (!isEnableShowHackDemo()) {
+        al::tryOnStageSwitch(mActor, "SwitchHackFirstEndOn");
+        return false;
+    }
+
+    mPlayerHack = rs::startHack(self, other, nullptr);
+    rs::startHackStartDemoPuppetable(mPlayerHack, mActor);
+
+    if (mDemoType != 2) {
+        if (mDemoType == 1)
+            rs::setDemoInfoDemoName(mActor, DemoName::cHackStartFirstTimeFrog);
+    } else {
+        rs::setDemoInfoDemoName(mActor, DemoName::cHackStartFirstTimeKoopa);
+    }
+
+    *playerHack = mPlayerHack;
+    return true;
+}
+
+void DemoStateHackFirst::exeDemo() {
+    if (al::isFirstStep(this))
+        mDemoHackFirstDirector->setHackFirstDemo(mActor, mPlayerHack);
+
+    if (mDemoHackFirstDirector->tryEndDemo())
+        endDemo();
+}
+
+void DemoStateHackFirst::exeEnd() {}
+
+DemoStateHackFirst* rs::tryCreateDemoStateHackFirst(al::LiveActor* actor,
+                                                    const al::ActorInitInfo& initInfo) {
+    if (!al::isExistLinkChild(initInfo, "DemoAfterPlayerPos", 0))
+        return nullptr;
+
+    return new DemoStateHackFirst(actor, initInfo);
+}

--- a/src/Demo/DemoStateHackFirst.h
+++ b/src/Demo/DemoStateHackFirst.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+class DemoHackFirstDirector;
+class IUsePlayerHack;
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+namespace DemoName {
+extern const char* cHackStartFirstTimeFrog;
+extern const char* cHackStartFirstTimeKoopa;
+}  // namespace DemoName
+
+class DemoStateHackFirst : public al::ActorStateBase, public IUseDemoSkip {
+public:
+    DemoStateHackFirst(al::LiveActor* actor, const al::ActorInitInfo& initInfo);
+
+    void appear() override;
+    void kill() override;
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+    void endDemo();
+    void updateOnlyDemoGraphics() override;
+    bool tryHackFirstDemoWait(const al::SensorMsg* message);
+    bool isEnableShowHackDemo() const;
+    bool tryHackFirst(IUsePlayerHack** playerHack, const al::SensorMsg* message,
+                      al::HitSensor* other, al::HitSensor* self);
+    void exeDemo();
+    void exeEnd();
+
+private:
+    s32 mDemoType = 0;
+    IUsePlayerHack* mPlayerHack = nullptr;
+    DemoHackFirstDirector* mDemoHackFirstDirector = nullptr;
+    s32 mDemoStartWaitFrame = 0;
+};
+
+static_assert(sizeof(DemoStateHackFirst) == 0x48);
+
+namespace rs {
+DemoStateHackFirst* tryCreateDemoStateHackFirst(al::LiveActor* actor,
+                                                const al::ActorInitInfo& initInfo);
+}  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1165)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - a93eaf4)

📈 **Matched code**: 14.67% (+0.01%, +1712 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::tryHackFirst(IUsePlayerHack**, al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +220 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::DemoStateHackFirst(al::LiveActor*, al::ActorInitInfo const&)` | +216 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::isEnableShowHackDemo() const` | +212 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::endDemo()` | +184 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::tryHackFirstDemoWait(al::SensorMsg const*)` | +148 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::isFirstDemo() const` | +100 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `non-virtual thunk to DemoStateHackFirst::isFirstDemo() const` | +100 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `rs::tryCreateDemoStateHackFirst(al::LiveActor*, al::ActorInitInfo const&)` | +100 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::appear()` | +92 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `(anonymous namespace)::DemoStateHackFirstNrvDemo::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::exeDemo()` | +76 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::skipDemo()` | +40 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `non-virtual thunk to DemoStateHackFirst::skipDemo()` | +40 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::~DemoStateHackFirst()` | +36 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::updateOnlyDemoGraphics()` | +16 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `non-virtual thunk to DemoStateHackFirst::updateOnlyDemoGraphics()` | +16 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::kill()` | +12 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `non-virtual thunk to DemoStateHackFirst::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `DemoStateHackFirst::exeEnd()` | +4 | 0.00% | 100.00% |
| `Demo/DemoStateHackFirst` | `(anonymous namespace)::DemoStateHackFirstNrvEnd::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->