### PR TITLE
Util: Implement `DynamicCollisionKeeper`

### DIFF
--- a/lib/al/Library/Obj/DynamicCollisionActor.h
+++ b/lib/al/Library/Obj/DynamicCollisionActor.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+
+class DynamicCollisionActor : public LiveActor {
+public:
+    DynamicCollisionActor(const ActorInitInfo& initInfo, s32 vertexNum,
+                          const sead::Matrix34f* baseMtx, HitSensor* sensor,
+                          const void* attributeByml);
+
+    void create(s32 vertexNum);
+    void begin();
+    void vertex(const sead::Vector3f& position);
+    void endData();
+    void updateCollisionParts();
+    void attribute(u16 attribute);
+    void makePrism();
+    void end();
+
+private:
+    u8 mDynamicCollisionActorStorage[0x70];
+};
+
+static_assert(sizeof(DynamicCollisionActor) == 0x178);
+
+}  // namespace al

--- a/lib/al/Library/Obj/DynamicDrawActor.h
+++ b/lib/al/Library/Obj/DynamicDrawActor.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+#include <gfx/seadColor.h>
+#include <math/seadVector.h>
+
 #include "Library/LiveActor/LiveActor.h"
 
 namespace al {
@@ -11,11 +15,44 @@ public:
 
 class DynamicDrawActor : public LiveActor, public IUseFinalize {
 public:
-    // incomplete
+    enum DrawCategory {
+        DrawCategory_Default = 0,
+        DrawCategory_Forward = 1,
+        DrawCategory_Indirect = 2,
+        DrawCategory_PreSilhouette = 3,
+    };
+
+    DynamicDrawActor(const ActorInitInfo& initInfo, s32 vertexNum, const char* archiveName,
+                     DrawCategory drawCategory, bool isDrawDepthShadow);
+
+    void drawDepthShadow() const;
+    void draw() const override;
     void finalize() override;
+    void setupHio();
+    void begin();
+    void normal(const sead::Vector3f& normal);
+    void color(const sead::Color4f& color);
+    void texCoord(const sead::Vector2f& texCoord, s32 index);
+    void tangent(const sead::Vector4f& tangent);
+    void weight(const sead::Vector4f& weight);
+    void skinId(const sead::Vector4u& skinId);
+    void vertex(const sead::Vector3f& position);
+    void end();
+    void beginModify();
+    void normal(u32 index, const sead::Vector3f& normal);
+    void color(u32 index, const sead::Color4f& color);
+    void texCoord(u32 vertexIndex, const sead::Vector2f& texCoord, s32 coordIndex);
+    void tangent(u32 index, const sead::Vector4f& tangent);
+    void weight(u32 index, const sead::Vector4f& weight);
+    void skinId(u32 index, const sead::Vector4u& skinId);
+    void vertex(u32 index, const sead::Vector3f& position);
+    void endModify();
+    void movement() override;
 
 private:
-    // missing
+    u8 mDynamicDrawActorStorage[0x70];
 };
+
+static_assert(sizeof(DynamicDrawActor) == 0x180);
 
 }  // namespace al

--- a/src/Util/DynamicCollisionKeeper.cpp
+++ b/src/Util/DynamicCollisionKeeper.cpp
@@ -1,0 +1,114 @@
+#include "Util/DynamicCollisionKeeper.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Obj/DynamicCollisionActor.h"
+#include "Library/Obj/DynamicDrawActor.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Library/Yaml/ByamlUtil.h"
+
+DynamicCollisionKeeper::DynamicCollisionKeeper() = default;
+
+void DynamicCollisionKeeper::endInit() {}
+
+s32 DynamicCollisionKeeper::checkStrikePoint(al::HitInfo* hitInfo,
+                                             const al::CollisionCheckInfoBase& checkInfo) const {
+    return 0;
+}
+
+s32 DynamicCollisionKeeper::checkStrikeSphere(al::SphereHitResultBuffer* resultBuffer,
+                                              const al::SphereCheckInfo& checkInfo,
+                                              bool isFollowMovingCollision,
+                                              const sead::Vector3f& movement) const {
+    return 0;
+}
+
+s32 DynamicCollisionKeeper::checkStrikeArrow(al::ArrowHitResultBuffer* resultBuffer,
+                                             const al::ArrowCheckInfo& checkInfo) const {
+    return 0;
+}
+
+s32 DynamicCollisionKeeper::checkStrikeSphereForPlayer(al::SphereHitResultBuffer* resultBuffer,
+                                                       const al::SphereCheckInfo& checkInfo) const {
+    return 0;
+}
+
+s32 DynamicCollisionKeeper::checkStrikeDisk(al::DiskHitResultBuffer* resultBuffer,
+                                            const al::DiskCheckInfo& checkInfo) const {
+    return 0;
+}
+
+void DynamicCollisionKeeper::movement() {}
+
+void DynamicCollisionKeeper::addCollisionParts(al::CollisionParts* parts) {}
+
+void DynamicCollisionKeeper::connectToCollisionPartsList(al::CollisionParts* parts) {}
+
+void DynamicCollisionKeeper::disconnectToCollisionPartsList(al::CollisionParts* parts) {}
+
+void DynamicCollisionKeeper::searchWithSphere(
+    const al::SphereCheckInfo& checkInfo, sead::IDelegate1<al::CollisionParts*>& callback) const {}
+
+al::DynamicCollisionActor* rs::createDynamicCollisionActor(const al::ActorInitInfo& initInfo,
+                                                           s32 vertexNum,
+                                                           const sead::Matrix34f* baseMtx,
+                                                           al::HitSensor* sensor) {
+    const u8* attributeByml =
+        al::getBymlFromObjectResource(sead::SafeString("DynamicCollisionAttribute"),
+                                      sead::SafeString("DynamicCollisionAttribute"));
+
+    return new al::DynamicCollisionActor(initInfo, vertexNum, baseMtx, sensor, attributeByml);
+}
+
+s32 rs::searchDynamicCollisionAttributeIndex(const char* attributeName) {
+    const u8* attributeByml =
+        al::getBymlFromObjectResource(sead::SafeString("DynamicCollisionAttribute"),
+                                      sead::SafeString("DynamicCollisionAttribute"));
+    al::ByamlIter attributeIter(attributeByml);
+
+    s32 dataNum = al::getByamlIterDataNum(attributeIter);
+    for (s32 i = 0; i < dataNum; i++) {
+        al::ByamlIter entryIter;
+        al::getByamlIterByIndex(&entryIter, attributeIter, i);
+
+        const char* name;
+        if (!al::tryGetByamlString(&name, entryIter, "Name"))
+            return 0;
+
+        if (al::isEqualString(name, attributeName))
+            return i;
+    }
+
+    return 0;
+}
+
+al::DynamicDrawActor* rs::createDynamicDrawActor(const al::ActorInitInfo& initInfo, s32 vertexNum,
+                                                 const char* archiveName, bool isDrawDepthShadow) {
+    return new al::DynamicDrawActor(initInfo, vertexNum, archiveName,
+                                    al::DynamicDrawActor::DrawCategory_Default, isDrawDepthShadow);
+}
+
+al::DynamicDrawActor* rs::createDynamicDrawActorForward(const al::ActorInitInfo& initInfo,
+                                                        s32 vertexNum, const char* archiveName,
+                                                        bool isDrawDepthShadow) {
+    return new al::DynamicDrawActor(initInfo, vertexNum, archiveName,
+                                    al::DynamicDrawActor::DrawCategory_Forward, isDrawDepthShadow);
+}
+
+al::DynamicDrawActor* rs::createDynamicDrawActorIndirect(const al::ActorInitInfo& initInfo,
+                                                         s32 vertexNum, const char* archiveName,
+                                                         bool isDrawDepthShadow) {
+    return new al::DynamicDrawActor(initInfo, vertexNum, archiveName,
+                                    al::DynamicDrawActor::DrawCategory_Indirect, isDrawDepthShadow);
+}
+
+al::DynamicDrawActor* rs::createDynamicDrawActorPreSilhouette(const al::ActorInitInfo& initInfo,
+                                                              s32 vertexNum,
+                                                              const char* archiveName,
+                                                              bool isDrawDepthShadow) {
+    return new al::DynamicDrawActor(initInfo, vertexNum, archiveName,
+                                    al::DynamicDrawActor::DrawCategory_PreSilhouette,
+                                    isDrawDepthShadow);
+}

--- a/src/Util/DynamicCollisionKeeper.h
+++ b/src/Util/DynamicCollisionKeeper.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+
+#include "Library/Collision/ICollisionPartsKeeper.h"
+
+namespace al {
+struct ActorInitInfo;
+class DynamicCollisionActor;
+class DynamicDrawActor;
+class HitSensor;
+}  // namespace al
+
+class DynamicCollisionKeeper : public al::ICollisionPartsKeeper {
+public:
+    DynamicCollisionKeeper();
+
+    void endInit() override;
+    void addCollisionParts(al::CollisionParts* parts) override;
+    void connectToCollisionPartsList(al::CollisionParts* parts) override;
+    void disconnectToCollisionPartsList(al::CollisionParts* parts) override;
+    void resetToCollisionPartsList(al::CollisionParts* parts) override = 0;
+    s32 checkStrikePoint(al::HitInfo* hitInfo,
+                         const al::CollisionCheckInfoBase& checkInfo) const override;
+    s32 checkStrikeSphere(al::SphereHitResultBuffer* resultBuffer,
+                          const al::SphereCheckInfo& checkInfo, bool isFollowMovingCollision,
+                          const sead::Vector3f& movement) const override;
+    s32 checkStrikeArrow(al::ArrowHitResultBuffer* resultBuffer,
+                         const al::ArrowCheckInfo& checkInfo) const override;
+    s32 checkStrikeSphereForPlayer(al::SphereHitResultBuffer* resultBuffer,
+                                   const al::SphereCheckInfo& checkInfo) const override;
+    s32 checkStrikeDisk(al::DiskHitResultBuffer* resultBuffer,
+                        const al::DiskCheckInfo& checkInfo) const override;
+    void searchWithSphere(const al::SphereCheckInfo& checkInfo,
+                          sead::IDelegate1<al::CollisionParts*>& callback) const override;
+    void movement() override;
+};
+
+static_assert(sizeof(DynamicCollisionKeeper) == 0x8);
+
+namespace rs {
+
+al::DynamicCollisionActor* createDynamicCollisionActor(const al::ActorInitInfo& initInfo,
+                                                       s32 vertexNum,
+                                                       const sead::Matrix34f* baseMtx,
+                                                       al::HitSensor* sensor);
+s32 searchDynamicCollisionAttributeIndex(const char* attributeName);
+al::DynamicDrawActor* createDynamicDrawActor(const al::ActorInitInfo& initInfo, s32 vertexNum,
+                                             const char* archiveName, bool isDrawDepthShadow);
+al::DynamicDrawActor* createDynamicDrawActorForward(const al::ActorInitInfo& initInfo,
+                                                    s32 vertexNum, const char* archiveName,
+                                                    bool isDrawDepthShadow);
+al::DynamicDrawActor* createDynamicDrawActorIndirect(const al::ActorInitInfo& initInfo,
+                                                     s32 vertexNum, const char* archiveName,
+                                                     bool isDrawDepthShadow);
+al::DynamicDrawActor* createDynamicDrawActorPreSilhouette(const al::ActorInitInfo& initInfo,
+                                                          s32 vertexNum, const char* archiveName,
+                                                          bool isDrawDepthShadow);
+
+}  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1201)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 0fab050)

📈 **Matched code**: 14.67% (+0.01%, +824 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/DynamicCollisionKeeper` | `rs::searchDynamicCollisionAttributeIndex(char const*)` | +208 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `rs::createDynamicCollisionActor(al::ActorInitInfo const&, int, sead::Matrix34<float> const*, al::HitSensor*)` | +148 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `rs::createDynamicDrawActor(al::ActorInitInfo const&, int, char const*, bool)` | +96 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `rs::createDynamicDrawActorForward(al::ActorInitInfo const&, int, char const*, bool)` | +96 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `rs::createDynamicDrawActorIndirect(al::ActorInitInfo const&, int, char const*, bool)` | +96 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `rs::createDynamicDrawActorPreSilhouette(al::ActorInitInfo const&, int, char const*, bool)` | +96 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::DynamicCollisionKeeper()` | +20 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::checkStrikePoint(al::HitInfo*, al::CollisionCheckInfoBase const&) const` | +8 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::checkStrikeSphere(al::SphereHitResultBuffer*, al::SphereCheckInfo const&, bool, sead::Vector3<float> const&) const` | +8 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::checkStrikeArrow(al::ArrowHitResultBuffer*, al::ArrowCheckInfo const&) const` | +8 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::checkStrikeSphereForPlayer(al::SphereHitResultBuffer*, al::SphereCheckInfo const&) const` | +8 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::checkStrikeDisk(al::DiskHitResultBuffer*, al::DiskCheckInfo const&) const` | +8 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::endInit()` | +4 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::movement()` | +4 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::addCollisionParts(al::CollisionParts*)` | +4 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::connectToCollisionPartsList(al::CollisionParts*)` | +4 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::disconnectToCollisionPartsList(al::CollisionParts*)` | +4 | 0.00% | 100.00% |
| `Util/DynamicCollisionKeeper` | `DynamicCollisionKeeper::searchWithSphere(al::SphereCheckInfo const&, sead::IDelegate1<al::CollisionParts*>&) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->