### PR TITLE
Layout: Implement `InformationWindowLayout`

### DIFF
--- a/src/Layout/InformationWindowLayout.cpp
+++ b/src/Layout/InformationWindowLayout.cpp
@@ -1,0 +1,161 @@
+#include "Layout/InformationWindowLayout.h"
+
+#include "Library/Layout/IUseLayout.h"
+#include "Library/Layout/IUseLayoutAction.h"
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+inline bool isValidLayout(const InformationWindowLayout* layout) {
+    return layout;
+}
+
+NERVE_IMPL(InformationWindowLayout, Wait);
+NERVE_IMPL(InformationWindowLayout, Appear);
+NERVE_IMPL(InformationWindowLayout, End);
+
+NERVES_MAKE_NOSTRUCT(InformationWindowLayout, Wait, Appear, End);
+}  // namespace
+
+InformationWindowLayout::InformationWindowLayout(const al::LayoutInitInfo& info)
+    : al::LayoutActor("") {
+    al::initLayoutActor(this, info, "PlayGuide");
+    initNerve(&Wait);
+}
+
+void InformationWindowLayout::changeSeparatePlay() {
+    mPlayMode = 1;
+}
+
+bool InformationWindowLayout::isSeparateTutorial() const {
+    return mPlayMode == 1;
+}
+
+bool InformationWindowLayout::isSingleTutorial() const {
+    return mPlayMode == 0;
+}
+
+void InformationWindowLayout::changeSinglePlay() {
+    mPlayMode = 0;
+}
+
+void InformationWindowLayout::setSeparatePlayerOnlyLayout() {
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::startAction(layoutAction, "1P", "State");
+}
+
+void InformationWindowLayout::setSinglePlayLayout() {
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::startAction(layoutAction, "Normal", "State");
+}
+
+void InformationWindowLayout::setHackTutorial(const al::LiveActor* actor, const char* label) {
+    const al::IUseMessageSystem* messageSystem = this;
+    const char16* message =
+        rs::getPlayerHackSystemMessageString(actor, messageSystem, "Tutorial", label);
+    s32 playMode = mPlayMode;
+    al::IUseLayout* layout = isValidLayout(this) ? this : nullptr;
+
+    al::setPaneString(layout, "TxtGuide", message);
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::setPaneString(layout, "TxtGuideSh", message);
+    al::requestCaptureRecursive(this);
+
+    if (playMode)
+        al::startAction(layoutAction, "1P", "State");
+    else
+        al::startAction(layoutAction, "Normal", "State");
+}
+
+void InformationWindowLayout::setTutorial(const char* label) {
+    const al::IUseMessageSystem* messageSystem = this;
+    const char16* message = al::getSystemMessageString(messageSystem, "Tutorial", label);
+    s32 playMode = mPlayMode;
+    al::IUseLayout* layout = isValidLayout(this) ? this : nullptr;
+
+    al::setPaneString(layout, "TxtGuide", message);
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::setPaneString(layout, "TxtGuideSh", message);
+    al::requestCaptureRecursive(this);
+
+    if (playMode)
+        al::startAction(layoutAction, "1P", "State");
+    else
+        al::startAction(layoutAction, "Normal", "State");
+}
+
+void InformationWindowLayout::setSeparatePlayTutorial(const char* leftLabel,
+                                                      const char* rightLabel) {
+    const al::IUseMessageSystem* messageSystem = this;
+    const char* category = "Tutorial";
+    const char16* leftMessage = al::getSystemMessageString(messageSystem, category, leftLabel);
+    const char16* rightMessage = al::getSystemMessageString(messageSystem, category, rightLabel);
+    al::IUseLayout* layout = isValidLayout(this) ? this : nullptr;
+
+    al::setPaneString(layout, "TxtGuideL", leftMessage);
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::setPaneString(layout, "TxtGuideLSh", leftMessage);
+    al::setPaneString(layout, "TxtGuideR", rightMessage);
+    al::setPaneString(layout, "TxtGuideRSh", rightMessage);
+    al::requestCaptureRecursive(this);
+    al::startAction(layoutAction, "2P", "State");
+}
+
+void InformationWindowLayout::setAreaTutorial(const char16* message) {
+    s32 playMode = mPlayMode;
+    al::IUseLayout* layout = isValidLayout(this) ? this : nullptr;
+
+    al::setPaneString(layout, "TxtGuide", message);
+    al::IUseLayoutAction* layoutAction = isValidLayout(this) ? this : nullptr;
+    al::setPaneString(layout, "TxtGuideSh", message);
+    al::requestCaptureRecursive(this);
+
+    if (playMode)
+        al::startAction(layoutAction, "1P", "State");
+    else
+        al::startAction(layoutAction, "Normal", "State");
+}
+
+void InformationWindowLayout::appear() {
+    al::adjustPaneSizeToTextSizeAll(this);
+    al::setNerve(this, &Appear);
+    al::LayoutActor::appear();
+}
+
+void InformationWindowLayout::end() {
+    al::setNerve(this, &End);
+}
+
+const char* InformationWindowLayout::getTutorialMstxtName() const {
+    return "Tutorial";
+}
+
+bool InformationWindowLayout::isWait() const {
+    return al::isNerve(this, &Wait);
+}
+
+void InformationWindowLayout::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+    if (al::isActionEnd(this))
+        al::setNerve(this, &Wait);
+}
+
+void InformationWindowLayout::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+}
+
+void InformationWindowLayout::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "End");
+    if (al::isActionEnd(this))
+        kill();
+}

--- a/src/Layout/InformationWindowLayout.h
+++ b/src/Layout/InformationWindowLayout.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Layout/LayoutActor.h"
+
+namespace al {
+class LayoutInitInfo;
+class LiveActor;
+}  // namespace al
+
+class InformationWindowLayout : public al::LayoutActor {
+public:
+    InformationWindowLayout(const al::LayoutInitInfo& info);
+
+    void appear() override;
+
+    void changeSeparatePlay();
+    bool isSeparateTutorial() const;
+    bool isSingleTutorial() const;
+    void changeSinglePlay();
+    void setSeparatePlayerOnlyLayout();
+    void setSinglePlayLayout();
+    void setHackTutorial(const al::LiveActor* actor, const char* label);
+    void setTutorial(const char* label);
+    void setSeparatePlayTutorial(const char* leftLabel, const char* rightLabel);
+    void setAreaTutorial(const char16* message);
+    void end();
+    const char* getTutorialMstxtName() const;
+    bool isWait() const;
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+
+private:
+    s32 mPlayMode = 0;
+};
+
+static_assert(sizeof(InformationWindowLayout) == 0x130);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1166)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 4c2a4e3)

📈 **Matched code**: 14.68% (+0.02%, +1888 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setSeparatePlayTutorial(char const*, char const*)` | +248 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setHackTutorial(al::LiveActor const*, char const*)` | +196 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setTutorial(char const*)` | +188 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::InformationWindowLayout(al::LayoutInitInfo const&)` | +176 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::InformationWindowLayout(al::LayoutInitInfo const&)` | +172 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setAreaTutorial(char16_t const*)` | +164 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `(anonymous namespace)::InformationWindowLayoutNrvAppear::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `(anonymous namespace)::InformationWindowLayoutNrvEnd::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::exeAppear()` | +100 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::exeEnd()` | +100 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `(anonymous namespace)::InformationWindowLayoutNrvWait::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::exeWait()` | +64 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::appear()` | +52 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setSeparatePlayerOnlyLayout()` | +32 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::setSinglePlayLayout()` | +32 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::isSeparateTutorial() const` | +16 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::isSingleTutorial() const` | +16 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::changeSeparatePlay()` | +12 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::end()` | +12 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::getTutorialMstxtName() const` | +12 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::isWait() const` | +12 | 0.00% | 100.00% |
| `Layout/InformationWindowLayout` | `InformationWindowLayout::changeSinglePlay()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->