### PR TITLE
Enemy: Implement `KakkuGlideAnimCtrl`

### DIFF
--- a/src/Enemy/KakkuGlideAnimCtrl.cpp
+++ b/src/Enemy/KakkuGlideAnimCtrl.cpp
@@ -1,0 +1,117 @@
+#include "Enemy/KakkuGlideAnimCtrl.h"
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Enemy/KakkuStateGlide.h"
+
+namespace {
+NERVE_IMPL(KakkuGlideAnimCtrl, GlideNormal);
+NERVE_IMPL(KakkuGlideAnimCtrl, GlideLeft);
+NERVE_IMPL(KakkuGlideAnimCtrl, GlideRight);
+NERVE_IMPL(KakkuGlideAnimCtrl, GlideLeftStart);
+NERVE_IMPL(KakkuGlideAnimCtrl, GlideRightStart);
+
+NERVES_MAKE_STRUCT(KakkuGlideAnimCtrl, GlideNormal, GlideLeft, GlideRight, GlideLeftStart,
+                   GlideRightStart);
+}  // namespace
+
+KakkuGlideAnimCtrl::KakkuGlideAnimCtrl(const char* name, al::LiveActor* actor,
+                                       KakkuStateGlide* stateGlide)
+    : al::ActorStateBase(name, actor), mStateGlide(stateGlide) {
+    initNerve(&NrvKakkuGlideAnimCtrl.GlideNormal, 0);
+}
+
+void KakkuGlideAnimCtrl::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideNormal);
+}
+
+bool KakkuGlideAnimCtrl::isNormal() const {
+    return al::isActionPlaying(mActor, "Glide");
+}
+
+void KakkuGlideAnimCtrl::exeGlideNormal() {
+    tryChangeAnim();
+}
+
+void KakkuGlideAnimCtrl::tryChangeAnim() {
+    sead::Vector2f stick = sead::Vector2f::zero;
+    mStateGlide->getStick(&stick);
+
+    if (stick.y <= -0.8f) {
+        al::tryStartActionIfNotPlaying(mActor, "GlideRise");
+        al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideNormal);
+        return;
+    }
+
+    if (stick.y >= 0.8f) {
+        al::tryStartActionIfNotPlaying(mActor, "GlideDrop");
+        al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideNormal);
+        return;
+    }
+
+    if (stick.x <= -0.8f) {
+        if (!al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeftStart) &&
+            !al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeft))
+            al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeftStart);
+        return;
+    }
+
+    if (stick.x >= 0.8f) {
+        if (!al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideRightStart) &&
+            !al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideRight))
+            al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideRightStart);
+        return;
+    }
+
+    al::tryStartActionIfNotPlaying(mActor, "Glide");
+    al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideNormal);
+}
+
+void KakkuGlideAnimCtrl::exeGlideLeftStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GlideLStart");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeft);
+    else
+        tryChangeAnim();
+}
+
+void KakkuGlideAnimCtrl::exeGlideLeft() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GlideL");
+
+    tryChangeAnim();
+}
+
+void KakkuGlideAnimCtrl::exeGlideRightStart() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GlideRStart");
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &NrvKakkuGlideAnimCtrl.GlideRight);
+    else
+        tryChangeAnim();
+}
+
+void KakkuGlideAnimCtrl::exeGlideRight() {
+    if (al::isFirstStep(this))
+        al::startAction(mActor, "GlideR");
+
+    tryChangeAnim();
+}
+
+bool KakkuGlideAnimCtrl::isCurrentLeftAnim() const {
+    return al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeftStart) ||
+           al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideLeft);
+}
+
+bool KakkuGlideAnimCtrl::isCurrentRightAnim() const {
+    return al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideRightStart) ||
+           al::isNerve(this, &NrvKakkuGlideAnimCtrl.GlideRight);
+}

--- a/src/Enemy/KakkuGlideAnimCtrl.h
+++ b/src/Enemy/KakkuGlideAnimCtrl.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class KakkuStateGlide;
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class KakkuGlideAnimCtrl : public al::ActorStateBase {
+public:
+    KakkuGlideAnimCtrl(const char* name, al::LiveActor* actor, KakkuStateGlide* stateGlide);
+
+    void appear() override;
+    bool isNormal() const;
+
+    void exeGlideNormal();
+    void tryChangeAnim();
+    void exeGlideLeftStart();
+    void exeGlideLeft();
+    void exeGlideRightStart();
+    void exeGlideRight();
+
+    bool isCurrentLeftAnim() const;
+    bool isCurrentRightAnim() const;
+
+private:
+    void* _20 = nullptr;
+    KakkuStateGlide* mStateGlide = nullptr;
+};
+
+static_assert(sizeof(KakkuGlideAnimCtrl) == 0x30);

--- a/src/Enemy/KakkuStateGlide.h
+++ b/src/Enemy/KakkuStateGlide.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class ExternalForceKeeper;
+class Kakku;
+
+class KakkuStateGlide : public al::HostStateBase<Kakku> {
+public:
+    KakkuStateGlide(Kakku* host, const al::ActorInitInfo& initInfo,
+                    const ExternalForceKeeper* externalForceKeeper);
+
+    void appear() override;
+    void updateCameraTarget(f32 rate);
+    void kill() override;
+    void control() override;
+    bool checkCollidedWall(bool isCheckFloor) const;
+    void getStick(sead::Vector2f* stick) const;
+    bool isEnableEndState() const;
+    bool isEndByOnGround() const;
+    bool tryCalcExternalVelocity(sead::Vector3f* velocity) const;
+
+    void exeGlideStart();
+    void exeGlide();
+    void updatePoseByStick();
+    void updateVelocitySide();
+    void exeGlideJump();
+    void updatePoseSideByStick();
+    void exeGlideJumpEnd();
+
+private:
+    u8 _20[0xc8] = {};
+};
+
+static_assert(sizeof(KakkuStateGlide) == 0xe8);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1188)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c4d724d - ffd7a86)

📈 **Matched code**: 15.14% (+0.01%, +1200 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::tryChangeAnim()` | +280 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `(anonymous namespace)::KakkuGlideAnimCtrlNrvGlideLeftStart::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `(anonymous namespace)::KakkuGlideAnimCtrlNrvGlideRightStart::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::exeGlideLeftStart()` | +96 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::exeGlideRightStart()` | +96 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::KakkuGlideAnimCtrl(char const*, al::LiveActor*, KakkuStateGlide*)` | +72 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::isCurrentLeftAnim() const` | +72 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::isCurrentRightAnim() const` | +72 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `(anonymous namespace)::KakkuGlideAnimCtrlNrvGlideLeft::execute(al::NerveKeeper*) const` | +60 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `(anonymous namespace)::KakkuGlideAnimCtrlNrvGlideRight::execute(al::NerveKeeper*) const` | +60 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::exeGlideLeft()` | +56 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::exeGlideRight()` | +56 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::~KakkuGlideAnimCtrl()` | +36 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::appear()` | +16 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::isNormal() const` | +16 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `(anonymous namespace)::KakkuGlideAnimCtrlNrvGlideNormal::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/KakkuGlideAnimCtrl` | `KakkuGlideAnimCtrl::exeGlideNormal()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->