### PR TITLE
Event: Implement `EventActorStateDemoTalkGK`

### DIFF
--- a/src/Event/EventActorStateDemoTalkGK.cpp
+++ b/src/Event/EventActorStateDemoTalkGK.cpp
@@ -1,0 +1,88 @@
+#include "Event/EventActorStateDemoTalkGK.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/NpcEventFlowUtil.h"
+
+namespace {
+NERVE_IMPL(EventActorStateDemoTalkGK, Wait)
+NERVE_IMPL(EventActorStateDemoTalkGK, Talk)
+NERVE_IMPL(EventActorStateDemoTalkGK, TalkAfter)
+
+NERVES_MAKE_NOSTRUCT(EventActorStateDemoTalkGK, Wait, Talk, TalkAfter)
+
+constexpr ParamEventActorStateDemoTalkGK cDefaultParam;
+}  // namespace
+
+EventActorStateDemoTalkGK::EventActorStateDemoTalkGK(al::LiveActor* actor,
+                                                     const ParamEventActorStateDemoTalkGK* param)
+    : al::ActorStateBase("", actor), mParam(param == nullptr ? &cDefaultParam : param) {
+    initNerve(&Wait, 0);
+}
+
+void EventActorStateDemoTalkGK::appear() {
+    al::NerveStateBase::appear();
+    al::startAction(mActor, mActionName);
+    if (rs::isPlayingTextPaneAnimEventTalkMessage(mActor)) {
+        al::setSklAnimBlendWeightDouble(mActor, 0.0f, 1.0f);
+        mBlendWeight = 1.0f;
+        al::setNerve(this, &Talk);
+    } else {
+        mBlendWeight = 0.0f;
+        al::setSklAnimBlendWeightDouble(mActor, 1.0f, 0.0f);
+        al::setNerve(this, &Wait);
+    }
+}
+
+void EventActorStateDemoTalkGK::exeWait() {
+    al::isFirstStep(this);
+    chaseWaitAnimWeightOne();
+    if (rs::isPlayingTextPaneAnimEventTalkMessage(mActor))
+        al::setNerve(this, &Talk);
+}
+
+void EventActorStateDemoTalkGK::chaseWaitAnimWeightOne() {
+    mBlendWeight = sead::Mathf::clampMin(mBlendWeight - mParam->blendStep, 0.0f);
+    f32 weight = al::easeByType(mBlendWeight, mParam->easeType);
+    al::setSklAnimBlendWeightDouble(mActor, 1.0f - weight, weight);
+}
+
+void EventActorStateDemoTalkGK::exeTalk() {
+    al::isFirstStep(this);
+    chaseTalkAnimWeightOne();
+    if (!rs::isPlayingTextPaneAnimEventTalkMessage(mActor))
+        al::setNerve(this, &TalkAfter);
+}
+
+void EventActorStateDemoTalkGK::chaseTalkAnimWeightOne() {
+    mBlendWeight = sead::Mathf::clampMax(mBlendWeight + mParam->blendStep, 1.0f);
+    f32 weight = al::easeByType(mBlendWeight, mParam->easeType);
+    al::setSklAnimBlendWeightDouble(mActor, 1.0f - weight, weight);
+}
+
+void EventActorStateDemoTalkGK::exeTalkAfter() {
+    chaseTalkAnimWeightOne();
+    if (!al::isGreaterEqualStep(this, 45))
+        return;
+
+    if (mIsWaitActionEnd) {
+        al::LiveActor* actor = mActor;
+        f32 frameMax = al::getActionFrameMax(actor, al::getActionName(actor));
+        if (!(frameMax <= al::getActionFrame(mActor) + 1.0f))
+            return;
+
+        mBlendWeight = 0.0f;
+        al::setSklAnimBlendWeightDouble(mActor, 1.0f);
+    } else if (rs::isPlayingTextPaneAnimEventTalkMessage(mActor)) {
+        al::setNerve(this, &Talk);
+        return;
+    }
+
+    al::setNerve(this, &Wait);
+}

--- a/src/Event/EventActorStateDemoTalkGK.h
+++ b/src/Event/EventActorStateDemoTalkGK.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+struct ParamEventActorStateDemoTalkGK {
+    constexpr ParamEventActorStateDemoTalkGK() = default;
+
+    constexpr ParamEventActorStateDemoTalkGK(f32 blendStep, s32 easeType)
+        : blendStep(blendStep), easeType(easeType) {}
+
+    f32 blendStep = 0.125f;
+    s32 easeType = 0;
+};
+
+static_assert(sizeof(ParamEventActorStateDemoTalkGK) == 0x8);
+
+class EventActorStateDemoTalkGK : public al::ActorStateBase {
+public:
+    EventActorStateDemoTalkGK(al::LiveActor* actor, const ParamEventActorStateDemoTalkGK* param);
+    void appear() override;
+    void exeWait();
+    void chaseWaitAnimWeightOne();
+    void exeTalk();
+    void chaseTalkAnimWeightOne();
+    void exeTalkAfter();
+
+private:
+    const char* mActionName = "Talk";
+    bool mIsWaitActionEnd = false;
+    f32 mBlendWeight = 0.0f;
+    const ParamEventActorStateDemoTalkGK* mParam = nullptr;
+};
+
+static_assert(sizeof(EventActorStateDemoTalkGK) == 0x38);

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -26,6 +26,7 @@ void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
                                         const al::ActorInitInfo& initInfo, const char* name);
 void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
 void resetEventBalloonFilter(const al::LiveActor*);
+bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor*);
 void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
 void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
 }  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1190)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 55949db)

📈 **Matched code**: 14.67% (+0.01%, +1216 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::exeTalkAfter()` | +232 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `(anonymous namespace)::EventActorStateDemoTalkGKNrvTalk::execute(al::NerveKeeper*) const` | +136 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::exeTalk()` | +132 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `(anonymous namespace)::EventActorStateDemoTalkGKNrvWait::execute(al::NerveKeeper*) const` | +132 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::exeWait()` | +128 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::EventActorStateDemoTalkGK(al::LiveActor*, ParamEventActorStateDemoTalkGK const*)` | +124 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::appear()` | +124 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::chaseTalkAnimWeightOne()` | +84 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::chaseWaitAnimWeightOne()` | +80 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `EventActorStateDemoTalkGK::~EventActorStateDemoTalkGK()` | +36 | 0.00% | 100.00% |
| `Event/EventActorStateDemoTalkGK` | `(anonymous namespace)::EventActorStateDemoTalkGKNrvTalkAfter::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->