### PR TITLE
Scene: Implement `StageSceneStateBreakCageShine`

### DIFF
--- a/src/MapObj/CageShineWatcher.h
+++ b/src/MapObj/CageShineWatcher.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class Shine;
+
+class CageShineWatcher : public al::LiveActor {
+public:
+    CageShineWatcher(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initBySwitch();
+    void initAfterPlacement() override;
+    void syncShineGetCamera();
+    void startBreakDemo();
+    bool isSameShine(const Shine* shine) const;
+    void exeShineWatch();
+    void exeWaitCameraStart();
+    void exeCameraInterpole();
+    void exeBreak();
+    void endBreakDemo();
+    void exeWaitEntranceCameraStart();
+    void exeLinkSwitchWatch();
+    bool isSwitchOn() const;
+
+private:
+    char filler_108[0x78];
+};
+
+static_assert(sizeof(CageShineWatcher) == 0x180);

--- a/src/Scene/StageSceneStateBreakCageShine.cpp
+++ b/src/Scene/StageSceneStateBreakCageShine.cpp
@@ -1,0 +1,64 @@
+#include "Scene/StageSceneStateBreakCageShine.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneUtil.h"
+
+#include "MapObj/CageShineWatcher.h"
+#include "Scene/StageScene.h"
+#include "Util/DemoUtil.h"
+
+namespace {
+NERVE_IMPL(StageSceneStateBreakCageShine, Wait);
+NERVES_MAKE_NOSTRUCT(StageSceneStateBreakCageShine, Wait);
+}  // namespace
+
+StageSceneStateBreakCageShine*
+StageSceneStateBreakCageShine::tryCreate(al::Scene* scene, const al::ActorInitInfo& actorInitInfo) {
+    al::DeriveActorGroup<CageShineWatcher>* cageShineWatcherGroup =
+        new al::DeriveActorGroup<CageShineWatcher>("ケージシャイン監視", 4);
+    if (!al::tryInitPlacementActorGroup(cageShineWatcherGroup, scene, actorInitInfo, 0,
+                                        "SceneWatchObjList", "CageShine"))
+        return nullptr;
+
+    return new StageSceneStateBreakCageShine("ケージ壊れる", scene, cageShineWatcherGroup);
+}
+
+StageSceneStateBreakCageShine::StageSceneStateBreakCageShine(
+    const char* name, al::Scene* scene,
+    al::DeriveActorGroup<CageShineWatcher>* cageShineWatcherGroup)
+    : al::HostStateBase<al::Scene>(name, scene), mCageShineWatcherGroup(cageShineWatcherGroup) {
+    initNerve(&Wait, 0);
+}
+
+void StageSceneStateBreakCageShine::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Wait);
+}
+
+void StageSceneStateBreakCageShine::kill() {
+    al::NerveStateBase::kill();
+}
+
+void StageSceneStateBreakCageShine::exeWait() {
+    if (al::isFirstStep(this)) {
+        Shine* demoShineActor = rs::getDemoShineActor(getHost());
+        al::DeriveActorGroup<CageShineWatcher>* cageShineWatcherGroup = mCageShineWatcherGroup;
+        for (s32 i = 0; i < cageShineWatcherGroup->getActorCount(); i++) {
+            bool isSameShine =
+                cageShineWatcherGroup->getDeriveActor(i)->isSameShine(demoShineActor);
+            cageShineWatcherGroup = mCageShineWatcherGroup;
+            if (isSameShine) {
+                cageShineWatcherGroup->getDeriveActor(i)->startBreakDemo();
+                break;
+            }
+        }
+    }
+
+    al::updateKitListPrev(getHost());
+    rs::updateKitListDemoNormalWithPauseEffect(getHost());
+    al::updateKitListPostDemoWithPauseNormalEffect(getHost());
+
+    if (!rs::isActiveDemo(getHost()))
+        kill();
+}

--- a/src/Scene/StageSceneStateBreakCageShine.h
+++ b/src/Scene/StageSceneStateBreakCageShine.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActorGroup.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class Scene;
+}  // namespace al
+
+class CageShineWatcher;
+
+class StageSceneStateBreakCageShine : public al::HostStateBase<al::Scene> {
+public:
+    static StageSceneStateBreakCageShine* tryCreate(al::Scene* scene,
+                                                    const al::ActorInitInfo& actorInitInfo);
+
+    StageSceneStateBreakCageShine(const char* name, al::Scene* scene,
+                                  al::DeriveActorGroup<CageShineWatcher>* cageShineWatcherGroup);
+    void appear() override;
+    void kill() override;
+    void exeWait();
+
+private:
+    al::DeriveActorGroup<CageShineWatcher>* mCageShineWatcherGroup = nullptr;
+};
+
+static_assert(sizeof(StageSceneStateBreakCageShine) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1172)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f47f87f)

📈 **Matched code**: 14.67% (+0.00%, +552 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::tryCreate(al::Scene*, al::ActorInitInfo const&)` | +200 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::exeWait()` | +196 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::StageSceneStateBreakCageShine(char const*, al::Scene*, al::DeriveActorGroup<CageShineWatcher>*)` | +84 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::~StageSceneStateBreakCageShine()` | +36 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::appear()` | +16 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `StageSceneStateBreakCageShine::kill()` | +12 | 0.00% | 100.00% |
| `Scene/StageSceneStateBreakCageShine` | `(anonymous namespace)::StageSceneStateBreakCageShineNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->