### PR TITLE
Library/Movement: Implement `RumbleCalculator`

### DIFF
--- a/lib/al/Library/Movement/RumbleCalculator.cpp
+++ b/lib/al/Library/Movement/RumbleCalculator.cpp
@@ -1,0 +1,65 @@
+#include "Library/Movement/RumbleCalculator.h"
+
+al::RumbleCalculator::RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime)
+    : mFrame(rampTime), mRampTime(rampTime), mFrequency(frequency), mAngleDev(angleDev),
+      mAmplitude(amplitude) {}
+
+void al::RumbleCalculator::setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime) {
+    mFrequency = frequency;
+    mAngleDev = angleDev;
+    mAmplitude = amplitude;
+    mRampTime = rampTime;
+}
+
+void al::RumbleCalculator::start(u32 rampTime) {
+    if (rampTime != 0)
+        mRampTime = rampTime;
+    mFrame = 0;
+    mOut.set(0.0f, 0.0f, 0.0f);
+}
+
+void al::RumbleCalculator::calc() {
+    if (mFrame >= mRampTime) {
+        mOut.set(0.0f, 0.0f, 0.0f);
+        return;
+    }
+
+    sead::Vector3f vec;
+    f32 rate = (f32)mFrame / mRampTime;
+    f32 invRate = 1.0f - rate;
+
+    f32 angle = rate * sead::Mathf::pi2() * mFrequency;
+
+    vec.x = angle;
+    vec.y = angle;
+    vec.y += mAngleDev;
+    vec.z = mAngleDev + vec.y;
+    calcValues(&mOut, vec);
+
+    mOut *= invRate * mAmplitude;
+    mFrame++;
+}
+
+void al::RumbleCalculator::reset() {
+    mFrame = mRampTime;
+    mOut.set(0.0f, 0.0f, 0.0f);
+}
+
+al::RumbleCalculatorCosAddOneMultLinear::RumbleCalculatorCosAddOneMultLinear(f32 frequency,
+                                                                             f32 angleDev,
+                                                                             f32 amplitude,
+                                                                             u32 rampTime)
+    : RumbleCalculator(frequency, angleDev, amplitude, rampTime) {}
+
+void al::RumbleCalculatorCosAddOneMultLinear::calcValues(sead::Vector3f* out,
+                                                         const sead::Vector3f& in) {
+    out->set(cosf(in.x) + 1, cosf(in.y) + 1, cosf(in.z) + 1);
+}
+
+al::RumbleCalculatorCosMultLinear::RumbleCalculatorCosMultLinear(f32 frequency, f32 angleDev,
+                                                                 f32 amplitude, u32 rampTime)
+    : RumbleCalculator(frequency, angleDev, amplitude, rampTime) {}
+
+void al::RumbleCalculatorCosMultLinear::calcValues(sead::Vector3f* out, const sead::Vector3f& in) {
+    out->set(cosf(in.x), cosf(in.y), cosf(in.z));
+}

--- a/lib/al/Library/Movement/RumbleCalculator.cpp
+++ b/lib/al/Library/Movement/RumbleCalculator.cpp
@@ -18,6 +18,7 @@ void al::RumbleCalculator::start(u32 rampTime) {
     mOut.set(0.0f, 0.0f, 0.0f);
 }
 
+// NON-MATCHING: https://decomp.me/scratch/4Dxv4
 void al::RumbleCalculator::calc() {
     if (mFrame >= mRampTime) {
         mOut.set(0.0f, 0.0f, 0.0f);

--- a/lib/al/Library/Movement/RumbleCalculator.cpp
+++ b/lib/al/Library/Movement/RumbleCalculator.cpp
@@ -1,40 +1,40 @@
 #include "Library/Movement/RumbleCalculator.h"
 
-al::RumbleCalculator::RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime)
-    : mFrame(rampTime), mRampTime(rampTime), mFrequency(frequency), mAngleDev(angleDev),
+al::RumbleCalculator::RumbleCalculator(f32 frequency, f32 angleOffset, f32 amplitude, u32 maxFrame)
+    : mFrame(maxFrame), mMaxFrame(maxFrame), mFrequency(frequency), mAngleOffset(angleOffset),
       mAmplitude(amplitude) {}
 
-void al::RumbleCalculator::setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime) {
+void al::RumbleCalculator::setParam(f32 frequency, f32 angleOffset, f32 amplitude, u32 maxFrame) {
     mFrequency = frequency;
-    mAngleDev = angleDev;
+    mAngleOffset = angleOffset;
     mAmplitude = amplitude;
-    mRampTime = rampTime;
+    mMaxFrame = maxFrame;
 }
 
-void al::RumbleCalculator::start(u32 rampTime) {
-    if (rampTime != 0)
-        mRampTime = rampTime;
+void al::RumbleCalculator::start(u32 maxFrame) {
+    if (maxFrame != 0)
+        mMaxFrame = maxFrame;
     mFrame = 0;
     mOut.set(0.0f, 0.0f, 0.0f);
 }
 
 // NON-MATCHING: https://decomp.me/scratch/4Dxv4
 void al::RumbleCalculator::calc() {
-    if (mFrame >= mRampTime) {
+    if (mFrame >= mMaxFrame) {
         mOut.set(0.0f, 0.0f, 0.0f);
         return;
     }
 
     sead::Vector3f vec;
-    f32 rate = (f32)mFrame / mRampTime;
+    f32 rate = (f32)mFrame / mMaxFrame;
     f32 invRate = 1.0f - rate;
 
     f32 angle = rate * sead::Mathf::pi2() * mFrequency;
 
     vec.x = angle;
     vec.y = angle;
-    vec.y += mAngleDev;
-    vec.z = mAngleDev + vec.y;
+    vec.y += mAngleOffset;
+    vec.z = angle + mAngleOffset + mAngleOffset;
     calcValues(&mOut, vec);
 
     mOut *= invRate * mAmplitude;
@@ -42,24 +42,24 @@ void al::RumbleCalculator::calc() {
 }
 
 void al::RumbleCalculator::reset() {
-    mFrame = mRampTime;
+    mFrame = mMaxFrame;
     mOut.set(0.0f, 0.0f, 0.0f);
 }
 
 al::RumbleCalculatorCosAddOneMultLinear::RumbleCalculatorCosAddOneMultLinear(f32 frequency,
-                                                                             f32 angleDev,
+                                                                             f32 angleOffset,
                                                                              f32 amplitude,
-                                                                             u32 rampTime)
-    : RumbleCalculator(frequency, angleDev, amplitude, rampTime) {}
+                                                                             u32 maxFrame)
+    : RumbleCalculator(frequency, angleOffset, amplitude, maxFrame) {}
 
 void al::RumbleCalculatorCosAddOneMultLinear::calcValues(sead::Vector3f* out,
                                                          const sead::Vector3f& in) {
-    out->set(cosf(in.x) + 1, cosf(in.y) + 1, cosf(in.z) + 1);
+    out->set(cosf(in.x) + 1.0f, cosf(in.y) + 1.0f, cosf(in.z) + 1.0f);
 }
 
-al::RumbleCalculatorCosMultLinear::RumbleCalculatorCosMultLinear(f32 frequency, f32 angleDev,
-                                                                 f32 amplitude, u32 rampTime)
-    : RumbleCalculator(frequency, angleDev, amplitude, rampTime) {}
+al::RumbleCalculatorCosMultLinear::RumbleCalculatorCosMultLinear(f32 frequency, f32 angleOffset,
+                                                                 f32 amplitude, u32 maxFrame)
+    : RumbleCalculator(frequency, angleOffset, amplitude, maxFrame) {}
 
 void al::RumbleCalculatorCosMultLinear::calcValues(sead::Vector3f* out, const sead::Vector3f& in) {
     out->set(cosf(in.x), cosf(in.y), cosf(in.z));

--- a/lib/al/Library/Movement/RumbleCalculator.h
+++ b/lib/al/Library/Movement/RumbleCalculator.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class RumbleCalculator {
+public:
+    RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    void setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    void start(u32);
+    void calc();
+    void reset();
+
+    virtual void calcValues(sead::Vector3f* out, const sead::Vector3f& in) = 0;
+
+protected:
+    u32 mFrame;
+    u32 mRampTime;
+    sead::Vector3f mOut = {0.0f, 0.0f, 0.0f};
+    f32 mFrequency;
+    f32 mAngleDev;
+    f32 mAmplitude;
+};
+
+class RumbleCalculatorCosAddOneMultLinear : public RumbleCalculator {
+public:
+    RumbleCalculatorCosAddOneMultLinear(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    void calcValues(sead::Vector3f* out, const sead::Vector3f& in);
+};
+
+class RumbleCalculatorCosMultLinear : public RumbleCalculator {
+public:
+    RumbleCalculatorCosMultLinear(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    void calcValues(sead::Vector3f* out, const sead::Vector3f& in);
+};
+}  // namespace al

--- a/lib/al/Library/Movement/RumbleCalculator.h
+++ b/lib/al/Library/Movement/RumbleCalculator.h
@@ -2,11 +2,11 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
-// Threw an incomplete type error when I tried forward declaring
+
 #include "Library/HostIO/HioNode.h"
 
 namespace al {
-class RumbleCalculator: public al::HioNode {
+class RumbleCalculator : public HioNode {
 public:
     RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
     void setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);

--- a/lib/al/Library/Movement/RumbleCalculator.h
+++ b/lib/al/Library/Movement/RumbleCalculator.h
@@ -18,10 +18,10 @@ public:
 
 protected:
     u32 mFrame;
-    u32 mRampTime;
+    u32 mMaxFrame;
     sead::Vector3f mOut = {0.0f, 0.0f, 0.0f};
     f32 mFrequency;
-    f32 mAngleDev;
+    f32 mAngleOffset;
     f32 mAmplitude;
 };
 

--- a/lib/al/Library/Movement/RumbleCalculator.h
+++ b/lib/al/Library/Movement/RumbleCalculator.h
@@ -8,9 +8,9 @@
 namespace al {
 class RumbleCalculator : public HioNode {
 public:
-    RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
-    void setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
-    void start(u32 rampTime);
+    RumbleCalculator(f32 frequency, f32 angleOffset, f32 amplitude, u32 maxFrame);
+    void setParam(f32 frequency, f32 angleOffset, f32 amplitude, u32 maxFrame);
+    void start(u32 maxFrame);
     void calc();
     void reset();
 
@@ -27,13 +27,14 @@ protected:
 
 class RumbleCalculatorCosAddOneMultLinear : public RumbleCalculator {
 public:
-    RumbleCalculatorCosAddOneMultLinear(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    RumbleCalculatorCosAddOneMultLinear(f32 frequency, f32 angleOffset, f32 amplitude,
+                                        u32 maxFrame);
     void calcValues(sead::Vector3f* out, const sead::Vector3f& in);
 };
 
 class RumbleCalculatorCosMultLinear : public RumbleCalculator {
 public:
-    RumbleCalculatorCosMultLinear(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
+    RumbleCalculatorCosMultLinear(f32 frequency, f32 angleOffset, f32 amplitude, u32 maxFrame);
     void calcValues(sead::Vector3f* out, const sead::Vector3f& in);
 };
 }  // namespace al

--- a/lib/al/Library/Movement/RumbleCalculator.h
+++ b/lib/al/Library/Movement/RumbleCalculator.h
@@ -2,13 +2,15 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+// Threw an incomplete type error when I tried forward declaring
+#include "Library/HostIO/HioNode.h"
 
 namespace al {
-class RumbleCalculator {
+class RumbleCalculator: public al::HioNode {
 public:
     RumbleCalculator(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
     void setParam(f32 frequency, f32 angleDev, f32 amplitude, u32 rampTime);
-    void start(u32);
+    void start(u32 rampTime);
     void calc();
     void reset();
 


### PR DESCRIPTION
Took way too long to come back to this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1217)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ba3730c - 2030595)

📈 **Matched code**: 14.70% (+0.00%, +380 bytes)

<details>
<summary>✅ 8 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculatorCosAddOneMultLinear::calcValues(sead::Vector3<float>*, sead::Vector3<float> const&)` | +100 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculatorCosMultLinear::calcValues(sead::Vector3<float>*, sead::Vector3<float> const&)` | +80 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculator::RumbleCalculator(float, float, float, unsigned int)` | +48 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculatorCosMultLinear::RumbleCalculatorCosMultLinear(float, float, float, unsigned int)` | +44 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculatorCosAddOneMultLinear::RumbleCalculatorCosAddOneMultLinear(float, float, float, unsigned int)` | +44 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculator::start(unsigned int)` | +24 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculator::setParam(float, float, float, unsigned int)` | +20 | 0.00% | 100.00% |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculator::reset()` | +20 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Movement/RumbleCalculator` | `al::RumbleCalculator::calc()` | +156 | 0.00% | 75.00% |

</details>


<!-- decomp.dev report end -->