### PR TITLE
MapObj: Implement `CapAccelerator` and `CapAcceleratorKeyMoveMapParts`

### DIFF
--- a/src/MapObj/CapAccelerator.cpp
+++ b/src/MapObj/CapAccelerator.cpp
@@ -1,0 +1,139 @@
+#include "MapObj/CapAccelerator.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(CapAccelerator, Wait);
+NERVE_IMPL(CapAccelerator, Hit);
+NERVE_IMPL(CapAccelerator, Trample);
+NERVE_IMPL(CapAccelerator, Reaction);
+
+NERVES_MAKE_STRUCT(CapAccelerator, Wait, Hit, Trample, Reaction);
+}  // namespace
+
+CapAccelerator::CapAccelerator(const char* name) : al::LiveActor(name) {}
+
+void CapAccelerator::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, "CapAccelerator", nullptr);
+    al::initNerve(this, &NrvCapAccelerator.Wait, 0);
+
+    if (al::isObjectName(info, "CapAcceleratorKeyMoveMapParts")) {
+        auto* keyMoveMapParts = new al::CapAcceleratorKeyMoveMapParts("キームーブマップパーツ");
+        al::initCreateActorWithPlacementInfo(keyMoveMapParts, info);
+        mKeyMoveMapParts = keyMoveMapParts;
+        al::initSubActorKeeperNoFile(this, info, 1);
+        al::registerSubActor(this, mKeyMoveMapParts);
+    } else {
+        mMtxConnector = al::tryCreateMtxConnector(this, info);
+    }
+
+    al::startAction(this, "Wait");
+    makeActorAlive();
+}
+
+void CapAccelerator::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+void CapAccelerator::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+    else if (mKeyMoveMapParts)
+        al::copyPose(this, mKeyMoveMapParts);
+}
+
+bool CapAccelerator::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (rs::isMsgCapBeamerBeam(message)) {
+        if (al::isGreaterStep(this, 20)) {
+            mHasRethrowReceive = false;
+            al::setNerve(this, &NrvCapAccelerator.Wait);
+            return true;
+        }
+
+        return false;
+    }
+
+    if (al::isMsgPlayerTrampleReflect(message) ||
+        rs::isMsgPlayerAndCapObjHipDropReflectAll(message)) {
+        mHasRethrowReceive = false;
+        rs::requestHitReactionToAttacker(message, self, other);
+        al::setNerve(this, &NrvCapAccelerator.Hit);
+        return true;
+    }
+
+    if ((rs::isMsgCapItemGet(message) || rs::isMsgCapStartLockOn(message)) &&
+        al::isSensorSimple(self) && !mHasRethrowReceive) {
+        sead::Vector3f front;
+        sead::Vector3f up;
+        al::calcFrontDir(&front, this);
+        al::calcUpDir(&up, this);
+
+        sead::Vector3f sendPos = al::getSensorPos(self) + front;
+
+        if (rs::sendMsgCapRethrow(other, self, sendPos, front, up)) {
+            mHasRethrowReceive = true;
+            al::setNerve(this, &NrvCapAccelerator.Trample);
+        }
+    }
+
+    return false;
+}
+
+void CapAccelerator::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorMapObj(self))
+        rs::sendMsgPushToPlayerAndKillVelocityToTarget(this, self, other);
+}
+
+void CapAccelerator::exeWait() {}
+
+void CapAccelerator::exeReaction() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Reaction");
+
+    if (al::isStep(this, 30))
+        mHasRethrowReceive = false;
+
+    if (al::isActionEnd(this)) {
+        mHasRethrowReceive = false;
+        al::startAction(this, "Wait");
+        al::setNerve(this, &NrvCapAccelerator.Wait);
+    }
+}
+
+void CapAccelerator::exeTrample() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "ReactionTrample");
+
+    if (al::isActionEnd(this)) {
+        al::startAction(this, "Wait");
+        al::setNerve(this, &NrvCapAccelerator.Wait);
+    }
+}
+
+void CapAccelerator::exeHit() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Hit");
+
+    if (al::isActionEnd(this)) {
+        al::startAction(this, "Wait");
+        al::setNerve(this, &NrvCapAccelerator.Wait);
+    }
+}

--- a/src/MapObj/CapAccelerator.h
+++ b/src/MapObj/CapAccelerator.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "MapObj/CapAcceleratorKeyMoveMapParts.h"
+
+namespace al {
+struct ActorInitInfo;
+class CapAcceleratorKeyMoveMapParts;
+class HitSensor;
+class IUseName;
+class KeyPoseKeeper;
+class MtxConnector;
+class NerveAction;
+class SensorMsg;
+}  // namespace al
+
+class CapAccelerator : public al::LiveActor {
+public:
+    CapAccelerator(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void control() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+
+    void exeWait();
+    void exeReaction();
+    void exeTrample();
+    void exeHit();
+
+private:
+    bool mHasRethrowReceive = false;
+    al::MtxConnector* mMtxConnector = nullptr;
+    al::CapAcceleratorKeyMoveMapParts* mKeyMoveMapParts = nullptr;
+};
+
+static_assert(sizeof(CapAccelerator) == 0x120);

--- a/src/MapObj/CapAcceleratorKeyMoveMapParts.cpp
+++ b/src/MapObj/CapAcceleratorKeyMoveMapParts.cpp
@@ -1,0 +1,73 @@
+#include "MapObj/CapAcceleratorKeyMoveMapParts.h"
+
+#include "Library/KeyPose/KeyPoseKeeper.h"
+#include "Library/KeyPose/KeyPoseKeeperUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+namespace {
+using CapAcceleratorKeyMoveMapParts = al::CapAcceleratorKeyMoveMapParts;
+NERVE_ACTION_IMPL(CapAcceleratorKeyMoveMapParts, Wait)
+NERVE_ACTION_IMPL(CapAcceleratorKeyMoveMapParts, Move)
+NERVE_ACTION_IMPL(CapAcceleratorKeyMoveMapParts, Stop)
+
+NERVE_ACTIONS_MAKE_STRUCT(CapAcceleratorKeyMoveMapParts, Wait, Move, Stop)
+}  // namespace
+
+al::CapAcceleratorKeyMoveMapParts::CapAcceleratorKeyMoveMapParts(const char* name)
+    : LiveActor(name) {}
+
+void al::CapAcceleratorKeyMoveMapParts::init(const ActorInitInfo& info) {
+    al::initNerveAction(this, "Wait", &::NrvCapAcceleratorKeyMoveMapParts.collector, 0);
+    al::initActorWithArchiveName(this, info, "CapAcceleratorKeyMoveMapParts", nullptr);
+    mKeyPoseKeeper = al::createKeyPoseKeeper(info);
+    makeActorAlive();
+}
+
+void al::CapAcceleratorKeyMoveMapParts::control() {}
+
+void al::CapAcceleratorKeyMoveMapParts::exeWait() {
+    if (al::isFirstStep(this)) {
+        s32 waitTime = al::calcKeyMoveWaitTime(mKeyPoseKeeper);
+        if (!((waitTime >> 31) & 1))
+            mKeyMoveWaitTime = waitTime;
+    }
+
+    if (al::isGreaterEqualStep(this, mKeyMoveWaitTime)) {
+        if (al::isRestart(mKeyPoseKeeper)) {
+            al::restartKeyPose(mKeyPoseKeeper, al::getTransPtr(this), al::getQuatPtr(this));
+            al::resetPosition(this);
+            al::startNerveAction(this, "Wait");
+        } else {
+            al::startNerveAction(this, "Move");
+        }
+    }
+}
+
+void al::CapAcceleratorKeyMoveMapParts::exeMove() {
+    if (al::isFirstStep(this))
+        mKeyMoveMoveTime = al::calcKeyMoveMoveTime(mKeyPoseKeeper);
+
+    f32 rate = al::calcNerveRate(this, mKeyMoveMoveTime);
+    al::calcLerpKeyTrans(al::getTransPtr(this), mKeyPoseKeeper, rate);
+    al::calcSlerpKeyQuat(al::getQuatPtr(this), mKeyPoseKeeper, rate);
+
+    if (al::isGreaterEqualStep(this, mKeyMoveMoveTime)) {
+        al::nextKeyPose(mKeyPoseKeeper);
+        if (al::isStop(mKeyPoseKeeper))
+            al::startNerveAction(this, "Stop");
+        else
+            al::startNerveAction(this, "Wait");
+    }
+}
+
+void al::CapAcceleratorKeyMoveMapParts::exeStop() {
+    if (al::isFirstStep(this) && al::isInvalidClipping(this))
+        al::validateClipping(this);
+}

--- a/src/MapObj/CapAcceleratorKeyMoveMapParts.h
+++ b/src/MapObj/CapAcceleratorKeyMoveMapParts.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class KeyPoseKeeper;
+
+class CapAcceleratorKeyMoveMapParts : public LiveActor {
+public:
+    CapAcceleratorKeyMoveMapParts(const char* name);
+
+    void init(const ActorInitInfo& info) override;
+    void control() override;
+
+    void exeWait();
+    void exeMove();
+    void exeStop();
+
+private:
+    KeyPoseKeeper* mKeyPoseKeeper = nullptr;
+    s32 mKeyMoveWaitTime = 30;
+    s32 mKeyMoveMoveTime = 0;
+};
+
+static_assert(sizeof(CapAcceleratorKeyMoveMapParts) == 0x118);
+}  // namespace al

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -74,6 +74,7 @@
 #include "MapObj/BlockQuestion2D.h"
 #include "MapObj/BossKnuckleFix.h"
 #include "MapObj/BreakablePole.h"
+#include "MapObj/CapAccelerator.h"
 #include "MapObj/CapBomb.h"
 #include "MapObj/CapHanger.h"
 #include "MapObj/CapSwitch.h"
@@ -214,8 +215,8 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"CandlestandBgmDirector", nullptr},
     {"CandlestandSaveWatcher", nullptr},
     {"CandlestandWatcher", nullptr},
-    {"CapAccelerator", nullptr},
-    {"CapAcceleratorKeyMoveMapParts", nullptr},
+    {"CapAccelerator", al::createActorFunction<CapAccelerator>},
+    {"CapAcceleratorKeyMoveMapParts", al::createActorFunction<al::CapAcceleratorKeyMoveMapParts>},
     {"CapAppearMapParts", nullptr},
     {"CapBeamer", nullptr},
     {"CapBomb", al::createActorFunction<CapBomb>},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1223)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ba3730c - 93c1c2c)

📈 **Matched code**: 14.72% (+0.02%, +2788 bytes)

<details>
<summary>✅ 29 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/CapAccelerator` | `CapAccelerator::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +344 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::init(al::ActorInitInfo const&)` | +248 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::exeMove()` | +204 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::exeWait()` | +176 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::init(al::ActorInitInfo const&)` | +144 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::CapAccelerator(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::CapAcceleratorKeyMoveMapParts(char const*)` | +140 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `(anonymous namespace)::CapAcceleratorNrvReaction::execute(al::NerveKeeper*) const` | +132 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::CapAccelerator(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::exeReaction()` | +128 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::CapAcceleratorKeyMoveMapParts(char const*)` | +128 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `_GLOBAL__sub_I_CapAcceleratorKeyMoveMapParts.cpp` | +116 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `(anonymous namespace)::CapAcceleratorNrvHit::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `(anonymous namespace)::CapAcceleratorNrvTrample::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::exeTrample()` | +104 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::exeHit()` | +104 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::attackSensor(al::HitSensor*, al::HitSensor*)` | +84 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvStop::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::exeStop()` | +64 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::initAfterPlacement()` | +28 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::control()` | +28 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvWait::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvMove::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvStop::getActionName() const` | +12 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `(anonymous namespace)::CapAcceleratorKeyMoveMapPartsNrvMove::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `CapAccelerator::exeWait()` | +4 | 0.00% | 100.00% |
| `MapObj/CapAccelerator` | `(anonymous namespace)::CapAcceleratorNrvWait::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |
| `MapObj/CapAcceleratorKeyMoveMapParts` | `al::CapAcceleratorKeyMoveMapParts::control()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->