### PR TITLE
Demo: Implement `CapManHeroDemoDirector`

### DIFF
--- a/src/Demo/CapManHeroBase.h
+++ b/src/Demo/CapManHeroBase.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class CapManHeroBase : public al::LiveActor {
+public:
+    CapManHeroBase(const char* name) : al::LiveActor(name) {}
+
+    void makeActorAlive() override;
+    void control() override;
+};
+
+static_assert(sizeof(CapManHeroBase) == 0x108);

--- a/src/Demo/CapManHeroDemoDirector.cpp
+++ b/src/Demo/CapManHeroDemoDirector.cpp
@@ -1,0 +1,95 @@
+#include "Demo/CapManHeroDemoDirector.h"
+
+#include <prim/seadSafeString.h>
+
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Demo/CapManHeroBase.h"
+#include "Demo/StageTalkDemoNpcCap.h"
+#include "Util/NpcAnimUtil.h"
+
+namespace CapManHeroDemoFunction {
+
+void capManHeroControl(al::LiveActor* actor) {}
+
+al::LiveActor* createDemoCapManHero(const char* actorName, const al::ActorInitInfo& info,
+                                    const char* suffix) {
+    al::LiveActor* capManHero = new CapManHeroBase(actorName);
+    al::initChildActorWithArchiveNameNoPlacementInfo(capManHero, info, "CapManHero", suffix);
+    al::initJointControllerKeeper(capManHero, 1);
+    rs::initCapWorldNpcTailJointController(capManHero);
+    al::invalidateClipping(capManHero);
+    capManHero->makeActorDead();
+    return capManHero;
+}
+
+void startCapManHeroCommonSettingAfterShowModel(al::LiveActor* actor) {}
+
+}  // namespace CapManHeroDemoFunction
+
+CapManHeroDemoDirector::CapManHeroDemoDirector() = default;
+
+void CapManHeroDemoDirector::init(const al::ActorInitInfo& info) {
+    al::LiveActor* capManHero = new CapManHeroBase("デモ用キャップ[Director]");
+    al::initChildActorWithArchiveNameNoPlacementInfo(capManHero, info, "CapManHero", "Demo");
+    al::initJointControllerKeeper(capManHero, 1);
+    rs::initCapWorldNpcTailJointController(capManHero);
+    al::invalidateClipping(capManHero);
+    capManHero->makeActorDead();
+    mCapManHero = capManHero;
+}
+
+bool CapManHeroDemoDirector::isEndDemo() const {
+    return mCurrentDemo->isEndDemo();
+}
+
+bool CapManHeroDemoDirector::isExistTalkDemoStageStart() const {
+    if (mTalkDemoStageStart)
+        return mTalkDemoStageStart->isEnableStageStartDemo();
+    return false;
+}
+
+bool CapManHeroDemoDirector::isExistTalkDemoMoonRockFind() const {
+    if (mTalkDemoMoonRock)
+        return mTalkDemoMoonRock->isEnableStartMoonRockFindDemo();
+    return false;
+}
+
+bool CapManHeroDemoDirector::isExistTalkDemoAfterMoonRockBreakDemo() const {
+    if (mTalkDemoMoonRock)
+        return mTalkDemoMoonRock->isEnableStartAfterBreakMoonRockDemo();
+    return false;
+}
+
+void CapManHeroDemoDirector::preEventFromSceneFirstMoonGet(const char* eventName) {
+    if (mTalkDemoFirstMoonGet)
+        mTalkDemoFirstMoonGet->preEventFromSceneFirstMoonGet(eventName);
+}
+
+void CapManHeroDemoDirector::startTalkDemoFirstMoonGet() {
+    mCurrentDemo = mTalkDemoFirstMoonGet;
+    mCurrentDemo->startDemoFromScene();
+}
+
+void CapManHeroDemoDirector::startTalkDemoCore(StageTalkDemoNpcCap* talkDemo) {
+    mCurrentDemo = talkDemo;
+    talkDemo->startDemoFromScene();
+}
+
+void CapManHeroDemoDirector::startTalkDemoStageStart() {
+    mCurrentDemo = mTalkDemoStageStart;
+    mCurrentDemo->startDemoFromScene();
+}
+
+void CapManHeroDemoDirector::startTalkDemoMoonRockFind() {
+    mCurrentDemo = mTalkDemoMoonRock;
+    mCurrentDemo->startDemoFromScene();
+}
+
+void CapManHeroDemoDirector::startTalkDemoAfterMoonRockBreakDemo() {
+    mCurrentDemo = mTalkDemoMoonRock;
+    mCurrentDemo->startDemoFromScene();
+}

--- a/src/Demo/CapManHeroDemoDirector.h
+++ b/src/Demo/CapManHeroDemoDirector.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadQuat.h>
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+struct ActorInitInfo;
+class IUseSceneObjHolder;
+class LiveActor;
+}  // namespace al
+
+class StageTalkDemoNpcCap;
+
+class CapManHeroDemoDirector : public al::HioNode, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_CapManHeroDemoDirector;
+
+    CapManHeroDemoDirector();
+
+    const char* getSceneObjName() const override { return "キャップ会話ディレクター"; }
+
+    void init(const al::ActorInitInfo& info);
+    bool isEndDemo() const;
+    bool isExistTalkDemoStageStart() const;
+    bool isExistTalkDemoMoonRockFind() const;
+    bool isExistTalkDemoAfterMoonRockBreakDemo() const;
+    void preEventFromSceneFirstMoonGet(const char* eventName);
+    void startTalkDemoFirstMoonGet();
+    void startTalkDemoCore(StageTalkDemoNpcCap* talkDemo);
+    void startTalkDemoStageStart();
+    void startTalkDemoMoonRockFind();
+    void startTalkDemoAfterMoonRockBreakDemo();
+
+    al::LiveActor* getCapManHero() const { return mCapManHero; }
+
+    void setTalkDemoFirstMoonGet(StageTalkDemoNpcCap* talkDemo) {
+        mTalkDemoFirstMoonGet = talkDemo;
+    }
+
+    void setTalkDemoStageStart(StageTalkDemoNpcCap* talkDemo) { mTalkDemoStageStart = talkDemo; }
+
+    void setTalkDemoMoonRock(StageTalkDemoNpcCap* talkDemo) { mTalkDemoMoonRock = talkDemo; }
+
+    void setDemoStartInfo(const sead::Quatf& quat) { mDemoStartQuat = quat; }
+
+    void getDemoStartInfo(sead::Quatf* quat) const { *quat = mDemoStartQuat; }
+
+private:
+    al::LiveActor* mCapManHero = nullptr;
+    StageTalkDemoNpcCap* mCurrentDemo = nullptr;
+    StageTalkDemoNpcCap* mTalkDemoFirstMoonGet = nullptr;
+    StageTalkDemoNpcCap* mTalkDemoStageStart = nullptr;
+    StageTalkDemoNpcCap* mTalkDemoMoonRock = nullptr;
+    sead::Quatf mDemoStartQuat;
+};
+
+static_assert(sizeof(CapManHeroDemoDirector) == 0x40);
+
+namespace CapManHeroDemoFunction {
+void capManHeroControl(al::LiveActor* actor);
+al::LiveActor* createDemoCapManHero(const char* actorName, const al::ActorInitInfo& info,
+                                    const char* suffix);
+void startCapManHeroCommonSettingAfterShowModel(al::LiveActor* actor);
+void setDemoStartInfo(const al::IUseSceneObjHolder* holder, const sead::Quatf& quat);
+void getDemoStartInfo(const al::IUseSceneObjHolder* holder, sead::Quatf* quat);
+}  // namespace CapManHeroDemoFunction

--- a/src/Demo/StageTalkDemoNpcCap.h
+++ b/src/Demo/StageTalkDemoNpcCap.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Event/IEventFlowEventReceiver.h"
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class StageTalkDemoNpcCap : public al::LiveActor, public al::IEventFlowEventReceiver {
+public:
+    StageTalkDemoNpcCap(const char* name, s32 demoType, s32 flowType = 0);
+
+    void init(const al::ActorInitInfo& info) override;
+    void startDemo();
+    bool isEnableShowDemoAfterOpenMoonRockFirst() const;
+    bool isEnableShowDemoMoonRockMapWorld() const;
+    bool isSceneDemo() const;
+    void kill() override;
+    bool receiveEvent(const al::EventFlowEventData* event) override;
+    bool tryStartDemo();
+    void startDemoFromScene();
+    bool isEnableStartMoonRockFindDemo() const;
+    bool isEnableStartAfterBreakMoonRockDemo() const;
+    void preEventFromSceneFirstMoonGet(const char* eventName);
+    bool isEnableStageStartDemo() const;
+    bool isEndDemo() const;
+    bool tryStartDemoAfterMoonRockBreak();
+    void exeWait();
+    void exeWaitSwitch();
+    void exeDelay();
+    void exeDemo();
+    void endDemoCommon();
+    void exeDemoMoonRockMap();
+
+private:
+    s32 mFlowType = 0;
+    const char* mEventFlowName = nullptr;
+    void* mStageStartInfo = nullptr;
+    bool mIsEnableDemo = true;
+    u8 _129[7] = {};
+    void* mAddDemoInfo = nullptr;
+    al::LiveActor* mMoonRock = nullptr;
+    void* mSaveObjInfo = nullptr;
+    s32 _148 = 0;
+    u8 _14c[4] = {};
+    void* mDemoState = nullptr;
+    al::LiveActor* mCapManHero = nullptr;
+    bool mIsStartedFromScene = false;
+    u8 _161[7] = {};
+    al::LiveActor* mRippleGeneratePoint = nullptr;
+};
+
+static_assert(sizeof(StageTalkDemoNpcCap) == 0x170);

--- a/src/Util/NpcAnimUtil.h
+++ b/src/Util/NpcAnimUtil.h
@@ -47,6 +47,7 @@ void invalidateNpcJointLookAtController(NpcJointLookAtController*);
 void validateNpcJointLookAtController(NpcJointLookAtController*);
 void requestLookAtTargetTrans(NpcJointLookAtController*, const sead::Vector3f&);
 void initCapWorldNpcTail(al::LiveActor*);
+void initCapWorldNpcTailJointController(al::LiveActor*);
 bool tryStartForestManFlowerAnim(al::LiveActor*);
 bool tryUpdateMaterialCodeByFloorCollisionOnArrow(al::LiveActor*);
 void tryAttachConnectorToCollisionTFSV(al::LiveActor*, al::MtxConnector*, sead::Quatf*);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1214)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - 5e56ba6)

📈 **Matched code**: 14.67% (+0.01%, +724 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::init(al::ActorInitInfo const&)` | +264 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoFunction::createDemoCapManHero(char const*, al::ActorInitInfo const&, char const*)` | +260 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::CapManHeroDemoDirector()` | +28 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::isExistTalkDemoStageStart() const` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::isExistTalkDemoMoonRockFind() const` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::isExistTalkDemoAfterMoonRockBreakDemo() const` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::preEventFromSceneFirstMoonGet(char const*)` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::startTalkDemoFirstMoonGet()` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::startTalkDemoStageStart()` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::startTalkDemoMoonRockFind()` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::startTalkDemoAfterMoonRockBreakDemo()` | +16 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::startTalkDemoCore(StageTalkDemoNpcCap*)` | +12 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::isEndDemo() const` | +8 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoFunction::capManHeroControl(al::LiveActor*)` | +4 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoFunction::startCapManHeroCommonSettingAfterShowModel(al::LiveActor*)` | +4 | 0.00% | 100.00% |
| `Demo/CapManHeroDemoDirector` | `CapManHeroDemoDirector::~CapManHeroDemoDirector()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->