### PR TITLE
Boss/Koopa: Implement `KoopaStateHipDrop`

### DIFF
--- a/src/Boss/Koopa/KoopaFlag.h
+++ b/src/Boss/Koopa/KoopaFlag.h
@@ -12,6 +12,8 @@ public:
 
     bool hasHitEnd() const { return mHasHitEnd; }
 
+    void setHasHipDropLandEnd() { _2 = true; }
+
     void setHasHitEnd() { mHasHitEnd = true; }
 
 private:
@@ -24,3 +26,5 @@ private:
     bool _6 = false;
     bool _7 = true;
 };
+
+static_assert(sizeof(KoopaFlag) == 0x8);

--- a/src/Boss/Koopa/KoopaJumpMovement.h
+++ b/src/Boss/Koopa/KoopaJumpMovement.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaJumpMovement {
+public:
+    KoopaJumpMovement();
+
+    void start(const al::LiveActor* actor, const sead::Vector3f& targetTrans,
+               const sead::Quatf& targetQuat, const sead::Vector3f& up);
+    bool move(al::LiveActor* actor, bool isTurnEndPose);
+    void turnEndPoseFaceToPlayer(const al::LiveActor* actor);
+
+private:
+    s32 mMoveStepMax = -1;
+    s32 mMoveStep = 0;
+    sead::Vector3f mStartTrans = sead::Vector3f::zero;
+    sead::Vector3f mMoveVector = sead::Vector3f::zero;
+    f32 mJumpSpeed = 0.0f;
+    sead::Quatf mStartQuat = sead::Quatf::unit;
+    sead::Quatf mEndQuat = sead::Quatf::unit;
+    sead::Vector3f mUp = sead::Vector3f::ey;
+};
+
+static_assert(sizeof(KoopaJumpMovement) == 0x50);

--- a/src/Boss/Koopa/KoopaLandPointHolder.h
+++ b/src/Boss/Koopa/KoopaLandPointHolder.h
@@ -19,6 +19,10 @@ public:
     void reset();
     const sead::Vector3f& findNearestPointTrans(const sead::Vector3f& pos) const;
 
+    const sead::Quatf& getCurrentPointQuat() const { return mPointsQuat[mCurrentLandPoint]; }
+
+    const sead::Vector3f& getCurrentPointTrans() const { return mPointsTrans[mCurrentLandPoint]; }
+
 private:
     sead::Vector3f mTrans = {0.0f, 0.0f, 0.0f};
     sead::Quatf mQuat = sead::Quatf::unit;

--- a/src/Boss/Koopa/KoopaRingBeamEmitter.h
+++ b/src/Boss/Koopa/KoopaRingBeamEmitter.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActorGroup;
+struct ActorInitInfo;
+}  // namespace al
+
+class KoopaRingBeamEmitter {
+public:
+    KoopaRingBeamEmitter(const al::ActorInitInfo& initInfo, bool isLineLight);
+
+    void emit(const sead::Vector3f& trans);
+    void emitHipDrop(const sead::Vector3f& trans);
+    void emitAttackTail(const sead::Vector3f& trans);
+    void cancelAll();
+    void killAll();
+    void killForDemoAll();
+
+private:
+    al::LiveActorGroup* mRingBeamGroup = nullptr;
+    sead::Vector3f mTrans = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(KoopaRingBeamEmitter) == 0x18);

--- a/src/Boss/Koopa/KoopaStateHipDrop.cpp
+++ b/src/Boss/Koopa/KoopaStateHipDrop.cpp
@@ -1,0 +1,157 @@
+#include "Boss/Koopa/KoopaStateHipDrop.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/Koopa/KoopaFlag.h"
+#include "Boss/Koopa/KoopaJumpMovement.h"
+#include "Boss/Koopa/KoopaLandPointHolder.h"
+#include "Boss/Koopa/KoopaRingBeamEmitter.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(KoopaStateHipDrop, JumpStart);
+NERVE_IMPL(KoopaStateHipDrop, HipDropLandStart);
+NERVE_IMPL(KoopaStateHipDrop, HipDropLand);
+NERVE_IMPL(KoopaStateHipDrop, HipDropLandEnd);
+NERVE_IMPL(KoopaStateHipDrop, HipDropSign);
+NERVE_IMPL(KoopaStateHipDrop, Jump);
+NERVE_IMPL(KoopaStateHipDrop, HipDropStart);
+NERVE_IMPL(KoopaStateHipDrop, HipDrop);
+NERVES_MAKE_NOSTRUCT(KoopaStateHipDrop, JumpStart, HipDropStart, HipDropLandStart, HipDropLand,
+                     HipDropLandEnd, HipDropSign, Jump, HipDrop);
+}  // namespace
+
+KoopaStateHipDrop::KoopaStateHipDrop(al::LiveActor* actor, KoopaFlag* flag,
+                                     KoopaRingBeamEmitter* ringBeamEmitter)
+    : al::ActorStateBase("ヒップドロップ", actor), mFlag(flag), mRingBeamEmitter(ringBeamEmitter) {
+    initNerve(&JumpStart, 0);
+    mJumpMovement = new KoopaJumpMovement();
+}
+
+void KoopaStateHipDrop::decideEitherFarSidePointAndStart(KoopaLandPointHolder* landPointHolder) {
+    landPointHolder->decidePointEitherFarSide(rs::getPlayerPos(mActor));
+    const sead::Vector3f& currentPointTrans = landPointHolder->getCurrentPointTrans();
+    f32 targetTransX = currentPointTrans.x + 0.0f;
+    f32 targetTransY = currentPointTrans.y + 800.0f;
+    f32 targetTransZ = currentPointTrans.z + 0.0f;
+    KoopaJumpMovement* jumpMovement = mJumpMovement;
+    al::LiveActor* actor = mActor;
+    sead::Vector3f targetTrans = {targetTransX, targetTransY, targetTransZ};
+    const sead::Quatf& targetQuat = landPointHolder->getCurrentPointQuat();
+    sead::Vector3f up = -al::getGravity(actor);
+    jumpMovement->start(actor, targetTrans, targetQuat, up);
+    al::setNerve(this, &JumpStart);
+}
+
+bool KoopaStateHipDrop::isAfterHipDropLand() const {
+    return al::isNerve(this, &HipDropLandStart) || al::isNerve(this, &HipDropLand) ||
+           al::isNerve(this, &HipDropLandEnd);
+}
+
+void KoopaStateHipDrop::exeJumpStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "JumpStart");
+
+    if (mJumpMovement->move(mActor, false)) {
+        al::setVelocityZero(mActor);
+        al::setNerve(this, &HipDropSign);
+    } else if (al::isActionEnd(mActor)) {
+        al::setNerve(this, &Jump);
+    }
+}
+
+void KoopaStateHipDrop::exeJump() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "Jump");
+
+    if (mJumpMovement->move(mActor, false)) {
+        al::setVelocityZero(mActor);
+        al::setNerve(this, &HipDropSign);
+    }
+}
+
+void KoopaStateHipDrop::exeHipDropSign() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "HipDropSign");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &HipDropStart);
+}
+
+void KoopaStateHipDrop::exeHipDropStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "HipDropStart");
+        al::setVelocityToGravity(mActor, 150.0f);
+        if (al::isNoCollide(mActor))
+            al::onCollide(mActor);
+    }
+
+    al::addVelocityToGravity(mActor, 2.0f);
+    al::scaleVelocity(mActor, 0.99f);
+
+    if (al::isOnGround(mActor, 0)) {
+        al::setVelocityZero(mActor);
+        al::setNerve(this, &HipDropLandStart);
+    } else if (al::isActionEnd(mActor)) {
+        al::setNerve(this, &HipDrop);
+    }
+}
+
+void KoopaStateHipDrop::exeHipDrop() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "HipDrop");
+
+    al::addVelocityToGravity(mActor, 2.0f);
+    al::scaleVelocity(mActor, 0.99f);
+
+    if (al::isOnGround(mActor, 0)) {
+        al::setVelocityZero(mActor);
+        al::setNerve(this, &HipDropLandStart);
+    }
+}
+
+void KoopaStateHipDrop::exeHipDropLandStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "HipDropLandStart");
+        al::startHitReaction(mActor, "ヒップドロップ着地");
+        mRingBeamEmitter->emitHipDrop(al::getTrans(mActor));
+        mRingBeamEmitter->emitHipDrop(al::getTrans(mActor));
+        mRingBeamEmitter->emitHipDrop(al::getTrans(mActor));
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &HipDropLand);
+}
+
+void KoopaStateHipDrop::exeHipDropLand() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "HipDropLand");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &HipDropLandEnd);
+}
+
+void KoopaStateHipDrop::exeHipDropLandEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "HipDropLandEnd");
+
+    if (al::isActionEnd(mActor)) {
+        mFlag->setHasHipDropLandEnd();
+        kill();
+    }
+}
+
+void KoopaStateHipDrop::appear() {
+    NerveStateBase::appear();
+    al::setNerve(this, &JumpStart);
+}
+
+void KoopaStateHipDrop::kill() {
+    NerveStateBase::kill();
+}

--- a/src/Boss/Koopa/KoopaStateHipDrop.h
+++ b/src/Boss/Koopa/KoopaStateHipDrop.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaFlag;
+class KoopaJumpMovement;
+class KoopaLandPointHolder;
+class KoopaRingBeamEmitter;
+
+class KoopaStateHipDrop : public al::ActorStateBase {
+public:
+    KoopaStateHipDrop(al::LiveActor* actor, KoopaFlag* flag, KoopaRingBeamEmitter* ringBeamEmitter);
+
+    void appear() override;
+    void kill() override;
+
+    void decideEitherFarSidePointAndStart(KoopaLandPointHolder* landPointHolder);
+    bool isAfterHipDropLand() const;
+    void exeJumpStart();
+    void exeJump();
+    void exeHipDropSign();
+    void exeHipDropStart();
+    void exeHipDrop();
+    void exeHipDropLandStart();
+    void exeHipDropLand();
+    void exeHipDropLandEnd();
+
+private:
+    KoopaFlag* mFlag = nullptr;
+    KoopaJumpMovement* mJumpMovement = nullptr;
+    KoopaRingBeamEmitter* mRingBeamEmitter = nullptr;
+};
+
+static_assert(sizeof(KoopaStateHipDrop) == 0x38);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1167)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - b01b78b)

📈 **Matched code**: 14.68% (+0.02%, +1956 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::decideEitherFarSidePointAndStart(KoopaLandPointHolder*)` | +216 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDropStart()` | +192 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDropLandStart()` | +180 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeJumpStart()` | +136 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::KoopaStateHipDrop(al::LiveActor*, KoopaFlag*, KoopaRingBeamEmitter*)` | +128 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDrop()` | +128 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvJump::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeJump()` | +108 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDropLandEnd::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDropLandEnd()` | +100 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDropLand::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDropLand()` | +92 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDropSign::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::isAfterHipDropLand() const` | +88 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::exeHipDropSign()` | +88 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::~KoopaStateHipDrop()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::appear()` | +16 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `KoopaStateHipDrop::kill()` | +12 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvJumpStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDropLandStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDropStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateHipDrop` | `(anonymous namespace)::KoopaStateHipDropNrvHipDrop::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->