### PR TITLE
MapObj: Implement `SubActorLodFixPartsScenarioAction`

### DIFF
--- a/src/MapObj/SubActorLodFixPartsScenarioAction.cpp
+++ b/src/MapObj/SubActorLodFixPartsScenarioAction.cpp
@@ -1,0 +1,84 @@
+#include "MapObj/SubActorLodFixPartsScenarioAction.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/MapObj/SubActorLodExecutor.h"
+#include "Library/MapObj/SupportFreezeSyncGroupHolder.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Scene/SceneEventNotifyFunction.h"
+#include "Scene/SceneObjFactory.h"
+#include "System/GameDataFunction.h"
+
+namespace {
+class SupportFreezeSyncGroupHolderSceneObj : public al::SupportFreezeSyncGroupHolder {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID__3d;
+};
+}  // namespace
+
+SubActorLodFixPartsScenarioAction::SubActorLodFixPartsScenarioAction(const char* name)
+    : al::LiveActor(name) {}
+
+void SubActorLodFixPartsScenarioAction::init(const al::ActorInitInfo& info) {
+    al::initMapPartsActor(this, info, nullptr);
+
+    al::StringTmp<64> actionName("Scenario%d", GameDataFunction::getScenarioNo(this));
+    mIsActionStarted = al::tryStartAction(this, actionName.cstr());
+
+    al::LiveActor* subActor = al::getSubActor(this, 0);
+    mIsActionStarted |= al::tryStartAction(subActor, actionName.cstr());
+
+    mSubActorLodExecutor = new al::SubActorLodExecutor(this, info, 0);
+    al::trySyncStageSwitchAppearAndKill(this);
+
+    using SnapShotFunctor = al::FunctorV0M<SubActorLodFixPartsScenarioAction*,
+                                           void (SubActorLodFixPartsScenarioAction::*)()>;
+    rs::listenSnapShotModeOnOff(
+        this, SnapShotFunctor(this, &SubActorLodFixPartsScenarioAction::listenStartSnapShotMode),
+        SnapShotFunctor(this, &SubActorLodFixPartsScenarioAction::listenEndSnapShotMode));
+
+    makeActorAlive();
+}
+
+void SubActorLodFixPartsScenarioAction::listenStartSnapShotMode() {
+    al::showModelIfHide(this);
+    mSubActorLodExecutor->getLodSubActor()->kill();
+}
+
+void SubActorLodFixPartsScenarioAction::listenEndSnapShotMode() {}
+
+void SubActorLodFixPartsScenarioAction::movement() {
+    mSubActorLodExecutor->control();
+
+    if (mIsActionStarted)
+        al::LiveActor::movement();
+}
+
+void SubActorLodFixPartsScenarioAction::calcAnim() {
+    if (mIsActionStarted) {
+        al::LiveActor::calcAnim();
+        return;
+    }
+
+    al::calcViewModel(this);
+}
+
+bool SubActorLodFixPartsScenarioAction::receiveMsg(const al::SensorMsg* message,
+                                                   al::HitSensor* other, al::HitSensor* self) {
+    return al::isMsgAskSafetyPoint(message);
+}
+
+namespace al {
+void registSupportFreezeSyncGroup(LiveActor* actor, const ActorInitInfo& info) {
+    if (actor->getHitSensorKeeper() &&
+        alPlacementFunction::isEnableLinkGroupId(info, "SupportFreezeSyncGroup"))
+        createSceneObj<SupportFreezeSyncGroupHolderSceneObj>(actor)->regist(actor, info);
+}
+}  // namespace al

--- a/src/MapObj/SubActorLodFixPartsScenarioAction.h
+++ b/src/MapObj/SubActorLodFixPartsScenarioAction.h
@@ -1,8 +1,32 @@
 #pragma once
 
+#include "Library/LiveActor/LiveActor.h"
+
 namespace al {
-class LiveActor;
+class HitSensor;
+class SensorMsg;
+class SubActorLodExecutor;
 struct ActorInitInfo;
 
 void registSupportFreezeSyncGroup(LiveActor* actor, const ActorInitInfo& info);
 }  // namespace al
+
+class SubActorLodFixPartsScenarioAction : public al::LiveActor {
+public:
+    SubActorLodFixPartsScenarioAction(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void movement() override;
+    void calcAnim() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void listenStartSnapShotMode();
+    void listenEndSnapShotMode();
+
+private:
+    al::SubActorLodExecutor* mSubActorLodExecutor = nullptr;
+    bool mIsActionStarted = false;
+};
+
+static_assert(sizeof(SubActorLodFixPartsScenarioAction) == 0x118);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -118,6 +118,7 @@
 #include "MapObj/SignBoardDanger.h"
 #include "MapObj/Souvenir.h"
 #include "MapObj/StageSwitchSelector.h"
+#include "MapObj/SubActorLodFixPartsScenarioAction.h"
 #include "MapObj/TalkPoint.h"
 #include "MapObj/TrampleBush.h"
 #include "MapObj/TrampleSwitch.h"
@@ -592,7 +593,8 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"Stake", nullptr},
     {"Statue", nullptr},
     {"StatueSnapMark", nullptr},
-    {"SubActorLodFixPartsScenarioAction", nullptr},
+    {"SubActorLodFixPartsScenarioAction",
+     al::createActorFunction<SubActorLodFixPartsScenarioAction>},
     {"SwitchAnd", nullptr},
     {"SwitchKeyMoveMapParts", nullptr},
     {"TalkMessageInfoPoint", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1211)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - fd5a18d)

📈 **Matched code**: 14.67% (+0.01%, +968 bytes)

<details>
<summary>✅ 13 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::init(al::ActorInitInfo const&)` | +300 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::SubActorLodFixPartsScenarioAction(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::SubActorLodFixPartsScenarioAction(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `al::registSupportFreezeSyncGroup(al::LiveActor*, al::ActorInitInfo const&)` | +104 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `al::FunctorV0M<SubActorLodFixPartsScenarioAction*, void (SubActorLodFixPartsScenarioAction::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::movement()` | +60 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SubActorLodFixPartsScenarioAction>(char const*)` | +52 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::listenStartSnapShotMode()` | +48 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `al::FunctorV0M<SubActorLodFixPartsScenarioAction*, void (SubActorLodFixPartsScenarioAction::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::calcAnim()` | +16 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `SubActorLodFixPartsScenarioAction::listenEndSnapShotMode()` | +4 | 0.00% | 100.00% |
| `MapObj/SubActorLodFixPartsScenarioAction` | `al::FunctorV0M<SubActorLodFixPartsScenarioAction*, void (SubActorLodFixPartsScenarioAction::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->