### PR TITLE
Enemy: Implement `SenobiGeneratePoint`

### DIFF
--- a/src/Enemy/Senobi.h
+++ b/src/Enemy/Senobi.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class EnemyCap;
+class SenobiStateEnemy;
+class SenobiStateHack;
+
+namespace al {
+class JointSpringControllerHolder;
+}  // namespace al
+
+class Senobi : public al::LiveActor {
+public:
+    Senobi(const char* actorName) : al::LiveActor(actorName) {}
+
+    const char* getStretchJointName();
+    s32 getStretchSensorNum();
+    const sead::Vector3f* getStretchJointLocalOffset();
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void makeActorDead() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+    void movement() override;
+    void calcAnim() override;
+    void updateCollider() override;
+
+    f32 getStretchRate() const;
+    void rebirth(const sead::Vector3f& trans, const sead::Vector3f& rotate);
+    void resetCounter();
+
+    void setUseResetState(bool isUseResetState) { mIsUseResetState = isUseResetState; }
+
+    void exeEnemy();
+    void exeReset();
+    void exeHack();
+
+private:
+    void* mParam = nullptr;
+    void* mPlayerHack = nullptr;
+    void* mPlayerCollision = nullptr;
+    EnemyCap* mEnemyCap = nullptr;
+    SenobiStateEnemy* mStateEnemy = nullptr;
+    SenobiStateHack* mStateHack = nullptr;
+    al::JointSpringControllerHolder* mJointSpringControllerHolder = nullptr;
+    f32 mStretchLength = 0.0f;
+    bool mIsUseResetState = false;
+    bool mIsHackStartSwoon = false;
+};
+
+static_assert(sizeof(Senobi) == 0x148);

--- a/src/Enemy/SenobiGeneratePoint.cpp
+++ b/src/Enemy/SenobiGeneratePoint.cpp
@@ -1,0 +1,69 @@
+#include "Enemy/SenobiGeneratePoint.h"
+
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Enemy/Senobi.h"
+
+namespace {
+NERVE_HOST_TYPE_IMPL(SenobiGeneratePoint, Standby)
+NERVE_HOST_TYPE_IMPL(SenobiGeneratePoint, Wait)
+NERVE_HOST_TYPE_IMPL(SenobiGeneratePoint, End)
+NERVE_HOST_TYPE_IMPL(SenobiGeneratePoint, Generate)
+
+NERVES_MAKE_NOSTRUCT(HostType, End, Generate)
+NERVES_MAKE_STRUCT(HostType, Standby, Wait)
+}  // namespace
+
+void SenobiGeneratePoint::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    const al::Nerve* standby = &NrvHostType.Standby;
+    const al::Nerve* wait = &NrvHostType.Wait;
+    al::initNerve(this, al::isValidSwitchStart(this) ? standby : wait, 0);
+
+    mSenobi = new Senobi("セノビー");
+    mSenobi->setUseResetState(false);
+    al::initCreateActorWithPlacementInfo(mSenobi, info);
+    mSenobi->makeActorDead();
+    makeActorAlive();
+}
+
+void SenobiGeneratePoint::forceKill() {
+    if (al::isAlive(mSenobi))
+        mSenobi->kill();
+    al::setNerve(this, &End);
+}
+
+bool SenobiGeneratePoint::tryGenerate() {
+    if (al::isAlive(mSenobi))
+        return false;
+    al::setNerve(this, &Generate);
+    return true;
+}
+
+void SenobiGeneratePoint::exeStandby() {
+    if (al::isOnSwitchStart(this))
+        al::setNerve(this, &NrvHostType.Wait);
+}
+
+void SenobiGeneratePoint::exeWait() {
+    if (!al::isAlive(mSenobi))
+        al::setNerve(this, &Generate);
+}
+
+void SenobiGeneratePoint::exeEnd() {}
+
+void SenobiGeneratePoint::exeGenerate() {
+    if (al::isLessStep(this, 180))
+        return;
+
+    Senobi* senobi = mSenobi;
+    const sead::Vector3f& trans = al::getTrans(this);
+    const sead::Vector3f& rotate = al::getRotate(this);
+    senobi->rebirth(trans, rotate);
+    al::setNerve(this, &NrvHostType.Wait);
+}

--- a/src/Enemy/SenobiGeneratePoint.h
+++ b/src/Enemy/SenobiGeneratePoint.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Senobi;
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class SenobiGeneratePoint : public al::LiveActor {
+public:
+    SenobiGeneratePoint(const char* actorName) : al::LiveActor(actorName) {}
+
+    void init(const al::ActorInitInfo& info) override;
+
+    void forceKill();
+    bool tryGenerate();
+    void exeStandby();
+    void exeWait();
+    void exeEnd();
+    void exeGenerate();
+
+private:
+    Senobi* mSenobi = nullptr;
+    sead::Vector3f mGenerateOffset = sead::Vector3f::zero;
+};
+
+static_assert(sizeof(SenobiGeneratePoint) == 0x120);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1206)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - f86b45d)

📈 **Matched code**: 14.67% (+0.01%, +856 bytes)

<details>
<summary>✅ 9 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::init(al::ActorInitInfo const&)` | +272 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `(anonymous namespace)::HostTypeNrvGenerate::execute(al::NerveKeeper*) const` | +124 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::exeGenerate()` | +120 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::forceKill()` | +68 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::tryGenerate()` | +68 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::exeStandby()` | +68 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `(anonymous namespace)::HostTypeNrvStandby::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::exeWait()` | +64 | 0.00% | 100.00% |
| `Enemy/SenobiGeneratePoint` | `SenobiGeneratePoint::exeEnd()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->