### PR TITLE
MapObj: Implement `RiseMapPartsOld`

### DIFF
--- a/src/MapObj/RiseMapPartsOld.cpp
+++ b/src/MapObj/RiseMapPartsOld.cpp
@@ -1,0 +1,99 @@
+#include "MapObj/RiseMapPartsOld.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Camera/CameraUtil.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+NERVE_IMPL(RiseMapPartsOld, Wait);
+NERVE_IMPL(RiseMapPartsOld, Stop);
+NERVE_IMPL(RiseMapPartsOld, Move);
+
+NERVES_MAKE_NOSTRUCT(RiseMapPartsOld, Wait, Stop, Move);
+}  // namespace
+
+RiseMapPartsOld::RiseMapPartsOld(const char* name) : al::LiveActor(name) {}
+
+void RiseMapPartsOld::init(const al::ActorInitInfo& info) {
+    using RiseMapPartsOldFunctor = al::FunctorV0M<RiseMapPartsOld*, void (RiseMapPartsOld::*)()>;
+
+    al::initMapPartsActor(this, info, nullptr);
+    al::initActorSeKeeper(this, info, "SuccessSeObj");
+    al::initNerve(this, &Wait, 0);
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    bool isStageSwitchListening = al::listenStageSwitchOnStart(
+        this, RiseMapPartsOldFunctor(this, &RiseMapPartsOld::startRise));
+    mPlacementId = al::createPlacementId(info);
+    mMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+    if (!isStageSwitchListening)
+        makeActorDead();
+
+    bool isValidObjectCamera = false;
+    al::tryGetArg(&isValidObjectCamera, info, "IsValidObjectCamera");
+    if (isValidObjectCamera)
+        mObjectCamera = al::initObjectCamera(this, info, nullptr, "固定");
+
+    makeActorAlive();
+}
+
+void RiseMapPartsOld::startRise() {
+    if (al::isDead(this))
+        appear();
+
+    const al::Nerve* stopNerve = &Stop;
+    const al::Nerve* moveNerve = &Move;
+    if (al::isNerve(this, stopNerve) || al::isNerve(this, moveNerve))
+        return;
+
+    if (mObjectCamera) {
+        al::startCamera(this, mObjectCamera, -1);
+        al::startSe(this, "Riddle");
+    }
+
+    al::invalidateClipping(this);
+    al::setNerve(this, moveNerve);
+}
+
+void RiseMapPartsOld::initAfterPlacement() {
+    if (al::isNerve(this, &Stop))
+        al::tryOnStageSwitch(this, "SwitchStopOn");
+}
+
+void RiseMapPartsOld::exeWait() {}
+
+void RiseMapPartsOld::exeMove() {
+    if (al::isGreaterEqualStep(this, mMoveTime)) {
+        if (mObjectCamera)
+            al::endCamera(this, mObjectCamera, -1, false);
+
+        al::setNerve(this, &Stop);
+        return;
+    }
+
+    sead::Vector3f trans = sead::Vector3f::zero;
+    const al::KeyPoseKeeper* keyPoseKeeper = mKeyPoseKeeper;
+    f32 rate = al::calcNerveRate(this, mMoveTime);
+    al::calcLerpKeyTrans(&trans, keyPoseKeeper, rate);
+    al::setTrans(this, trans);
+}
+
+void RiseMapPartsOld::exeStop() {
+    if (al::isFirstStep(this)) {
+        al::resetPosition(this, al::getNextKeyTrans(mKeyPoseKeeper));
+        al::validateClipping(this);
+        al::tryOnStageSwitch(this, "SwitchStopOn");
+    }
+}

--- a/src/MapObj/RiseMapPartsOld.cpp
+++ b/src/MapObj/RiseMapPartsOld.cpp
@@ -53,18 +53,16 @@ void RiseMapPartsOld::startRise() {
     if (al::isDead(this))
         appear();
 
-    const al::Nerve* stopNerve = &Stop;
-    const al::Nerve* moveNerve = &Move;
-    if (al::isNerve(this, stopNerve) || al::isNerve(this, moveNerve))
+    if (al::isNerve(this, &Stop) || al::isNerve(this, &Move))
         return;
 
     if (mObjectCamera) {
-        al::startCamera(this, mObjectCamera, -1);
+        al::startCamera(this, mObjectCamera);
         al::startSe(this, "Riddle");
     }
 
     al::invalidateClipping(this);
-    al::setNerve(this, moveNerve);
+    al::setNerve(this, &Move);
 }
 
 void RiseMapPartsOld::initAfterPlacement() {
@@ -84,9 +82,7 @@ void RiseMapPartsOld::exeMove() {
     }
 
     sead::Vector3f trans = sead::Vector3f::zero;
-    const al::KeyPoseKeeper* keyPoseKeeper = mKeyPoseKeeper;
-    f32 rate = al::calcNerveRate(this, mMoveTime);
-    al::calcLerpKeyTrans(&trans, keyPoseKeeper, rate);
+    al::calcLerpKeyTrans(&trans, mKeyPoseKeeper, al::calcNerveRate(this, mMoveTime));
     al::setTrans(this, trans);
 }
 

--- a/src/MapObj/RiseMapPartsOld.h
+++ b/src/MapObj/RiseMapPartsOld.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class CameraTicket;
+class KeyPoseKeeper;
+class PlacementId;
+}  // namespace al
+
+class RiseMapPartsOld : public al::LiveActor {
+public:
+    RiseMapPartsOld(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void startRise();
+    void initAfterPlacement() override;
+    void exeWait();
+    void exeMove();
+    void exeStop();
+
+private:
+    al::KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    al::PlacementId* mPlacementId = nullptr;
+    s32 mMoveTime = 0;
+    al::CameraTicket* mObjectCamera = nullptr;
+};
+
+static_assert(sizeof(RiseMapPartsOld) == 0x128);

--- a/src/MapObj/RiseMapPartsOld.h
+++ b/src/MapObj/RiseMapPartsOld.h
@@ -27,5 +27,3 @@ private:
     s32 mMoveTime = 0;
     al::CameraTicket* mObjectCamera = nullptr;
 };
-
-static_assert(sizeof(RiseMapPartsOld) == 0x128);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1177)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - e5d21dc)

📈 **Matched code**: 15.50% (+0.01%, +1268 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::init(al::ActorInitInfo const&)` | +276 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::startRise()` | +180 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::exeMove()` | +164 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::RiseMapPartsOld(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::RiseMapPartsOld(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `(anonymous namespace)::RiseMapPartsOldNrvStop::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::exeStop()` | +88 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `al::FunctorV0M<RiseMapPartsOld*, void (RiseMapPartsOld::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::initAfterPlacement()` | +68 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `al::FunctorV0M<RiseMapPartsOld*, void (RiseMapPartsOld::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `(anonymous namespace)::RiseMapPartsOldNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `RiseMapPartsOld::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `(anonymous namespace)::RiseMapPartsOldNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/RiseMapPartsOld` | `al::FunctorV0M<RiseMapPartsOld*, void (RiseMapPartsOld::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->