### PR TITLE
Demo: Implement `SimpleDemoState`

### DIFF
--- a/lib/al/Library/Demo/DemoActorFunction.h
+++ b/lib/al/Library/Demo/DemoActorFunction.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace sead {
+template <typename T>
+class Matrix34;
+using Matrix34f = Matrix34<f32>;
+}  // namespace sead
+
+namespace al {
+struct ActorInitInfo;
+class DemoActorHolder;
+
+namespace alDemoFunction {
+DemoActorHolder* createDemoActorHolder(const char* demoName, const ActorInitInfo& info,
+                                       const sead::Matrix34f* baseMtx, s32 placementIndex,
+                                       bool isDemoScene);
+DemoActorHolder* createDemoActorHolderForDemoScene(const char* demoName, const ActorInitInfo& info,
+                                                   const sead::Matrix34f* baseMtx,
+                                                   s32 placementIndex);
+}  // namespace alDemoFunction
+}  // namespace al

--- a/lib/al/Library/Demo/DemoActorHolder.h
+++ b/lib/al/Library/Demo/DemoActorHolder.h
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+
+namespace al {
+struct ActorInitInfo;
+class DemoActor;
+class DemoCamera;
+class LiveActor;
+class PlacementInfo;
+
+class DesignActorInfo {
+public:
+    DesignActorInfo(LiveActor* actor, const ActorInitInfo& info, const ActorInitInfo& demoInfo,
+                    const sead::Matrix34f& baseMtx);
+
+private:
+    LiveActor* mActor = nullptr;
+    sead::Matrix34f mBaseMtx = sead::Matrix34f::ident;
+};
+
+static_assert(sizeof(DesignActorInfo) == 0x38);
+
+class DemoActorHolder {
+public:
+    DemoActorHolder(bool isDemoScene);
+
+    void initPlacementDemoActor(const PlacementInfo& placementInfo, const ActorInitInfo& info,
+                                const sead::Matrix34f* baseMtx);
+    void initPlacementDesignActor(const PlacementInfo& placementInfo, const ActorInitInfo& info,
+                                  const sead::Matrix34f* baseMtx);
+    void appear();
+    void kill();
+    void setEndCameraInterpolateFrame(s32 frame);
+    void startAction(s32 actionIndex);
+    void startSequence();
+    void updateSequence();
+    void updateGraphics();
+    bool isActionEndCamera(s32 actionIndex) const;
+    bool isEndSequence() const;
+    s32 getDemoCameraNum() const;
+    bool isExistCamera() const;
+    DemoActor* tryFindDemoActor(const char* actorName);
+    const char* getCurrentDemoActionName() const;
+    s32 getCurrentDemoFrame() const;
+    s32 getCurrentDemoFrameMax() const;
+    DemoActor* getDemoActor(s32 index) const;
+
+    bool isActiveSequence() const { return mIsActiveSequence; }
+
+private:
+    sead::Matrix34f mBaseMtx = sead::Matrix34f::ident;
+    DemoActor** mDemoActors = nullptr;
+    DemoCamera* mDemoCamera = nullptr;
+    void* _40 = nullptr;
+    s32 mDemoActorNum = 0;
+    bool mIsActiveSequence = false;
+    bool mIsDemoScene = false;
+    u8 _4e[2] = {};
+    s32 mCurrentDemoCameraIndex = 0;
+    u8 _54[4] = {};
+    DesignActorInfo** mDesignActorInfos = nullptr;
+    s32 mDesignActorNum = 0;
+};
+
+static_assert(sizeof(DemoActorHolder) == 0x68);
+}  // namespace al

--- a/src/Demo/SimpleDemoState.cpp
+++ b/src/Demo/SimpleDemoState.cpp
@@ -1,0 +1,126 @@
+#include "Demo/SimpleDemoState.h"
+
+#include "Library/Demo/DemoActorFunction.h"
+#include "Library/Demo/DemoActorHolder.h"
+#include "Library/Demo/DemoFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Util/DemoUtil.h"
+#include "Util/PlayerDemoUtil.h"
+
+namespace {
+NERVE_IMPL(SimpleDemoState, Demo);
+
+NERVES_MAKE_NOSTRUCT(SimpleDemoState, Demo);
+}  // namespace
+
+SimpleDemoState::SimpleDemoState(al::LiveActor* actor, const al::ActorInitInfo& info,
+                                 const char* demoName, const sead::Matrix34f* baseMtx)
+    : al::ActorStateBase("シンプルデモ状態", actor) {
+    if (baseMtx)
+        mDemoActorHolder =
+            al::alDemoFunction::createDemoActorHolder(demoName, info, baseMtx, 1, false);
+    else
+        mDemoActorHolder =
+            al::alDemoFunction::createDemoActorHolder(demoName, info, nullptr, 1, false);
+    initNerve(&Demo, 0);
+}
+
+void SimpleDemoState::appear() {
+    al::NerveStateBase::appear();
+    al::setNerve(this, &Demo);
+}
+
+void SimpleDemoState::exeDemo() {
+    if (al::isFirstStep(this)) {
+        if (!requestStartDemo() || !(mIsDemoStarted = startDemoProc())) {
+            if (mIsDemoStarted) {
+                al::setNerve(this, &Demo);
+                return;
+            }
+            kill();
+            return;
+        }
+    }
+
+    mDemoActorHolder->updateSequence();
+    if (mDemoActorHolder->isEndSequence()) {
+        endDemoProcBeforeRequest();
+        requestEndDemo();
+        endDemoProc();
+    }
+}
+
+bool SimpleDemoState::tryStartDemo() {
+    bool isStart = false;
+    if (requestStartDemo())
+        isStart = mIsDemoStarted = startDemoProc();
+    return isStart;
+}
+
+bool SimpleDemoState::tryEndDemo() {
+    endDemoProcBeforeRequest();
+    requestEndDemo();
+    endDemoProc();
+    return true;
+}
+
+bool SimpleDemoState::requestStartDemo() {
+    return rs::requestStartDemoNormal(mActor, false);
+}
+
+void SimpleDemoState::requestEndDemo() {
+    rs::requestEndDemoNormal(mActor);
+}
+
+bool SimpleDemoState::startDemoProc() {
+    al::addDemoActorFromDemoActorHolder(mActor, mDemoActorHolder);
+    if (!al::isInvalidClipping(mActor)) {
+        mIsInvalidateClipping = true;
+        al::invalidateClipping(mActor);
+    }
+    mDemoActorHolder->startSequence();
+    return true;
+}
+
+void SimpleDemoState::endDemoProc() {
+    mDemoActorHolder->kill();
+    if (mIsInvalidateClipping)
+        al::validateClipping(mActor);
+    al::NerveStateBase::kill();
+}
+
+void SimpleDemoState::endDemoProcBeforeRequest() {}
+
+void SimpleDemoStateSkip::updateOnlyDemoGraphics() {
+    al::DemoActorHolder* holder = mDemoActorHolder;
+    if (holder && holder->isActiveSequence())
+        holder->updateGraphics();
+}
+
+bool SimpleDemoStateSkip::requestStartDemo() {
+    if (mIsUsePlayer) {
+        if (!rs::requestStartDemoWithPlayerCinemaFrame(mActor, true))
+            return false;
+    } else {
+        if (!rs::requestStartDemoNormalWithCinemaFrame(mActor))
+            return false;
+    }
+
+    rs::requestValidateDemoSkip(mDemoSkipRequester, mActor);
+    if (mIsHideDemoPlayer)
+        rs::hideDemoPlayerAndStartDemoResetAction(mActor);
+    return true;
+}
+
+void SimpleDemoStateSkip::requestEndDemo() {
+    if (!mIsUsePlayer)
+        return rs::requestEndDemoNormalWithCinemaFrame(mActor);
+
+    rs::startActionDemoPlayer(mActor, "Wait");
+    rs::showDemoPlayer(mActor);
+    rs::requestEndDemoWithPlayerCinemaFrame(mActor);
+}

--- a/src/Demo/SimpleDemoState.h
+++ b/src/Demo/SimpleDemoState.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class IUseDemoSkip;
+
+namespace al {
+struct ActorInitInfo;
+class DemoActorHolder;
+class LiveActor;
+}  // namespace al
+
+class SimpleDemoState : public al::ActorStateBase {
+public:
+    SimpleDemoState(al::LiveActor* actor, const al::ActorInitInfo& info, const char* demoName,
+                    const sead::Matrix34f* baseMtx);
+
+    void appear() override;
+    virtual bool requestStartDemo();
+    virtual void requestEndDemo();
+    virtual bool startDemoProc();
+    virtual void endDemoProcBeforeRequest();
+    virtual void endDemoProc();
+
+    void exeDemo();
+    bool tryStartDemo();
+    bool tryEndDemo();
+
+protected:
+    al::DemoActorHolder* mDemoActorHolder = nullptr;
+    bool mIsDemoStarted = true;
+    bool mIsInvalidateClipping = false;
+};
+
+static_assert(sizeof(SimpleDemoState) == 0x30);
+
+class SimpleDemoStateSkip : public SimpleDemoState {
+public:
+    SimpleDemoStateSkip(al::LiveActor* actor, const al::ActorInitInfo& info, const char* demoName,
+                        const sead::Matrix34f* baseMtx, IUseDemoSkip* demoSkipRequester,
+                        bool isUsePlayer, bool isHideDemoPlayer)
+        : SimpleDemoState(actor, info, demoName, baseMtx), mDemoSkipRequester(demoSkipRequester),
+          mIsUsePlayer(isUsePlayer), mIsHideDemoPlayer(isHideDemoPlayer) {}
+
+    void updateOnlyDemoGraphics();
+    bool requestStartDemo() override;
+    void requestEndDemo() override;
+
+protected:
+    IUseDemoSkip* mDemoSkipRequester = nullptr;
+    bool mIsUsePlayer = false;
+    bool mIsHideDemoPlayer = false;
+};
+
+static_assert(sizeof(SimpleDemoStateSkip) == 0x40);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1212)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - db9e8ca)

📈 **Matched code**: 14.67% (+0.01%, +972 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Demo/SimpleDemoState` | `SimpleDemoState::exeDemo()` | +204 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::SimpleDemoState(al::LiveActor*, al::ActorInitInfo const&, char const*, sead::Matrix34<float> const*)` | +152 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoStateSkip::requestStartDemo()` | +104 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::tryStartDemo()` | +80 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::tryEndDemo()` | +76 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::startDemoProc()` | +76 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoStateSkip::requestEndDemo()` | +76 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::endDemoProc()` | +60 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::~SimpleDemoState()` | +36 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoStateSkip::~SimpleDemoStateSkip()` | +36 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoStateSkip::updateOnlyDemoGraphics()` | +24 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::appear()` | +16 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::requestStartDemo()` | +12 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::requestEndDemo()` | +8 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `(anonymous namespace)::SimpleDemoStateNrvDemo::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Demo/SimpleDemoState` | `SimpleDemoState::endDemoProcBeforeRequest()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->