### PR TITLE
System: Implement `VisitStageData`

### DIFF
--- a/src/System/VisitStageData.cpp
+++ b/src/System/VisitStageData.cpp
@@ -1,0 +1,66 @@
+#include "System/VisitStageData.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/Writer/ByamlWriter.h"
+
+namespace {
+constexpr s32 cVisitStageMax = 300;
+}  // namespace
+
+VisitStageData::VisitStageData() {
+    mStageNames = new sead::FixedSafeString<128>[cVisitStageMax];
+}
+
+void VisitStageData::init() {
+    mVisitStageNum = 0;
+
+    for (s32 i = 0; i < cVisitStageMax; i++)
+        mStageNames[i].clear();
+}
+
+bool VisitStageData::checkAlreadyVisit(const char* stageName) const {
+    for (s32 i = 0; i < mVisitStageNum; i++)
+        if (al::isEqualString(stageName, mStageNames[i].cstr()))
+            return true;
+
+    return false;
+}
+
+void VisitStageData::visit(const char* stageName) {
+    for (s32 i = 0; i < mVisitStageNum; i++)
+        if (al::isEqualString(stageName, mStageNames[i].cstr()))
+            return;
+
+    mStageNames[mVisitStageNum].format("%s", stageName);
+    mVisitStageNum++;
+}
+
+void VisitStageData::write(al::ByamlWriter* writer) {
+    writer->pushArray("VisitStageData");
+
+    for (s32 i = 0; i < mVisitStageNum; i++)
+        writer->addString(mStageNames[i].cstr());
+
+    writer->pop();
+}
+
+void VisitStageData::read(const al::ByamlIter& save) {
+    mVisitStageNum = 0;
+
+    for (s32 i = 0; i < cVisitStageMax; i++)
+        mStageNames[i].clear();
+
+    al::ByamlIter visitStageData;
+    save.tryGetIterByKey(&visitStageData, "VisitStageData");
+
+    for (s32 i = 0; i < visitStageData.getSize(); i++) {
+        const char* stageName = nullptr;
+        visitStageData.tryGetStringByIndex(&stageName, i);
+        mStageNames[i].format("%s", stageName);
+    }
+
+    mVisitStageNum = visitStageData.getSize();
+}

--- a/src/System/VisitStageData.h
+++ b/src/System/VisitStageData.h
@@ -9,18 +9,23 @@ class ByamlIter;
 class ByamlWriter;
 }  // namespace al
 
+namespace sead {
+template <s32 L>
+class FixedSafeString;
+}  // namespace sead
+
 class VisitStageData : public ByamlSave {
 public:
     VisitStageData();
     void init();
-    bool checkAlreadyVisit(const char*) const;
-    void visit(const char*);
+    bool checkAlreadyVisit(const char* stageName) const;
+    void visit(const char* stageName);
     void write(al::ByamlWriter* writer) override;
     void read(const al::ByamlIter& save) override;
 
 private:
-    void* _8;
-    s32 _10;
+    sead::FixedSafeString<128>* mStageNames = nullptr;
+    s32 mVisitStageNum = 0;
 };
 
 static_assert(sizeof(VisitStageData) == 0x18);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1199)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 9fc4f7f)

📈 **Matched code**: 14.67% (+0.01%, +976 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/VisitStageData` | `VisitStageData::read(al::ByamlIter const&)` | +252 | 0.00% | 100.00% |
| `System/VisitStageData` | `VisitStageData::VisitStageData()` | +200 | 0.00% | 100.00% |
| `System/VisitStageData` | `VisitStageData::visit(char const*)` | +168 | 0.00% | 100.00% |
| `System/VisitStageData` | `VisitStageData::write(al::ByamlWriter*)` | +144 | 0.00% | 100.00% |
| `System/VisitStageData` | `VisitStageData::checkAlreadyVisit(char const*) const` | +140 | 0.00% | 100.00% |
| `System/VisitStageData` | `VisitStageData::init()` | +72 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->