### PR TITLE
MapObj: Implement `ElectricAttackTarget`

### DIFF
--- a/src/MapObj/ElectricAttackTarget.cpp
+++ b/src/MapObj/ElectricAttackTarget.cpp
@@ -1,0 +1,82 @@
+#include "MapObj/ElectricAttackTarget.h"
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Rail/RailUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(ElectricAttackTarget, Wait);
+NERVES_MAKE_NOSTRUCT(ElectricAttackTarget, Wait);
+}  // namespace
+
+ElectricAttackTarget::ElectricAttackTarget(const char* name) : al::LiveActor(name) {}
+
+void ElectricAttackTarget::init(const al::ActorInitInfo& info) {
+    using ElectricAttackTargetFunctor =
+        al::FunctorV0M<ElectricAttackTarget*, void (ElectricAttackTarget::*)()>;
+
+    al::initActor(this, info);
+    al::initNerve(this, &Wait, 0);
+    al::tryGetArg(&mRailMoveSpeed, info, "RailMoveSpeed");
+    mMtxConnector = al::tryCreateMtxConnector(this, info);
+    makeActorAlive();
+
+    if (al::listenStageSwitchOnAppear(
+            this, ElectricAttackTargetFunctor(this, &ElectricAttackTarget::appearBySwitch)))
+        kill();
+
+    al::listenStageSwitchOnKill(
+        this, ElectricAttackTargetFunctor(this, &ElectricAttackTarget::killBySwitch));
+}
+
+void ElectricAttackTarget::appearBySwitch() {
+    if (!al::isAlive(this))
+        al::LiveActor::appear();
+}
+
+void ElectricAttackTarget::killBySwitch() {
+    if (!al::isDead(this))
+        al::LiveActor::kill();
+}
+
+void ElectricAttackTarget::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+bool ElectricAttackTarget::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                      al::HitSensor* self) {
+    if (al::isNerve(this, &Wait)) {
+        if (rs::isMsgHackAttack(message))
+            return true;
+
+        if (rs::isMsgConductLightning(message))
+            return true;
+    }
+
+    return false;
+}
+
+void ElectricAttackTarget::exeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Wait");
+
+    if (al::isExistRail(this)) {
+        if (al::isLoopRail(this))
+            al::moveSyncRailLoop(this, mRailMoveSpeed);
+        else
+            al::moveSyncRailTurn(this, mRailMoveSpeed);
+    }
+
+    if (mMtxConnector && al::isMtxConnectorConnecting(mMtxConnector))
+        al::connectPoseQT(this, mMtxConnector);
+}

--- a/src/MapObj/ElectricAttackTarget.h
+++ b/src/MapObj/ElectricAttackTarget.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class MtxConnector;
+}
+
+class ElectricAttackTarget : public al::LiveActor {
+public:
+    ElectricAttackTarget(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void appearBySwitch();
+    void killBySwitch();
+    void initAfterPlacement() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void exeWait();
+
+private:
+    al::MtxConnector* mMtxConnector = nullptr;
+    f32 mRailMoveSpeed = 60.0f;
+};
+
+static_assert(sizeof(ElectricAttackTarget) == 0x118);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1198)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 5edf6c6)

📈 **Matched code**: 14.67% (+0.01%, +976 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::init(al::ActorInitInfo const&)` | +224 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::ElectricAttackTarget(char const*)` | +144 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::exeWait()` | +140 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::ElectricAttackTarget(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +88 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `al::FunctorV0M<ElectricAttackTarget*, void (ElectricAttackTarget::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::appearBySwitch()` | +52 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::killBySwitch()` | +52 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `ElectricAttackTarget::initAfterPlacement()` | +28 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `al::FunctorV0M<ElectricAttackTarget*, void (ElectricAttackTarget::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `(anonymous namespace)::ElectricAttackTargetNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/ElectricAttackTarget` | `al::FunctorV0M<ElectricAttackTarget*, void (ElectricAttackTarget::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->