### PR TITLE
Player: Implement `PlayerStateAbyss`

### DIFF
--- a/src/Player/PlayerStateAbyss.cpp
+++ b/src/Player/PlayerStateAbyss.cpp
@@ -1,0 +1,113 @@
+#include "Player/PlayerStateAbyss.h"
+
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Player/PlayerAnimator.h"
+#include "Player/PlayerConst.h"
+#include "Player/PlayerRecoverySafetyPoint.h"
+#include "Player/PlayerStateRecoveryDead.h"
+#include "Util/PlayerUtil.h"
+
+namespace al {
+void activateAudioEventController(const IUseAudioKeeper* audioKeeper);
+void allowAudioEventActivation(const IUseAudioKeeper* audioKeeper);
+void banAudioEventActivation(const IUseAudioKeeper* audioKeeper);
+void deactivateAudioEventController(const IUseAudioKeeper* audioKeeper);
+}  // namespace al
+
+namespace alSeFunction {
+void startSeFromUpperLayerSeKeeper(const al::IUseAudioKeeper* audioKeeper, const char* name);
+}  // namespace alSeFunction
+
+namespace {
+NERVE_IMPL(PlayerStateAbyss, Fall);
+NERVE_IMPL(PlayerStateAbyss, Recovery);
+
+NERVES_MAKE_NOSTRUCT(PlayerStateAbyss, Fall, Recovery);
+}  // namespace
+
+PlayerStateAbyss::PlayerStateAbyss(al::LiveActor* player, const PlayerConst* pConst,
+                                   PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                                   PlayerColliderHakoniwa* collider, PlayerAnimator* animator,
+                                   al::LiveActor* capActor)
+    : al::ActorStateBase("奈落死", player), mConst(pConst),
+      mRecoverySafetyPoint(recoverySafetyPoint), mAnimator(animator) {
+    initNerve(&Fall, 1);
+    mStateRecoveryDead = new PlayerStateRecoveryDead(player, recoverySafetyPoint, collider,
+                                                     animator, pConst, capActor);
+    al::initNerveState(this, mStateRecoveryDead, &Recovery, "奈落復帰");
+}
+
+void PlayerStateAbyss::appear() {
+    al::ActorStateBase::appear();
+
+    if (mRecoverySafetyPoint->isValid()) {
+        al::offAreaTarget(mActor);
+        al::setNerve(this, &Recovery);
+        return;
+    }
+
+    if (rs::isPlayer2D(mActor))
+        mAnimator->startAnim("Fall");
+
+    al::offAreaTarget(mActor);
+    al::setNerve(this, &Fall);
+}
+
+void PlayerStateAbyss::kill() {
+    al::onAreaTarget(mActor);
+    al::setNerve(this, &Fall);
+    al::ActorStateBase::kill();
+}
+
+void PlayerStateAbyss::prepareRecovery() {
+    al::setNerve(this, &Recovery);
+}
+
+bool PlayerStateAbyss::isRecovery() const {
+    return al::isNerve(this, &Recovery);
+}
+
+bool PlayerStateAbyss::isRecoveryLandFall() const {
+    return !isDead() && al::isNerve(this, &Recovery) && mStateRecoveryDead->isLandFall();
+}
+
+void PlayerStateAbyss::exeFall() {
+    if (al::isFirstStep(this)) {
+        if (rs::isPlayer3D(mActor)) {
+            if (mAnimator->isSubAnimPlaying())
+                mAnimator->endSubAnim();
+
+            mAnimator->startAnim("DeadFall");
+            al::startSe(mActor, "FallDown");
+            al::startSe(mActor, "vDeadFallDown");
+        } else {
+            alSeFunction::startSeFromUpperLayerSeKeeper(mActor, "FallDown2D");
+        }
+    }
+
+    al::LiveActor* player = mActor;
+    f32 gravity = mConst->getGravityAir();
+    f32 fallSpeedMax = mConst->getFallSpeedMax();
+    al::addVelocityToGravityLimit(player, gravity, fallSpeedMax);
+}
+
+void PlayerStateAbyss::exeRecovery() {
+    if (al::isFirstStep(this)) {
+        al::deactivateAudioEventController(mActor);
+        al::banAudioEventActivation(mActor);
+    }
+
+    if (al::updateNerveState(this)) {
+        al::allowAudioEventActivation(mActor);
+        al::activateAudioEventController(mActor);
+        al::startAndStopBgmInCurPosition(mActor, false);
+        kill();
+    }
+}

--- a/src/Player/PlayerStateAbyss.h
+++ b/src/Player/PlayerStateAbyss.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class PlayerAnimator;
+class PlayerColliderHakoniwa;
+class PlayerConst;
+class PlayerRecoverySafetyPoint;
+class PlayerStateRecoveryDead;
+
+class PlayerStateAbyss : public al::ActorStateBase {
+public:
+    PlayerStateAbyss(al::LiveActor* player, const PlayerConst* pConst,
+                     PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                     PlayerColliderHakoniwa* collider, PlayerAnimator* animator,
+                     al::LiveActor* capActor);
+
+    void appear() override;
+    void kill() override;
+    void prepareRecovery();
+    bool isRecovery() const;
+    bool isRecoveryLandFall() const;
+    void exeFall();
+    void exeRecovery();
+
+private:
+    const PlayerConst* mConst = nullptr;
+    PlayerRecoverySafetyPoint* mRecoverySafetyPoint = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    PlayerStateRecoveryDead* mStateRecoveryDead = nullptr;
+};
+
+static_assert(sizeof(PlayerStateAbyss) == 0x40);

--- a/src/Player/PlayerStateRecoveryDead.h
+++ b/src/Player/PlayerStateRecoveryDead.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class ActorDimensionKeeper;
+class PlayerColliderHakoniwa;
+class PlayerAnimator;
+class PlayerConst;
+class PlayerRecoverySafetyPoint;
+
+class PlayerStateRecoveryDead : public al::ActorStateBase {
+public:
+    PlayerStateRecoveryDead(al::LiveActor* player, PlayerRecoverySafetyPoint* recoverySafetyPoint,
+                            PlayerColliderHakoniwa* collider, PlayerAnimator* animator,
+                            const PlayerConst* pConst, al::LiveActor* capActor);
+
+    void appear() override;
+    void kill() override;
+    bool isLandFall() const;
+    void exeStart();
+    void exeRecovery();
+    void exeFall();
+
+private:
+    PlayerRecoverySafetyPoint* mRecoverySafetyPoint = nullptr;
+    PlayerColliderHakoniwa* mCollider = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    const PlayerConst* mConst = nullptr;
+    al::LiveActor* mCapActor = nullptr;
+    f32 mRecoveryAccel = 0.0f;
+    f32 mRecoverySpeed = 0.0f;
+    sead::Vector3f mStartTrans = sead::Vector3f::zero;
+    sead::Vector3f mStartUp = sead::Vector3f::zero;
+    sead::Vector3f mVelocityH = sead::Vector3f::zero;
+    s32 mRecoveryFrame = 0;
+    s32 mFallStartFrame = 0;
+    f32 mQuatRotationRate = 0.0f;
+    sead::Quatf mStartQuat = sead::Quatf::unit;
+    sead::Vector3f mSideDir = sead::Vector3f::ex;
+    sead::Vector3f mRecoveryUp = sead::Vector3f::ey;
+    ActorDimensionKeeper* mDimensionKeeper = nullptr;
+    sead::Vector3f mMoveDir2D = sead::Vector3f::zero;
+    sead::Vector3f mMoveDir2DPrev = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(PlayerStateRecoveryDead) == 0xc8);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1191)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 82892fd)

📈 **Matched code**: 14.67% (+0.01%, +1052 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::exeFall()` | +272 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::PlayerStateAbyss(al::LiveActor*, PlayerConst const*, PlayerRecoverySafetyPoint*, PlayerColliderHakoniwa*, PlayerAnimator*, al::LiveActor*)` | +212 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::exeRecovery()` | +176 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::appear()` | +168 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::isRecoveryLandFall() const` | +80 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::kill()` | +60 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::~PlayerStateAbyss()` | +36 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::prepareRecovery()` | +16 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `PlayerStateAbyss::isRecovery() const` | +16 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `(anonymous namespace)::PlayerStateAbyssNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Player/PlayerStateAbyss` | `(anonymous namespace)::PlayerStateAbyssNrvRecovery::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->