### PR TITLE
Util: Implement `ScenePlayerCapFunction`

### DIFF
--- a/src/Player/PlayerHackKeeper.h
+++ b/src/Player/PlayerHackKeeper.h
@@ -22,6 +22,7 @@ class PlayerCollider;
 class CapTargetInfo;
 class PlayerHackStartTexKeeper;
 class IUsePlayerHack;
+class IUsePlayerCollision;
 
 class PlayerHackKeeper {
 public:
@@ -63,7 +64,7 @@ public:
     void sendSyncDamageVisibility();
     void pushWorldEndBorder(const sead::Vector3f&);
     const char* getCurrentHackName() const;
-    PlayerCollider* getPlayerCollision() const;
+    IUsePlayerCollision* getPlayerCollision() const;
     f32 getHackGuideHeight() const;
     bool isHackGuideEnable() const;
     f32 getHackStayGravityMargine() const;

--- a/src/Player/PlayerInfo.h
+++ b/src/Player/PlayerInfo.h
@@ -49,6 +49,8 @@ class PlayerInfo {
 public:
     PlayerInfo();
 
+    HackCap* getHackCap() const { return mHackCap; }
+
 private:
     PlayerModelChangerHakoniwa* mModelChangerHakoniwa = nullptr;
     PlayerOxygen* mOxygen = nullptr;

--- a/src/Util/ScenePlayerCapFunction.cpp
+++ b/src/Util/ScenePlayerCapFunction.cpp
@@ -1,0 +1,167 @@
+#include "Util/ScenePlayerCapFunction.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Controller/InputFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+
+#include "Player/CapTargetInfo.h"
+#include "Player/HackCap.h"
+#include "Player/PlayerActorBase.h"
+#include "Player/PlayerHackKeeper.h"
+#include "Player/PlayerInfo.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataHolderWriter.h"
+#include "Util/PlayerCollisionUtil.h"
+
+namespace al {
+PlayerActorBase* getPlayerActor(const LiveActor* actor, s32 index);
+}
+
+namespace {
+const char* sHackTypeNames[] = {
+    "",
+    "RigidBodyBox",
+    "Kuribo",
+    "Statue",
+    "HammerBros",
+    "Bull",
+    "KaronWing",
+    "",
+    "Megane",
+    "",
+    "",
+    "",
+    "Frog",
+    "",
+    "ElectricWire",
+    "RigidBodyBox",
+    "CityManFlying",
+    "TRex",
+    "Pukupuku",
+    "Kakku",
+    "Fukankun",
+    "Hosui",
+    "Yukimaru",
+    "Tsukkun",
+    "KuriboWing",
+    "BazookaElectric",
+    "Bubble",
+    "Tank",
+    "KillerMagnum",
+    "JugemFishing",
+    "Radicon",
+    "Senobi",
+    "Yoshi",
+    "Imomu",
+    "Fastener",
+    "Koopa",
+    "PukupukuSnow",
+};
+}  // namespace
+
+namespace PlayerCapFunction {
+
+bool tryCalcHackCapThrowInputNormal(sead::Vector3f* out, const al::LiveActor* actor) {
+    PlayerHackKeeper* hackKeeper = al::getPlayerActor(actor, 0)->getPlayerHackKeeper();
+    if (hackKeeper && hackKeeper->getCurrentHackName()) {
+        hackKeeper = al::getPlayerActor(actor, 0)->getPlayerHackKeeper();
+        if (!hackKeeper)
+            return false;
+
+        if (hackKeeper->getHackSensor()) {
+            if (hackKeeper->isHackUsePlayerCollision()) {
+                if (rs::isCollidedGround(hackKeeper->getPlayerCollision())) {
+                    out->e = rs::getCollidedGroundNormal(hackKeeper->getPlayerCollision()).e;
+                    return true;
+                }
+            } else {
+                const al::LiveActor* hackActor = hackKeeper->getHack();
+                if (al::isExistActorCollider(hackActor) && al::isCollidedGround(hackActor)) {
+                    out->e = al::getCollidedGroundNormal(hackActor).e;
+                    return true;
+                }
+            }
+        }
+    } else {
+        const IUsePlayerCollision* collision = al::getPlayerActor(actor, 0)->getPlayerCollision();
+        if (!collision)
+            return false;
+
+        if (rs::isCollidedGround(collision)) {
+            out->e = rs::getCollidedGroundNormal(collision).e;
+            return true;
+        }
+    }
+
+    return false;
+}
+
+s32 getCapPadRumblePort(const al::LiveActor* actor) {
+    PlayerInfo* playerInfo = al::getPlayerActor(actor, 0)->getPlayerInfo();
+    if (playerInfo) {
+        HackCap* hackCap = playerInfo->getHackCap();
+        if (hackCap)
+            return hackCap->getPadRumblePort();
+    }
+
+    return al::getPlayerControllerPort(0);
+}
+
+bool isEnableBirdLandPlayerCapOn(const al::LiveActor* actor) {
+    PlayerInfo* playerInfo = al::getPlayerActor(actor, 0)->getPlayerInfo();
+    if (!playerInfo)
+        return false;
+
+    HackCap* hackCap = playerInfo->getHackCap();
+    if (!hackCap)
+        return false;
+
+    if (hackCap->isEnableThrowSeparate())
+        return false;
+
+    return hackCap->isPutOn();
+}
+
+}  // namespace PlayerCapFunction
+
+namespace InformationWindowFunction {
+
+bool isShowPlayerHackHackTutorial(const al::LiveActor* actor, const char* suffix) {
+    GameDataHolderAccessor accessor(actor);
+    PlayerHackKeeper* hackKeeper = al::getPlayerActor(actor, 0)->getPlayerHackKeeper();
+    const char* hackName = nullptr;
+    if (hackKeeper)
+        hackName = hackKeeper->getCurrentHackName();
+
+    return GameDataFunction::isShowHackTutorial(accessor, hackName, suffix);
+}
+
+bool isShowPlayerBindTutorial(const al::LiveActor* actor, const BindInfo& bindInfo) {
+    GameDataHolderAccessor accessor(actor);
+    return GameDataFunction::isShowBindTutorial(accessor, bindInfo);
+}
+
+void setShowPlayerHackHackTutorial(const al::LiveActor* actor, const char* suffix) {
+    GameDataHolderWriter writer(actor);
+    PlayerHackKeeper* hackKeeper = al::getPlayerActor(actor, 0)->getPlayerHackKeeper();
+    const char* hackName = nullptr;
+    if (hackKeeper)
+        hackName = hackKeeper->getCurrentHackName();
+
+    GameDataFunction::setShowHackTutorial(writer, hackName, suffix);
+}
+
+}  // namespace InformationWindowFunction
+
+namespace EventFlowFunction {
+
+bool isCapTargetHackType(const CapTargetInfo* capTargetInfo, s32 hackType) {
+    const char* hackName = capTargetInfo->getHackName();
+    if (!hackName)
+        return false;
+
+    return al::isEqualString(sHackTypeNames[hackType], hackName);
+}
+
+}  // namespace EventFlowFunction

--- a/src/Util/ScenePlayerCapFunction.h
+++ b/src/Util/ScenePlayerCapFunction.h
@@ -1,17 +1,27 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadVector.h>
 
 namespace al {
 class LiveActor;
 }
 
+struct BindInfo;
 class CapTargetInfo;
 
 namespace PlayerCapFunction {
-bool isEnableBirdLandPlayerCapOn(const al::LiveActor*);
-}
+bool tryCalcHackCapThrowInputNormal(sead::Vector3f* out, const al::LiveActor* actor);
+s32 getCapPadRumblePort(const al::LiveActor* actor);
+bool isEnableBirdLandPlayerCapOn(const al::LiveActor* actor);
+}  // namespace PlayerCapFunction
+
+namespace InformationWindowFunction {
+bool isShowPlayerHackHackTutorial(const al::LiveActor* actor, const char* suffix);
+bool isShowPlayerBindTutorial(const al::LiveActor* actor, const BindInfo& bindInfo);
+void setShowPlayerHackHackTutorial(const al::LiveActor* actor, const char* suffix);
+}  // namespace InformationWindowFunction
 
 namespace EventFlowFunction {
-bool isCapTargetHackType(const CapTargetInfo*, s32);
-}
+bool isCapTargetHackType(const CapTargetInfo* capTargetInfo, s32 hackType);
+}  // namespace EventFlowFunction


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1207)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 5a38b1d)

📈 **Matched code**: 14.67% (+0.01%, +752 bytes)

<details>
<summary>✅ 7 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/ScenePlayerCapFunction` | `PlayerCapFunction::tryCalcHackCapThrowInputNormal(sead::Vector3<float>*, al::LiveActor const*)` | +276 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `InformationWindowFunction::isShowPlayerHackHackTutorial(al::LiveActor const*, char const*)` | +116 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `InformationWindowFunction::setShowPlayerHackHackTutorial(al::LiveActor const*, char const*)` | +112 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `PlayerCapFunction::isEnableBirdLandPlayerCapOn(al::LiveActor const*)` | +88 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `InformationWindowFunction::isShowPlayerBindTutorial(al::LiveActor const*, BindInfo const&)` | +64 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `PlayerCapFunction::getCapPadRumblePort(al::LiveActor const*)` | +60 | 0.00% | 100.00% |
| `Util/ScenePlayerCapFunction` | `EventFlowFunction::isCapTargetHackType(CapTargetInfo const*, int)` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->