### PR TITLE
MapObj: Implement `StateMapPartsForceReset`

### DIFF
--- a/src/MapObj/StateMapPartsForceReset.cpp
+++ b/src/MapObj/StateMapPartsForceReset.cpp
@@ -1,0 +1,84 @@
+#include "MapObj/StateMapPartsForceReset.h"
+
+#include "Library/Area/AreaObjUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAreaFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/Nerve.h"
+#include "Library/Nerve/NerveKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(StateMapPartsForceReset, Reset)
+
+class StateMapPartsForceResetNrvResetEnd : public al::Nerve {
+public:
+    void execute(al::NerveKeeper* keeper) const override {}
+};
+
+NERVES_MAKE_NOSTRUCT(StateMapPartsForceReset, Reset, ResetEnd)
+}  // namespace
+
+StateMapPartsForceReset::StateMapPartsForceReset(al::LiveActor* actor,
+                                                 const al::ActorInitInfo& initInfo)
+    : al::ActorStateBase("マップパーツ強制リセット", actor) {
+    mEnableResetDist = 2000.0f;
+    mIsInvalidClipping = false;
+    mInitTrans.z = 0.0f;
+    mLinkResetAreaGroup = nullptr;
+    mInitTrans.x = 0.0f;
+    mInitTrans.y = 0.0f;
+
+    initNerve(&Reset, 0);
+    mLinkResetAreaGroup =
+        al::createLinkAreaGroup(actor, initInfo, "LinkResetArea",
+                                "リフト位置リセットエリアグループ", "リフト位置リセットエリア");
+    al::tryGetArg(&mEnableResetDist, initInfo, "EnableResetDist");
+
+    const sead::Vector3f& trans = al::getTrans(actor);
+    mInitTrans.e = trans.e;
+    mInitQuat = al::getQuat(actor);
+}
+
+void StateMapPartsForceReset::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &ResetEnd);
+    mIsInvalidClipping = al::isInvalidClipping(mActor);
+    al::invalidateClipping(mActor);
+}
+
+bool StateMapPartsForceReset::isEnableForceReset() const {
+    if (!mLinkResetAreaGroup)
+        return false;
+
+    if (!al::isInAreaObj(mLinkResetAreaGroup, rs::getPlayerPos(mActor)))
+        return false;
+
+    const sead::Vector3f& trans = al::getTrans(mActor);
+    return (trans - mInitTrans).length() > mEnableResetDist;
+}
+
+void StateMapPartsForceReset::exeReset() {
+    if (al::isFirstStep(this)) {
+        al::startHitReaction(mActor, "消滅");
+        if (al::isExistAction(mActor, "Reset"))
+            al::tryStartAction(mActor, "Reset");
+        if (!mIsInvalidClipping)
+            al::validateClipping(mActor);
+    }
+
+    al::setQuat(mActor, mInitQuat);
+    al::setTrans(mActor, mInitTrans);
+    al::resetPosition(mActor);
+    al::startHitReaction(mActor, "出現");
+    al::setNerve(this, &Reset);
+    kill();
+}
+
+void StateMapPartsForceReset::exeResetEnd() {}

--- a/src/MapObj/StateMapPartsForceReset.h
+++ b/src/MapObj/StateMapPartsForceReset.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+struct ActorInitInfo;
+class AreaObjGroup;
+class LiveActor;
+}  // namespace al
+
+class StateMapPartsForceReset : public al::ActorStateBase {
+public:
+    StateMapPartsForceReset(al::LiveActor* actor, const al::ActorInitInfo& initInfo);
+
+    void appear() override;
+    bool isEnableForceReset() const;
+    void exeReset();
+    void exeResetEnd();
+
+private:
+    f32 mEnableResetDist;
+    al::AreaObjGroup* mLinkResetAreaGroup;
+    sead::Vector3f mInitTrans;
+    sead::Quatf mInitQuat;
+    bool mIsInvalidClipping;
+};
+
+static_assert(sizeof(StateMapPartsForceReset) == 0x50);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1202)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 973b511)

📈 **Matched code**: 14.67% (+0.01%, +696 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::StateMapPartsForceReset(al::LiveActor*, al::ActorInitInfo const&)` | +244 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::exeReset()` | +180 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::isEnableForceReset() const` | +156 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::appear()` | +64 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::~StateMapPartsForceReset()` | +36 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `(anonymous namespace)::StateMapPartsForceResetNrvReset::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `StateMapPartsForceReset::exeResetEnd()` | +4 | 0.00% | 100.00% |
| `MapObj/StateMapPartsForceReset` | `(anonymous namespace)::StateMapPartsForceResetNrvResetEnd::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->