### PR TITLE
Item: Implement `CoinStackGroup`

### DIFF
--- a/src/Item/CoinStack.h
+++ b/src/Item/CoinStack.h
@@ -42,6 +42,8 @@ public:
 
     f32 getTransY() const { return mTransY; }
 
+    void setTransY(f32 transY) { mTransY = transY; }
+
 private:
     const f32* mExternalFallDistance = nullptr;
     f32 mTransY = 0.0f;

--- a/src/Item/CoinStackGroup.cpp
+++ b/src/Item/CoinStackGroup.cpp
@@ -1,0 +1,156 @@
+#include "Item/CoinStackGroup.h"
+
+#include <random/seadRandom.h>
+
+#include "Library/Clipping/ClippingActorHolder.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseKeeper.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSceneInfo.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Stage/StageSwitchKeeper.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Item/CoinStack.h"
+#include "System/GameDataUtil.h"
+
+constexpr f32 cFallDistance = 74.5f;
+
+CoinStackGroup::CoinStackGroup(const char* name) : al::LiveActor(name) {}
+
+void CoinStackGroup::init(const al::ActorInitInfo& initInfo) {
+    using CoinStackGroupFunctor = al::FunctorV0M<CoinStackGroup*, void (CoinStackGroup::*)()>;
+
+    al::initActorSceneInfo(this, initInfo);
+    al::initActorPoseTFSV(this);
+    al::initActorSRT(this, initInfo);
+    al::initActorClipping(this, initInfo);
+    initHitSensor(1);
+    al::addHitSensor(this, initInfo, "Body", 13, 0.0f, 8, sead::Vector3f::zero);
+    al::initExecutorMapObjMovement(this, initInfo);
+    al::initStageSwitch(this, initInfo);
+    mPlacementId = new al::PlacementId();
+    al::tryGetArg(&mStackAmount, initInfo, "StacksAmount");
+    al::tryGetArg(&mIsMustSave, initInfo, "MustSave");
+    if (mIsMustSave && al::tryGetPlacementId(mPlacementId, initInfo))
+        rs::tryFindCoinStackSave(&mStackAmount, this, mPlacementId);
+    generateCoinStackGroup(initInfo, mStackAmount);
+    if (al::isValidStageSwitch(this, "SwitchAppear")) {
+        if (al::listenStageSwitchOn(
+                this, "SwitchAppear",
+                CoinStackGroupFunctor(this, &CoinStackGroup::makeStackAppear)) &&
+            al::listenStageSwitchOff(
+                this, "SwitchAppear",
+                CoinStackGroupFunctor(this, &CoinStackGroup::makeStackDisappear)) &&
+            al::trySyncStageSwitchAppear(this)) {
+            return;
+        }
+    }
+    if (mCoinStack)
+        mCoinStack->makeStackAppear();
+    makeActorAlive();
+}
+
+void CoinStackGroup::control() {
+    for (CoinStack* stack = mCoinStack; stack != nullptr; stack = stack->getAbove())
+        stack->setTransY(al::getTrans(stack).y - stack->getFallSpeed());
+}
+
+bool CoinStackGroup::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                al::HitSensor* self) {
+    if (al::isMsgChangeAlpha(message)) {
+        mCoinStack->changeAlpha(al::getChangeAlphaValue(message));
+        return true;
+    }
+
+    return false;
+}
+
+void CoinStackGroup::makeActorDead() {
+    if (mCoinStack)
+        mCoinStack->makeStackDisappear();
+    al::LiveActor::makeActorDead();
+}
+
+void CoinStackGroup::makeActorAlive() {
+    al::LiveActor::makeActorAlive();
+    if (mCoinStack)
+        mCoinStack->makeStackAppear();
+}
+
+inline f32 getRandomRange(f32 scale) {
+    f32 value = sead::Random().getF32();
+    return scale * value * ((value > 0.5f) ? 1.0f : -1.0f) + 0.0f;
+}
+
+void CoinStackGroup::generateCoinStackGroup(const al::ActorInitInfo& initInfo, s32 stackSize) {
+    f32 clippingRadius = updateClippingInfo(stackSize);
+    sead::Vector3f stackTrans = al::getTrans(this);
+
+    CoinStack* previousStack = nullptr;
+    for (u32 index = 0; index != (u32)stackSize; index++) {
+        CoinStack* newStack = new CoinStack("CoinStack");
+        newStack->init(initInfo);
+
+        if (index == 0) {
+            sead::Vector3f coinTrans(stackTrans);
+            newStack->postInit(this, coinTrans, previousStack, mClippingPos, clippingRadius,
+                               &cFallDistance);
+            mCoinStack = newStack;
+            previousStack = newStack;
+            continue;
+        }
+
+        sead::Vector3f coinTrans = {getRandomRange(10.0f), index * cFallDistance,
+                                    getRandomRange(10.0f)};
+        newStack->postInit(this, stackTrans + coinTrans, previousStack, mClippingPos,
+                           clippingRadius, &cFallDistance);
+        previousStack = newStack;
+    }
+}
+
+void CoinStackGroup::makeStackAppear() {
+    if (mCoinStack)
+        mCoinStack->makeStackAppear();
+}
+
+void CoinStackGroup::makeStackDisappear() {
+    if (mCoinStack)
+        mCoinStack->makeStackDisappear();
+}
+
+f32 CoinStackGroup::setStackAsCollected(CoinStack* stack) {
+    mStackAmount--;
+    al::invalidateClipping(this);
+    if (mIsMustSave)
+        rs::saveCoinStack(this, mPlacementId, mStackAmount);
+
+    if (mStackAmount == 0) {
+        kill();
+        return 0.0f;
+    }
+
+    if (mCoinStack == stack)
+        mCoinStack = stack->getAbove();
+
+    return updateClippingInfo(mStackAmount);
+}
+
+f32 CoinStackGroup::updateClippingInfo(u32 stackSize) {
+    f32 clippingRadius = stackSize * 0.75f * cFallDistance;
+    mClippingPos = al::getTrans(this) + sead::Vector3f(0.0f, clippingRadius * 0.75f, 0.0f);
+
+    al::setClippingInfo(this, clippingRadius, &mClippingPos);
+    return clippingRadius;
+}
+
+void CoinStackGroup::validateClipping() {
+    al::validateClipping(this);
+}

--- a/src/Item/CoinStackGroup.cpp
+++ b/src/Item/CoinStackGroup.cpp
@@ -21,7 +21,7 @@
 #include "Item/CoinStack.h"
 #include "System/GameDataUtil.h"
 
-constexpr f32 cFallDistance = 74.5f;
+constexpr f32 cStackDistH = 74.5f;
 
 CoinStackGroup::CoinStackGroup(const char* name) : al::LiveActor(name) {}
 
@@ -90,6 +90,7 @@ inline f32 getRandomRange(f32 scale) {
     return scale * value * ((value > 0.5f) ? 1.0f : -1.0f) + 0.0f;
 }
 
+// NON_MATCHING: https://decomp.me/scratch/kFqhl. Hack fix https://decomp.me/scratch/51zHf
 void CoinStackGroup::generateCoinStackGroup(const al::ActorInitInfo& initInfo, s32 stackSize) {
     f32 clippingRadius = updateClippingInfo(stackSize);
     sead::Vector3f stackTrans = al::getTrans(this);
@@ -100,18 +101,18 @@ void CoinStackGroup::generateCoinStackGroup(const al::ActorInitInfo& initInfo, s
         newStack->init(initInfo);
 
         if (index == 0) {
-            sead::Vector3f coinTrans(stackTrans);
+            sead::Vector3f coinTrans = stackTrans;
             newStack->postInit(this, coinTrans, previousStack, mClippingPos, clippingRadius,
-                               &cFallDistance);
+                               &cStackDistH);
             mCoinStack = newStack;
             previousStack = newStack;
             continue;
         }
 
-        sead::Vector3f coinTrans = {getRandomRange(10.0f), index * cFallDistance,
+        sead::Vector3f coinTrans = {getRandomRange(10.0f), index * cStackDistH,
                                     getRandomRange(10.0f)};
         newStack->postInit(this, stackTrans + coinTrans, previousStack, mClippingPos,
-                           clippingRadius, &cFallDistance);
+                           clippingRadius, &cStackDistH);
         previousStack = newStack;
     }
 }
@@ -144,7 +145,7 @@ f32 CoinStackGroup::setStackAsCollected(CoinStack* stack) {
 }
 
 f32 CoinStackGroup::updateClippingInfo(u32 stackSize) {
-    f32 clippingRadius = stackSize * 0.75f * cFallDistance;
+    f32 clippingRadius = stackSize * 0.75f * cStackDistH;
     mClippingPos = al::getTrans(this) + sead::Vector3f(0.0f, clippingRadius * 0.75f, 0.0f);
 
     al::setClippingInfo(this, clippingRadius, &mClippingPos);

--- a/src/Item/CoinStackGroup.h
+++ b/src/Item/CoinStackGroup.h
@@ -25,15 +25,15 @@ public:
     void makeActorDead() override;
     void makeActorAlive() override;
 
-    void generateCoinStackGroup(const al::ActorInitInfo&, s32);
+    void generateCoinStackGroup(const al::ActorInitInfo& initInfo, s32 stackSize);
     void makeStackAppear();
     void makeStackDisappear();
     f32 setStackAsCollected(CoinStack* stack);
-    f32 updateClippingInfo(u32 stackAmount);
+    f32 updateClippingInfo(u32 stackSize);
     void validateClipping();
 
 private:
-    sead::Vector3f mClippingPos = sead::Vector3f(0.0f, 0.0f, 0.0f);
+    sead::Vector3f mClippingPos = {0.0f, 0.0f, 0.0f};
     s32 mStackAmount = 0;
     CoinStack* mCoinStack = nullptr;
     al::PlacementId* mPlacementId = nullptr;


### PR DESCRIPTION
The non matching part is kind of a lie. Special thanks to @guymakinggames  for fixing the mismatch at `generateCoinStackGroup`. We actually know the solution https://decomp.me/scratch/51zHf

The issue here is that by removing `init()` from Random ctor we change every instance of this object for the whole codebase of sead/smo/botw. We need to do some research to discover if this change is really necessary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1224)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (4b82fce - 2d65dae)

📈 **Matched code**: 15.05% (+0.01%, +1492 bytes)

<details>
<summary>✅ 15 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/CoinStackGroup` | `CoinStackGroup::init(al::ActorInitInfo const&)` | +444 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::setStackAsCollected(CoinStack*)` | +236 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::CoinStackGroup(char const*)` | +148 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::CoinStackGroup(char const*)` | +136 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::updateClippingInfo(unsigned int)` | +128 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::control()` | +84 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +76 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `al::FunctorV0M<CoinStackGroup*, void (CoinStackGroup::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::makeActorAlive()` | +52 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::makeActorDead()` | +44 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `al::FunctorV0M<CoinStackGroup*, void (CoinStackGroup::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::makeStackAppear()` | +16 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::makeStackDisappear()` | +16 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `CoinStackGroup::validateClipping()` | +4 | 0.00% | 100.00% |
| `Item/CoinStackGroup` | `al::FunctorV0M<CoinStackGroup*, void (CoinStackGroup::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/CoinStackGroup` | `CoinStackGroup::generateCoinStackGroup(al::ActorInitInfo const&, int)` | +429 | 0.00% | 75.00% |

</details>


<!-- decomp.dev report end -->