### PR TITLE
Util: Implement `StageLayoutFunction`

### DIFF
--- a/src/Util/StageLayoutFunction.cpp
+++ b/src/Util/StageLayoutFunction.cpp
@@ -1,0 +1,321 @@
+#include "Util/StageLayoutFunction.h"
+
+#include <basis/seadTypes.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+
+#include "System/CollectBgm.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+#include "Util/SequentialUtil.h"
+
+namespace {
+const char16 cEmptyMessage[] = {0};
+}  // namespace
+
+namespace rs {
+
+const char16* searchNpcMessage(const al::ActorInitInfo& initInfo, const al::LayoutActor* layout) {
+    al::StringTmp<256> label;
+    makeActorMessageLabel(&label, initInfo, nullptr);
+
+    const char* stageName = GameDataFunction::getCurrentStageName(GameDataHolderAccessor(layout));
+    if (!al::isExistStageMessage(layout, stageName))
+        return nullptr;
+    if (!al::isExistLabelInStageMessage(layout, stageName, label.cstr()))
+        return nullptr;
+    return al::getStageMessageString(layout, stageName, label.cstr());
+}
+
+void makeActorMessageLabel(sead::BufferedSafeString* out, const al::ActorInitInfo& initInfo,
+                           const char* objectName) {
+    const al::PlacementInfo& placementInfo = al::getPlacementInfo(initInfo);
+    const char* labelName = objectName;
+    if (!labelName)
+        al::getObjectName(&labelName, placementInfo);
+    al::PlacementId placementId;
+    al::getPlacementId(&placementId, placementInfo);
+    out->format("%s_%s", labelName, placementId.getId());
+}
+
+void makeMessageLabel(sead::BufferedSafeString* out, const al::PlacementInfo& placementInfo,
+                      const char* objectName) {
+    const char* labelName = objectName;
+    if (!labelName)
+        al::getObjectName(&labelName, placementInfo);
+    al::PlacementId placementId;
+    al::getPlacementId(&placementId, placementInfo);
+    out->format("%s_%s", labelName, placementId.getId());
+}
+
+void makeMessageLabel(sead::BufferedSafeString* out, const al::PlacementId* placementId,
+                      const char* objectName) {
+    out->format("%s_%s", objectName, placementId->getId());
+}
+
+void setPaneStageMessageActorLabel(al::LayoutActor* layout, const char* paneName,
+                                   const al::ActorInitInfo& initInfo, const char* objectName) {
+    al::StringTmp<128> label;
+    makeActorMessageLabel(&label, initInfo, objectName);
+    const char* labelStr = label.cstr();
+
+    GameDataHolder* holder = GameDataHolderAccessor(layout);
+    const al::PlacementInfo& placementInfo = al::getPlacementInfo(initInfo);
+    const char* stageName;
+    {
+        const char* zoneName = nullptr;
+        if (al::tryGetZoneNameIfExist(&zoneName, placementInfo))
+            stageName = zoneName;
+        else
+            stageName = GameDataFunction::getCurrentStageName(holder);
+    }
+    if (!stageName) {
+        GameDataHolderAccessor fallbackAccessor(layout);
+        stageName = GameDataFunction::getCurrentStageName(fallbackAccessor);
+    }
+    if (al::isExistLabelInStageMessage(layout, stageName, labelStr))
+        al::setPaneStageMessage(layout, paneName, stageName, labelStr);
+}
+
+bool trySetPaneStageMessageIfExist(al::LayoutActor* layout, const char* paneName, const char* label,
+                                   const char* stageName) {
+    const char* messageStageName = stageName;
+    if (!messageStageName)
+        messageStageName = GameDataFunction::getCurrentStageName(GameDataHolderAccessor(layout));
+    if (!al::isExistLabelInStageMessage(layout, messageStageName, label))
+        return false;
+    al::setPaneStageMessage(layout, paneName, messageStageName, label);
+    return true;
+}
+
+const char* getPlacementStageName(GameDataHolderAccessor accessor,
+                                  const al::ActorInitInfo& initInfo) {
+    const al::PlacementInfo& placementInfo = al::getPlacementInfo(initInfo);
+    const char* stageName = nullptr;
+    if (al::tryGetZoneNameIfExist(&stageName, placementInfo))
+        return stageName;
+    return GameDataFunction::getCurrentStageName(accessor);
+}
+
+const char16* getStageMessageActorLabel(al::LayoutActor* layout, const al::ActorInitInfo& initInfo,
+                                        const char* objectName) {
+    al::StringTmp<128> label;
+    makeActorMessageLabel(&label, initInfo, objectName);
+
+    GameDataHolder* holder = GameDataHolderAccessor(layout);
+    const al::PlacementInfo& placementInfo = al::getPlacementInfo(initInfo);
+    const char* zoneName = nullptr;
+    const char* stageName;
+    if (al::tryGetZoneNameIfExist(&zoneName, placementInfo))
+        stageName = zoneName;
+    else
+        stageName = GameDataFunction::getCurrentStageName(holder);
+    if (!al::isExistLabelInStageMessage(layout, stageName, label.cstr()))
+        return cEmptyMessage;
+    return al::getStageMessageString(layout, stageName, label.cstr());
+}
+
+bool isExistLabelInSystemMessageWithFileName(const al::IUseMessageSystem* messageSystem,
+                                             const char* fileName, const char* label) {
+    return al::isExistLabelInSystemMessage(messageSystem, fileName, label);
+}
+
+bool isExistLabelInStageMessageWithFileName(const al::IUseMessageSystem* messageSystem,
+                                            const char* fileName, const char* label) {
+    return al::isExistLabelInStageMessage(messageSystem, fileName, label);
+}
+
+bool trySetPaneSystemMessageIfExist(al::LayoutActor* layout, const char* paneName,
+                                    const char* fileName, const char* label) {
+    if (!al::isExistLabelInSystemMessage(layout, fileName, label))
+        return false;
+    al::setPaneSystemMessage(layout, paneName, fileName, label);
+    return true;
+}
+
+bool trySetPaneStringCheckpointName(al::LayoutActor* layout, const char* paneName,
+                                    s32 checkpointIndex, const char* stageName) {
+    const char* messageStageName = stageName;
+    if (!messageStageName)
+        messageStageName = GameDataFunction::getCurrentStageName(GameDataHolderAccessor(layout));
+
+    al::StringTmp<128> label;
+    label.format("%s_%s", "Checkpoint",
+                 GameDataFunction::getCheckpointObjIdInWorld(GameDataHolderAccessor(layout),
+                                                             checkpointIndex));
+    if (!al::isExistLabelInStageMessage(layout, messageStageName, label.cstr()))
+        return false;
+    al::setPaneStageMessage(layout, paneName, messageStageName, label.cstr());
+    return true;
+}
+
+const char* getCheckpointLabelPrefix() {
+    return "Checkpoint";
+}
+
+void setPaneStringWorldNameForWorldMap(al::LayoutActor* layout, const char* paneName, s32 worldId) {
+    const char16* worldName = GameDataFunction::tryGetWorldName(layout, worldId);
+    al::setPaneString(layout, paneName, worldName);
+}
+
+void setPaneStringWorldNameForWorldMapWithoutRuby(al::LayoutActor* layout, const char* paneName,
+                                                  s32 worldId) {
+    char16 message[256];
+    al::copyMessageWithoutTag(message, 256, GameDataFunction::tryGetWorldName(layout, worldId));
+    al::setPaneString(layout, paneName, message);
+}
+
+void setRaceRecordMessage(al::LayoutActor* layout, const char* paneName, s32 recordFrame) {
+    s32 minutes = recordFrame / 3600;
+    s32 framesInHour = recordFrame + minutes * -3600;
+    s32 seconds = framesInHour / 60 % 60;
+    s32 centiseconds = ((framesInHour + seconds * -60) % 60) * 100 / 60;
+
+    al::WStringTmp<256> message;
+    al::ReplaceTimeInfo replaceTimeInfo;
+    al::createReplaceTimeInfoForRaceTime(&replaceTimeInfo, minutes, seconds, centiseconds);
+    al::replaceMessageTagTimeDirectRaceTime(&message, layout, replaceTimeInfo);
+    al::setPaneString(layout, paneName, message.cstr());
+}
+
+void setRaceRecordMessageCsec(al::LayoutActor* layout, const char* paneName, s32 recordCsec) {
+    s32 clampedCsec = RaceTimeFunction::clampRaceRecordCsec(recordCsec);
+    s32 secondsTotal = clampedCsec / 100;
+    s32 minutes = clampedCsec / 6000;
+    s32 seconds = secondsTotal + minutes * -60;
+    s32 centiseconds = clampedCsec % 100;
+
+    al::WStringTmp<256> message;
+    al::ReplaceTimeInfo replaceTimeInfo;
+    al::createReplaceTimeInfoForRaceTime(&replaceTimeInfo, minutes, seconds, centiseconds);
+    al::replaceMessageTagTimeDirectRaceTime(&message, layout, replaceTimeInfo);
+    al::setPaneString(layout, paneName, message.cstr());
+}
+
+void replaceRaceRecordMessageCsec(al::LayoutActor* layout, const char* paneName, s32 recordCsec,
+                                  const char16* messageTag, const char* tagName) {
+    s32 secondsTotal = recordCsec / 100;
+    s32 minutes = recordCsec / 6000;
+    s32 seconds = secondsTotal + minutes * -60;
+    s32 centiseconds = recordCsec % 100;
+
+    al::WStringTmp<256> message;
+    al::ReplaceTimeInfo replaceTimeInfo;
+    al::createReplaceTimeInfoForRaceTime(&replaceTimeInfo, minutes, seconds, centiseconds);
+    al::replaceMessageTagTimeDirectRaceTime(&message, layout, replaceTimeInfo);
+    al::replaceMessageTagTime(&message, layout, messageTag, replaceTimeInfo, tagName);
+    al::setPaneString(layout, paneName, message.cstr());
+}
+
+void setRaceNoRecordMessage(al::LayoutActor* layout, const char* paneName) {
+    al::setPaneString(layout, paneName, al::getSystemMessageString(layout, "Time", "NoRaceTime"));
+}
+
+void setMiniGameNoCountMessage(al::LayoutActor* layout, const char* paneName) {
+    al::setPaneString(layout, paneName, al::getSystemMessageString(layout, "MiniGame", "NoCount"));
+}
+
+const char16* getWorldShinePictureFont(const al::LayoutActor* layout, s32 worldId,
+                                       bool isUseCompleteIcon) {
+    al::StringTmp<128> label;
+    label.format("ShineIcon_%s",
+                 GameDataFunction::getWorldDevelopName(GameDataHolderAccessor(layout), worldId));
+    if (isUseCompleteIcon && GameDataFunction::isGameClear(GameDataHolderAccessor(layout)))
+        label.format("ShineIcon_All");
+    return al::getSystemMessageString(layout, "IconTag", label.cstr());
+}
+
+const char16* getNullShinePictureFont(const al::LayoutActor* layout) {
+    al::StringTmp<128> label;
+    label.format("ShineIcon_Null");
+    return al::getSystemMessageString(layout, "IconTag", label.cstr());
+}
+
+const char16* getWorldCoinCollectPictureFont(const al::LayoutActor* layout, s32 worldId) {
+    s32 iconWorldId = worldId;
+    if (GameDataFunction::getCoinCollectNumMax(GameDataHolderAccessor(layout), worldId) == 0)
+        iconWorldId = 0;
+
+    al::StringTmp<128> label;
+    label.format("CoinCollectIcon_%s", GameDataFunction::getWorldDevelopName(
+                                           GameDataHolderAccessor(layout), iconWorldId));
+    return al::getSystemMessageString(layout, "IconTag", label.cstr());
+}
+
+const char16* getWorldCoinCollectPictureFont(const al::LayoutActor* layout) {
+    return getWorldCoinCollectPictureFont(
+        layout, GameDataFunction::getCurrentWorldId(GameDataHolderAccessor(layout)));
+}
+
+const char* getPlacementStageName(GameDataHolderAccessor accessor,
+                                  const al::PlacementInfo& placementInfo) {
+    const char* stageName = nullptr;
+    if (al::tryGetZoneNameIfExist(&stageName, placementInfo))
+        return stageName;
+    return GameDataFunction::getCurrentStageName(accessor);
+}
+
+const char16* getCollectBgmMessage(const al::IUseMessageSystem* messageSystem,
+                                   const CollectBgm* bgm) {
+    al::StringTmp<256> label;
+    if (bgm->situationName)
+        label.format("%s@%s", bgm->name, bgm->situationName);
+    else
+        label.format("%s", bgm->name);
+
+    if (!al::isExistLabelInSystemMessage(messageSystem, "CollectBgmList", label.cstr()))
+        return nullptr;
+    return al::getSystemMessageString(messageSystem, "CollectBgmList", label.cstr());
+}
+
+void setPaneCurrentCoinNum(al::LayoutActor* layout) {
+    al::setPaneStringFormat(layout, "TxtCounter", "%04d",
+                            GameDataFunction::getCoinNum(GameDataHolderAccessor(layout)));
+}
+
+bool tryGetMapMainScenarioLabel(sead::BufferedSafeString* outLabel,
+                                sead::BufferedSafeString* outStageName, bool* isNextScenario,
+                                const al::IUseSceneObjHolder* holder) {
+    GameDataHolderAccessor accessor(holder);
+    if (GameDataFunction::isExistJango(accessor)) {
+        outStageName->format("%s", "StageMapMessage");
+        outLabel->format("TxtJango");
+        *isNextScenario = false;
+        return true;
+    }
+
+    if (isSequenceCollectShineForRepairHome(holder)) {
+        outStageName->format("%s", "StageMapMessage");
+        outLabel->format("TxtCollectShineForRepairHome");
+        *isNextScenario = false;
+        return true;
+    }
+
+    if (isSequenceGoToMoonRock(holder) || isSequenceCollectShine(holder)) {
+        outStageName->format("%s", "StageMapMessage");
+        outLabel->format("TxtCollectShine");
+        *isNextScenario = false;
+        return true;
+    }
+
+    if (isSequenceGoToNextWorld(holder)) {
+        outStageName->format("%s", "StageMapMessage");
+        outLabel->format("TxtGoToNextWorld");
+        *isNextScenario = false;
+        return true;
+    }
+
+    if (!GameDataFunction::tryGetNextMainScenarioLabel(outLabel, outStageName, holder))
+        return false;
+    *isNextScenario = true;
+    return true;
+}
+
+}  // namespace rs

--- a/src/Util/StageLayoutFunction.h
+++ b/src/Util/StageLayoutFunction.h
@@ -27,7 +27,7 @@ bool isExistLabelInSystemMessageWithFileName(const al::IUseMessageSystem*, const
                                              const char*);
 bool isExistLabelInStageMessageWithFileName(const al::IUseMessageSystem*, const char*, const char*);
 bool trySetPaneSystemMessageIfExist(al::LayoutActor*, const char*, const char*, const char*);
-bool trySetPaneStringCheckpos32Name(al::LayoutActor*, const char*, s32, const char*);
+bool trySetPaneStringCheckpointName(al::LayoutActor*, const char*, s32, const char*);
 const char* getCheckpointLabelPrefix();
 void setPaneStringWorldNameForWorldMap(al::LayoutActor*, const char*, s32);
 void setPaneStringWorldNameForWorldMapWithoutRuby(al::LayoutActor*, const char*, s32);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1208)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 7c31588)

📈 **Matched code**: 14.70% (+0.04%, +5104 bytes)

<details>
<summary>✅ 29 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/StageLayoutFunction` | `rs::setPaneStageMessageActorLabel(al::LayoutActor*, char const*, al::ActorInitInfo const&, char const*)` | +400 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getStageMessageActorLabel(al::LayoutActor*, al::ActorInitInfo const&, char const*)` | +380 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setRaceRecordMessage(al::LayoutActor*, char const*, int)` | +376 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::searchNpcMessage(al::ActorInitInfo const&, al::LayoutActor const*)` | +340 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::replaceRaceRecordMessageCsec(al::LayoutActor*, char const*, int, char16_t const*, char const*)` | +332 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::trySetPaneStringCheckpointName(al::LayoutActor*, char const*, int, char const*)` | +328 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::tryGetMapMainScenarioLabel(sead::BufferedSafeStringBase<char>*, sead::BufferedSafeStringBase<char>*, bool*, al::IUseSceneObjHolder const*)` | +324 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setRaceRecordMessageCsec(al::LayoutActor*, char const*, int)` | +296 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getWorldShinePictureFont(al::LayoutActor const*, int, bool)` | +280 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getWorldCoinCollectPictureFont(al::LayoutActor const*)` | +276 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getWorldCoinCollectPictureFont(al::LayoutActor const*, int)` | +256 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getCollectBgmMessage(al::IUseMessageSystem const*, CollectBgm const*)` | +256 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getNullShinePictureFont(al::LayoutActor const*)` | +180 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::trySetPaneStageMessageIfExist(al::LayoutActor*, char const*, char const*, char const*)` | +152 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::makeActorMessageLabel(sead::BufferedSafeStringBase<char>*, al::ActorInitInfo const&, char const*)` | +124 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::trySetPaneSystemMessageIfExist(al::LayoutActor*, char const*, char const*, char const*)` | +108 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::makeMessageLabel(sead::BufferedSafeStringBase<char>*, al::PlacementInfo const&, char const*)` | +104 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setPaneStringWorldNameForWorldMapWithoutRuby(al::LayoutActor*, char const*, int)` | +100 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setPaneCurrentCoinNum(al::LayoutActor*)` | +88 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setRaceNoRecordMessage(al::LayoutActor*, char const*)` | +84 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setMiniGameNoCountMessage(al::LayoutActor*, char const*)` | +84 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getPlacementStageName(GameDataHolderAccessor, al::ActorInitInfo const&)` | +72 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::setPaneStringWorldNameForWorldMap(al::LayoutActor*, char const*, int)` | +64 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getPlacementStageName(GameDataHolderAccessor, al::PlacementInfo const&)` | +60 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::makeMessageLabel(sead::BufferedSafeStringBase<char>*, al::PlacementId const*, char const*)` | +16 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::getCheckpointLabelPrefix()` | +12 | 0.00% | 100.00% |
| `Layout/SouvenirListLayout` | `al::WStringTmp<256>::~WStringTmp()` | +4 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::isExistLabelInSystemMessageWithFileName(al::IUseMessageSystem const*, char const*, char const*)` | +4 | 0.00% | 100.00% |
| `Util/StageLayoutFunction` | `rs::isExistLabelInStageMessageWithFileName(al::IUseMessageSystem const*, char const*, char const*)` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->