### PR TITLE
workflow: auto-label PRs with `ai`

### DIFF
--- a/.github/workflows/pr-label-ai.yml
+++ b/.github/workflows/pr-label-ai.yml
@@ -1,0 +1,33 @@
+name: Add "ai"-label to new PRs by authors that usually use AI
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  new_pr:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_target' && github.event.action == 'opened'
+    steps:
+    - name: Label new PR as "status:waiting for review"
+      uses: actions/github-script@v9
+      env:
+        PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+      with:
+        script: |
+          const known_authors = [
+            "guymakinggames",
+            "GRAnimated"
+          ]
+          
+          if (known_authors.includes(process.env.PR_AUTHOR)) {
+            github.rest.issues.addLabels({
+              ...context.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['ai']
+            })
+          }


### PR DESCRIPTION
For all authors in a given list, auto assign all their new PRs with the label https://github.com/MonsterDruide1/OdysseyDecomp/labels/ai.

Requires approval of @guymakinggames and @GRAnimated to name them explicitly here and assume that they always use AI by default (can be un-labeled with `/no-ai`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1221)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (2be04d7 - 69218ab)

No changes

<!-- decomp.dev report end -->