### PR TITLE
Player: Implement `PlayerStateRun2D3D`

### DIFF
--- a/src/Player/PlayerJudgeStartDash.h
+++ b/src/Player/PlayerJudgeStartDash.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Player/IJudge.h"
+
+class PlayerInput;
+
+class PlayerJudgeStartDash : public IJudge {
+public:
+    PlayerJudgeStartDash(const PlayerInput* input);
+
+    void reset() override;
+    void update() override;
+    bool judge() const override;
+
+private:
+    const PlayerInput* mInput = nullptr;
+    bool mIsEnableDashInput = false;
+    u8 _11[7] = {};
+};
+
+static_assert(sizeof(PlayerJudgeStartDash) == 0x18);

--- a/src/Player/PlayerStateRun.h
+++ b/src/Player/PlayerStateRun.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IJudge;
+class IUsePlayerCollision;
+class PlayerActionGroundMoveControl;
+class PlayerActionPivotTurnControl;
+class PlayerAnimator;
+class PlayerConst;
+class PlayerInput;
+
+class PlayerStateRun : public al::ActorStateBase {
+public:
+    PlayerStateRun(al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+                   const IUsePlayerCollision* collision, PlayerAnimator* animator,
+                   IJudge* judgeStartDash);
+
+    void appear() override;
+
+    bool tryTurnJump(IJudge* judge);
+    void exePivot();
+    void exeRun();
+    bool tryChangeRunAnim(const char* animName);
+    void exeBrake();
+    void exeTurn();
+
+private:
+    const PlayerConst* mConst = nullptr;
+    const PlayerInput* mInput = nullptr;
+    const IUsePlayerCollision* mCollision = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    PlayerActionPivotTurnControl* mPivotTurnControl = nullptr;
+    PlayerActionGroundMoveControl* mGroundMoveControl = nullptr;
+    u8 _50[4] = {};
+    bool mIsEnableTurnJump = false;
+    u8 _55[3] = {};
+};
+
+static_assert(sizeof(PlayerStateRun) == 0x58);

--- a/src/Player/PlayerStateRun2D.h
+++ b/src/Player/PlayerStateRun2D.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerCollision;
+class PlayerActionGroundMoveControl;
+class PlayerAnimator;
+class PlayerConst;
+class PlayerInput;
+
+class PlayerStateRun2D : public al::ActorStateBase {
+public:
+    PlayerStateRun2D(al::LiveActor* player, const PlayerConst* pConst, const PlayerInput* input,
+                     const IUsePlayerCollision* collision, PlayerAnimator* animator);
+
+    void appear() override;
+
+    bool isBrake() const;
+    void exeRun();
+    void exeBrake();
+    void exeTurn();
+
+private:
+    const PlayerConst* mConst = nullptr;
+    const PlayerInput* mInput = nullptr;
+    const IUsePlayerCollision* mCollision = nullptr;
+    PlayerAnimator* mAnimator = nullptr;
+    PlayerActionGroundMoveControl* mGroundMoveControl = nullptr;
+};
+
+static_assert(sizeof(PlayerStateRun2D) == 0x48);

--- a/src/Player/PlayerStateRun2D3D.cpp
+++ b/src/Player/PlayerStateRun2D3D.cpp
@@ -1,0 +1,67 @@
+#include "Player/PlayerStateRun2D3D.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/IPlayerModelChanger.h"
+#include "Player/PlayerJudgeStartDash.h"
+#include "Player/PlayerStateRun.h"
+#include "Player/PlayerStateRun2D.h"
+
+namespace {
+NERVE_IMPL(PlayerStateRun2D3D, Run3D)
+NERVE_IMPL(PlayerStateRun2D3D, Run2D)
+NERVES_MAKE_NOSTRUCT(PlayerStateRun2D3D, Run3D, Run2D)
+}  // namespace
+
+PlayerStateRun2D3D::PlayerStateRun2D3D(al::LiveActor* player, const PlayerConst* pConst,
+                                       const IUseDimension* dimension,
+                                       const IPlayerModelChanger* modelChanger,
+                                       const PlayerInput* input,
+                                       const IUsePlayerCollision* collision,
+                                       PlayerAnimator* animator)
+    : al::ActorStateBase("走り[2D3D]", player), mConst(pConst), mModelChanger(modelChanger) {
+    initNerve(&Run3D, 2);
+
+    PlayerJudgeStartDash* judgeStartDash = new PlayerJudgeStartDash(input);
+    mStateRun3D = new PlayerStateRun(player, mConst, input, collision, animator, judgeStartDash);
+    mStateRun2D = new PlayerStateRun2D(player, mConst, input, collision, animator);
+    al::initNerveState(this, mStateRun3D, &Run3D, "走り3D");
+    al::initNerveState(this, mStateRun2D, &Run2D, "走り2D");
+}
+
+void PlayerStateRun2D3D::appear() {
+    const IPlayerModelChanger* modelChanger = mModelChanger;
+    al::NerveStateBase::appear();
+
+    if (modelChanger->is2DModel())
+        al::setNerve(this, &Run2D);
+    else
+        al::setNerve(this, &Run3D);
+}
+
+void PlayerStateRun2D3D::syncModel() {
+    if (isDead())
+        return;
+
+    if (al::isNerve(this, &Run2D)) {
+        if (mModelChanger->is2DModel())
+            return;
+
+        al::setNerve(this, &Run3D);
+        return;
+    }
+
+    if (al::isNerve(this, &Run3D) && mModelChanger->is2DModel())
+        al::setNerve(this, &Run2D);
+}
+
+void PlayerStateRun2D3D::exeRun3D() {
+    if (al::updateNerveState(this))
+        kill();
+}
+
+void PlayerStateRun2D3D::exeRun2D() {
+    if (al::updateNerveState(this))
+        kill();
+}

--- a/src/Player/PlayerStateRun2D3D.h
+++ b/src/Player/PlayerStateRun2D3D.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IPlayerModelChanger;
+class IUseDimension;
+class IUsePlayerCollision;
+class PlayerAnimator;
+class PlayerConst;
+class PlayerInput;
+class PlayerStateRun;
+class PlayerStateRun2D;
+
+class PlayerStateRun2D3D : public al::ActorStateBase {
+public:
+    PlayerStateRun2D3D(al::LiveActor* player, const PlayerConst* pConst,
+                       const IUseDimension* dimension, const IPlayerModelChanger* modelChanger,
+                       const PlayerInput* input, const IUsePlayerCollision* collision,
+                       PlayerAnimator* animator);
+
+    void appear() override;
+
+    void syncModel();
+    void exeRun3D();
+    void exeRun2D();
+
+private:
+    const PlayerConst* mConst = nullptr;
+    const IPlayerModelChanger* mModelChanger = nullptr;
+    PlayerStateRun* mStateRun3D = nullptr;
+    PlayerStateRun2D* mStateRun2D = nullptr;
+};
+
+static_assert(sizeof(PlayerStateRun2D3D) == 0x40);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1205)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 565fb9c)

📈 **Matched code**: 14.67% (+0.01%, +808 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::PlayerStateRun2D3D(al::LiveActor*, PlayerConst const*, IUseDimension const*, IPlayerModelChanger const*, PlayerInput const*, IUsePlayerCollision const*, PlayerAnimator*)` | +288 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::syncModel()` | +156 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::appear()` | +80 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `(anonymous namespace)::PlayerStateRun2D3DNrvRun3D::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `(anonymous namespace)::PlayerStateRun2D3DNrvRun2D::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::exeRun3D()` | +60 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::exeRun2D()` | +60 | 0.00% | 100.00% |
| `Player/PlayerStateRun2D3D` | `PlayerStateRun2D3D::~PlayerStateRun2D3D()` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->