### PR TITLE
MapObj: Implement `ElectricWirePole`

### DIFF
--- a/src/MapObj/ElectricWire/CollisionPartsFilterMultiActor.h
+++ b/src/MapObj/ElectricWire/CollisionPartsFilterMultiActor.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Collision/CollisionParts.h"
+#include "Library/Collision/KCollisionServer.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+
+namespace {
+
+class CollisionPartsFilterMultiActor : public al::CollisionPartsFilterBase {
+public:
+    CollisionPartsFilterMultiActor(const al::LiveActor* actor, const al::LiveActor* actorBase,
+                                   const al::LiveActor* actorExtra)
+        : mActor(actor), mActorBase(actorBase), mActorExtra(actorExtra) {}
+
+    bool isInvalidParts(al::CollisionParts* collisionParts) override {
+        al::HitSensor* sensor = collisionParts->getConnectedSensor();
+        if (!sensor)
+            return false;
+
+        al::LiveActor* host = al::getSensorHost(sensor);
+        if (mActor && host == mActor)
+            return true;
+        if (mActorBase && host == mActorBase)
+            return true;
+        return mActorExtra && host == mActorExtra;
+    }
+
+private:
+    const al::LiveActor* mActor;
+    const al::LiveActor* mActorBase;
+    const al::LiveActor* mActorExtra;
+};
+
+}  // namespace

--- a/src/MapObj/ElectricWire/ElectricWirePole.cpp
+++ b/src/MapObj/ElectricWire/ElectricWirePole.cpp
@@ -1,0 +1,65 @@
+#include "MapObj/ElectricWire/ElectricWirePole.h"
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+
+#include "MapObj/ElectricWire/CollisionPartsFilterMultiActor.h"
+
+ElectricWirePole::ElectricWirePole(const char* name) : al::LiveActor(name) {}
+
+void ElectricWirePole::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "ElectricWirePole", nullptr);
+    makeActorAlive();
+
+    mBaseActor = new al::LiveActor("");
+    al::initActorWithArchiveName(mBaseActor, info, "ElectricWirePoleBase", nullptr);
+    mBaseActor->makeActorAlive();
+    mBaseActor->getName();
+}
+
+bool ElectricWirePole::isExistSelfCollisionBeneath(sead::Vector3f* out, const al::LiveActor* actor,
+                                                   const sead::Vector3f& pos, f32 startOffset,
+                                                   f32 length) {
+    sead::Vector3f up;
+    al::calcUpDir(&up, actor);
+    CollisionPartsFilterMultiActor filter(this, mBaseActor, nullptr);
+    const al::IUseCollision* collisionActor = actor;
+
+    sead::Vector3f start = up * startOffset + pos;
+    sead::Vector3f dir = -(up * length);
+
+    return alCollisionUtil::getFirstPolyOnArrow(collisionActor, out, nullptr, start, dir, &filter,
+                                                nullptr);
+}
+
+void ElectricWirePole::initAfterPlacement() {
+    al::copyPose(mBaseActor, this);
+    const sead::Vector3f& trans = al::getTrans(this);
+
+    sead::Vector3f up;
+    al::calcUpDir(&up, this);
+    CollisionPartsFilterMultiActor filter(this, mBaseActor, nullptr);
+    const al::LiveActor* collisionActorBase = this;
+    const al::IUseCollision* collisionActor = collisionActorBase;
+
+    sead::Vector3f start = trans - up * 150.0f;
+
+    sead::Vector3f dir = -(up * 1000.0f);
+
+    sead::Vector3f hitPos;
+    if (alCollisionUtil::getFirstPolyOnArrow(collisionActor, &hitPos, nullptr, start, dir, &filter,
+                                             nullptr))
+        al::resetPosition(mBaseActor, hitPos);
+}
+
+void ElectricWirePole::kill() {
+    al::LiveActor::kill();
+    mBaseActor->kill();
+}
+
+void ElectricWirePole::appear() {
+    al::LiveActor::appear();
+    mBaseActor->appear();
+}

--- a/src/MapObj/ElectricWire/ElectricWirePole.h
+++ b/src/MapObj/ElectricWire/ElectricWirePole.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class ElectricWirePole : public al::LiveActor {
+public:
+    ElectricWirePole(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool isExistSelfCollisionBeneath(sead::Vector3f* out, const al::LiveActor* actor,
+                                     const sead::Vector3f& pos, f32 startOffset, f32 length);
+    void initAfterPlacement() override;
+    void kill() override;
+    void appear() override;
+
+private:
+    al::LiveActor* mBaseActor = nullptr;
+};
+
+static_assert(sizeof(ElectricWirePole) == 0x110);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1181)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - b83f50c)

📈 **Matched code**: 14.67% (+0.01%, +1112 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ElectricWirePole` | `ElectricWirePole::initAfterPlacement()` | +240 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::isExistSelfCollisionBeneath(sead::Vector3<float>*, al::LiveActor const*, sead::Vector3<float> const&, float, float)` | +220 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::init(al::ActorInitInfo const&)` | +192 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::ElectricWirePole(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::ElectricWirePole(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `(anonymous namespace)::CollisionPartsFilterMultiActor::isInvalidParts(al::CollisionParts*)` | +112 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::kill()` | +44 | 0.00% | 100.00% |
| `MapObj/ElectricWirePole` | `ElectricWirePole::appear()` | +44 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->