### PR TITLE
Event: Implement `EventFlowNodeCapManHeroTalkReturn`

### DIFF
--- a/src/Event/EventFlowNodeCapManHeroTalkReturn.cpp
+++ b/src/Event/EventFlowNodeCapManHeroTalkReturn.cpp
@@ -1,0 +1,91 @@
+#include "Event/EventFlowNodeCapManHeroTalkReturn.h"
+
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
+
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/PlayerDemoUtil.h"
+
+namespace {
+NERVE_IMPL(EventFlowNodeCapManHeroTalkReturn, Return);
+NERVE_IMPL(EventFlowNodeCapManHeroTalkReturn, TurnToPlayer);
+NERVE_IMPL(EventFlowNodeCapManHeroTalkReturn, ReactionCapOn);
+NERVE_IMPL(EventFlowNodeCapManHeroTalkReturn, EndWait);
+NERVES_MAKE_NOSTRUCT(EventFlowNodeCapManHeroTalkReturn, Return, TurnToPlayer, ReactionCapOn,
+                     EndWait);
+}  // namespace
+
+EventFlowNodeCapManHeroTalkReturn::EventFlowNodeCapManHeroTalkReturn(const char* name)
+    : al::EventFlowNode(name) {}
+
+void EventFlowNodeCapManHeroTalkReturn::init(const al::EventFlowNodeInitInfo& info) {
+    al::initEventFlowNode(this, info);
+    initNerve(&Return, 0);
+    mDemoStartTrans = al::getTrans(getActor());
+    sead::Vector3f front;
+    al::calcFrontDir(&front, getActor());
+    al::makeQuatUpFront(&mDemoStartQuat, sead::Vector3f::ey, front);
+}
+
+void EventFlowNodeCapManHeroTalkReturn::start() {
+    al::EventFlowNode::start();
+    rs::startCloseNpcDemoEventTalkMessage(getActor());
+    mReturnStartTrans = al::getTrans(getActor());
+    al::setNerve(this, &TurnToPlayer);
+}
+
+void EventFlowNodeCapManHeroTalkReturn::exeTurnToPlayer() {
+    if (al::isFirstStep(this))
+        al::startAction(getActor(), "Turn");
+
+    al::LiveActor* player = al::tryFindNearestPlayerActor(getActor());
+    if (al::turnToTarget(getActor(), player, 3.0f))
+        al::setNerve(this, &Return);
+}
+
+void EventFlowNodeCapManHeroTalkReturn::exeReturn() {
+    if (al::isFirstStep(this))
+        al::startAction(getActor(), "DemoTalkCapManHeroDisappear");
+
+    f32 frameMax = al::getActionFrameMax(getActor(), "DemoTalkCapManHeroDisappear");
+    f32 rate = al::getActionFrame(getActor()) / frameMax;
+    if (rate > 1.0f)
+        rate = 1.0f;
+    else if (rate < 0.0f)
+        rate = 0.0f;
+    f32 easeRate = al::easeByType(rate, mEaseType);
+
+    al::LiveActor* player = al::tryFindNearestPlayerActor(getActor());
+    sead::Vector3f playerTrans = al::getTrans(player);
+    sead::Vector3f trans;
+    al::lerpVec(&trans, mReturnStartTrans, playerTrans, easeRate);
+    al::setTrans(getActor(), trans);
+
+    if (al::isActionEnd(getActor())) {
+        al::hideModelIfShow(getActor());
+        rs::invalidateWatchTarget(getActor());
+        al::setNerve(this, &ReactionCapOn);
+    }
+}
+
+void EventFlowNodeCapManHeroTalkReturn::exeReactionCapOn() {
+    if (al::isFirstStep(this))
+        rs::startActionDemoPlayer(getActor(), "ReactionCapOn");
+
+    if (rs::isActionEndDemoPlayer(getActor())) {
+        rs::startActionDemoPlayer(getActor(), "Wait");
+        al::setNerve(this, &EndWait);
+    }
+}
+
+void EventFlowNodeCapManHeroTalkReturn::exeEndWait() {
+    if (al::isGreaterEqualStep(this, 0))
+        end();
+}

--- a/src/Event/EventFlowNodeCapManHeroTalkReturn.h
+++ b/src/Event/EventFlowNodeCapManHeroTalkReturn.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Event/EventFlowNode.h"
+
+namespace al {
+class EventFlowNodeInitInfo;
+}  // namespace al
+
+class EventFlowNodeCapManHeroTalkReturn : public al::EventFlowNode {
+public:
+    EventFlowNodeCapManHeroTalkReturn(const char* name);
+
+    void init(const al::EventFlowNodeInitInfo& info) override;
+    void start() override;
+
+    void exeTurnToPlayer();
+    void exeReturn();
+    void exeReactionCapOn();
+    void exeEndWait();
+
+private:
+    sead::Vector3f mReturnStartTrans = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mDemoStartTrans = {0.0f, 0.0f, 0.0f};
+    sead::Quatf mDemoStartQuat;
+    s32 mEaseType = 2;
+};
+
+static_assert(sizeof(EventFlowNodeCapManHeroTalkReturn) == 0x98);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -19,6 +19,7 @@ bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
 bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
 void startEventFlow(al::EventFlowExecutor*, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
+void startCloseNpcDemoEventTalkMessage(al::LiveActor*);
 void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);
 void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
                            const char* name);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1186)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 4e93c01)

📈 **Matched code**: 14.67% (+0.01%, +1180 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::exeReturn()` | +252 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::init(al::EventFlowNodeInitInfo const&)` | +124 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `(anonymous namespace)::EventFlowNodeCapManHeroTalkReturnNrvTurnToPlayer::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `(anonymous namespace)::EventFlowNodeCapManHeroTalkReturnNrvReactionCapOn::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::exeTurnToPlayer()` | +112 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::exeReactionCapOn()` | +112 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::start()` | +88 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `(anonymous namespace)::EventFlowNodeCapManHeroTalkReturnNrvEndWait::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::EventFlowNodeCapManHeroTalkReturn(char const*)` | +76 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `EventFlowNodeCapManHeroTalkReturn::exeEndWait()` | +68 | 0.00% | 100.00% |
| `Event/EventFlowNodeCapManHeroTalkReturn` | `(anonymous namespace)::EventFlowNodeCapManHeroTalkReturnNrvReturn::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->