### PR TITLE
MapObj: Implement `GrowFlowerPotStateReactionWater`

### DIFF
--- a/src/MapObj/GrowFlowerPot.h
+++ b/src/MapObj/GrowFlowerPot.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class GrowFlowerWatcher;
+class Shine;
+
+class GrowFlowerPot : public al::LiveActor {
+public:
+    GrowFlowerPot(const char* name, bool isLong, GrowFlowerWatcher* watcher);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initSetShinePtrFromSeed(Shine* shine);
+    void initAfterPlacement() override;
+    void tryMaxGrowLevel();
+    void setGrowFlowerTimeLocal(al::HitSensor* sensor);
+    u32 calcGrowLevelFromImplantTime() const;
+    void calcGrowLevelTarget();
+    bool isGrowAlready() const;
+    void control() override;
+    void calcAnim() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void setShineFromSeed(Shine* shine);
+    void growLevelFromGamaner();
+    void exeNoSeed();
+    void exeImplant();
+    void growSetting();
+    void startGrow();
+    void tryStartActionReactionParts();
+    bool updateGrow();
+    void endGrow();
+    void endPartsReactionTrans();
+    void growLevelFromHosui();
+    void exeGrow();
+    bool isEnableGrow() const;
+    void exeGrowWait();
+    void tryStartActionWaitParts();
+    void exeBerryWait();
+    void exeAppearShine();
+    void endAppearShine();
+    void exeWaitShine();
+    void exeResumeShine();
+    void exeReaction();
+    void exeReactionWater();
+    u64 calcGrowLevelTargetLocal(u32 growLevel);
+    bool isEqualPlacementId(const char* placementId) const;
+
+    void setIsReactionWater(bool isReactionWater) { mIsReactionWater = isReactionWater; }
+
+private:
+    u8 _108[0x88]{};
+    bool mIsReactionWater = false;
+    u8 _191 = 0;
+    u8 _192 = 0;
+    u8 _193[5]{};
+};
+
+static_assert(sizeof(GrowFlowerPot) == 0x198);

--- a/src/MapObj/GrowFlowerPotStateReactionWater.cpp
+++ b/src/MapObj/GrowFlowerPotStateReactionWater.cpp
@@ -1,0 +1,110 @@
+#include "MapObj/GrowFlowerPotStateReactionWater.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "MapObj/GrowFlowerPot.h"
+
+namespace {
+NERVE_IMPL(GrowFlowerPotStateReactionWater, Start);
+NERVE_IMPL(GrowFlowerPotStateReactionWater, Reaction);
+NERVE_IMPL(GrowFlowerPotStateReactionWater, ReactionGrow);
+NERVE_IMPL(GrowFlowerPotStateReactionWater, End);
+
+NERVES_MAKE_NOSTRUCT(GrowFlowerPotStateReactionWater, Start, Reaction, ReactionGrow, End);
+}  // namespace
+
+GrowFlowerPotStateReactionWater::GrowFlowerPotStateReactionWater(GrowFlowerPot* pot)
+    : al::HostStateBase<GrowFlowerPot>("ホウスイの水との反応ステート", pot) {
+    initNerve(&Start, 0);
+}
+
+void GrowFlowerPotStateReactionWater::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Start);
+}
+
+void GrowFlowerPotStateReactionWater::control() {
+    mReactionTimer--;
+}
+
+void GrowFlowerPotStateReactionWater::exeStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(getHost(), "ReactionWaterStart");
+        getHost()->tryStartActionReactionParts();
+    }
+
+    getHost()->setIsReactionWater(true);
+    if (al::isActionEnd(getHost())) {
+        getHost()->endPartsReactionTrans();
+        if (getHost()->isGrowAlready())
+            al::setNerve(this, &Reaction);
+        else
+            al::setNerve(this, &ReactionGrow);
+    }
+}
+
+void GrowFlowerPotStateReactionWater::exeReaction() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(getHost(), "ReactionWater");
+
+    getHost()->setIsReactionWater(true);
+    getHost()->tryStartActionReactionParts();
+    if (mReactionTimer <= 0) {
+        getHost()->endPartsReactionTrans();
+        al::setNerve(this, &End);
+    }
+}
+
+void GrowFlowerPotStateReactionWater::exeReactionGrow() {
+    if (al::isFirstStep(this)) {
+        al::tryStartActionIfNotPlaying(getHost(), "ReactionWater");
+        getHost()->startGrow();
+    }
+
+    if (mReactionTimer >= 1) {
+        if (!getHost()->isGrowAlready()) {
+            getHost()->growLevelFromHosui();
+            getHost()->calcGrowLevelTarget();
+        }
+    }
+
+    if (mReactionTimer <= 0 && !getHost()->isEnableGrow()) {
+        al::setNerve(this, &End);
+        return;
+    }
+
+    if (!getHost()->updateGrow())
+        return;
+
+    getHost()->endGrow();
+    if (mReactionTimer >= 1 && getHost()->isGrowAlready()) {
+        al::setNerve(this, &Reaction);
+        return;
+    }
+
+    if (getHost()->isEnableGrow()) {
+        getHost()->tryStartActionWaitParts();
+        al::setNerve(this, &Start);
+        al::setNerve(this, &ReactionGrow);
+        return;
+    }
+
+    al::setNerve(this, &End);
+}
+
+void GrowFlowerPotStateReactionWater::exeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(getHost(), "ReactionWaterEnd");
+
+    getHost()->setIsReactionWater(true);
+    if (al::isActionEnd(getHost())) {
+        getHost()->endPartsReactionTrans();
+        kill();
+    }
+}
+
+void GrowFlowerPotStateReactionWater::requestReaction() {
+    mReactionTimer = 10;
+}

--- a/src/MapObj/GrowFlowerPotStateReactionWater.h
+++ b/src/MapObj/GrowFlowerPotStateReactionWater.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class GrowFlowerPot;
+
+class GrowFlowerPotStateReactionWater : public al::HostStateBase<GrowFlowerPot> {
+public:
+    GrowFlowerPotStateReactionWater(GrowFlowerPot* pot);
+
+    void appear() override;
+    void control() override;
+
+    void exeStart();
+    void exeReaction();
+    void exeReactionGrow();
+    void exeEnd();
+    void requestReaction();
+
+private:
+    s32 mReactionTimer = 0;
+};
+
+static_assert(sizeof(GrowFlowerPotStateReactionWater) == 0x28);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1192)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - ad99102)

📈 **Matched code**: 14.67% (+0.01%, +1044 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::exeReactionGrow()` | +260 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::exeStart()` | +140 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `(anonymous namespace)::GrowFlowerPotStateReactionWaterNrvReaction::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::exeReaction()` | +120 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `(anonymous namespace)::GrowFlowerPotStateReactionWaterNrvEnd::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::exeEnd()` | +108 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::GrowFlowerPotStateReactionWater(GrowFlowerPot*)` | +84 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::~GrowFlowerPotStateReactionWater()` | +36 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::appear()` | +16 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::control()` | +16 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `GrowFlowerPotStateReactionWater::requestReaction()` | +12 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `(anonymous namespace)::GrowFlowerPotStateReactionWaterNrvStart::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/GrowFlowerPotStateReactionWater` | `(anonymous namespace)::GrowFlowerPotStateReactionWaterNrvReactionGrow::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->