### PR TITLE
Scene: Implement `InformationWindowObjectRequester`

### DIFF
--- a/src/Scene/InformationWindowFunction.h
+++ b/src/Scene/InformationWindowFunction.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "Library/Base/StringUtil.h"
+
+namespace InformationWindowFunction {
+bool isExistMovieFile(const char* name);
+al::StringTmp<64> getMovieFilePath(const char* name);
+}  // namespace InformationWindowFunction

--- a/src/Scene/InformationWindowObjectRequester.cpp
+++ b/src/Scene/InformationWindowObjectRequester.cpp
@@ -1,0 +1,82 @@
+#include "Scene/InformationWindowObjectRequester.h"
+
+#include "Library/Nerve/NerveKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+
+#include "Scene/InformationWindowFunction.h"
+#include "Scene/InformationWindowRequestHolder.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(InformationWindowObjectRequester, Show);
+NERVE_IMPL(InformationWindowObjectRequester, Hide);
+
+NERVES_MAKE_NOSTRUCT(InformationWindowObjectRequester, Show, Hide);
+}  // namespace
+
+InformationWindowObjectRequester::InformationWindowObjectRequester(
+    InformationWindowRequestHolder* requestHolder, InformationWindowStateHolder* stateHolder,
+    const al::PlayerHolder* playerHolder)
+    : InformationWindowRequester(requestHolder, stateHolder, playerHolder) {
+    mNerveKeeper = new al::NerveKeeper(this, &Show, 0);
+}
+
+void InformationWindowObjectRequester::update() {
+    getNerveKeeper()->update();
+}
+
+void InformationWindowObjectRequester::requestAppearObject(
+    const al::IUseSceneObjHolder* sceneObjHolder, const char* name) {
+    const al::LiveActor* player = al::getPlayerActor(mPlayerHolder, 0);
+
+    TutorialInfo info;
+    info.type = TutorialType_Object;
+    info.hasMovieFile = InformationWindowFunction::isExistMovieFile(name);
+    info.name.format("%s", name);
+    info.sceneObjHolder = sceneObjHolder;
+    info.requester = this;
+    info.isAutoShow = true;
+    volatile u8* updateTextFlag = &info.updateTextFlag;
+    *updateTextFlag = 0;
+
+    if (rs::isPlayerHack(player) || rs::isPlayerBinding(player))
+        info.isHide = true;
+
+    requestAppear(info);
+}
+
+void InformationWindowObjectRequester::requestCloseObject(
+    const al::IUseSceneObjHolder* sceneObjHolder, const char* name) {
+    TutorialInfo info;
+    info.type = TutorialType_Object;
+    info.hasMovieFile = InformationWindowFunction::isExistMovieFile(name);
+    info.name.format("%s", name);
+    info.isAutoShow = true;
+    info.sceneObjHolder = sceneObjHolder;
+    info.requester = this;
+    volatile u8* updateTextFlag = &info.updateTextFlag;
+    *updateTextFlag = 0;
+
+    requestCancel(info);
+}
+
+void InformationWindowObjectRequester::exeShow() {
+    const al::LiveActor* player = al::getPlayerActor(mPlayerHolder, 0);
+
+    if (rs::isPlayerHack(player) || rs::isPlayerBinding(player)) {
+        mRequestHolder->hide(TutorialType_Object);
+        al::setNerve(this, &Hide);
+    }
+}
+
+void InformationWindowObjectRequester::exeHide() {
+    const al::LiveActor* player = al::getPlayerActor(mPlayerHolder, 0);
+
+    if (rs::isPlayerHack(player) || rs::isPlayerBinding(player))
+        return;
+
+    mRequestHolder->show(TutorialType_Object);
+    al::setNerve(this, &Show);
+}

--- a/src/Scene/InformationWindowObjectRequester.h
+++ b/src/Scene/InformationWindowObjectRequester.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include "Library/Nerve/IUseNerve.h"
+
+#include "Scene/InformationWindowRequester.h"
+
+namespace al {
+class IUseSceneObjHolder;
+class NerveKeeper;
+class PlayerHolder;
+}  // namespace al
+
+class InformationWindowObjectRequester : public InformationWindowRequester, public al::IUseNerve {
+public:
+    InformationWindowObjectRequester(InformationWindowRequestHolder* requestHolder,
+                                     InformationWindowStateHolder* stateHolder,
+                                     const al::PlayerHolder* playerHolder);
+
+    void update();
+    void requestAppearObject(const al::IUseSceneObjHolder* sceneObjHolder, const char* name);
+    void requestCloseObject(const al::IUseSceneObjHolder* sceneObjHolder, const char* name);
+    void exeShow();
+    void exeHide();
+
+    al::NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
+
+private:
+    al::NerveKeeper* mNerveKeeper = nullptr;
+};
+
+static_assert(sizeof(InformationWindowObjectRequester) == 0x30);

--- a/src/Scene/InformationWindowRequestHolder.h
+++ b/src/Scene/InformationWindowRequestHolder.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+#include "Scene/InformationWindowTutorialInfo.h"
+
+class InformationWindowRequestHolder {
+public:
+    InformationWindowRequestHolder();
+
+    void requestAppear(const TutorialInfo& info);
+    void requestCancel(const TutorialInfo& info);
+    void requestChangeText(const TutorialInfo& info);
+    void requestAppearMovie(const TutorialInfo& info);
+    void requestKillMovie(const TutorialInfo& info);
+    void requestAppearSystem();
+    void requestCloseSystem();
+    void reflesh(const TutorialInfo* info);
+    TutorialInfo* tryFindHighPriorityInfo(s32* index);
+    TutorialInfo* tryFindInfo(TutorialType type);
+    void show(TutorialType type);
+    void hide(TutorialType type);
+    void cancel(const TutorialInfo* info);
+    void invalidate(TutorialType type);
+    void endStart(const TutorialInfo* info);
+    void done(const TutorialInfo* info);
+    void killNotRetry();
+    void killCanceled();
+    bool isExist(TutorialType type, const char* name) const;
+    bool isExist(const TutorialInfo& info) const;
+    s32 calcCount() const;
+
+private:
+    sead::PtrArray<TutorialInfo> mInfos;
+    bool mIsEnabled = true;
+};
+
+static_assert(sizeof(InformationWindowRequestHolder) == 0x18);

--- a/src/Scene/InformationWindowRequester.h
+++ b/src/Scene/InformationWindowRequester.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Scene/InformationWindowTutorialInfo.h"
+
+namespace al {
+class PlayerHolder;
+}  // namespace al
+
+class InformationWindowLayout;
+class InformationWindowRequestHolder;
+class InformationWindowStateHolder;
+
+class InformationWindowRequester {
+public:
+    InformationWindowRequester(InformationWindowRequestHolder* requestHolder,
+                               InformationWindowStateHolder* stateHolder,
+                               const al::PlayerHolder* playerHolder);
+
+    virtual void accept(TutorialInfo* info);
+    virtual void endStart(const TutorialInfo* info);
+    virtual void done(const TutorialInfo* info);
+    virtual void cancel(const TutorialInfo* info);
+    virtual void retry(TutorialInfo* info);
+    virtual void setText(InformationWindowLayout* layout, const TutorialInfo* info);
+
+    void requestAppear(const TutorialInfo& info);
+    void requestAppearForce(const TutorialInfo& info);
+    void requestCancel(const TutorialInfo& info);
+    void requestShowSystem();
+    void requestHideSystem();
+
+protected:
+    InformationWindowRequestHolder* mRequestHolder = nullptr;
+    InformationWindowStateHolder* mStateHolder = nullptr;
+    const al::PlayerHolder* mPlayerHolder = nullptr;
+};
+
+static_assert(sizeof(InformationWindowRequester) == 0x20);

--- a/src/Scene/InformationWindowTutorialInfo.h
+++ b/src/Scene/InformationWindowTutorialInfo.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+namespace al {
+class IUseSceneObjHolder;
+}  // namespace al
+
+class InformationAreaData;
+class InformationWindowRequester;
+
+enum TutorialType {
+    TutorialType_Object = 14,
+    TutorialType_None = 19,
+};
+
+struct TutorialInfo {
+    const al::IUseSceneObjHolder* sceneObjHolder = nullptr;
+    InformationWindowRequester* requester = nullptr;
+    TutorialType type = TutorialType_None;
+    sead::FixedSafeString<128> name;
+    bool hasMovieFile = false;
+    bool isAutoShow = false;
+    u8 updateTextFlag = 1;
+    u8 _b3 = 0;
+    u8 _b4 = 0;
+    u8 _b5 = 0;
+    bool isRegistered = false;
+    bool isHide = false;
+    const char* textSuffix = nullptr;
+    InformationAreaData* areaData = nullptr;
+};
+
+static_assert(sizeof(TutorialInfo) == 0xc8);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1182)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 0111be1)

📈 **Matched code**: 14.67% (+0.01%, +1120 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::requestAppearObject(al::IUseSceneObjHolder const*, char const*)` | +300 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::requestCloseObject(al::IUseSceneObjHolder const*, char const*)` | +256 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `(anonymous namespace)::InformationWindowObjectRequesterNrvShow::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `(anonymous namespace)::InformationWindowObjectRequesterNrvHide::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::exeShow()` | +100 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::exeHide()` | +100 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::InformationWindowObjectRequester(InformationWindowRequestHolder*, InformationWindowStateHolder*, al::PlayerHolder const*)` | +96 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::update()` | +28 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `InformationWindowObjectRequester::getNerveKeeper() const` | +8 | 0.00% | 100.00% |
| `Scene/InformationWindowObjectRequester` | `non-virtual thunk to InformationWindowObjectRequester::getNerveKeeper() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->