### PR TITLE
Boss/Koopa: Implement `KoopaStateAttackSpinShell`

### DIFF
--- a/src/Boss/Koopa/KoopaShell.h
+++ b/src/Boss/Koopa/KoopaShell.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Player/IUsePlayerCollision.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class PlayerCollider;
+
+class KoopaShell : public al::LiveActor, public IUsePlayerCollision {
+public:
+    KoopaShell(const char* name);
+    void init(const al::ActorInitInfo& initInfo) override;
+    void appear() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void updateCollider() override;
+    PlayerCollider* getPlayerCollider() const override;
+
+    void appearRecover();
+    bool isDeactive() const;
+    void exeAppear();
+    void exeSpinStart();
+    void exeSpin();
+    void exeBlow();
+    void exeEnd();
+    void exeDeactive();
+    void exeRecoverJump();
+    void exeRecoverFallSign();
+    void exeRecoverFall();
+    void exeRecoverLand();
+
+private:
+    u8 _110[0x50];
+};
+
+static_assert(sizeof(KoopaShell) == 0x160);

--- a/src/Boss/Koopa/KoopaStateAttackSpinShell.cpp
+++ b/src/Boss/Koopa/KoopaStateAttackSpinShell.cpp
@@ -1,0 +1,83 @@
+#include "Boss/Koopa/KoopaStateAttackSpinShell.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Boss/Koopa/KoopaFunction.h"
+#include "Boss/Koopa/KoopaShell.h"
+#include "Util/CameraUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(KoopaStateAttackSpinShell, AttackShellStart);
+NERVE_IMPL(KoopaStateAttackSpinShell, AttackShell);
+NERVE_IMPL(KoopaStateAttackSpinShell, AttackShellEnd);
+NERVES_MAKE_NOSTRUCT(KoopaStateAttackSpinShell, AttackShellStart, AttackShell, AttackShellEnd);
+}  // namespace
+
+KoopaStateAttackSpinShell::KoopaStateAttackSpinShell(al::LiveActor* actor, KoopaShell* shell)
+    : al::ActorStateBase("コウラスピン攻撃", actor), mShell(shell) {
+    initNerve(&AttackShellStart, 0);
+}
+
+void KoopaStateAttackSpinShell::startOnGround() {
+    mIsRecover = false;
+    appear();
+}
+
+void KoopaStateAttackSpinShell::startRecover() {
+    mIsRecover = true;
+    appear();
+}
+
+void KoopaStateAttackSpinShell::exeAttackShellStart() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mActor, "AttackShellStart");
+        rs::setKoopaShellCameraDistanceCurve(mActor);
+    }
+
+    if (al::isActionEnd(mActor))
+        al::setNerve(this, &AttackShell);
+}
+
+void KoopaStateAttackSpinShell::exeAttackShell() {
+    if (al::isFirstStep(this)) {
+        al::hideModelIfShow(mActor);
+        al::copyPose(mShell, mActor);
+        if (mIsRecover)
+            mShell->appearRecover();
+        else
+            mShell->appear();
+    }
+
+    al::resetPosition(mActor, al::getTrans(mShell));
+    if (mShell->isDeactive()) {
+        al::faceToTarget(mActor, rs::getPlayerPos(mActor));
+        al::showModelIfHide(mActor);
+        al::startAction(mActor, "AttackShellEnd");
+        if (mIsRecover) {
+            KoopaFunction::startCapOnAnim(mActor);
+            al::onCollide(mActor);
+        }
+        mShell->kill();
+        al::setNerve(this, &AttackShellEnd);
+    }
+}
+
+void KoopaStateAttackSpinShell::exeAttackShellEnd() {
+    if (al::isFirstStep(this))
+        rs::resetKoopaShellCameraDistanceCurve(mActor);
+
+    if (al::isActionEnd(mActor))
+        kill();
+}
+
+void KoopaStateAttackSpinShell::appear() {
+    NerveStateBase::appear();
+    al::setNerve(this, &AttackShellStart);
+}

--- a/src/Boss/Koopa/KoopaStateAttackSpinShell.h
+++ b/src/Boss/Koopa/KoopaStateAttackSpinShell.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class KoopaShell;
+
+class KoopaStateAttackSpinShell : public al::ActorStateBase {
+public:
+    KoopaStateAttackSpinShell(al::LiveActor* actor, KoopaShell* shell);
+    void appear() override;
+    void startOnGround();
+    void startRecover();
+    void exeAttackShellStart();
+    void exeAttackShell();
+    void exeAttackShellEnd();
+
+private:
+    KoopaShell* mShell = nullptr;
+    bool mIsRecover = false;
+};
+
+static_assert(sizeof(KoopaStateAttackSpinShell) == 0x30);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1200)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 69a88cd)

📈 **Matched code**: 14.67% (+0.01%, +804 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::exeAttackShell()` | +256 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `(anonymous namespace)::KoopaStateAttackSpinShellNrvAttackShellStart::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::exeAttackShellStart()` | +96 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::KoopaStateAttackSpinShell(al::LiveActor*, KoopaShell*)` | +92 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `(anonymous namespace)::KoopaStateAttackSpinShellNrvAttackShellEnd::execute(al::NerveKeeper*) const` | +84 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::exeAttackShellEnd()` | +80 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::~KoopaStateAttackSpinShell()` | +36 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::startRecover()` | +20 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::startOnGround()` | +16 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `KoopaStateAttackSpinShell::appear()` | +16 | 0.00% | 100.00% |
| `Boss/Koopa/KoopaStateAttackSpinShell` | `(anonymous namespace)::KoopaStateAttackSpinShellNrvAttackShell::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->