### PR TITLE
MapObj: Implement `ShopCamera`

### DIFF
--- a/src/MapObj/ShopCamera.cpp
+++ b/src/MapObj/ShopCamera.cpp
@@ -1,0 +1,78 @@
+#include "MapObj/ShopCamera.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Camera/CameraUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+struct ShopCameraParam {
+    ShopCameraParam() : cameraPos(sead::Vector3f::zero) {
+        cameraAt.x = 0.0f;
+        cameraAt.y = 0.01f;
+        cameraAt.z = 1.0f;
+    }
+
+    sead::Vector3f cameraAt;
+    sead::Vector3f cameraPos;
+};
+
+ShopCameraParam sCameraParam;
+
+NERVE_IMPL(ShopCamera, None);
+NERVE_IMPL(ShopCamera, Appear);
+NERVE_IMPL(ShopCamera, Wait);
+NERVE_IMPL(ShopCamera, End);
+
+NERVES_MAKE_NOSTRUCT(ShopCamera, None, Appear, Wait, End);
+}  // namespace
+
+ShopCamera::ShopCamera(const al::LiveActor* actor)
+    : mActor(actor), mCameraPos(sCameraParam.cameraPos), mCameraAt(sCameraParam.cameraAt) {
+    mNerveKeeper = new al::NerveKeeper(this, &None, 0);
+    mCameraTicket = al::initProgramableCamera(mActor, "ショップ内のライト方向統一用カメラ",
+                                              &mCameraPos, &mCameraAt, nullptr);
+}
+
+void ShopCamera::execute() {
+    getNerveKeeper()->update();
+}
+
+void ShopCamera::tryStart() {
+    if (al::isNerve(this, &None)) {
+        mCameraPos.set(sCameraParam.cameraPos);
+        mCameraAt.set(sCameraParam.cameraAt);
+        mStartCameraPos = al::getCameraPos(mActor, 0);
+        mStartCameraAt = al::getCameraAt(mActor, 0);
+        al::setNerve(this, &Appear);
+    }
+}
+
+void ShopCamera::tryEnd() {
+    if (al::isNerve(this, &Wait)) {
+        mCameraPos.set(mStartCameraPos);
+        mCameraAt.set(mStartCameraAt);
+        al::setNerve(this, &End);
+    }
+}
+
+void ShopCamera::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startCamera(mActor, mCameraTicket, 0);
+
+    al::setNerve(this, &Wait);
+}
+
+void ShopCamera::exeWait() {}
+
+void ShopCamera::exeEnd() {
+    if (al::isStep(this, 1)) {
+        al::endCamera(mActor, mCameraTicket, 0, false);
+        al::setNerve(this, &None);
+    }
+}
+
+void ShopCamera::exeNone() {}

--- a/src/MapObj/ShopCamera.h
+++ b/src/MapObj/ShopCamera.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Execute/IUseExecutor.h"
+#include "Library/Nerve/IUseNerve.h"
+
+namespace al {
+class CameraTicket;
+class LiveActor;
+class NerveKeeper;
+}  // namespace al
+
+class ShopCamera : public al::IUseExecutor, public al::IUseNerve {
+public:
+    ShopCamera(const al::LiveActor* actor);
+
+    void execute() override;
+
+    al::NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
+
+    void tryStart();
+    void tryEnd();
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void exeNone();
+
+private:
+    const al::LiveActor* mActor = nullptr;
+    al::CameraTicket* mCameraTicket = nullptr;
+    sead::Vector3f mCameraPos;
+    sead::Vector3f mCameraAt;
+    sead::Vector3f mStartCameraPos = sead::Vector3f::zero;
+    sead::Vector3f mStartCameraAt = sead::Vector3f::zero;
+    al::NerveKeeper* mNerveKeeper = nullptr;
+};
+
+static_assert(sizeof(ShopCamera) == 0x58);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1179)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 6c5f947)

📈 **Matched code**: 14.67% (+0.01%, +1088 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ShopCamera` | `ShopCamera::ShopCamera(al::LiveActor const*)` | +236 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::tryStart()` | +224 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::tryEnd()` | +120 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `(anonymous namespace)::ShopCameraNrvEnd::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::exeEnd()` | +100 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `(anonymous namespace)::ShopCameraNrvAppear::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::exeAppear()` | +84 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `_GLOBAL__sub_I_ShopCamera.cpp` | +56 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::execute()` | +28 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::getNerveKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `non-virtual thunk to ShopCamera::getNerveKeeper() const` | +8 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `ShopCamera::exeNone()` | +4 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `(anonymous namespace)::ShopCameraNrvNone::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/ShopCamera` | `(anonymous namespace)::ShopCameraNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->