### PR TITLE
Enemy: Implement `HosuiWaterBallHolder`

### DIFF
--- a/src/Enemy/HosuiWaterBall.h
+++ b/src/Enemy/HosuiWaterBall.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class HosuiWaterBall : public al::LiveActor {
+public:
+    HosuiWaterBall();
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void hitKill(al::HitSensor* receiver, al::HitSensor* sender);
+    void clearIgnoreActors();
+    void addIgnoreActor(const al::LiveActor* actor);
+    void shoot(const sead::Vector3f& pos, const sead::Vector3f& velocity, u32 life,
+               al::HitSensor* sender, bool isStrong);
+    void exeShoot();
+    void calcEffectMtx(const sead::Vector3f& pos, const sead::Vector3f& dir);
+
+private:
+    sead::FixedPtrArray<const al::LiveActor, 2> mIgnoreActors;
+    s32 mLife = 0;
+    al::HitSensor* mSender = nullptr;
+    sead::Matrix34f mEffectMtx = sead::Matrix34f::ident;
+    bool mIsStrong = false;
+    u32 mShootStep = 0;
+    al::HitSensor* mAttackSensor = nullptr;
+};
+
+static_assert(sizeof(HosuiWaterBall) == 0x178);

--- a/src/Enemy/HosuiWaterBallHolder.cpp
+++ b/src/Enemy/HosuiWaterBallHolder.cpp
@@ -1,0 +1,69 @@
+#include "Enemy/HosuiWaterBallHolder.h"
+
+#include "Library/Effect/EffectSystemInfo.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+
+#include "Enemy/HosuiWaterBall.h"
+
+HosuiWaterBallHolder::HosuiWaterBallHolder(const al::ActorInitInfo& initInfo) {
+    for (s32 i = 0; i < mWaterBalls.capacity(); i++) {
+        HosuiWaterBall* waterBall = new HosuiWaterBall();
+        waterBall->init(initInfo);
+        mWaterBalls.pushBack(waterBall);
+    }
+}
+
+HosuiWaterBall* HosuiWaterBallHolder::get() {
+    s32 capacity = mWaterBalls.capacity();
+    if (capacity < 1)
+        return nullptr;
+
+    for (s32 i = 0; i < capacity; i++) {
+        HosuiWaterBall* waterBall = mWaterBalls[mIndex];
+        mIndex = al::modi(capacity + 1 + mIndex, capacity);
+        if (al::isDead(waterBall)) {
+            waterBall->clearIgnoreActors();
+            return waterBall;
+        }
+    }
+
+    return nullptr;
+}
+
+void HosuiWaterBallHolder::killAll() {
+    for (s32 i = 0; i < mWaterBalls.size(); i++) {
+        if (al::isAlive(mWaterBalls[i])) {
+            al::tryKillEmitterAndParticleAll(mWaterBalls[i]);
+            mWaterBalls[i]->makeActorDead();
+        }
+    }
+
+    mIndex = 0;
+}
+
+namespace HosuiUtil {
+void tryCreateHosuiWaterBallHolder(const al::IUseSceneObjHolder* objHolder,
+                                   const al::ActorInitInfo& initInfo) {
+    if (al::isExistSceneObj<HosuiWaterBallHolder>(objHolder))
+        return;
+
+    HosuiWaterBallHolder* waterBallHolder = new HosuiWaterBallHolder(initInfo);
+    al::setSceneObj(objHolder, waterBallHolder);
+}
+
+HosuiWaterBall* tryGetHosuiWaterBall(const al::IUseSceneObjHolder* objHolder) {
+    HosuiWaterBallHolder* waterBallHolder = al::tryGetSceneObj<HosuiWaterBallHolder>(objHolder);
+    if (!waterBallHolder)
+        return nullptr;
+
+    return waterBallHolder->get();
+}
+
+void killAllHosuiWaterBall(const al::IUseSceneObjHolder* objHolder) {
+    HosuiWaterBallHolder* waterBallHolder = al::tryGetSceneObj<HosuiWaterBallHolder>(objHolder);
+    if (waterBallHolder)
+        waterBallHolder->killAll();
+}
+}  // namespace HosuiUtil

--- a/src/Enemy/HosuiWaterBallHolder.h
+++ b/src/Enemy/HosuiWaterBallHolder.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+class HosuiWaterBall;
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+
+class HosuiWaterBallHolder : public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_HosuiWaterBallHolder;
+
+    HosuiWaterBallHolder(const al::ActorInitInfo& initInfo);
+
+    HosuiWaterBall* get();
+    void killAll();
+
+private:
+    sead::FixedPtrArray<HosuiWaterBall, 128> mWaterBalls;
+    s32 mIndex = 0;
+};
+
+static_assert(sizeof(HosuiWaterBallHolder) == 0x420);
+
+namespace HosuiUtil {
+void tryCreateHosuiWaterBallHolder(const al::IUseSceneObjHolder* objHolder,
+                                   const al::ActorInitInfo& initInfo);
+HosuiWaterBall* tryGetHosuiWaterBall(const al::IUseSceneObjHolder* objHolder);
+void killAllHosuiWaterBall(const al::IUseSceneObjHolder* objHolder);
+}  // namespace HosuiUtil


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1185)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 70a3a92)

📈 **Matched code**: 14.67% (+0.01%, +1176 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/HosuiWaterBallHolder` | `HosuiUtil::tryCreateHosuiWaterBallHolder(al::IUseSceneObjHolder const*, al::ActorInitInfo const&)` | +280 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiWaterBallHolder::HosuiWaterBallHolder(al::ActorInitInfo const&)` | +212 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiWaterBallHolder::killAll()` | +180 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiUtil::killAllHosuiWaterBall(al::IUseSceneObjHolder const*)` | +176 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiUtil::tryGetHosuiWaterBall(al::IUseSceneObjHolder const*)` | +168 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiWaterBallHolder::get()` | +156 | 0.00% | 100.00% |
| `Enemy/HosuiWaterBallHolder` | `HosuiWaterBallHolder::~HosuiWaterBallHolder()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->