### PR TITLE
MapObj: Implement `CageShine`

### DIFF
--- a/src/MapObj/CageShine.cpp
+++ b/src/MapObj/CageShine.cpp
@@ -1,0 +1,72 @@
+#include "MapObj/CageShine.h"
+
+#include "Library/Audio/System/SimpleAudioUser.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Shadow/ActorShadowUtil.h"
+
+#include "Util/DemoUtil.h"
+
+namespace {
+NERVE_IMPL(CageShine, Wait)
+NERVE_IMPL(CageShine, Break)
+
+NERVES_MAKE_NOSTRUCT(CageShine, Wait, Break)
+}  // namespace
+
+CageShine::CageShine(const char* name) : al::LiveActor(name) {}
+
+void CageShine::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "CageShine", nullptr);
+
+    bool isPlaySuccessSe = false;
+    al::tryGetArg(&isPlaySuccessSe, info, "IsPlaySuccessSe");
+    if (isPlaySuccessSe)
+        mSuccessSeObj = new al::SimpleAudioUser("SuccessSeObj", info);
+
+    al::initNerve(this, &Wait, 0);
+    makeActorAlive();
+    mBreakModel = al::tryGetSubActor(this, "壊れモデル");
+}
+
+void CageShine::addDemoActor() {
+    rs::addDemoActor(this, false);
+    if (mBreakModel)
+        rs::addDemoActor(mBreakModel, false);
+}
+
+void CageShine::startBreak() {
+    al::invalidateClipping(this);
+    al::setNerve(this, &Break);
+}
+
+void CageShine::exeWait() {}
+
+void CageShine::exeBreak() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Break");
+
+        if (mBreakModel)
+            mBreakModel->appear();
+
+        if (mSuccessSeObj)
+            al::startSe(mSuccessSeObj, "Riddle");
+
+        al::startHitReaction(this, "破壊[仮]");
+    }
+
+    if (al::isStep(this, 60) && al::isExistShadowMaskCtrl(this))
+        al::hideShadowMask(this);
+
+    if (al::isActionEnd(this)) {
+        if (!mBreakModel || al::isDead(mBreakModel))
+            kill();
+    }
+}

--- a/src/MapObj/CageShine.h
+++ b/src/MapObj/CageShine.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class SimpleAudioUser;
+struct ActorInitInfo;
+}  // namespace al
+
+class CageShine : public al::LiveActor {
+public:
+    CageShine(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void addDemoActor();
+    void startBreak();
+    void exeWait();
+    void exeBreak();
+
+private:
+    al::LiveActor* mBreakModel = nullptr;
+    al::SimpleAudioUser* mSuccessSeObj = nullptr;
+};
+
+static_assert(sizeof(CageShine) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -74,6 +74,7 @@
 #include "MapObj/BlockQuestion2D.h"
 #include "MapObj/BossKnuckleFix.h"
 #include "MapObj/BreakablePole.h"
+#include "MapObj/CageShine.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -198,7 +199,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"Byugo", nullptr},
     {"Cactus", nullptr},
     {"CactusMini", nullptr},
-    {"CageShine", nullptr},
+    {"CageShine", al::createActorFunction<CageShine>},
     {"CageSaveSwitch", nullptr},
     {"CageStageSwitch", nullptr},
     {"CageBreakable", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1203)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 547a9ff)

📈 **Matched code**: 14.67% (+0.01%, +808 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CageShine` | `CageShine::exeBreak()` | +220 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::init(al::ActorInitInfo const&)` | +208 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::CageShine(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::CageShine(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::addDemoActor()` | +60 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::startBreak()` | +44 | 0.00% | 100.00% |
| `MapObj/CageShine` | `(anonymous namespace)::CageShineNrvBreak::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/CageShine` | `CageShine::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/CageShine` | `(anonymous namespace)::CageShineNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->