### PR TITLE
Camera: Implement `ScenarioStartCameraHolder`

### DIFF
--- a/src/Camera/ScenarioStartCamera.h
+++ b/src/Camera/ScenarioStartCamera.h
@@ -24,7 +24,7 @@ public:
     void* getPoser(s32 index) const;  // TODO unknown return type
     void exePlayAnim();
     void exeEnd();
-    s32 getMaxPlayStep();
+    static s32 getMaxPlayStep();
 
 private:
     void* _110[0x8];

--- a/src/Camera/ScenarioStartCameraHolder.cpp
+++ b/src/Camera/ScenarioStartCameraHolder.cpp
@@ -1,0 +1,92 @@
+#include "Camera/ScenarioStartCameraHolder.h"
+
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Scene/SceneUtil.h"
+
+#include "Camera/ScenarioStartCamera.h"
+
+namespace al {
+ScenarioStartCamera* createPlacementActorFromFactory(const ActorInitInfo& actorInitInfo,
+                                                     const PlacementInfo* placementInfo);
+}  // namespace al
+
+ScenarioStartCameraHolder::ScenarioStartCameraHolder() = default;
+
+void ScenarioStartCameraHolder::init(const al::Scene* scene,
+                                     const al::ActorInitInfo& actorInitInfo) {
+    s32 stageInfoMapNum = al::getStageInfoMapNum(scene);
+    if (stageInfoMapNum < 1)
+        return;
+
+    for (s32 i = 0; i < stageInfoMapNum; i++) {
+        const al::StageInfo* stageInfo = al::getStageInfoMap(scene, i);
+        al::PlacementInfo placementInfo;
+        s32 count = 0;
+        al::tryGetPlacementInfoAndCount(&placementInfo, &count, stageInfo,
+                                        "ScenarioStartCameraList");
+
+        if (count < 1)
+            continue;
+
+        for (s32 j = 0; j < count; j++) {
+            al::PlacementInfo entryPlacementInfo;
+            al::getPlacementInfoByIndex(&entryPlacementInfo, placementInfo, j);
+            mScenarioStartCameras.pushBack(
+                al::createPlacementActorFromFactory(actorInitInfo, &entryPlacementInfo));
+        }
+    }
+}
+
+bool ScenarioStartCameraHolder::isExistEnableNextScenarioStartCamera() const {
+    s32 count = mScenarioStartCameras.size();
+    if (count < 1)
+        return false;
+
+    for (s32 i = 0; i < count; i++) {
+        ScenarioStartCamera* camera = mScenarioStartCameras[i];
+        if (camera->isEnableStart())
+            return true;
+        count = mScenarioStartCameras.size();
+    }
+
+    return false;
+}
+
+bool ScenarioStartCameraHolder::tryStartNextScenarioStartCamera() {
+    s32 count = mScenarioStartCameras.size();
+    if (count < 1)
+        return false;
+
+    for (s32 i = 0; i < count; i++) {
+        ScenarioStartCamera* camera = mScenarioStartCameras[i];
+        if (camera->isEnableStart()) {
+            mCurrentScenarioStartCamera = camera;
+            camera->appear();
+            return true;
+        }
+        count = mScenarioStartCameras.size();
+    }
+
+    return false;
+}
+
+void ScenarioStartCameraHolder::startNextScenarioStartCamera() {
+    s32 count = mScenarioStartCameras.size();
+    if (count < 1)
+        return;
+
+    for (s32 i = 0; i < count; i++) {
+        ScenarioStartCamera* camera = mScenarioStartCameras[i];
+        if (camera->isEnableStart()) {
+            mCurrentScenarioStartCamera = camera;
+            camera->appear();
+            return;
+        }
+        count = mScenarioStartCameras.size();
+    }
+}
+
+s32 ScenarioStartCameraHolder::getCurrentScenarioStartCameraMaxPlayStep() const {
+    return ScenarioStartCamera::getMaxPlayStep();
+}

--- a/src/Camera/ScenarioStartCameraHolder.h
+++ b/src/Camera/ScenarioStartCameraHolder.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+class ScenarioStartCamera;
+
+namespace al {
+struct ActorInitInfo;
+class Scene;
+}  // namespace al
+
+class ScenarioStartCameraHolder {
+public:
+    ScenarioStartCameraHolder();
+
+    void init(const al::Scene* scene, const al::ActorInitInfo& actorInitInfo);
+    bool isExistEnableNextScenarioStartCamera() const;
+    bool tryStartNextScenarioStartCamera();
+    void startNextScenarioStartCamera();
+    s32 getCurrentScenarioStartCameraMaxPlayStep() const;
+
+private:
+    sead::FixedPtrArray<ScenarioStartCamera, 8> mScenarioStartCameras;
+    ScenarioStartCamera* mCurrentScenarioStartCamera = nullptr;
+};
+
+static_assert(sizeof(ScenarioStartCameraHolder) == 0x58);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1215)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0326744 - d5f2182)

📈 **Matched code**: 14.67% (+0.01%, +708 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::init(al::Scene const*, al::ActorInitInfo const&)` | +268 | 0.00% | 100.00% |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::tryStartNextScenarioStartCamera()` | +140 | 0.00% | 100.00% |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::startNextScenarioStartCamera()` | +140 | 0.00% | 100.00% |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::isExistEnableNextScenarioStartCamera() const` | +108 | 0.00% | 100.00% |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::ScenarioStartCameraHolder()` | +48 | 0.00% | 100.00% |
| `Camera/ScenarioStartCameraHolder` | `ScenarioStartCameraHolder::getCurrentScenarioStartCameraMaxPlayStep() const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->