### PR TITLE
Player: Implement `YoshiStateHackDown`

### DIFF
--- a/src/Player/HackerStateBase.h
+++ b/src/Player/HackerStateBase.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerHack;
+
+class HackerStateBase : public al::NerveStateBase {
+public:
+    HackerStateBase(const char* stateName, al::LiveActor* actor, IUsePlayerHack** hacker);
+
+protected:
+    al::LiveActor* mActor = nullptr;
+    IUsePlayerHack** mHacker = nullptr;
+};
+
+static_assert(sizeof(HackerStateBase) == 0x28);

--- a/src/Player/PlayerActionAirMoveControl.h
+++ b/src/Player/PlayerActionAirMoveControl.h
@@ -6,25 +6,69 @@
 namespace al {
 class LiveActor;
 }
+class IUsePlayerHack;
 class PlayerConst;
 class PlayerInput;
 class IUsePlayerCollision;
+class PlayerActionTurnControl;
 
 class PlayerActionAirMoveControl {
 public:
-    PlayerActionAirMoveControl(al::LiveActor*, const PlayerConst*, const PlayerInput*,
-                               const IUsePlayerCollision*, bool);
-    void setup(f32, f32, s32, f32, f32, s32, f32);
-    void setupTurn(f32, f32, f32, f32, s32, s32, s32);
-    void setExtendFrame(s32);
-    void setupCollideWallScaleVelocity(f32, f32, f32);
-    void verticalizeStartMoveDir(const sead::Vector3f&);
+    PlayerActionAirMoveControl(al::LiveActor* player, const PlayerConst* pConst,
+                               const PlayerInput* input, const IUsePlayerCollision* collision,
+                               bool isSlerpGravity);
+    void setup(f32 speedMax, f32 velocityH, s32 extendFrame, f32 velocityV, f32 gravity,
+               s32 noInputFrame, f32 jumpInertia);
+    void setupTurn(f32 turnAngleStart, f32 turnAngleLimit, f32 turnAngleFast,
+                   f32 turnAngleFastLimit, s32 turnAccelFrame, s32 turnAccelFrameFast,
+                   s32 turnBrakeFrame);
+    void setExtendFrame(s32 extendFrame);
+    void setupCollideWallScaleVelocity(f32 scaleH, f32 scaleV, f32 scaleLimit);
+    void verticalizeStartMoveDir(const sead::Vector3f& up);
     void update();
     bool isHoldJumpExtend() const;
-    void calcMoveInput(sead::Vector3f*, const sead::Vector3f&) const;
+    void calcMoveInput(sead::Vector3f* moveInput, const sead::Vector3f& up) const;
+
+    void setHacker(IUsePlayerHack** hacker) { mHacker = hacker; }
+
+    void setCalcGroundNormalOrUpDir(bool isCalcGroundNormalOrUpDir) {
+        mIsCalcGroundNormalOrUpDir = isCalcGroundNormalOrUpDir;
+    }
 
 private:
-    void* filler[0x90 / 8];
+    al::LiveActor* mPlayer = nullptr;
+    const PlayerConst* mConst = nullptr;
+    const PlayerInput* mInput = nullptr;
+    const IUsePlayerCollision* mCollision = nullptr;
+    IUsePlayerHack** mHacker = nullptr;
+    PlayerActionTurnControl* mTurnControl = nullptr;
+    bool mIsSlerpGravity = false;
+    bool mIsHoldJumpExtend = false;
+    bool mIsForceHoldJumpExtend = false;
+    bool mIsSnap2D = false;
+    s32 mExtendFrame = 0;
+    s32 mExtendFrameCounter = 0;
+    s32 mNoInputFrame = 0;
+    bool mIsCalcGroundNormalOrUpDir = false;
+    bool mIsInertiaWall = false;
+    bool mHasSpeedRange = false;
+    u8 _43 = 0;
+    f32 mSpeedMin = 0.0f;
+    f32 mSpeedMax = 0.0f;
+    sead::Vector3f mMoveDir = sead::Vector3f::zero;
+    sead::Vector3f mSideDir = sead::Vector3f::zero;
+    f32 mVelocityLimit = 0.0f;
+    f32 mGravity = 0.0f;
+    f32 mFallSpeedMax = 0.0f;
+    bool mIsScaleVelocityInertiaWallHit = false;
+    u8 _71 = 0;
+    u8 _72 = 0;
+    u8 _73 = 0;
+    f32 mCollideWallScaleH = 1.0f;
+    f32 mCollideWallScaleV = 0.0f;
+    f32 mCollideWallScaleLimit = 0.0f;
+    f32 mSlerpQuatRate = 0.0f;
+    sead::Vector3f mTurnDir = sead::Vector3f::zero;
 };
 
 static_assert(sizeof(PlayerActionAirMoveControl) == 0x90);

--- a/src/Player/YoshiStateHackDown.cpp
+++ b/src/Player/YoshiStateHackDown.cpp
@@ -1,0 +1,87 @@
+#include "Player/YoshiStateHackDown.h"
+
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/PlayerActionAirMoveControl.h"
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Util/ObjUtil.h"
+#include "Util/PlayerCollisionUtil.h"
+
+namespace {
+NERVE_IMPL(YoshiStateHackDown, Down);
+NERVE_IMPL(YoshiStateHackDown, Land);
+
+NERVES_MAKE_NOSTRUCT(YoshiStateHackDown, Down, Land);
+}  // namespace
+
+YoshiStateHackDown::YoshiStateHackDown(al::LiveActor* player, IUsePlayerHack** hacker,
+                                       const PlayerConst* pConst,
+                                       const IUsePlayerCollision* collider,
+                                       PlayerAnimator* animator)
+    : HackerStateBase("ダウン", player, hacker), mConst(pConst), mCollider(collider),
+      mAnimator(animator) {
+    mAirMoveControl = new PlayerActionAirMoveControl(player, pConst, nullptr, collider, false);
+    mAirMoveControl->setCalcGroundNormalOrUpDir(true);
+    mAirMoveControl->setHacker(hacker);
+    initNerve(&Down, 0);
+}
+
+void YoshiStateHackDown::appear() {
+    al::LiveActor* player = mActor;
+    al::NerveStateBase::appear();
+    rs::calcGroundNormalOrGravityDir(&mUp, player, mCollider);
+
+    sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+    al::calcFrontDir(&front, player);
+    al::setVelocity(player, front * -mConst->getPushPowerDamage());
+
+    mAirMoveControl->setup(mConst->getJumpMoveSpeedMax(), mConst->getPushPowerDamage(), 0,
+                           mConst->getHopPowerDamage(), mConst->getGravityDamage(), 9999, 1.0f);
+    al::setNerve(this, &Down);
+}
+
+bool YoshiStateHackDown::isLand() const {
+    return al::isNerve(this, &Land);
+}
+
+bool YoshiStateHackDown::isEnableCancel() const {
+    return isLand() && al::isGreaterEqualStep(this, mConst->getDamageCancelFrame());
+}
+
+void YoshiStateHackDown::exeDown() {
+    al::LiveActor* player = mActor;
+    if (al::isFirstStep(this))
+        mAnimator->startAnim("NoDamageDown");
+
+    mAirMoveControl->update();
+    if (rs::isOnGroundLessAngle(player, mCollider, mConst->getStandAngleMin())) {
+        rs::startHitReactionLandIfLanding(player, mCollider, false);
+        rs::brakeLandVelocityGroundNormal(player, &mUp, mCollider, -al::getGravity(player), 0.0f,
+                                          mConst->getGravity());
+        al::setNerve(this, &Land);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, 120))
+        kill();
+}
+
+void YoshiStateHackDown::exeLand() {
+    if (al::isFirstStep(this))
+        mAnimator->startAnim("DamageLand");
+
+    al::LiveActor* player = mActor;
+    if (rs::isOnGroundLessAngle(player, mCollider, mConst->getStandAngleMin())) {
+        rs::brakeLandVelocityGroundNormal(player, &mUp, mCollider, mUp, 0.0f, mConst->getGravity());
+    } else {
+        al::tryAddVelocityLimit(player, al::getGravity(player) * mConst->getGravityAir(),
+                                mConst->getFallSpeedMax());
+    }
+
+    if (mAnimator->isAnimEnd())
+        kill();
+}

--- a/src/Player/YoshiStateHackDown.h
+++ b/src/Player/YoshiStateHackDown.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Player/HackerStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerCollision;
+class IUsePlayerHack;
+class PlayerActionAirMoveControl;
+class PlayerAnimator;
+class PlayerConst;
+
+class YoshiStateHackDown : public HackerStateBase {
+public:
+    YoshiStateHackDown(al::LiveActor* player, IUsePlayerHack** hacker, const PlayerConst* pConst,
+                       const IUsePlayerCollision* collider, PlayerAnimator* animator);
+
+    void appear() override;
+    bool isLand() const;
+    bool isEnableCancel() const;
+    void exeDown();
+    void exeLand();
+
+private:
+    const PlayerConst* mConst = nullptr;
+    const IUsePlayerCollision* mCollider = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    PlayerActionAirMoveControl* mAirMoveControl = nullptr;
+    sead::Vector3f mUp = {0.0f, 0.0f, 0.0f};
+};
+
+static_assert(sizeof(YoshiStateHackDown) == 0x58);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1189)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f16616b)

📈 **Matched code**: 14.67% (+0.01%, +1204 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::exeDown()` | +292 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::exeLand()` | +292 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::appear()` | +288 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::YoshiStateHackDown(al::LiveActor*, IUsePlayerHack**, PlayerConst const*, IUsePlayerCollision const*, PlayerAnimator*)` | +184 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::isEnableCancel() const` | +84 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::~YoshiStateHackDown()` | +36 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `YoshiStateHackDown::isLand() const` | +12 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `(anonymous namespace)::YoshiStateHackDownNrvDown::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Player/YoshiStateHackDown` | `(anonymous namespace)::YoshiStateHackDownNrvLand::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->