### PR TITLE
MapObj: Implement `PeachWorldGate`

### DIFF
--- a/src/MapObj/PeachWorldGate.cpp
+++ b/src/MapObj/PeachWorldGate.cpp
@@ -1,0 +1,86 @@
+#include "MapObj/PeachWorldGate.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "System/GameDataUtil.h"
+
+namespace {
+NERVE_IMPL(PeachWorldGate, OpenWait)
+NERVE_IMPL(PeachWorldGate, CloseWait)
+NERVE_IMPL(PeachWorldGate, Open)
+
+NERVES_MAKE_NOSTRUCT(PeachWorldGate, OpenWait, CloseWait, Open)
+}  // namespace
+
+PeachWorldGate::PeachWorldGate(const char* actorName) : al::LiveActor(actorName) {}
+
+void PeachWorldGate::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    mSaveObjInfo = rs::createSaveObjInfoNoWriteSaveDataInSameWorldResetMiniGame(info);
+    mCollisionObj = al::createCollisionObj(this, info, "OpenGate",
+                                           al::getHitSensor(this, "Collision"), nullptr, nullptr);
+
+    if (rs::isOnSaveObjInfo(mSaveObjInfo) && !rs::isSequenceTimeBalloonOrRace(this)) {
+        mCollisionObj->makeActorAlive();
+        al::initNerve(this, &OpenWait, 0);
+        al::invalidateCollisionParts(this);
+    } else {
+        mCollisionObj->makeActorDead();
+        al::initNerve(this, &CloseWait, 0);
+
+        using PeachWorldGateFunctor = al::FunctorV0M<PeachWorldGate*, void (PeachWorldGate::*)()>;
+
+        al::listenStageSwitchOnStart(this, PeachWorldGateFunctor(this, &PeachWorldGate::start));
+    }
+
+    makeActorAlive();
+}
+
+void PeachWorldGate::start() {
+    if (rs::isSequenceTimeBalloonOrRace(this))
+        return;
+
+    if (al::isNerve(this, &CloseWait)) {
+        al::invalidateClipping(this);
+        al::setNerve(this, &Open);
+    }
+}
+
+void PeachWorldGate::exeCloseWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "CloseWait");
+}
+
+void PeachWorldGate::exeOpen() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Open");
+
+    if (al::isStep(this, 80)) {
+        al::invalidateCollisionParts(this);
+        mCollisionObj->makeActorAlive();
+    }
+
+    if (al::isActionEnd(this)) {
+        al::setNerve(this, &OpenWait);
+        al::startSe(this, "PgOpenEnd");
+    }
+}
+
+void PeachWorldGate::exeOpenWait() {
+    if (al::isFirstStep(this)) {
+        al::validateClipping(this);
+        al::startAction(this, "OpenWait");
+        rs::onSaveObjInfo(mSaveObjInfo);
+    }
+}

--- a/src/MapObj/PeachWorldGate.h
+++ b/src/MapObj/PeachWorldGate.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class SaveObjInfo;
+
+namespace al {
+class CollisionObj;
+}  // namespace al
+
+class PeachWorldGate : public al::LiveActor {
+public:
+    PeachWorldGate(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void start();
+    void exeCloseWait();
+    void exeOpen();
+    void exeOpenWait();
+
+private:
+    SaveObjInfo* mSaveObjInfo = nullptr;
+    al::CollisionObj* mCollisionObj = nullptr;
+};
+
+static_assert(sizeof(PeachWorldGate) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -103,6 +103,7 @@
 #include "MapObj/MoonBasementSlideObj.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/MoviePlayerMapParts.h"
+#include "MapObj/PeachWorldGate.h"
 #include "MapObj/PeachWorldTree.h"
 #include "MapObj/PlayerMotionObserver.h"
 #include "MapObj/PoleGrabCeil.h"
@@ -469,7 +470,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"PaulineAtCeremony", nullptr},
     {"PaulineAudience", nullptr},
     {"PeachWorldHomeCastleCap", nullptr},
-    {"PeachWorldGate", nullptr},
+    {"PeachWorldGate", al::createActorFunction<PeachWorldGate>},
     {"PeachWorldMoatWater", nullptr},
     {"PeachWorldTree", al::createActorFunction<PeachWorldTree>},
     {"Pecho", al::createActorFunction<Pecho>},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1187)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c4d724d - 6abbab0)

📈 **Matched code**: 15.14% (+0.01%, +1244 bytes)

<details>
<summary>✅ 14 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PeachWorldGate` | `PeachWorldGate::init(al::ActorInitInfo const&)` | +280 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::exeOpen()` | +168 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::PeachWorldGate(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::PeachWorldGate(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::start()` | +88 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `(anonymous namespace)::PeachWorldGateNrvOpenWait::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::exeOpenWait()` | +76 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `al::FunctorV0M<PeachWorldGate*, void (PeachWorldGate::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `(anonymous namespace)::PeachWorldGateNrvCloseWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `PeachWorldGate::exeCloseWait()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<PeachWorldGate>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `al::FunctorV0M<PeachWorldGate*, void (PeachWorldGate::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `(anonymous namespace)::PeachWorldGateNrvOpen::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/PeachWorldGate` | `al::FunctorV0M<PeachWorldGate*, void (PeachWorldGate::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->