### PR TITLE
MapObj: Implement `RouteGuideRailArrow`

### DIFF
--- a/src/MapObj/RouteGuideArrowBase.h
+++ b/src/MapObj/RouteGuideArrowBase.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+class RouteGuideArrowBase {
+public:
+    virtual const sead::Vector3f& getGuideTrans() const = 0;
+
+    virtual void setGuideAlpha(f32 alpha) {}
+
+    virtual void validateGuide() { mIsValidateGuide = true; }
+
+    virtual void invalidateGuide() { mIsValidateGuide = false; }
+
+    virtual bool isValidateGuide() const { return mIsValidateGuide; }
+
+private:
+    bool mIsValidateGuide = true;
+};
+
+static_assert(sizeof(RouteGuideArrowBase) == 0x10);

--- a/src/MapObj/RouteGuideRailArrow.cpp
+++ b/src/MapObj/RouteGuideRailArrow.cpp
@@ -1,0 +1,88 @@
+#include "MapObj/RouteGuideRailArrow.h"
+
+#include "Library/Collision/PartsConnector.h"
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/ActorDimensionUtil.h"
+
+RouteGuideRailArrow::RouteGuideRailArrow(const char* name) : al::LiveActor(name) {
+    mCollisionPartsConnector = new al::CollisionPartsConnector();
+}
+
+void RouteGuideRailArrow::makeActorAlive() {
+    if (isValidateGuide()) {
+        al::LiveActor::makeActorAlive();
+        al::connectPoseQT(this, mCollisionPartsConnector);
+    }
+}
+
+void RouteGuideRailArrow::makeActorDead() {
+    al::LiveActor::makeActorDead();
+}
+
+void RouteGuideRailArrow::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+    al::tryGetArg(&mDisplayOffsetY, info, "DisplayOffsetY");
+    al::initJointControllerKeeper(this, 1);
+    al::initJointLocalTransControllerY(this, &mDisplayOffsetY, "KidsGuide3DArrow");
+    mDimensionKeeper = rs::createDimensionKeeper(this);
+    rs::updateDimensionKeeper(mDimensionKeeper);
+
+    if (rs::isIn2DArea(this))
+        rs::snap2DUp(this, this, 500.0f);
+
+    if (isValidateGuide())
+        al::LiveActor::makeActorAlive();
+    else
+        al::LiveActor::makeActorDead();
+}
+
+void RouteGuideRailArrow::control() {
+    if (mCollisionPartsConnector->isConnectInvalidCollision() && al::isAlive(this))
+        makeActorDead();
+
+    if (mCollisionPartsConnector->isMoved())
+        al::connectPoseQT(this, mCollisionPartsConnector);
+}
+
+const sead::Vector3f& RouteGuideRailArrow::getGuideTrans() const {
+    return al::getTrans(this);
+}
+
+void RouteGuideRailArrow::setGuideAlpha(f32 alpha) {
+    if (mCollisionPartsConnector->isConnectInvalidCollision())
+        return;
+
+    if (0.0f >= alpha) {
+        if (al::isAlive(this))
+            makeActorDead();
+        return;
+    }
+
+    if (al::isDead(this))
+        makeActorAlive();
+    al::setModelAlphaMask(this, alpha);
+}
+
+void RouteGuideRailArrow::invalidateGuide() {
+    if (al::isAlive(this))
+        makeActorDead();
+
+    RouteGuideArrowBase::invalidateGuide();
+}
+
+void RouteGuideRailArrow::attach(const al::CollisionParts* collisionParts) {
+    al::attachCollisionPartsConnector(mCollisionPartsConnector, collisionParts);
+}
+
+void RouteGuideRailArrow::setBaseQuatTrans() {
+    const sead::Quatf& quat = al::getQuat(this);
+    const sead::Vector3f& trans = al::getTrans(this);
+    al::setConnectorBaseQuatTrans(quat, trans, mCollisionPartsConnector);
+}

--- a/src/MapObj/RouteGuideRailArrow.h
+++ b/src/MapObj/RouteGuideRailArrow.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "MapObj/RouteGuideArrowBase.h"
+#include "Util/IUseDimension.h"
+
+class ActorDimensionKeeper;
+
+namespace al {
+struct ActorInitInfo;
+class CollisionParts;
+class CollisionPartsConnector;
+}  // namespace al
+
+class RouteGuideRailArrow : public al::LiveActor, public RouteGuideArrowBase, public IUseDimension {
+public:
+    RouteGuideRailArrow(const char* name);
+
+    void makeActorAlive() override;
+    void makeActorDead() override;
+    void init(const al::ActorInitInfo& info) override;
+    void control() override;
+    const sead::Vector3f& getGuideTrans() const override;
+    void setGuideAlpha(f32 alpha) override;
+    void invalidateGuide() override;
+
+    void attach(const al::CollisionParts* collisionParts);
+    void setBaseQuatTrans();
+
+    ActorDimensionKeeper* getActorDimensionKeeper() const override { return mDimensionKeeper; }
+
+private:
+    al::CollisionPartsConnector* mCollisionPartsConnector = nullptr;
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    f32 mDisplayOffsetY = 0.0f;
+};
+
+static_assert(sizeof(RouteGuideRailArrow) == 0x138);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1176)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 128a9a3)

📈 **Matched code**: 14.67% (+0.01%, +1348 bytes)

<details>
<summary>✅ 20 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::RouteGuideRailArrow(char const*)` | +204 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::init(al::ActorInitInfo const&)` | +200 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::RouteGuideRailArrow(char const*)` | +184 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `non-virtual thunk to RouteGuideRailArrow::setGuideAlpha(float)` | +152 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::setGuideAlpha(float)` | +148 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::control()` | +108 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::makeActorAlive()` | +76 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `non-virtual thunk to RouteGuideRailArrow::invalidateGuide()` | +60 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::invalidateGuide()` | +56 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::setBaseQuatTrans()` | +56 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `non-virtual thunk to RouteGuideRailArrow::getGuideTrans() const` | +24 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::getGuideTrans() const` | +20 | 0.00% | 100.00% |
| `MapObj/RouteGuideArrow` | `RouteGuideArrowBase::validateGuide()` | +12 | 0.00% | 100.00% |
| `MapObj/RouteGuideArrow` | `RouteGuideArrowBase::invalidateGuide()` | +8 | 0.00% | 100.00% |
| `MapObj/RouteGuideArrow` | `RouteGuideArrowBase::isValidateGuide() const` | +8 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::attach(al::CollisionParts const*)` | +8 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `non-virtual thunk to RouteGuideRailArrow::getActorDimensionKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/RouteGuideArrow` | `RouteGuideArrowBase::setGuideAlpha(float)` | +4 | 0.00% | 100.00% |
| `MapObj/RouteGuideRailArrow` | `RouteGuideRailArrow::makeActorDead()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->