### PR TITLE
MapObj: Implement `EchoEmitter`

### DIFF
--- a/src/MapObj/EchoEmitter.cpp
+++ b/src/MapObj/EchoEmitter.cpp
@@ -1,0 +1,94 @@
+#include "MapObj/EchoEmitter.h"
+
+#include <cmath>
+
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+NERVE_IMPL(EchoEmitter, Wait)
+NERVE_IMPL(EchoEmitter, Keep)
+NERVE_IMPL(EchoEmitter, Stop)
+NERVES_MAKE_NOSTRUCT(EchoEmitter, Wait, Keep, Stop)
+}  // namespace
+
+EchoEmitter::EchoEmitter(const char* name) : al::LiveActor(name) {}
+
+void EchoEmitter::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorUpdate(this, info, "敵[Movement]");
+    al::initActorPoseTQSV(this);
+    al::initActorClipping(this, info);
+    al::invalidateClipping(this);
+    al::initNerve(this, &Wait, 0);
+    makeActorDead();
+}
+
+void EchoEmitter::start(const sead::Vector3f& trans, f32 radius, s32 life) {
+    al::resetPosition(this, trans);
+    al::setNerve(this, &Wait);
+
+    f32 halfRadius = radius * 0.5f;
+
+    mAlpha = 1.0f;
+    mLife = life;
+    mOffsetStart = 0.0f;
+    mOffsetEnd = 0.0f;
+    mRadiusStart = halfRadius;
+    mRadiusEnd = radius + radius;
+    mExpansionRate = 0.0f;
+    mRadius = halfRadius;
+    appear();
+}
+
+void EchoEmitter::startKeep(const sead::Vector3f& trans, f32 radius, s32 life) {
+    al::resetPosition(this, trans);
+    al::setNerve(this, &Keep);
+
+    mAlpha = 1.0f;
+    mLife = life;
+    mExpansionRate = 0.0f;
+    mKeepRadius = fmaxf(radius, 0.0f);
+    appear();
+}
+
+void EchoEmitter::exeWait() {
+    mExpansionRate = al::calcNerveEaseOutValue(this, mLife / 3, mOffsetStart, mOffsetEnd);
+    mRadius = al::calcNerveEaseOutValue(this, mLife / 3, mRadiusStart, mRadiusEnd);
+    mAlpha = al::calcNerveValue(this, mLife / 2, mLife, 1.0f, 0.0f);
+
+    if (al::isGreaterEqualStep(this, mLife)) {
+        al::setNerve(this, &Stop);
+        mRadius = 10.0f;
+        kill();
+    }
+}
+
+void EchoEmitter::exeKeep() {
+    mAlpha = al::calcNerveEaseInOutValue(this, mLife, 1.0f, 0.0f);
+    mRadius = al::lerpValue(mRadius, mKeepRadius, 0.1f);
+
+    if (al::isGreaterEqualStep(this, mLife)) {
+        al::setNerve(this, &Stop);
+        mRadius = 10.0f;
+        kill();
+    }
+}
+
+void EchoEmitter::exeStop() {
+    mExpansionRate = 0.0f;
+    mRadius = 10.0f;
+    mAlpha = 0.0f;
+}
+
+s32 EchoEmitter::getLife() const {
+    if (!al::isNerve(this, &Wait))
+        return 0;
+
+    return mLife - al::getNerveStep(this);
+}

--- a/src/MapObj/EchoEmitter.h
+++ b/src/MapObj/EchoEmitter.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVectorFwd.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class EchoEmitter : public al::LiveActor {
+public:
+    EchoEmitter(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void start(const sead::Vector3f& trans, f32 radius, s32 life);
+    void startKeep(const sead::Vector3f& trans, f32 radius, s32 life);
+    void exeWait();
+    void exeKeep();
+    void exeStop();
+    s32 getLife() const;
+
+private:
+    s32 mLife = 0;
+    f32 mExpansionRate = 0.0f;
+    f32 mRadius = 10.0f;
+    f32 mAlpha = 1.0f;
+    f32 mKeepRadius = 0.0f;
+    f32 mOffsetStart = -300.0f;
+    f32 mOffsetEnd = 600.0f;
+    f32 mRadiusStart = 300.0f;
+    f32 mRadiusEnd = 300.0f;
+};
+
+static_assert(sizeof(EchoEmitter) == 0x130);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1175)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 163b08d)

📈 **Matched code**: 14.67% (+0.01%, +1320 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/EchoEmitter` | `EchoEmitter::exeWait()` | +212 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::EchoEmitter(char const*)` | +192 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::EchoEmitter(char const*)` | +180 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `(anonymous namespace)::EchoEmitterNrvKeep::execute(al::NerveKeeper*) const` | +140 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::exeKeep()` | +136 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::start(sead::Vector3<float> const&, float, int)` | +124 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::init(al::ActorInitInfo const&)` | +116 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::startKeep(sead::Vector3<float> const&, float, int)` | +104 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::getLife() const` | +68 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `EchoEmitter::exeStop()` | +20 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `(anonymous namespace)::EchoEmitterNrvStop::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `MapObj/EchoEmitter` | `(anonymous namespace)::EchoEmitterNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->