### PR TITLE
MapObj: Implement `GrowPlantParts`

### DIFF
--- a/src/MapObj/GrowPlantLeaf.h
+++ b/src/MapObj/GrowPlantLeaf.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GrowPlantLeaf : public al::LiveActor {
+public:
+    GrowPlantLeaf();
+
+    void init(const al::ActorInitInfo& info) override;
+    void appear() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    void startGrow();
+    void endGrow();
+
+private:
+    f32* mJointRotators = nullptr;
+    f32* mJointRotatorVelocities = nullptr;
+    bool mIsEndGrow = false;
+};
+
+static_assert(sizeof(GrowPlantLeaf) == 0x120);

--- a/src/MapObj/GrowPlantParts.cpp
+++ b/src/MapObj/GrowPlantParts.cpp
@@ -1,0 +1,91 @@
+#include "MapObj/GrowPlantParts.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/GrowPlantLeaf.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(GrowPlantParts, Wait);
+NERVE_IMPL(GrowPlantParts, Grow);
+NERVE_IMPL(GrowPlantParts, GrowEnd);
+
+NERVES_MAKE_NOSTRUCT(GrowPlantParts, Wait, Grow, GrowEnd);
+}  // namespace
+
+GrowPlantParts::GrowPlantParts(const char* name) : al::LiveActor(name) {}
+
+void GrowPlantParts::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "GrowPlantParts", nullptr);
+    al::startAction(this, "Wait");
+
+    mGrowPlantLeaf = new GrowPlantLeaf();
+    mGrowPlantLeaf->init(info);
+
+    al::initSubActorKeeperNoFile(this, info, 1);
+    al::registerSubActorSyncAll(this, mGrowPlantLeaf);
+    al::setRotateY(mGrowPlantLeaf, al::getRandom(360));
+    al::initNerve(this, &Wait, 0);
+    makeActorDead();
+}
+
+bool GrowPlantParts::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+    if (rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+    if (rs::isMsgPlayerDisregardTargetMarker(message))
+        return true;
+    if (rs::isMsgPlayerPoleClimbKeep(message)) {
+        mIsPoleClimbKeep = true;
+        return true;
+    }
+    return false;
+}
+
+void GrowPlantParts::control() {
+    al::setTrans(mGrowPlantLeaf, al::getTrans(this));
+}
+
+void GrowPlantParts::exeWait() {}
+
+void GrowPlantParts::exeGrow() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Grow");
+        mGrowPlantLeaf->startGrow();
+    }
+}
+
+void GrowPlantParts::exeGrowEnd() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Wait");
+        mGrowPlantLeaf->endGrow();
+    }
+}
+
+void GrowPlantParts::trySetNerveGrow() {
+    if (al::isNerve(this, &Grow))
+        return;
+
+    al::invalidateClipping(this);
+    al::setTrans(mGrowPlantLeaf, al::getTrans(this));
+    appear();
+    al::setNerve(this, &Grow);
+}
+
+void GrowPlantParts::trySetNerveGrowEnd() {
+    if (al::isNerve(this, &GrowEnd))
+        return;
+
+    al::validateClipping(this);
+    al::setNerve(this, &GrowEnd);
+}

--- a/src/MapObj/GrowPlantParts.h
+++ b/src/MapObj/GrowPlantParts.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class GrowPlantLeaf;
+
+class GrowPlantParts : public al::LiveActor {
+public:
+    GrowPlantParts(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    void exeWait();
+    void exeGrow();
+    void exeGrowEnd();
+    void trySetNerveGrow();
+    void trySetNerveGrowEnd();
+
+private:
+    GrowPlantLeaf* mGrowPlantLeaf = nullptr;
+    bool mIsPoleClimbKeep = false;
+};
+
+static_assert(sizeof(GrowPlantParts) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1184)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - b4127f1)

📈 **Matched code**: 14.67% (+0.01%, +1140 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/GrowPlantParts` | `GrowPlantParts::init(al::ActorInitInfo const&)` | +232 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::GrowPlantParts(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::GrowPlantParts(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +120 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::trySetNerveGrow()` | +116 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::trySetNerveGrowEnd()` | +76 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `(anonymous namespace)::GrowPlantPartsNrvGrow::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `(anonymous namespace)::GrowPlantPartsNrvGrowEnd::execute(al::NerveKeeper*) const` | +72 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::exeGrow()` | +68 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::exeGrowEnd()` | +68 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::control()` | +40 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `GrowPlantParts::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/GrowPlantParts` | `(anonymous namespace)::GrowPlantPartsNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->