### PR TITLE
MapObj: Implement `CapMessageAfterInformation`

### DIFF
--- a/src/MapObj/CapMessageAfterInformation.cpp
+++ b/src/MapObj/CapMessageAfterInformation.cpp
@@ -1,0 +1,72 @@
+#include "MapObj/CapMessageAfterInformation.h"
+
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/InputInterruptTutorialUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(CapMessageAfterInformation, Wait);
+NERVE_END_IMPL(CapMessageAfterInformation, Show);
+
+NERVES_MAKE_NOSTRUCT(CapMessageAfterInformation, Wait, Show);
+}  // namespace
+
+CapMessageAfterInformation::CapMessageAfterInformation(const char* name) : al::LiveActor(name) {}
+
+void CapMessageAfterInformation::makeActorDead() {
+    if (!al::isNerve(this, &Wait))
+        al::setNerve(this, &Wait);
+
+    al::LiveActor::makeActorDead();
+}
+
+void CapMessageAfterInformation::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorUpdate(this, info, "監視オブジェ");
+    al::initStageSwitch(this, info);
+    mInfoAreaGroup =
+        al::createLinkAreaGroup(this, info, "InfoArea", "インフォメーション起動エリアグループ",
+                                "インフォメーション起動エリア");
+    al::tryGetStringArg(&mLabel, info, "Label");
+    al::initNerve(this, &Wait, 0);
+    al::tryGetArg(&mHackActorType, info, "HackActorType");
+
+    if (mInfoAreaGroup && mLabel) {
+        al::trySyncStageSwitchAppearAndKill(this);
+        return;
+    }
+
+    makeActorDead();
+}
+
+void CapMessageAfterInformation::exeWait() {
+    if (al::isInAreaObjPlayerAnyOne(this, mInfoAreaGroup) &&
+        rs::isPlayerHackType(this, mHackActorType))
+        al::setNerve(this, &Show);
+}
+
+bool CapMessageAfterInformation::isEnable() const {
+    if (al::isInAreaObjPlayerAnyOne(this, mInfoAreaGroup))
+        return rs::isPlayerHackType(this, mHackActorType);
+
+    return false;
+}
+
+void CapMessageAfterInformation::exeShow() {
+    if (al::isFirstStep(this))
+        rs::appearCapMsgTutorial(this, mLabel);
+
+    if (!al::isInAreaObjPlayerAnyOne(this, mInfoAreaGroup) ||
+        !rs::isPlayerHackType(this, mHackActorType))
+        al::setNerve(this, &Wait);
+}
+
+void CapMessageAfterInformation::endShow() {
+    rs::closeCapMsgTutorial(this);
+}

--- a/src/MapObj/CapMessageAfterInformation.h
+++ b/src/MapObj/CapMessageAfterInformation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class AreaObjGroup;
+}  // namespace al
+
+class CapMessageAfterInformation : public al::LiveActor {
+public:
+    CapMessageAfterInformation(const char* name);
+
+    void makeActorDead() override;
+    void init(const al::ActorInitInfo& info) override;
+
+    void exeWait();
+    bool isEnable() const;
+    void exeShow();
+    void endShow();
+
+private:
+    al::AreaObjGroup* mInfoAreaGroup = nullptr;
+    const char* mLabel = nullptr;
+    s32 mHackActorType = -2;
+};
+
+static_assert(sizeof(CapMessageAfterInformation) == 0x120);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -76,6 +76,7 @@
 #include "MapObj/BreakablePole.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
+#include "MapObj/CapMessageAfterInformation.h"
 #include "MapObj/CapSwitch.h"
 #include "MapObj/CarWatcher.h"
 #include "MapObj/CheckpointFlag.h"
@@ -222,7 +223,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"CapFlower", nullptr},
     {"CapFlowerGroup", nullptr},
     {"CapHanger", al::createActorFunction<CapHanger>},
-    {"CapMessageAfterInformation", nullptr},
+    {"CapMessageAfterInformation", al::createActorFunction<CapMessageAfterInformation>},
     {"CapRack", nullptr},
     {"CapRackTimer", nullptr},
     {"CapRailMover", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1195)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 2e92179)

📈 **Matched code**: 14.67% (+0.01%, +1080 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::init(al::ActorInitInfo const&)` | +228 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::CapMessageAfterInformation(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::CapMessageAfterInformation(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `(anonymous namespace)::CapMessageAfterInformationNrvShow::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::exeShow()` | +104 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `(anonymous namespace)::CapMessageAfterInformationNrvWait::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::exeWait()` | +80 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::makeActorDead()` | +64 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::isEnable() const` | +64 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<CapMessageAfterInformation>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `(anonymous namespace)::CapMessageAfterInformationNrvShow::executeOnEnd(al::NerveKeeper*) const` | +12 | 0.00% | 100.00% |
| `MapObj/CapMessageAfterInformation` | `CapMessageAfterInformation::endShow()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->