### PR TITLE
MapObj: Implement `MoonWorldBell`

### DIFF
--- a/src/MapObj/MoonWorldBell.cpp
+++ b/src/MapObj/MoonWorldBell.cpp
@@ -1,0 +1,68 @@
+#include "MapObj/MoonWorldBell.h"
+
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "System/GameDataFunction.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(MoonWorldBell, Wait)
+NERVE_IMPL(MoonWorldBell, CapReaction)
+NERVE_IMPL(MoonWorldBell, HipDropReaction)
+
+NERVES_MAKE_NOSTRUCT(MoonWorldBell, Wait, CapReaction, HipDropReaction)
+}  // namespace
+
+MoonWorldBell::MoonWorldBell(const char* name) : al::LiveActor(name) {}
+
+void MoonWorldBell::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "MoonWorldHomeBell", nullptr);
+    al::initNerve(this, &Wait, 0);
+    al::invalidateClipping(this);
+    al::registActorToDemoInfo(this, info);
+
+    if (GameDataFunction::isGameClear(GameDataHolderAccessor(this)))
+        al::startAction(this, "WaitNoSound");
+
+    makeActorAlive();
+}
+
+bool MoonWorldBell::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                               al::HitSensor* self) {
+    if (rs::isMsgCapAttackCollide(message) && !al::isNerve(this, &CapReaction)) {
+        al::startHitReaction(this, "帽子ヒット");
+        al::setNerve(this, &CapReaction);
+        return true;
+    }
+
+    if (rs::isMsgPlayerAndCapHipDropAll(message) && !al::isNerve(this, &HipDropReaction)) {
+        al::startHitReaction(this, "ヒップドロップ");
+        al::setNerve(this, &HipDropReaction);
+        return true;
+    }
+
+    if (al::isMsgPlayerUpperPunch(message)) {
+        al::startHitReaction(this, "アッパーパンチ");
+        return true;
+    }
+
+    return false;
+}
+
+void MoonWorldBell::exeWait() {}
+
+void MoonWorldBell::exeCapReaction() {
+    if (al::isGreaterEqualStep(this, 60))
+        al::setNerve(this, &Wait);
+}
+
+void MoonWorldBell::exeHipDropReaction() {
+    if (al::isGreaterEqualStep(this, 60))
+        al::setNerve(this, &Wait);
+}

--- a/src/MapObj/MoonWorldBell.h
+++ b/src/MapObj/MoonWorldBell.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class MoonWorldBell : public al::LiveActor {
+public:
+    MoonWorldBell(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void exeWait();
+    void exeCapReaction();
+    void exeHipDropReaction();
+};
+
+static_assert(sizeof(MoonWorldBell) == 0x108);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -101,6 +101,7 @@
 #include "MapObj/MoonBasementBreakParts.h"
 #include "MapObj/MoonBasementFloor.h"
 #include "MapObj/MoonBasementSlideObj.h"
+#include "MapObj/MoonWorldBell.h"
 #include "MapObj/MoonWorldCaptureParadeLift.h"
 #include "MapObj/MoviePlayerMapParts.h"
 #include "MapObj/PeachWorldTree.h"
@@ -438,7 +439,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"MoonBasementRock", nullptr},
     {"MoonBasementSlideObj", al::createActorFunction<MoonBasementSlideObj>},
     {"MoonRock", nullptr},
-    {"MoonWorldBell", nullptr},
+    {"MoonWorldBell", al::createActorFunction<MoonWorldBell>},
     {"MoonWorldCaptureParadeLift", al::createActorFunction<MoonWorldCaptureParadeLift>},
     {"Mofumofu", nullptr},
     {"MofumofuLv2", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1210)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 43dabf3)

📈 **Matched code**: 14.67% (+0.01%, +968 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/MoonWorldBell` | `MoonWorldBell::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +216 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::init(al::ActorInitInfo const&)` | +176 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::MoonWorldBell(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::MoonWorldBell(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `(anonymous namespace)::MoonWorldBellNrvCapReaction::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `(anonymous namespace)::MoonWorldBellNrvHipDropReaction::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::exeCapReaction()` | +64 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::exeHipDropReaction()` | +64 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<MoonWorldBell>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `MoonWorldBell::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/MoonWorldBell` | `(anonymous namespace)::MoonWorldBellNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->