### PR TITLE
Sequence: Implement `HakoniwaStateDeleteScene`

### DIFF
--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -43,6 +43,8 @@ public:
 
     DrawSystemInfo* getDrawInfo() const { return mDrawSystemInfo; }
 
+    void setCurrentScene(Scene* scene) { mCurrentScene = scene; }
+
 private:
     sead::FixedSafeString<0x40> mName;
     Scene* mCurrentScene = nullptr;

--- a/src/Sequence/HakoniwaStateDeleteScene.cpp
+++ b/src/Sequence/HakoniwaStateDeleteScene.cpp
@@ -1,0 +1,104 @@
+#include "Sequence/HakoniwaStateDeleteScene.h"
+
+#include <thread/seadThread.h>
+
+#include "Library/Audio/AudioDirector.h"
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/Scene.h"
+#include "Library/Scene/SceneUtil.h"
+#include "Library/Sequence/Sequence.h"
+#include "Library/Thread/AsyncFunctorThread.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Sequence/WorldResourceLoader.h"
+
+namespace {
+using namespace al;
+
+NERVE_IMPL(HakoniwaStateDeleteScene, Prepare)
+NERVE_IMPL(HakoniwaStateDeleteScene, DeleteScene)
+NERVE_IMPL(HakoniwaStateDeleteScene, FinalizeAudio)
+
+NERVES_MAKE_NOSTRUCT(HakoniwaStateDeleteScene, Prepare)
+NERVES_MAKE_STRUCT(HakoniwaStateDeleteScene, DeleteScene, FinalizeAudio)
+}  // namespace
+
+const s32 cDefaultPriority = sead::Thread::cDefaultPriority;
+const s32 cPriority = cDefaultPriority + 1;
+
+HakoniwaStateDeleteScene::HakoniwaStateDeleteScene(al::Sequence* sequence,
+                                                   WorldResourceLoader* resourceLoader)
+    : al::HostStateBase<al::Sequence>("シーン破棄", sequence), mResourceLoader(resourceLoader) {
+    using DeleteSceneFunctor =
+        al::FunctorV0M<HakoniwaStateDeleteScene*, void (HakoniwaStateDeleteScene::*)()>;
+
+    initNerve(&Prepare, 0);
+    mDeleteSceneThread = new al::AsyncFunctorThread(
+        "DeleteScene", DeleteSceneFunctor{this, &HakoniwaStateDeleteScene::deleteScene}, cPriority,
+        0x80000, sead::CoreId::cMain);
+}
+
+HakoniwaStateDeleteScene::~HakoniwaStateDeleteScene() {
+    if (mDeleteSceneThread)
+        delete mDeleteSceneThread;
+}
+
+void HakoniwaStateDeleteScene::deleteScene() {
+    if (mScene)
+        delete mScene;
+    mScene = nullptr;
+    al::destroySceneHeap(mIsDestroySceneHeap);
+}
+
+void HakoniwaStateDeleteScene::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Prepare);
+}
+
+void HakoniwaStateDeleteScene::kill() {
+    al::NerveStateBase::kill();
+}
+
+void HakoniwaStateDeleteScene::start(al::Scene* scene, bool isDestroySceneHeap,
+                                     bool isFinalizeAudio, s32 stopSeIndex) {
+    mIsDestroySceneHeap = isDestroySceneHeap;
+    mScene = scene;
+    mStopSeIndex = stopSeIndex;
+    mIsFinalizeAudio = isFinalizeAudio;
+}
+
+void HakoniwaStateDeleteScene::exePrepare() {
+    getHost()->setCurrentScene(nullptr);
+    if (mIsFinalizeAudio)
+        al::setNerve(this, &NrvHakoniwaStateDeleteScene.FinalizeAudio);
+    else
+        al::setNerve(this, &NrvHakoniwaStateDeleteScene.DeleteScene);
+}
+
+void HakoniwaStateDeleteScene::exeFinalizeAudio() {
+    al::AudioDirector* audioDirector = mScene->getAudioDirector();
+    if (al::isFirstStep(this)) {
+        if (!audioDirector) {
+            al::setNerve(this, &NrvHakoniwaStateDeleteScene.DeleteScene);
+            return;
+        }
+        audioDirector->startFinalizeUnsafeModuleInParallelThread();
+    }
+
+    audioDirector->updateFinalizeUnsafeModuleInParallelThread();
+    if (!audioDirector->isFinalizedUnsafeModuleInParallelThread())
+        return;
+
+    al::stopAllSe(mScene, mStopSeIndex);
+    al::setNerve(this, &NrvHakoniwaStateDeleteScene.DeleteScene);
+}
+
+void HakoniwaStateDeleteScene::exeDeleteScene() {
+    if (al::isFirstStep(this))
+        mDeleteSceneThread->start();
+
+    if (mDeleteSceneThread->isDone() && mResourceLoader->isEndLoadWorldResource())
+        kill();
+}

--- a/src/Sequence/HakoniwaStateDeleteScene.h
+++ b/src/Sequence/HakoniwaStateDeleteScene.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class WorldResourceLoader;
+
+namespace al {
+class AsyncFunctorThread;
+class Scene;
+class Sequence;
+}  // namespace al
+
+class HakoniwaStateDeleteScene : public al::HostStateBase<al::Sequence> {
+public:
+    HakoniwaStateDeleteScene(al::Sequence* sequence, WorldResourceLoader* resourceLoader);
+    ~HakoniwaStateDeleteScene() override;
+
+    void appear() override;
+    void kill() override;
+
+    void start(al::Scene* scene, bool isDestroySceneHeap, bool isFinalizeAudio, s32 stopSeIndex);
+    void deleteScene();
+    void exePrepare();
+    void exeFinalizeAudio();
+    void exeDeleteScene();
+
+private:
+    al::Scene* mScene = nullptr;
+    al::AsyncFunctorThread* mDeleteSceneThread = nullptr;
+    bool mIsDestroySceneHeap = false;
+    bool mIsFinalizeAudio = false;
+    s32 mStopSeIndex = 0;
+    WorldResourceLoader* mResourceLoader = nullptr;
+};
+
+static_assert(sizeof(HakoniwaStateDeleteScene) == 0x40);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1196)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 46f7697)

📈 **Matched code**: 14.67% (+0.01%, +1012 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::HakoniwaStateDeleteScene(al::Sequence*, WorldResourceLoader*)` | +216 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::exeFinalizeAudio()` | +112 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `(anonymous namespace)::HakoniwaStateDeleteSceneNrvDeleteScene::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::exeDeleteScene()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::~HakoniwaStateDeleteScene()` | +76 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `al::FunctorV0M<HakoniwaStateDeleteScene*, void (HakoniwaStateDeleteScene::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::~HakoniwaStateDeleteScene()` | +68 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::deleteScene()` | +56 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `(anonymous namespace)::HakoniwaStateDeleteSceneNrvPrepare::execute(al::NerveKeeper*) const` | +48 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::exePrepare()` | +44 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `_GLOBAL__sub_I_HakoniwaStateDeleteScene.cpp` | +32 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::start(al::Scene*, bool, bool, int)` | +28 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `al::FunctorV0M<HakoniwaStateDeleteScene*, void (HakoniwaStateDeleteScene::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::appear()` | +16 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `HakoniwaStateDeleteScene::kill()` | +12 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `(anonymous namespace)::HakoniwaStateDeleteSceneNrvFinalizeAudio::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDeleteScene` | `al::FunctorV0M<HakoniwaStateDeleteScene*, void (HakoniwaStateDeleteScene::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->