### PR TITLE
MapObj: Implement `FixMapPartsDitherAppear`

### DIFF
--- a/src/MapObj/FixMapPartsDitherAppear.cpp
+++ b/src/MapObj/FixMapPartsDitherAppear.cpp
@@ -1,0 +1,78 @@
+#include "MapObj/FixMapPartsDitherAppear.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+namespace {
+NERVE_IMPL(FixMapPartsDitherAppear, Wait);
+NERVE_IMPL(FixMapPartsDitherAppear, Appear);
+NERVES_MAKE_NOSTRUCT(FixMapPartsDitherAppear, Wait, Appear);
+}  // namespace
+
+FixMapPartsDitherAppear::FixMapPartsDitherAppear(const char* actorName)
+    : al::LiveActor(actorName) {}
+
+void FixMapPartsDitherAppear::init(const al::ActorInitInfo& info) {
+    using FixMapPartsDitherAppearFunctor =
+        al::FunctorV0M<FixMapPartsDitherAppear*, void (FixMapPartsDitherAppear::*)()>;
+
+    al::initMapPartsActor(this, info, nullptr);
+    al::registActorToDemoInfo(this, info);
+    al::initNerve(this, &Wait, 0);
+
+    bool isListenSwitchAppear = al::listenStageSwitchOn(
+        this, "SwitchAppear",
+        FixMapPartsDitherAppearFunctor(this, &FixMapPartsDitherAppear::ditherAppear));
+    bool isListenSwitchAppeared = al::listenStageSwitchOn(
+        this, "SwitchAppeared",
+        FixMapPartsDitherAppearFunctor(this, &FixMapPartsDitherAppear::waitAppear));
+    al::tryGetArg(&mAnimFrame, info, "AnimFrame");
+
+    if (isListenSwitchAppear || isListenSwitchAppeared)
+        makeActorDead();
+    else
+        makeActorAlive();
+}
+
+void FixMapPartsDitherAppear::ditherAppear() {
+    al::LiveActor::appear();
+    al::setModelAlphaMask(this, 0.0f);
+    al::setNerve(this, &Appear);
+}
+
+void FixMapPartsDitherAppear::waitAppear() {
+    if (al::isNerve(this, &Appear))
+        return;
+
+    al::LiveActor::appear();
+    al::setModelAlphaMask(this, 1.0f);
+    al::setNerve(this, &Wait);
+}
+
+void FixMapPartsDitherAppear::calcAnim() {
+    al::calcViewModel(this);
+}
+
+bool FixMapPartsDitherAppear::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                         al::HitSensor* self) {
+    if (al::isMsgAskSafetyPoint(message) && al::isNerve(this, &Wait))
+        return true;
+    return false;
+}
+
+void FixMapPartsDitherAppear::exeAppear() {
+    f32 rate = al::calcNerveRate(this, mAnimFrame);
+    al::setModelAlphaMask(this, rate);
+
+    if (al::isGreaterEqualStep(this, mAnimFrame))
+        al::setNerve(this, &Wait);
+}
+
+void FixMapPartsDitherAppear::exeWait() {}

--- a/src/MapObj/FixMapPartsDitherAppear.h
+++ b/src/MapObj/FixMapPartsDitherAppear.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class FixMapPartsDitherAppear : public al::LiveActor {
+public:
+    FixMapPartsDitherAppear(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void ditherAppear();
+    void waitAppear();
+    void exeAppear();
+    void exeWait();
+
+private:
+    s32 mAnimFrame = -1;
+};
+
+static_assert(sizeof(FixMapPartsDitherAppear) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -90,6 +90,7 @@
 #include "MapObj/ElectricWire/ElectricWire.h"
 #include "MapObj/FireDrum2D.h"
 #include "MapObj/FixMapPartsBgmChangeAction.h"
+#include "MapObj/FixMapPartsDitherAppear.h"
 #include "MapObj/HackFork.h"
 #include "MapObj/HipDropMoveLift.h"
 #include "MapObj/HipDropRepairParts.h"
@@ -326,7 +327,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"FixMapPartsAppearKillAsync", nullptr},
     {"FixMapPartsBgmChangeAction", al::createActorFunction<FixMapPartsBgmChangeAction>},
     {"FixMapPartsCapHanger", nullptr},
-    {"FixMapPartsDitherAppear", nullptr},
+    {"FixMapPartsDitherAppear", al::createActorFunction<FixMapPartsDitherAppear>},
     {"FixMapPartsForceSafetyPoint", nullptr},
     {"FixMapPartsFukankunZoomCapMessage", nullptr},
     {"FixMapPartsScenarioAction", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1194)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 9a29694)

📈 **Matched code**: 14.67% (+0.01%, +1088 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::init(al::ActorInitInfo const&)` | +252 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::FixMapPartsDitherAppear(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::FixMapPartsDitherAppear(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::waitAppear()` | +92 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `(anonymous namespace)::FixMapPartsDitherAppearNrvAppear::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::exeAppear()` | +84 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `al::FunctorV0M<FixMapPartsDitherAppear*, void (FixMapPartsDitherAppear::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +72 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::ditherAppear()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<FixMapPartsDitherAppear>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `al::FunctorV0M<FixMapPartsDitherAppear*, void (FixMapPartsDitherAppear::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::calcAnim()` | +4 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `FixMapPartsDitherAppear::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `(anonymous namespace)::FixMapPartsDitherAppearNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/FixMapPartsDitherAppear` | `al::FunctorV0M<FixMapPartsDitherAppear*, void (FixMapPartsDitherAppear::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->