### PR TITLE
Demo: Implement `StageEventDemoBase`

### DIFF
--- a/lib/al/Library/Demo/DemoActorFunction.h
+++ b/lib/al/Library/Demo/DemoActorFunction.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+
+namespace al {
+struct ActorInitInfo;
+class DemoActorHolder;
+
+namespace alDemoFunction {
+DemoActorHolder* createDemoActorHolder(const char* demoName, const ActorInitInfo& initInfo,
+                                       const sead::Matrix34f* mtx, s32 index, bool isCreateDummy);
+DemoActorHolder* createDemoActorHolderForDemoScene(const char* demoName,
+                                                   const ActorInitInfo& initInfo,
+                                                   const sead::Matrix34f* mtx, s32 index);
+}  // namespace alDemoFunction
+
+}  // namespace al

--- a/lib/al/Library/Demo/DemoActorHolder.h
+++ b/lib/al/Library/Demo/DemoActorHolder.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class DemoActorHolder {
+public:
+    void kill();
+    void startSequence();
+    void updateSequence();
+    bool isEndSequence() const;
+    void updateGraphics();
+
+    bool isAlive() const { return mIsAlive; }
+
+private:
+    u8 _0[0x4c];
+    bool mIsAlive;
+};
+
+}  // namespace al

--- a/src/Demo/StageEventDemoBase.cpp
+++ b/src/Demo/StageEventDemoBase.cpp
@@ -1,0 +1,151 @@
+#include "Demo/StageEventDemoBase.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Demo/DemoActorFunction.h"
+#include "Library/Demo/DemoActorHolder.h"
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Demo/StageEventDemoFunction.h"
+#include "System/GameDataUtil.h"
+#include "Util/DemoUtil.h"
+
+namespace {
+NERVE_IMPL(StageEventDemo, Wait)
+NERVE_IMPL(StageEventDemo, Demo)
+NERVE_IMPL(StageEventDemo, End)
+NERVES_MAKE_NOSTRUCT(StageEventDemo, Wait, Demo, End)
+}  // namespace
+
+StageEventDemo::StageEventDemo(const char* name) : StageEventDemoBase(name) {}
+
+void StageEventDemo::init(const al::ActorInitInfo& info) {
+    if (al::isObjectName(info, "StageEventDemoNoSave"))
+        mIsSaveDemo = false;
+
+    StageEventDemoFunction::initStageEventDemoBase(this, info);
+    al::initNerve(this, &Wait, 0);
+    al::getStringArg(&mDemoStageName, info, "DemoStageName");
+
+    if (al::isEqualString(mDemoStageName, "DemoStartWorldWaterfallStage"))
+        mIsEnableSkipDemo = true;
+
+    using StartFunctor = al::FunctorV0M<StageEventDemo*, void (StageEventDemo::*)()>;
+    if (al::listenStageSwitchOnStart(this, StartFunctor(this, &StageEventDemo::startDemo)))
+        mIsStageStartDemo = false;
+
+    mSaveObjInfo = rs::createSaveObjInfoWriteSaveData(info);
+    if (mIsSaveDemo && rs::isOnSaveObjInfo(mSaveObjInfo)) {
+        mIsStageStartDemo = false;
+        mIsEnableStartDemo = false;
+    } else {
+        mDemoActorHolder =
+            al::alDemoFunction::createDemoActorHolder(mDemoStageName, info, nullptr, 1, false);
+        mAddDemoInfo = al::registDemoRequesterToAddDemoInfo(this, info, 0);
+    }
+
+    makeActorDead();
+}
+
+void StageEventDemo::startDemo() {
+    if (!mIsEnableStartDemo)
+        return;
+
+    if (!al::isNerve(this, &Wait)) {
+        isStageStartDemo();
+        return;
+    }
+
+    al::LiveActor::appear();
+
+    if (isStageStartDemo()) {
+        if (!rs::requestStartDemoNormalWithCinemaFrame(this))
+            return;
+
+        if (mIsEnableSkipDemo)
+            rs::requestValidateDemoSkip(this, this);
+    } else {
+        rs::requestStartDemoNormal(this, false);
+    }
+
+    al::addDemoActorFromDemoActorHolder(this, mDemoActorHolder);
+    al::addDemoActorFromAddDemoInfo(this, mAddDemoInfo);
+    mDemoActorHolder->startSequence();
+    al::setNerve(this, &Demo);
+}
+
+void StageEventDemo::endDemo() {
+    mIsDemoLastStep = true;
+    al::setNerve(this, &End);
+}
+
+bool StageEventDemo::isDemoLastStep() const {
+    return mIsDemoLastStep;
+}
+
+bool StageEventDemo::isEndDemo() const {
+    return al::isDead(this);
+}
+
+bool StageEventDemo::isFirstDemo() const {
+    if (!mIsSaveDemo)
+        return false;
+
+    return !rs::isOnSaveObjInfo(mSaveObjInfo);
+}
+
+bool StageEventDemo::isEnableSkipDemo() const {
+    return mIsEnableSkipDemo;
+}
+
+void StageEventDemo::skipDemo() {
+    endDemoCore();
+}
+
+void StageEventDemo::endDemoCore() {
+    if (isStageStartDemo())
+        rs::requestEndDemoNormalWithCinemaFrame(this);
+    else
+        rs::requestEndDemoNormal(this);
+
+    if (mIsSaveDemo)
+        rs::onSaveObjInfo(mSaveObjInfo);
+
+    mIsDemoLastStep = false;
+    mDemoActorHolder->kill();
+    al::tryOnStageSwitch(this, "SwitchDemoEndOn");
+    kill();
+}
+
+void StageEventDemo::updateOnlyDemoGraphics() {
+    if (mDemoActorHolder != nullptr && mDemoActorHolder->isAlive())
+        mDemoActorHolder->updateGraphics();
+}
+
+void StageEventDemo::exeWait() {}
+
+void StageEventDemo::exeDemo() {
+    al::isFirstStep(this);
+    mDemoActorHolder->updateSequence();
+
+    if (mDemoActorHolder->isEndSequence())
+        endDemo();
+}
+
+void StageEventDemo::exeEnd() {
+    if (al::isFirstStep(this))
+        endDemoCore();
+}
+
+bool StageEventDemo::isStageStartDemo() const {
+    return mIsStageStartDemo;
+}
+
+__attribute__((noinline)) StageEventDemoBase::StageEventDemoBase(const char* name)
+    : al::LiveActor(name) {}

--- a/src/Demo/StageEventDemoBase.h
+++ b/src/Demo/StageEventDemoBase.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Demo/IUseDemoSkip.h"
+
+class SaveObjInfo;
+
+namespace al {
+class AddDemoInfo;
+struct ActorInitInfo;
+class DemoActorHolder;
+}  // namespace al
+
+class StageEventDemoBase : public al::LiveActor {
+public:
+    StageEventDemoBase(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    virtual void startDemo() = 0;
+    virtual void endDemo() = 0;
+    virtual bool isStageStartDemo() const = 0;
+    virtual bool isDemoLastStep() const = 0;
+    virtual bool isEndDemo() const = 0;
+};
+
+static_assert(sizeof(StageEventDemoBase) == 0x108);
+
+class StageEventDemo : public StageEventDemoBase, public IUseDemoSkip {
+public:
+    StageEventDemo(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void startDemo() override;
+    void endDemo() override;
+    bool isStageStartDemo() const override;
+    bool isDemoLastStep() const override;
+    bool isEndDemo() const override;
+    bool isFirstDemo() const override;
+    bool isEnableSkipDemo() const override;
+    void skipDemo() override;
+    void updateOnlyDemoGraphics() override;
+
+    void endDemoCore();
+    void exeWait();
+    void exeDemo();
+    void exeEnd();
+
+private:
+    al::DemoActorHolder* mDemoActorHolder = nullptr;
+    bool mIsStageStartDemo = true;
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    bool mIsEnableStartDemo = true;
+    const char* mDemoStageName = nullptr;
+    bool mIsSaveDemo = true;
+    bool mIsEnableSkipDemo = false;
+    bool mIsDemoLastStep = false;
+    al::AddDemoInfo* mAddDemoInfo = nullptr;
+};
+
+static_assert(sizeof(StageEventDemo) == 0x148);

--- a/src/Demo/StageEventDemoFunction.h
+++ b/src/Demo/StageEventDemoFunction.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+namespace StageEventDemoFunction {
+void initStageEventDemoBase(al::LiveActor* actor, const al::ActorInitInfo& info);
+}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1168)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 06e3985)

📈 **Matched code**: 14.68% (+0.02%, +1960 bytes)

<details>
<summary>✅ 27 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Demo/StageEventDemoBase` | `StageEventDemo::init(al::ActorInitInfo const&)` | +300 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::startDemo()` | +212 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::StageEventDemo(char const*)` | +180 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::StageEventDemo(char const*)` | +176 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::exeEnd()` | +144 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `non-virtual thunk to StageEventDemo::skipDemo()` | +124 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::skipDemo()` | +120 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::endDemoCore()` | +120 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemoBase::StageEventDemoBase(char const*)` | +120 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `(anonymous namespace)::StageEventDemoNrvDemo::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::exeDemo()` | +76 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `al::FunctorV0M<StageEventDemo*, void (StageEventDemo::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::isFirstDemo() const` | +40 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `non-virtual thunk to StageEventDemo::isFirstDemo() const` | +40 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `al::FunctorV0M<StageEventDemo*, void (StageEventDemo::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::updateOnlyDemoGraphics()` | +24 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `non-virtual thunk to StageEventDemo::updateOnlyDemoGraphics()` | +24 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::endDemo()` | +20 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::isDemoLastStep() const` | +8 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `non-virtual thunk to StageEventDemo::isEnableSkipDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::isStageStartDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `(anonymous namespace)::StageEventDemoNrvEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::isEndDemo() const` | +4 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `StageEventDemo::exeWait()` | +4 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `(anonymous namespace)::StageEventDemoNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `Demo/StageEventDemoBase` | `al::FunctorV0M<StageEventDemo*, void (StageEventDemo::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->