### PR TITLE
MapObj: Implement `PlayerSubjectiveWatchCheckObj`

### DIFF
--- a/src/MapObj/PlayerSubjectiveWatchCheckObj.cpp
+++ b/src/MapObj/PlayerSubjectiveWatchCheckObj.cpp
@@ -1,0 +1,113 @@
+#include "MapObj/PlayerSubjectiveWatchCheckObj.h"
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Screen/ScreenFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_ACTION_IMPL(PlayerSubjectiveWatchCheckObj, NotSubjective)
+NERVE_ACTION_IMPL(PlayerSubjectiveWatchCheckObj, In)
+NERVE_ACTION_IMPL(PlayerSubjectiveWatchCheckObj, Out)
+NERVE_ACTIONS_MAKE_STRUCT(PlayerSubjectiveWatchCheckObj, NotSubjective, In, Out)
+
+bool isInWatchScreenRange(const al::LiveActor* actor) {
+    sead::Vector3f layoutPos = {0.0f, 0.0f, 0.0f};
+    const al::IUseCamera* camera = actor;
+    const sead::Vector3f& trans = al::getTrans(actor);
+    al::calcLayoutPosFromWorldPosWithClampOutRange(&layoutPos, camera, trans, 50.0f, 0);
+
+    if (layoutPos.z > 0.0f)
+        return false;
+
+    const f32 posX = layoutPos.x;
+    const f32 minX = 320.0f - al::getDisplayWidth() * 0.5f;
+    const f32 maxX = al::getDisplayWidth() * 0.5f + -320.0f;
+    if (!al::isInRange(posX, minX, maxX))
+        return false;
+
+    const f32 posY = layoutPos.y;
+    const f32 minY = 180.0f - al::getDisplayHeight() * 0.5f;
+    const f32 maxY = al::getDisplayHeight() * 0.5f + -180.0f;
+    return al::isInRange(posY, minY, maxY);
+}
+}  // namespace
+
+PlayerSubjectiveWatchCheckObj::PlayerSubjectiveWatchCheckObj(const char* name)
+    : al::LiveActor(name) {}
+
+void PlayerSubjectiveWatchCheckObj::init(const al::ActorInitInfo& info) {
+    al::initNerveAction(this, "NotSubjective", &NrvPlayerSubjectiveWatchCheckObj.collector, 0);
+    al::initActor(this, info);
+    al::trySyncStageSwitchAppearAndKill(this);
+}
+
+void PlayerSubjectiveWatchCheckObj::control() {}
+
+void PlayerSubjectiveWatchCheckObj::appear() {
+    al::LiveActor::appear();
+    if (!al::isNerve(this, NrvPlayerSubjectiveWatchCheckObj.In.data()))
+        return;
+
+    if (rs::isPlayerCameraSubjective(this))
+        al::startNerveAction(this, "Out");
+    else
+        al::startNerveAction(this, "NotSubjective");
+}
+
+void PlayerSubjectiveWatchCheckObj::kill() {
+    al::LiveActor::kill();
+}
+
+void PlayerSubjectiveWatchCheckObj::endClipped() {
+    al::LiveActor::endClipped();
+    if (!al::isNerve(this, NrvPlayerSubjectiveWatchCheckObj.In.data()))
+        return;
+
+    if (rs::isPlayerCameraSubjective(this))
+        al::startNerveAction(this, "Out");
+    else
+        al::startNerveAction(this, "NotSubjective");
+}
+
+void PlayerSubjectiveWatchCheckObj::exeNotSubjective() {
+    if (rs::isPlayerCameraSubjective(this))
+        al::startNerveAction(this, "Out");
+}
+
+void PlayerSubjectiveWatchCheckObj::exeIn() {
+    if (!isInWatchScreenRange(this)) {
+        al::startNerveAction(this, "Out");
+        return;
+    }
+
+    if (!rs::isPlayerCameraSubjective(this)) {
+        al::startNerveAction(this, "NotSubjective");
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 120)) {
+        al::tryOnStageSwitch(this, "SwitchWatchOn");
+        al::startHitReaction(this, "スイッチオン");
+        kill();
+    }
+}
+
+void PlayerSubjectiveWatchCheckObj::exeOut() {
+    if (isInWatchScreenRange(this)) {
+        al::startNerveAction(this, "In");
+        return;
+    }
+
+    if (!rs::isPlayerCameraSubjective(this))
+        al::startNerveAction(this, "NotSubjective");
+}

--- a/src/MapObj/PlayerSubjectiveWatchCheckObj.h
+++ b/src/MapObj/PlayerSubjectiveWatchCheckObj.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class PlayerSubjectiveWatchCheckObj : public al::LiveActor {
+public:
+    PlayerSubjectiveWatchCheckObj(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void control() override;
+    void appear() override;
+    void kill() override;
+    void endClipped() override;
+    void exeNotSubjective();
+    void exeIn();
+    void exeOut();
+};
+
+static_assert(sizeof(PlayerSubjectiveWatchCheckObj) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -104,6 +104,7 @@
 #include "MapObj/MoviePlayerMapParts.h"
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PlayerMotionObserver.h"
+#include "MapObj/PlayerSubjectiveWatchCheckObj.h"
 #include "MapObj/PoleGrabCeil.h"
 #include "MapObj/QuestObj.h"
 #include "MapObj/ReactionMapParts.h"
@@ -478,7 +479,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"PillarSwitchOpenMapParts", nullptr},
     {"PlayerMotionObserver", al::createActorFunction<PlayerMotionObserver>},
     {"PlayerStartObj", nullptr},
-    {"PlayerSubjectiveWatchCheckObj", nullptr},
+    {"PlayerSubjectiveWatchCheckObj", al::createActorFunction<PlayerSubjectiveWatchCheckObj>},
     {"PlayGuideBoard", nullptr},
     {"PlayRecorder", nullptr},
     {"PlayerStartObjNoLink", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1174)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 5ba1447)

📈 **Matched code**: 14.67% (+0.01%, +1356 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::isInWatchScreenRange(al::LiveActor const*)` | +264 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::exeIn()` | +156 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::PlayerSubjectiveWatchCheckObj(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::PlayerSubjectiveWatchCheckObj(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::appear()` | +104 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::endClipped()` | +104 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvOut::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::exeOut()` | +84 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::init(al::ActorInitInfo const&)` | +76 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvNotSubjective::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::exeNotSubjective()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<PlayerSubjectiveWatchCheckObj>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvNotSubjective::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvIn::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvOut::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `(anonymous namespace)::PlayerSubjectiveWatchCheckObjNrvIn::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::control()` | +4 | 0.00% | 100.00% |
| `MapObj/PlayerSubjectiveWatchCheckObj` | `PlayerSubjectiveWatchCheckObj::kill()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->