### PR TITLE
MapObj: Implement `KinokoUfo`

### DIFF
--- a/src/MapObj/KinokoUfo.cpp
+++ b/src/MapObj/KinokoUfo.cpp
@@ -1,0 +1,51 @@
+#include "MapObj/KinokoUfo.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "System/GameDataUtil.h"
+
+KinokoUfo::KinokoUfo(const char* actorName) : al::LiveActor(actorName) {}
+
+void KinokoUfo::init(const al::ActorInitInfo& info) {
+    using KinokoUfoFunctor = al::FunctorV0M<KinokoUfo*, void (KinokoUfo::*)()>;
+
+    al::initActor(this, info);
+    if (al::listenStageSwitchOnOff(this, "SwitchClose",
+                                   KinokoUfoFunctor(this, &KinokoUfo::listenClose),
+                                   KinokoUfoFunctor(this, &KinokoUfo::listenOpen)) ||
+        rs::isSequenceTimeBalloonOrRace(this)) {
+        mCollisionObj = al::createCollisionObj(
+            this, info, "Close", al::getHitSensor(this, "Collision"), nullptr, nullptr);
+        mCollisionObj->makeActorDead();
+    }
+    makeActorAlive();
+}
+
+void KinokoUfo::listenClose() {
+    al::invalidateCollisionParts(this);
+    mCollisionObj->appear();
+    al::startAction(this, "Close");
+}
+
+void KinokoUfo::listenOpen() {
+    al::validateCollisionParts(this);
+    mCollisionObj->kill();
+    al::startAction(this, "Open");
+}
+
+void KinokoUfo::initAfterPlacement() {
+    const char* actionName = "Open";
+    if (rs::isSequenceTimeBalloonOrRace(this)) {
+        al::invalidateCollisionParts(this);
+        mCollisionObj->appear();
+        actionName = "Close";
+    }
+    al::startAction(this, actionName);
+}

--- a/src/MapObj/KinokoUfo.h
+++ b/src/MapObj/KinokoUfo.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CollisionObj;
+struct ActorInitInfo;
+}  // namespace al
+
+class KinokoUfo : public al::LiveActor {
+public:
+    KinokoUfo(const char* actorName);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+
+    void listenClose();
+    void listenOpen();
+
+private:
+    al::CollisionObj* mCollisionObj = nullptr;
+};
+
+static_assert(sizeof(KinokoUfo) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -94,6 +94,7 @@
 #include "MapObj/HipDropMoveLift.h"
 #include "MapObj/HipDropRepairParts.h"
 #include "MapObj/HipDropSwitch.h"
+#include "MapObj/KinokoUfo.h"
 #include "MapObj/KoopaShip.h"
 #include "MapObj/LavaFryingPan.h"
 #include "MapObj/LavaPan.h"
@@ -394,7 +395,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"KickStone", nullptr},
     {"KillerLauncher", nullptr},
     {"KillerLauncherDot", nullptr},
-    {"KinokoUfo", nullptr},
+    {"KinokoUfo", al::createActorFunction<KinokoUfo>},
     {"Koopa", nullptr},
     {"KoopaCapPlayer", nullptr},
     {"KoopaChurch", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1209)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - e71ffad)

📈 **Matched code**: 14.67% (+0.01%, +836 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/KinokoUfo` | `KinokoUfo::init(al::ActorInitInfo const&)` | +212 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `KinokoUfo::KinokoUfo(char const*)` | +136 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `KinokoUfo::KinokoUfo(char const*)` | +124 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `KinokoUfo::initAfterPlacement()` | +84 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `al::FunctorV0M<KinokoUfo*, void (KinokoUfo::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `KinokoUfo::listenClose()` | +60 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `KinokoUfo::listenOpen()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<KinokoUfo>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `al::FunctorV0M<KinokoUfo*, void (KinokoUfo::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/KinokoUfo` | `al::FunctorV0M<KinokoUfo*, void (KinokoUfo::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->