### PR TITLE
Enemy: Implement `TRexPatrolRouteRider`

### DIFF
--- a/src/Enemy/TRexPatrolRouteBuilder.h
+++ b/src/Enemy/TRexPatrolRouteBuilder.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+struct ActorInitInfo;
+class PlacementInfo;
+}  // namespace al
+
+class TRexRouteInfoBase {
+public:
+    TRexRouteInfoBase(const al::PlacementInfo& placementInfo);
+
+    const sead::Vector3f& getTrans() const { return mTrans; }
+
+private:
+    sead::Vector3f mTrans;
+    s32 mPlacementIdHash;
+};
+
+static_assert(sizeof(TRexRouteInfoBase) == 0x10);
+
+class TRexPatrolRouteBuilder {
+public:
+    TRexPatrolRouteBuilder();
+
+    void init(const al::ActorInitInfo& initInfo);
+    void calcFirstRoute(const TRexRouteInfoBase** route, const TRexRouteInfoBase** goalRoute) const;
+    void calcNearestRoute(const TRexRouteInfoBase** route, const TRexRouteInfoBase** goalRoute,
+                          const sead::Vector3f& trans) const;
+    void calcRecoveryRoute(const TRexRouteInfoBase** route, const TRexRouteInfoBase** goalRoute,
+                           const sead::Vector3f& trans) const;
+    void calcNextRouteGoal(const TRexRouteInfoBase** goalRoute,
+                           const TRexRouteInfoBase* route) const;
+
+private:
+    s32 mMainRouteInfoCount;
+    TRexRouteInfoBase** mMainRouteInfos;
+    s32 mSubRouteInfoCount;
+    TRexRouteInfoBase** mSubRouteInfos;
+};
+
+static_assert(sizeof(TRexPatrolRouteBuilder) == 0x20);

--- a/src/Enemy/TRexPatrolRouteRider.cpp
+++ b/src/Enemy/TRexPatrolRouteRider.cpp
@@ -1,0 +1,83 @@
+#include "Enemy/TRexPatrolRouteRider.h"
+
+#include <cmath>
+
+#include "Library/Math/MathUtil.h"
+
+#include "Enemy/TRexPatrolRouteBuilder.h"
+
+TRexPatrolRouteRider::TRexPatrolRouteRider() {
+    mRouteDistance = 0.0f;
+    mRoute = nullptr;
+    mGoalRoute = nullptr;
+    mBuilder = nullptr;
+}
+
+void TRexPatrolRouteRider::init(const TRexPatrolRouteBuilder* builder) {
+    mBuilder = builder;
+    mBuilder->calcFirstRoute(&mRoute, &mGoalRoute);
+    mRouteDistance = 0.0f;
+}
+
+void TRexPatrolRouteRider::resetRoute() {
+    mBuilder->calcFirstRoute(&mRoute, &mGoalRoute);
+    mRouteDistance = 0.0f;
+}
+
+void TRexPatrolRouteRider::move(f32 distance) {
+    while (true) {
+        const sead::Vector3f routeTrans = mRoute->getTrans();
+        const sead::Vector3f goalTrans = mGoalRoute->getTrans();
+        const f32 routeLength = (routeTrans - goalTrans).length();
+        const f32 nextDistance = distance + mRouteDistance;
+        if (routeLength < nextDistance) {
+            distance -= routeLength - mRouteDistance;
+            mRouteDistance = 0.0f;
+            mRoute = mGoalRoute;
+            mBuilder->calcNextRouteGoal(&mGoalRoute, mGoalRoute);
+        } else {
+            mRouteDistance = nextDistance;
+            return;
+        }
+    }
+}
+
+void TRexPatrolRouteRider::recoveryRoute(const sead::Vector3f& trans) {
+    mBuilder->calcRecoveryRoute(&mRoute, &mGoalRoute, trans);
+    mRouteDistance = 0.0f;
+}
+
+void TRexPatrolRouteRider::rebuildRoute(const sead::Vector3f& trans) {
+    mBuilder->calcNearestRoute(&mRoute, &mGoalRoute, trans);
+
+    sead::Vector3f routeDir = mGoalRoute->getTrans() - mRoute->getTrans();
+    al::normalize(&routeDir);
+
+    sead::Vector3f routeDiff = trans - mRoute->getTrans();
+    al::parallelizeVec(&routeDiff, routeDir, routeDiff);
+    mRouteDistance = routeDiff.length();
+}
+
+void TRexPatrolRouteRider::calcTrans(sead::Vector3f* out, f32 distance) const {
+    out->set(mRoute->getTrans());
+
+    const sead::Vector3f& goalTrans = mGoalRoute->getTrans();
+    distance += mRouteDistance;
+
+    const sead::Vector3f diff = goalTrans - *out;
+    const f32 routeLength = diff.length();
+
+    if (routeLength <= distance) {
+        out->set(goalTrans);
+        return;
+    }
+
+    const f32 invRouteLength = 1.0f / routeLength;
+    out->setScaleAdd(distance, diff * invRouteLength, *out);
+}
+
+bool TRexPatrolRouteRider::calcMoveDirH(sead::Vector3f* out, const sead::Vector3f& vertical) const {
+    sead::Vector3f routeDir = mGoalRoute->getTrans() - mRoute->getTrans();
+    al::verticalizeVec(out, vertical, routeDir);
+    return al::tryNormalizeOrZero(out);
+}

--- a/src/Enemy/TRexPatrolRouteRider.h
+++ b/src/Enemy/TRexPatrolRouteRider.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+class TRexPatrolRouteBuilder;
+class TRexRouteInfoBase;
+
+class TRexPatrolRouteRider {
+public:
+    TRexPatrolRouteRider();
+
+    void init(const TRexPatrolRouteBuilder* builder);
+    void resetRoute();
+    void move(f32 distance);
+    void recoveryRoute(const sead::Vector3f& trans);
+    void rebuildRoute(const sead::Vector3f& trans);
+    void calcTrans(sead::Vector3f* out, f32 distance) const;
+    bool calcMoveDirH(sead::Vector3f* out, const sead::Vector3f& vertical) const;
+
+private:
+    const TRexPatrolRouteBuilder* mBuilder;
+    const TRexRouteInfoBase* mRoute;
+    const TRexRouteInfoBase* mGoalRoute;
+    f32 mRouteDistance;
+};
+
+static_assert(sizeof(TRexPatrolRouteRider) == 0x20);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1204)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - fd433f6)

📈 **Matched code**: 14.67% (+0.01%, +920 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::rebuildRoute(sead::Vector3<float> const&)` | +232 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::calcTrans(sead::Vector3<float>*, float) const` | +232 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::move(float)` | +172 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::calcMoveDirH(sead::Vector3<float>*, sead::Vector3<float> const&) const` | +108 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::init(TRexPatrolRouteBuilder const*)` | +56 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::recoveryRoute(sead::Vector3<float> const&)` | +56 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::resetRoute()` | +48 | 0.00% | 100.00% |
| `Enemy/TRexPatrolRouteRider` | `TRexPatrolRouteRider::TRexPatrolRouteRider()` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->