### PR TITLE
Player: Implement `YoshiStateEgg`

### DIFF
--- a/src/Player/PlayerModelChangerYoshi.h
+++ b/src/Player/PlayerModelChangerYoshi.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+
+#include "Player/IPlayerModelChanger.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class PlayerModelHolder;
+
+class PlayerModelChangerYoshi : public al::HioNode, public IPlayerModelChanger {
+public:
+    PlayerModelChangerYoshi(const al::LiveActor* host, PlayerModelHolder* modelHolder);
+
+    bool isFireFlower() const override;
+    bool isMini() const override;
+    bool isChange() const override;
+    bool is2DModel() const override;
+    bool isHiddenModel() const override;
+    bool isHiddenShadowMask() const override;
+    void resetPosition() override;
+    void hideModel() override;
+    void hideSilhouette() override;
+    void hideShadowMask() override;
+    void showModel() override;
+    void showSilhouette() override;
+    void showShadowMask() override;
+
+    void syncHost();
+    void syncModelFlag(al::LiveActor* actor);
+    void appearModel();
+    void killModel();
+    void changeModel(al::LiveActor* actor);
+
+private:
+    const al::LiveActor* mHost = nullptr;
+    al::LiveActor* mModelActor = nullptr;
+    PlayerModelHolder* mModelHolder = nullptr;
+    u16 mModelFlags = 0;
+    bool mIsSilhouetteVisible = false;
+    u8 _23[0x35] = {};
+};
+
+static_assert(sizeof(PlayerModelChangerYoshi) == 0x58);

--- a/src/Player/YoshiEgg.h
+++ b/src/Player/YoshiEgg.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class IUsePlayerCollision;
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class YoshiEgg : public al::LiveActor {
+public:
+    YoshiEgg(const al::LiveActor* host, const IUsePlayerCollision* collision);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void initPlacementEgg();
+    void appearEgg();
+    bool isEndAppear() const;
+    bool isBreak() const;
+    void exeAppear();
+    void exeWait();
+    void exeBreak();
+
+private:
+    const al::LiveActor* mHost = nullptr;
+    const IUsePlayerCollision* mCollision = nullptr;
+    al::HitSensor* mBodySensor = nullptr;
+};
+
+static_assert(sizeof(YoshiEgg) == 0x120);

--- a/src/Player/YoshiStateEgg.cpp
+++ b/src/Player/YoshiStateEgg.cpp
@@ -1,0 +1,112 @@
+#include "Player/YoshiStateEgg.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nature/NatureUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerModelChangerYoshi.h"
+#include "Player/YoshiEgg.h"
+#include "Util/Hack.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+namespace {
+void updateEggMove(al::LiveActor* actor, const IUsePlayerCollision* collision,
+                   const PlayerConst* playerConst);
+
+NERVE_IMPL(YoshiStateEgg, Wait);
+NERVE_IMPL(YoshiStateEgg, Appear);
+
+NERVES_MAKE_NOSTRUCT(YoshiStateEgg, Wait, Appear);
+}  // namespace
+
+YoshiStateEgg::YoshiStateEgg(const al::ActorInitInfo& info, al::LiveActor* player,
+                             const IUsePlayerCollision* collision, const PlayerConst* playerConst,
+                             const al::WaterSurfaceFinder* waterSurfaceFinder,
+                             PlayerModelChangerYoshi* modelChanger)
+    : al::ActorStateBase("卵", player), mCollision(collision), mConst(playerConst),
+      mWaterSurfaceFinder(waterSurfaceFinder), mModelChanger(modelChanger) {
+    mEgg = new YoshiEgg(player, collision);
+    mEgg->init(info);
+    initNerve(&Wait, 0);
+}
+
+void YoshiStateEgg::appear() {
+    al::ActorStateBase::appear();
+    mEgg->kill();
+    al::invalidateHitSensors(mActor);
+
+    if (mIsFirstPlacement) {
+        mIsFirstPlacement = false;
+        mEgg->initPlacementEgg();
+        al::setNerve(this, &Wait);
+    } else {
+        al::setNerve(this, &Appear);
+    }
+}
+
+void YoshiStateEgg::kill() {
+    al::ActorStateBase::kill();
+    al::validateHitSensors(mActor);
+}
+
+void YoshiStateEgg::exeAppear() {
+    if (al::isFirstStep(this))
+        mEgg->appearEgg();
+
+    updateEggMove(mActor, mCollision, mConst);
+
+    if (mEgg->isEndAppear())
+        al::setNerve(this, &Wait);
+}
+
+namespace {
+void updateEggMove(al::LiveActor* actor, const IUsePlayerCollision* collision,
+                   const PlayerConst* playerConst) {
+    if (rs::isCollidedGround(collision)) {
+        rs::waitGround(actor, collision, playerConst->getGravity(), playerConst->getFallSpeedMax(),
+                       playerConst->getSlerpQuatGrav(), 0.0f);
+        return;
+    }
+
+    const sead::Vector3f& gravity = al::getGravity(actor);
+    f32 gravityValue = playerConst->getGravity();
+    sead::Vector3f velocity = {gravityValue * gravity.x, gravityValue * gravity.y,
+                               gravityValue * gravity.z};
+    al::tryAddVelocityLimit(actor, velocity, playerConst->getFallSpeedMax());
+}
+}  // namespace
+
+void YoshiStateEgg::exeWait() {
+    if (al::isFirstStep(this))
+        al::validateClipping(mActor);
+
+    updateEggMove(mActor, mCollision, mConst);
+
+    if (mEgg->isBreak()) {
+        mModelChanger->appearModel();
+        kill();
+    }
+}
+
+bool YoshiStateEgg::reactionCollidedCollisionCode() {
+    if (isDead())
+        return false;
+
+    al::LiveActor* player = mActor;
+    if (al::isInDeathArea(player) ||
+        (al::isNerve(this, &Wait) &&
+         (rs::isTouchHackCancelCollisionCode(player, mCollision) || al::isInWater(player)))) {
+        al::startHitReaction(player, "[ヨッシー]死亡");
+        return true;
+    }
+
+    return false;
+}

--- a/src/Player/YoshiStateEgg.cpp
+++ b/src/Player/YoshiStateEgg.cpp
@@ -1,0 +1,112 @@
+#include "Player/YoshiStateEgg.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nature/NatureUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/PlayerModelChangerYoshi.h"
+#include "Player/YoshiEgg.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/PlayerHackFunction.h"
+
+namespace {
+void updateEggMove(al::LiveActor* actor, const IUsePlayerCollision* collision,
+                   const PlayerConst* playerConst);
+
+NERVE_IMPL(YoshiStateEgg, Wait);
+NERVE_IMPL(YoshiStateEgg, Appear);
+
+NERVES_MAKE_NOSTRUCT(YoshiStateEgg, Wait, Appear);
+}  // namespace
+
+YoshiStateEgg::YoshiStateEgg(const al::ActorInitInfo& info, al::LiveActor* player,
+                             const IUsePlayerCollision* collision, const PlayerConst* playerConst,
+                             const al::WaterSurfaceFinder* waterSurfaceFinder,
+                             PlayerModelChangerYoshi* modelChanger)
+    : al::ActorStateBase("卵", player), mCollision(collision), mConst(playerConst),
+      mWaterSurfaceFinder(waterSurfaceFinder), mModelChanger(modelChanger) {
+    mEgg = new YoshiEgg(player, collision);
+    mEgg->init(info);
+    initNerve(&Wait, 0);
+}
+
+void YoshiStateEgg::appear() {
+    al::ActorStateBase::appear();
+    mEgg->kill();
+    al::invalidateHitSensors(mActor);
+
+    if (mIsFirstPlacement) {
+        mIsFirstPlacement = false;
+        mEgg->initPlacementEgg();
+        al::setNerve(this, &Wait);
+    } else {
+        al::setNerve(this, &Appear);
+    }
+}
+
+void YoshiStateEgg::kill() {
+    al::ActorStateBase::kill();
+    al::validateHitSensors(mActor);
+}
+
+void YoshiStateEgg::exeAppear() {
+    if (al::isFirstStep(this))
+        mEgg->appearEgg();
+
+    updateEggMove(mActor, mCollision, mConst);
+
+    if (mEgg->isEndAppear())
+        al::setNerve(this, &Wait);
+}
+
+namespace {
+void updateEggMove(al::LiveActor* actor, const IUsePlayerCollision* collision,
+                   const PlayerConst* playerConst) {
+    if (rs::isCollidedGround(collision)) {
+        rs::waitGround(actor, collision, playerConst->getGravity(), playerConst->getFallSpeedMax(),
+                       playerConst->getSlerpQuatGrav(), 0.0f);
+        return;
+    }
+
+    const sead::Vector3f& gravity = al::getGravity(actor);
+    f32 gravityValue = playerConst->getGravity();
+    sead::Vector3f velocity = {gravityValue * gravity.x, gravityValue * gravity.y,
+                               gravityValue * gravity.z};
+    al::tryAddVelocityLimit(actor, velocity, playerConst->getFallSpeedMax());
+}
+}  // namespace
+
+void YoshiStateEgg::exeWait() {
+    if (al::isFirstStep(this))
+        al::validateClipping(mActor);
+
+    updateEggMove(mActor, mCollision, mConst);
+
+    if (mEgg->isBreak()) {
+        mModelChanger->appearModel();
+        kill();
+    }
+}
+
+bool YoshiStateEgg::reactionCollidedCollisionCode() {
+    if (isDead())
+        return false;
+
+    al::LiveActor* player = mActor;
+    if (al::isInDeathArea(player) ||
+        (al::isNerve(this, &Wait) &&
+         (rs::isTouchHackCancelCollisionCode(player, mCollision) || al::isInWater(player)))) {
+        al::startHitReaction(player, "[ヨッシー]死亡");
+        return true;
+    }
+
+    return false;
+}

--- a/src/Player/YoshiStateEgg.h
+++ b/src/Player/YoshiStateEgg.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class WaterSurfaceFinder;
+}  // namespace al
+
+class IUsePlayerCollision;
+class PlayerConst;
+class PlayerModelChangerYoshi;
+class YoshiEgg;
+
+class YoshiStateEgg : public al::ActorStateBase {
+public:
+    YoshiStateEgg(const al::ActorInitInfo& info, al::LiveActor* player,
+                  const IUsePlayerCollision* collision, const PlayerConst* playerConst,
+                  const al::WaterSurfaceFinder* waterSurfaceFinder,
+                  PlayerModelChangerYoshi* modelChanger);
+
+    void appear() override;
+    void kill() override;
+
+    void exeAppear();
+    void exeWait();
+    bool reactionCollidedCollisionCode();
+
+private:
+    const IUsePlayerCollision* mCollision = nullptr;
+    const PlayerConst* mConst = nullptr;
+    const al::WaterSurfaceFinder* mWaterSurfaceFinder = nullptr;
+    YoshiEgg* mEgg = nullptr;
+    PlayerModelChangerYoshi* mModelChanger = nullptr;
+    bool mIsFirstPlacement = true;
+};
+
+static_assert(sizeof(YoshiStateEgg) == 0x50);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1183)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c4d724d - 7f959c5)

📈 **Matched code**: 15.14% (+0.01%, +1124 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/YoshiStateEgg` | `(anonymous namespace)::updateEggMove(al::LiveActor*, IUsePlayerCollision const*, PlayerConst const*)` | +260 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::YoshiStateEgg(al::ActorInitInfo const&, al::LiveActor*, IUsePlayerCollision const*, PlayerConst const*, al::WaterSurfaceFinder const*, PlayerModelChangerYoshi*)` | +188 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::reactionCollidedCollisionCode()` | +128 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::appear()` | +104 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `(anonymous namespace)::YoshiStateEggNrvWait::execute(al::NerveKeeper*) const` | +104 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::exeWait()` | +100 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `(anonymous namespace)::YoshiStateEggNrvAppear::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::exeAppear()` | +92 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::~YoshiStateEgg()` | +36 | 0.00% | 100.00% |
| `Player/YoshiStateEgg` | `YoshiStateEgg::kill()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->