### PR TITLE
Library/Bgm: Implement `BgmLineFunction`

### DIFF
--- a/lib/al/Library/Audio/AudioEventController.h
+++ b/lib/al/Library/Audio/AudioEventController.h
@@ -1,28 +1,73 @@
 #pragma once
 
 #include <basis/seadTypes.h>
-#include <math/seadVector.h>
+#include <math/seadVectorFwd.h>
+
+#include "Library/Area/IUseAreaObj.h"
+#include "Library/Audio/IUseAudioKeeper.h"
 
 namespace al {
+class AreaObjDirector;
+class AudioEffectController;
+class AudioKeeper;
 class ByamlIter;
 class Resource;
 
 template <typename T>
 class AudioInfoListWithParts;
-class AudioEventController;
 class BgmPlayObj;
+class BgmPlayEventController;
 class AudioDirector;
+class PlayerHolder;
+
+class AudioEventController : public IUseAudioKeeper, public IUseAreaObj {
+public:
+    AudioEventController(const AudioDirector* audioDirector, const char* stageEffectName);
+
+    void init3D(AreaObjDirector* areaObjDirector, AudioEffectController* audioEffectController);
+    void initAfterInitPlacement(const AudioDirector* audioDirector);
+    void update();
+    bool isEnableAudioEvent(s32 audioEvent) const;
+    void finalize();
+    void setPlayerHolder(const PlayerHolder* playerHolder);
+    void activate();
+    void deactivate();
+    void activateEachAudioEvent(s32 audioEvent, bool isActivate);
+    void deactivateEachAudioEvent(s32 audioEvent, bool isDeactivate);
+    bool isInBgmStopArea(const char* playName);
+    const char* getBgmSituationNameByAreaChecker();
+    const char* getAudioEffectNameByAreaChecker();
+    bool isEnableBgmChangeEvent() const;
+    bool isEnableBgmSituationChangeEvent() const;
+    bool isEnableAllAudioEvent() const;
+    bool isDisableAllAudioEvent() const;
+
+    AudioKeeper* getAudioKeeper() const override;
+    AreaObjDirector* getAreaObjDirector() const override;
+
+    BgmPlayEventController* getBgmPlayEventController() const { return mBgmPlayEventController; }
+
+private:
+    AudioKeeper* mAudioKeeper = nullptr;
+    BgmPlayEventController* mBgmPlayEventController = nullptr;
+    u8 _20[0x78];
+};
+
+static_assert(sizeof(AudioEventController) == 0x98);
 }  // namespace al
 
 namespace alAudioEventControllerFunction {
-bool tryRegistBgmPlayObj(al::AudioEventController*, al::BgmPlayObj*);
-const char* getBgmPlayNameInCurPosition(al::AudioEventController* audioEventController, bool);
+bool tryRegistBgmPlayObj(al::AudioEventController* audioEventController, al::BgmPlayObj* obj);
+const char* getBgmPlayNameInCurPosition(al::AudioEventController* audioEventController,
+                                        bool isStopArea);
 const char* getBgmPlayNameInTargetPosition(al::AudioEventController* audioEventController,
-                                           const sead::Vector3f&);
-void tryStartAndStopBgmInCurPosition(al::AudioEventController* audioEventController, bool, bool);
-void activateAudioEventCtrl(al::AudioDirector*);
-void deactivateAudioEventCtrl(al::AudioDirector*);
-void tryActivateOrDeactivateAudioEventCtrl(al::AudioDirector*, bool, s32);
+                                           const sead::Vector3f& position);
+void tryStartAndStopBgmInCurPosition(al::AudioEventController* audioEventController,
+                                     bool isStopArea, bool isForceStart);
+void activateAudioEventCtrl(al::AudioDirector* audioDirector);
+void deactivateAudioEventCtrl(al::AudioDirector* audioDirector);
+void tryActivateOrDeactivateAudioEventCtrl(al::AudioDirector* audioDirector, bool isActivate,
+                                           s32 audioEvent);
 }  // namespace alAudioEventControllerFunction
 
 namespace al {

--- a/lib/al/Library/Audio/AudioInfo.h
+++ b/lib/al/Library/Audio/AudioInfo.h
@@ -51,7 +51,6 @@ public:
     AudioInfoList() = default;
 
     void init(s32 listSize) {
-        mIsLinearSearch = false;
         mList = new sead::PtrArray<const T>();
         mList->allocBuffer((listSize == 0) ? 1 : listSize, nullptr);
     }
@@ -83,9 +82,17 @@ public:
 
     bool isValidIndex(s32 index) const { return index < getSize(); }
 
+    const sead::PtrArray<const T>* getList() const { return mList; }
+
+    sead::PtrArray<const T>* getListForSort() const { return mList; }
+
+    bool isLinearSearch() const { return mIsLinearSearch; }
+
+    void setLinearSearch(bool isLinearSearch) { mIsLinearSearch = isLinearSearch; }
+
 private:
     sead::PtrArray<const T>* mList;
-    bool mIsLinearSearch = false;
+    bool mIsLinearSearch;
 };
 
 template <typename T>
@@ -113,6 +120,12 @@ public:
             mParts->at(i)->sort();
     }
 
+    bool addParts(AudioInfoList<T>* parts) const {
+        if (!mParts || !parts)
+            return false;
+        return mParts->pushBack(parts);
+    }
+
     const T* getInfoAt(s32 index) const {
         if (AudioInfoList<T>::isValidIndex(index))
             return AudioInfoList<T>::getInfoAt(index);
@@ -133,6 +146,10 @@ public:
             return 0;
         return mParts->size();
     }
+
+    const AudioInfoList<T>* getPartsListAt(s32 index) const { return mParts->at(index); }
+
+    sead::PtrArray<AudioInfoList<T>>* getParts() const { return mParts; }
 
     s32 getSize() const {
         if (!mParts)
@@ -155,11 +172,34 @@ AudioInfoListWithParts<T>* createAudioInfoList(const ByamlIter& iter, s32 maxNum
     AudioInfoListWithParts<T>* audioInfoList = new AudioInfoListWithParts<T>;
 
     s32 listSize = alAudioInfoListFunction::getCreateAudioInfoListSize(iter, 0);
+    audioInfoList->setLinearSearch(false);
     audioInfoList->init(listSize, maxNumParts);
 
     AudioInfoListCreateFunctor<T> functor(audioInfoList, T::createInfo);
     alAudioInfoListFunction::createAudioInfoAndSetToList(&functor, iter);
     audioInfoList->sort();
+
+    return audioInfoList;
+}
+
+template <typename T>
+AudioInfoListWithParts<T>* createAudioInfoList(const ByamlIter& iter,
+                                               const ByamlIter& localizedIter, s32 maxNumParts,
+                                               bool disableSort) {
+    AudioInfoListWithParts<T>* audioInfoList = new AudioInfoListWithParts<T>;
+
+    s32 listSize = alAudioInfoListFunction::getCreateAudioInfoListSize(iter, localizedIter);
+    audioInfoList->setLinearSearch(false);
+    audioInfoList->init(listSize, maxNumParts);
+
+    AudioInfoListCreateFunctor<T> functor(audioInfoList, T::createInfo);
+    alAudioInfoListFunction::createAudioInfoAndSetToList(&functor, iter);
+
+    AudioInfoListCreateFunctor<T> localizedFunctor(audioInfoList, T::createInfo);
+    alAudioInfoListFunction::createAudioInfoAndSetToList(&localizedFunctor, localizedIter);
+
+    if (!disableSort)
+        audioInfoList->sort();
 
     return audioInfoList;
 }
@@ -197,6 +237,7 @@ AudioInfoListWithParts<T>* copyAudioInfoList(const AudioInfoListWithParts<T>* au
     s32 newSize = originalSize + additionalSize;
 
     AudioInfoListWithParts<T>* newAudioInfoList = new AudioInfoListWithParts<T>;
+    newAudioInfoList->setLinearSearch(false);
     newAudioInfoList->init(newSize, 0);
 
     for (s32 i = 0; i < originalSize; i++) {

--- a/lib/al/Library/Audio/System/AudioKeeper.h
+++ b/lib/al/Library/Audio/System/AudioKeeper.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <basis/seadTypes.h>
 #include <math/seadMatrix.h>
 #include <math/seadVector.h>
 
@@ -15,6 +16,17 @@ class AudioRequestKeeperSyncedBgm;
 class AudioMic;
 class SeKeeper;
 class BgmKeeper;
+struct BgmPlayingRequest;
+
+enum BgmPlayingType : s32 {
+    BgmPlayingType_Start = 1,
+    BgmPlayingType_Stop = 3,
+};
+
+class AudioRequestKeeperSyncedBgm {
+public:
+    void requestBgm(BgmPlayingType type, const BgmPlayingRequest& request, s32 syncBeat);
+};
 
 class AudioKeeper : public HioNode {
 public:

--- a/lib/al/Library/Audio/System/AudioKeeperFunction.h
+++ b/lib/al/Library/Audio/System/AudioKeeperFunction.h
@@ -12,14 +12,14 @@ class AudioEffectDataBase;
 template <typename T>
 class AudioInfoListWithParts;
 class AudioResourceLoadGroupInfo;
-class AudioResourceLoadingInfo;
+struct AudioResourceLoadingInfo;
 class AudioResourcePlayerKeeper;
 class AudioSystem;
 class AudioSystemDebug;
 struct AudioSystemInfo;
 class AudioSystemInitInfo;
 class BgmDataBase;
-class BgmMusicalInfo;
+struct BgmMusicalInfo;
 struct GameSystemInfo;
 class IUseSeadAudioPlayer;
 class PadRumbleDirector;

--- a/lib/al/Library/Bgm/Bgm3DParamsController.h
+++ b/lib/al/Library/Bgm/Bgm3DParamsController.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/Audio/IUseAudioKeeper.h"
+
+namespace al {
+class AudioDirector;
+class AudioKeeper;
+class IBgmParamsChanger;
+
+class Bgm3DParamsController : public IUseAudioKeeper {
+public:
+    Bgm3DParamsController(const AudioDirector* audioDirector);
+
+    void update();
+    void finalize();
+    void start3D();
+    void end3D();
+    void change3DParams(f32 volume, f32 pitch, f32 lpfFreq, f32 auxBusSend, bool isForce);
+    void activate();
+    void deactivate();
+
+    AudioKeeper* getAudioKeeper() const override;
+
+    bool isActive() const { return mIsActive; }
+
+private:
+    sead::PtrArray<IBgmParamsChanger>* mParamsChangers = nullptr;
+    AudioKeeper* mAudioKeeper = nullptr;
+    bool mIs3DStarted = false;
+    bool mIsActive = false;
+    u8 _1a[6] = {};
+};
+
+static_assert(sizeof(Bgm3DParamsController) == 0x20);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmDirector.h
+++ b/lib/al/Library/Bgm/BgmDirector.h
@@ -1,9 +1,93 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
 namespace al {
+class AudioBusSendController;
+class AudioDirector;
+struct AudioSystemInfo;
+class Bgm3DParamsController;
+class BgmDataBase;
+class BgmDirectorInitInfo;
+class BgmLine;
+class BgmLineKeeper;
+class BgmMultiPlayingController;
+class BgmRhythmSyncDirector;
+class BgmSituationDirector;
+struct BgmPlayingRequest;
+class FunctorBase;
+class IBgmParamsChanger;
 
 class BgmDirector {
 public:
     BgmDirector();
+
+    virtual BgmLine* getActiveBgmLine() const;
+
+    void init(const AudioSystemInfo* audioSystemInfo, const AudioDirector* audioDirector,
+              const BgmDirectorInitInfo& initInfo, const char* userName, s32 lineNum);
+    void setDependentModule(BgmDirector* director);
+    void reset(const char* userName, s32 lineNum);
+    void update();
+    void clearPlayData();
+    void enableLineChange();
+    void finalize();
+    void startBgm(const BgmPlayingRequest& request, bool isForceStart);
+    void prepareBgm(const BgmPlayingRequest& request);
+    void stopBgm(const char* playName, s32 fadeFrame);
+    void endSituation(const char* situationName, bool isApply, bool isForce);
+    void pauseBgm(const char* playName, s32 fadeFrame);
+    void resumeBgm(const char* playName, s32 fadeFrame);
+    bool isPlayingBgm();
+    bool isPlayingBgm(const char* playName);
+    bool isRunningBgm(const char* playName);
+    void stopAllBgm(s32 fadeFrame, bool isForce);
+    void tryStopAllBgm(s32 fadeFrame);
+    void setTriggerEventForStopAllBgm(const FunctorBase& functor);
+    void tryPauseBgmIfNotPlaying(const char* playName, s32 fadeFrame);
+    void tryPauseBgmIfLowPriority(const char* playName, s32 fadeFrame);
+    void startSituation(const char* situationName, bool isApply, bool isForce, bool isForceStart);
+    void startSituation(sead::PtrArray<IBgmParamsChanger>* paramsChangers,
+                        const char* situationName, bool isApply, bool isForce, bool isForceStart);
+    void endSituation(sead::PtrArray<IBgmParamsChanger>* paramsChangers, const char* situationName,
+                      bool isApply, bool isForce);
+    void disableLineChange();
+    bool isDisableLineChange();
+    bool isUsedLineGroupName(const char* groupName) const;
+    BgmLine* getPlayingBgmLine(const char* playName) const;
+    BgmLine* getBgmLineByLineName(const char* lineName) const;
+    BgmLine* getActiveBgmLineWithoutUpperLayer() const;
+    s64 getLoopEndSamplePosition(const char* playName) const;
+    void setAudioBusSendController(AudioBusSendController* controller);
+    BgmMultiPlayingController* tryAllocMultiPlayingController();
+    void tryReleaseMultiPlayingController(BgmMultiPlayingController* controller);
+    void deactiveAllBgmMultiPlayingController(s32 fadeFrame);
+    s32 getBgmLineNum(bool isWithoutUpperLayer);
+    BgmLine* getBgmLineAccessor(s32 index, bool isWithoutUpperLayer);
+    s32 getBgmLineIndex(const char* lineName, bool isWithoutUpperLayer) const;
+
+    BgmDataBase* getBgmDataBase() const { return mBgmDataBase; }
+
+    BgmLineKeeper* getBgmLineKeeper() const { return mBgmLineKeeper; }
+
+    BgmSituationDirector* getBgmSituationDirector() const { return mBgmSituationDirector; }
+
+    Bgm3DParamsController* getBgm3DParamsController() const { return mBgm3DParamsController; }
+
+    BgmRhythmSyncDirector* getBgmRhythmSyncDirector() const { return mBgmRhythmSyncDirector; }
+
+private:
+    BgmDataBase* mBgmDataBase = nullptr;
+    BgmDirector* mDependentModule = nullptr;
+    BgmLineKeeper* mBgmLineKeeper = nullptr;
+    u8 _20[0x28] = {};
+    BgmSituationDirector* mBgmSituationDirector = nullptr;
+    Bgm3DParamsController* mBgm3DParamsController = nullptr;
+    sead::PtrArray<BgmMultiPlayingController>* mMultiPlayingControllers = nullptr;
+    BgmRhythmSyncDirector* mBgmRhythmSyncDirector = nullptr;
+    AudioBusSendController* mAudioBusSendController = nullptr;
 };
+
+static_assert(sizeof(BgmDirector) == 0x70);
 }  // namespace al

--- a/lib/al/Library/Bgm/BgmFunction.h
+++ b/lib/al/Library/Bgm/BgmFunction.h
@@ -3,9 +3,17 @@
 namespace al {
 class AudioDirector;
 class BgmDataBase;
+struct BgmPlayInfo;
+struct BgmResourceInfo;
+struct BgmStageInfo;
+struct BgmSituationInfo;
 struct BgmUserInfo;
 }  // namespace al
 
 namespace alBgmFunction {
+al::BgmPlayInfo* tryFindBgmPlayInfo(const al::BgmDataBase*, const char*);
+al::BgmResourceInfo* tryFindBgmResourceInfo(const al::BgmDataBase*, const char*);
+al::BgmStageInfo* tryFindBgmStageInfo(const al::BgmDataBase*, const char*);
+al::BgmSituationInfo* tryFindBgmSituationInfo(const al::BgmDataBase*, const char*);
 al::BgmUserInfo* tryFindBgmUserInfo(const al::BgmDataBase*, const char*);
-}
+}  // namespace alBgmFunction

--- a/lib/al/Library/Bgm/BgmKeeper.h
+++ b/lib/al/Library/Bgm/BgmKeeper.h
@@ -19,6 +19,8 @@ public:
     const char* getUserName() const;
     void update();
 
+    BgmDirector* getBgmDirector() const { return mBgmDirector; }
+
 private:
     BgmDirector* mBgmDirector;
     BgmUserInfo* mBgmUserInfo = nullptr;

--- a/lib/al/Library/Bgm/BgmLine.h
+++ b/lib/al/Library/Bgm/BgmLine.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+namespace al {
+class AudioBusSendController;
+class Bgm;
+class BgmDataBase;
+class BgmLinePlayInfo;
+class BgmParamsChanger;
+class BgmPlayPointRecorder;
+struct BgmPlayingRequest;
+class IBgmParamsChanger;
+class SeadAudioPlayer;
+struct BgmEnableSituationInfo;
+struct BgmLineInfo;
+struct BgmMusicalInfo;
+struct BgmResourceInfo;
+struct BgmResourceSuffixInfo;
+struct BgmSampleDataInfo;
+struct BgmResourceSpecificInfo;
+template <typename T>
+class AudioInfoListWithParts;
+
+class BgmLine {
+public:
+    BgmLine();
+
+    virtual bool isRunning() const;
+    virtual bool isPause() const;
+    virtual bool isWaitStart() const;
+    virtual bool isFadeOut() const;
+    virtual bool isPrepared() const;
+    virtual bool isPreparedByPlayName(const char* playName) const;
+    virtual bool isRunningByPlayName(const char* playName) const;
+    virtual bool isUnnecessaryPrepare(const char* playName) const;
+    virtual bool isEnableRhythmDetection() const;
+    virtual bool isPlaying() const;
+    virtual const char* getCurPlayName() const;
+    virtual const char* getCurResourceName() const;
+    virtual const char* getLineName() const;
+    virtual const char* getResourceName(const char* playName) const;
+    virtual s32 getLineIndex() const;
+    virtual f32 getCurBpm() const;
+
+    void init(const BgmDataBase* dataBase,
+              const AudioInfoListWithParts<BgmMusicalInfo>* musicalInfoList,
+              SeadAudioPlayer* seadAudioPlayer, const BgmLineInfo* lineInfo, const char* lineName,
+              s32 lineIndex, BgmPlayPointRecorder* playPointRecorder,
+              sead::PtrArray<BgmParamsChanger>* paramsChangers);
+    void stopBgm(s32 fadeFrame);
+    void pauseBgm(s32 fadeFrame);
+    void resumeBgm(s32 fadeFrame, bool isLineChange);
+    void replacePlayInfoResourceName(const char* playName, const char* resourceName);
+
+    Bgm* getActiveBgmPlayer() const { return mBgmPlayers[mActiveBgmPlayerIndex]; }
+
+private:
+    u8 _8[0x40] = {};
+    Bgm** mBgmPlayers = nullptr;
+    u32 mActiveBgmPlayerIndex = 0;
+};
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmLineFunction.cpp
+++ b/lib/al/Library/Bgm/BgmLineFunction.cpp
@@ -1,0 +1,1043 @@
+#include "Library/Bgm/BgmLineFunction.h"
+
+#include "Library/Audio/AudioEventController.h"
+#include "Library/Audio/AudioInfo.h"
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Audio/System/AudioKeeperFunction.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/Bgm3DParamsController.h"
+#include "Library/Bgm/BgmDirector.h"
+#include "Library/Bgm/BgmFunction.h"
+#include "Library/Bgm/BgmKeeper.h"
+#include "Library/Bgm/BgmLine.h"
+#include "Library/Bgm/BgmLineKeeper.h"
+#include "Library/Bgm/BgmPlayEventController.h"
+#include "Library/Bgm/BgmPlayingRequest.h"
+#include "Library/Bgm/BgmRhythmDetector.h"
+#include "Library/Bgm/BgmRhythmSyncDirector.h"
+#include "Library/Bgm/BgmSituationDirector.h"
+#include "Library/File/FileUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Resource/Resource.h"
+#include "Library/Yaml/ByamlIter.h"
+#include "Project/Bgm/Bgm.h"
+#include "Project/Bgm/BgmInfo.h"
+
+namespace al {
+namespace {
+
+AudioKeeper* tryGetAudioKeeper(const IUseAudioKeeper* audioUser) {
+    return audioUser->getAudioKeeper();
+}
+
+BgmKeeper* tryGetBgmKeeper(const IUseAudioKeeper* audioUser) {
+    AudioKeeper* audioKeeper = tryGetAudioKeeper(audioUser);
+    if (!audioKeeper)
+        return nullptr;
+    return audioKeeper->getBgmKeeper();
+}
+
+BgmDirector* tryGetDirector(const IUseAudioKeeper* audioUser) {
+    BgmKeeper* bgmKeeper = tryGetBgmKeeper(audioUser);
+    if (!bgmKeeper)
+        return nullptr;
+    return bgmKeeper->getBgmDirector();
+}
+
+AudioEventController* tryGetAudioEventController(const IUseAudioKeeper* audioUser) {
+    AudioKeeper* audioKeeper = tryGetAudioKeeper(audioUser);
+    if (!audioKeeper)
+        return nullptr;
+    return audioKeeper->getAudioEventController();
+}
+
+BgmSituationDirector* tryGetSituationDirector(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getBgmSituationDirector();
+}
+
+Bgm3DParamsController* tryGet3DParamsController(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getBgm3DParamsController();
+}
+
+BgmRhythmSyncDirector* tryGetRhythmSyncDirector(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getBgmRhythmSyncDirector();
+}
+
+BgmRhythmDetector* tryGetRhythmDetector(const IUseAudioKeeper* audioUser) {
+    BgmRhythmSyncDirector* rhythmSyncDirector = tryGetRhythmSyncDirector(audioUser);
+    if (!rhythmSyncDirector)
+        return nullptr;
+    return rhythmSyncDirector->getActiveRhythmDetector();
+}
+
+BgmLine* tryGetActiveLine(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getActiveBgmLine();
+}
+
+bool canStartBgm(const IUseAudioKeeper* audioUser, const char* playName, bool isForceStart) {
+    if (isForceStart)
+        return true;
+
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+    if (!eventController)
+        return true;
+
+    BgmPlayEventController* bgmEventController = eventController->getBgmPlayEventController();
+    if (!bgmEventController)
+        return true;
+
+    return bgmEventController->checkWhetherItCanStartBgm(playName);
+}
+
+bool canStartBgm(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request,
+                 bool isForceStart) {
+    if (isForceStart)
+        return true;
+
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+    if (!eventController)
+        return true;
+
+    BgmPlayEventController* bgmEventController = eventController->getBgmPlayEventController();
+    if (!bgmEventController)
+        return true;
+
+    return bgmEventController->checkWhetherItCanStartBgm(request.bgmName);
+}
+
+}  // namespace
+
+BgmDirector* getBgmDirector(const IUseAudioKeeper* audioUser) {
+    return tryGetDirector(audioUser);
+}
+
+BgmDirector* tryGetBgmDirector(const IUseAudioKeeper* audioUser) {
+    return tryGetDirector(audioUser);
+}
+
+BgmSituationDirector* getBgmSituationDirector(const IUseAudioKeeper* audioUser) {
+    return tryGetSituationDirector(audioUser);
+}
+
+Bgm3DParamsController* getBgm3DParamsController(const IUseAudioKeeper* audioUser) {
+    return tryGet3DParamsController(audioUser);
+}
+
+BgmLine* getActiveBgmLine(const IUseAudioKeeper* audioUser) {
+    return tryGetActiveLine(audioUser);
+}
+
+BgmLine* getPlayingBgmLine(const IUseAudioKeeper* audioUser, const char* playName) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getPlayingBgmLine(playName);
+}
+
+const char* getCurPlayingBgmPlayName(const IUseAudioKeeper* audioUser) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (!line)
+        return nullptr;
+    return line->getCurPlayName();
+}
+
+const char* getCurPlayingBgmResourceName(const IUseAudioKeeper* audioUser) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (!line)
+        return nullptr;
+
+    Bgm* bgm = line->getActiveBgmPlayer();
+    if (!bgm)
+        return nullptr;
+
+    return bgm->getRunningResourceName();
+}
+
+const char* getBgmPlayNameInCurPosition(const IUseAudioKeeper* audioUser, bool isStopArea) {
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+    if (!eventController)
+        return nullptr;
+    return alAudioEventControllerFunction::getBgmPlayNameInCurPosition(eventController, isStopArea);
+}
+
+const char* getBgmResourceNameInCurPosition(const IUseAudioKeeper* audioUser, bool isStopArea) {
+    const char* playName = getBgmPlayNameInCurPosition(audioUser, isStopArea);
+    if (!playName)
+        return nullptr;
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+
+    BgmPlayInfo* playInfo = alBgmFunction::tryFindBgmPlayInfo(director->getBgmDataBase(), playName);
+    if (!playInfo)
+        return nullptr;
+
+    BgmLine* line = director->getBgmLineByLineName(playInfo->lineName);
+    if (!line)
+        return nullptr;
+
+    return line->getResourceName(playName);
+}
+
+s64 getActiveBgmCurSamplePosition(const IUseAudioKeeper* audioUser) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (!line)
+        return -1;
+
+    Bgm* bgm = line->getActiveBgmPlayer();
+    if (!bgm)
+        return -1;
+
+    return bgm->getCurSamplePosition();
+}
+
+s64 getBgmLoopEndSamplePosition(const IUseAudioKeeper* audioUser, const char* playName) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return 0;
+    return director->getLoopEndSamplePosition(playName);
+}
+
+void startBgm(const IUseAudioKeeper* audioUser, const char* playName, s32 fadeFrame,
+              s32 startFrame) {
+    BgmPlayingRequest request(playName, nullptr, nullptr, fadeFrame, startFrame, -1, 0, 0, false,
+                              false, false, false);
+
+    if (!canStartBgm(audioUser, playName, false))
+        return;
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startBgm(request, false);
+}
+
+void startBgm(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request, bool isForceStart,
+              bool isImmediate) {
+    if (!canStartBgm(audioUser, request, isForceStart))
+        return;
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startBgm(request, isImmediate);
+}
+
+void startBgmWithSuffix(const IUseAudioKeeper* audioUser, const char* playName, const char* suffix,
+                        s32 fadeFrame, s32 startFrame) {
+    BgmPlayingRequest request(playName, suffix, nullptr, fadeFrame, startFrame, -1, 0, 0, false,
+                              false, false, false);
+
+    if (!canStartBgm(audioUser, playName, false))
+        return;
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startBgm(request, false);
+}
+
+void startAndStopBgmInCurPosition(const IUseAudioKeeper* audioUser, bool isStopArea) {
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+    if (!eventController || !eventController->isEnableBgmChangeEvent())
+        return;
+
+    alAudioEventControllerFunction::tryStartAndStopBgmInCurPosition(eventController, isStopArea,
+                                                                    true);
+
+    const char* situationName = eventController->getBgmSituationNameByAreaChecker();
+    if (!situationName)
+        return;
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startSituation(situationName, false, false, false);
+}
+
+void startBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName, bool isApply) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startSituation(situationName, isApply, false, false);
+}
+
+void prepareBgm(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->prepareBgm(request);
+}
+
+void prepareBgmWithAreaCheck(const IUseAudioKeeper* audioUser) {
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+    if (!eventController)
+        return;
+
+    const char* playName =
+        alAudioEventControllerFunction::getBgmPlayNameInCurPosition(eventController, false);
+    if (eventController->isInBgmStopArea(playName))
+        return;
+
+    BgmPlayingRequest request(playName, nullptr, nullptr, -1, 0, -1, 0, 0, false, false, false,
+                              false);
+    prepareBgm(audioUser, request);
+}
+
+void stopBgm(const IUseAudioKeeper* audioUser, const char* playName, s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->stopBgm(playName, fadeFrame);
+}
+
+void stopBgm(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->stopBgm(request.bgmName, request._18);
+}
+
+void pauseBgm(const IUseAudioKeeper* audioUser, const char* playName, s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->pauseBgm(playName, fadeFrame);
+}
+
+void resumeBgm(const IUseAudioKeeper* audioUser, const char* playName, s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->resumeBgm(playName, fadeFrame);
+}
+
+bool isPlayingBgm(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    return director && director->isPlayingBgm();
+}
+
+bool isPlayingBgm(const IUseAudioKeeper* audioUser, const char* playName) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    return director && director->isPlayingBgm(playName);
+}
+
+bool isRunningBgm(const IUseAudioKeeper* audioUser, const char* playName) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    return director && director->isRunningBgm(playName);
+}
+
+bool isPlayingResourceCategoryBgm(const IUseAudioKeeper* audioUser, const char* categoryName) {
+    const char* resourceName = getCurPlayingBgmResourceName(audioUser);
+    if (!resourceName)
+        return false;
+    return isEqualString(resourceName, categoryName);
+}
+
+void stopActiveBgm(const IUseAudioKeeper* audioUser, s32 fadeFrame) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (line)
+        line->stopBgm(fadeFrame);
+}
+
+void pauseActiveBgm(const IUseAudioKeeper* audioUser, s32 fadeFrame) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (line)
+        line->pauseBgm(fadeFrame);
+}
+
+void resumeActiveBgm(const IUseAudioKeeper* audioUser, s32 fadeFrame) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (line)
+        line->resumeBgm(fadeFrame, false);
+}
+
+bool isPlayingActiveBgm(const IUseAudioKeeper* audioUser, const char* playName) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    if (!line || !line->isRunning())
+        return false;
+
+    if (!playName)
+        return true;
+
+    const char* currentPlayName = line->getCurPlayName();
+    return currentPlayName && isEqualString(playName, currentPlayName);
+}
+
+bool isPauseActiveBgm(const IUseAudioKeeper* audioUser) {
+    BgmLine* line = tryGetActiveLine(audioUser);
+    return line && line->isPause();
+}
+
+void stopAllBgm(const IUseAudioKeeper* audioUser, s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->stopAllBgm(fadeFrame, false);
+}
+
+void tryStopAllBgm(const IUseAudioKeeper* audioUser, s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->tryStopAllBgm(fadeFrame);
+}
+
+void setTriggerEventForStopAllBgm(const IUseAudioKeeper* audioUser, const FunctorBase& functor) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->setTriggerEventForStopAllBgm(functor);
+}
+
+void tryPauseBgmIfDifferBgmArea(const LiveActor* actor, const sead::Vector3f& position,
+                                s32 fadeFrame) {
+    const IUseAudioKeeper* audioUser = actor;
+    AudioEventController* eventController = tryGetAudioEventController(audioUser);
+
+    const char* currentPlayName = alAudioEventControllerFunction::getBgmPlayNameInTargetPosition(
+        eventController, getTrans(actor));
+    const char* targetPlayName =
+        alAudioEventControllerFunction::getBgmPlayNameInTargetPosition(eventController, position);
+
+    if (!currentPlayName)
+        return;
+
+    if (!targetPlayName) {
+        getBgmDirector(audioUser)->tryPauseBgmIfNotPlaying(currentPlayName, fadeFrame);
+        return;
+    }
+
+    if (!isEqualString(currentPlayName, targetPlayName))
+        getBgmDirector(audioUser)->tryPauseBgmIfLowPriority(targetPlayName, fadeFrame);
+}
+
+void tryPauseBgmIfLowPriority(const IUseAudioKeeper* audioUser, const char* playName,
+                              s32 fadeFrame) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->tryPauseBgmIfLowPriority(playName, fadeFrame);
+}
+
+void startBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName, bool isApply,
+                       bool isForce) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startSituation(situationName, isApply, isForce, false);
+}
+
+void startBgmSituation(const IUseAudioKeeper* audioUser,
+                       sead::PtrArray<IBgmParamsChanger>* paramsChangers, const char* situationName,
+                       bool isApply, bool isForce) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startSituation(paramsChangers, situationName, isApply, isForce, false);
+}
+
+void forceStartBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName,
+                            bool isApply, bool isForce) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->startSituation(situationName, isApply, isForce, true);
+}
+
+void endBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName, bool isApply) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->endSituation(situationName, isApply, false);
+}
+
+void endBgmSituation(const IUseAudioKeeper* audioUser,
+                     sead::PtrArray<IBgmParamsChanger>* paramsChangers, const char* situationName,
+                     bool isApply) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->endSituation(paramsChangers, situationName, isApply, false);
+}
+
+void forceEndBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName,
+                          bool isApply) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->endSituation(situationName, isApply, true);
+}
+
+void startBgm3D(const IUseAudioKeeper* audioUser) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    if (controller)
+        controller->start3D();
+}
+
+void endBgm3D(const IUseAudioKeeper* audioUser) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    if (controller)
+        controller->end3D();
+}
+
+void changeBgm3DParams(const IUseAudioKeeper* audioUser, f32 volume, f32 pitch, f32 lpfFreq,
+                       f32 auxBusSend, bool isForce) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    if (controller)
+        controller->change3DParams(volume, pitch, lpfFreq, auxBusSend, isForce);
+}
+
+void activateBgm3DController(const IUseAudioKeeper* audioUser) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    if (controller)
+        controller->activate();
+}
+
+void deactivateBgm3DController(const IUseAudioKeeper* audioUser) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    if (controller)
+        controller->deactivate();
+}
+
+bool isActivateBgm3DController(const IUseAudioKeeper* audioUser) {
+    Bgm3DParamsController* controller = tryGet3DParamsController(audioUser);
+    return controller && controller->isActive();
+}
+
+s32 getActiveBgmSituationNum(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (!director)
+        return 0;
+    return director->getActiveSituationNum();
+}
+
+const char* getActiveBgmSituationName(const IUseAudioKeeper* audioUser, s32 index) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getActiveSituationName(index);
+}
+
+s32 getDeactiveBgmSituationNum(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (!director)
+        return 0;
+    return director->getDeactiveSituationNum();
+}
+
+const char* getDeactiveBgmSituationName(const IUseAudioKeeper* audioUser, s32 index) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getDeactiveSituationName(index);
+}
+
+void takeBgmSituationSnapShot(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->takeBgmSituationSnapShot();
+}
+
+void applyBgmSituationSnapShot(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->applyBgmSituationSnapShot();
+}
+
+void applyNoAppliedSituationRecord(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->applyNoAppliedSituationRecord();
+}
+
+bool isStartedBgmSituation(const IUseAudioKeeper* audioUser, const char* situationName) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (!director || director->getActiveSituationNum() < 1)
+        return false;
+
+    for (s32 i = 0; i < director->getActiveSituationNum(); i++)
+        if (isEqualString(situationName, director->getActiveSituationName(i)))
+            return true;
+
+    return false;
+}
+
+void endAllBgmSituation(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->clear();
+}
+
+void clearBgmDataForStepOverScene(const IUseAudioKeeper* audioUser) {
+    stopAllBgm(audioUser, 0);
+
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->clearPlayData();
+}
+
+void clearBgmPlayPointRecord(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return;
+
+    BgmLineKeeper* lineKeeper = director->getBgmLineKeeper();
+    if (lineKeeper)
+        lineKeeper->clearPlayPointRecord();
+}
+
+void startBgmSyncedCurBgmBeat(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request,
+                              s32 syncBeat) {
+    AudioKeeper* audioKeeper = tryGetAudioKeeper(audioUser);
+    AudioRequestKeeperSyncedBgm* requestKeeper = nullptr;
+    if (audioKeeper)
+        requestKeeper = audioKeeper->getAudioRequestKeeperSyncedBgm();
+
+    requestKeeper->requestBgm(BgmPlayingType_Start, request, syncBeat);
+}
+
+void stopBgmSyncedCurBgmBeat(const IUseAudioKeeper* audioUser, const BgmPlayingRequest& request,
+                             s32 syncBeat) {
+    AudioKeeper* audioKeeper = tryGetAudioKeeper(audioUser);
+    AudioRequestKeeperSyncedBgm* requestKeeper = nullptr;
+    if (audioKeeper)
+        requestKeeper = audioKeeper->getAudioRequestKeeperSyncedBgm();
+
+    requestKeeper->requestBgm(BgmPlayingType_Stop, request, syncBeat);
+}
+
+void disableBgmLineChange(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->disableLineChange();
+}
+
+void enableBgmLineChange(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->enableLineChange();
+}
+
+bool isDisableBgmLineChange(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    return director && director->isDisableLineChange();
+}
+
+void disableBgmSituationChange(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->disableSituationChange();
+}
+
+void enableBgmSituationChange(const IUseAudioKeeper* audioUser, bool isForce) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    if (director)
+        director->enableSituationChange(isForce);
+}
+
+bool isDisableBgmSituationChange(const IUseAudioKeeper* audioUser) {
+    BgmSituationDirector* director = tryGetSituationDirector(audioUser);
+    return director && director->isDisableSituationChange();
+}
+
+BgmMultiPlayingController* tryAllocBgmMultiPlayingController(const IUseAudioKeeper* audioUser) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->tryAllocMultiPlayingController();
+}
+
+void tryReleaseBgmMultiPlayingController(const IUseAudioKeeper* audioUser,
+                                         BgmMultiPlayingController* controller) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (director)
+        director->tryReleaseMultiPlayingController(controller);
+}
+
+s32 getBgmLineNum(const IUseAudioKeeper* audioUser, bool isWithoutUpperLayer) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return -1;
+    return director->getBgmLineNum(isWithoutUpperLayer);
+}
+
+BgmLine* getBgmLineAccessor(const IUseAudioKeeper* audioUser, s32 index, bool isWithoutUpperLayer) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return nullptr;
+    return director->getBgmLineAccessor(index, isWithoutUpperLayer);
+}
+
+s32 getgBgmLineIndex(const IUseAudioKeeper* audioUser, const char* lineName,
+                     bool isWithoutUpperLayer) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return 0;
+    return director->getBgmLineIndex(lineName, isWithoutUpperLayer);
+}
+
+void replaceBgmPlayInfoResourceName(const IUseAudioKeeper* audioUser, const char* playName,
+                                    const char* resourceName) {
+    BgmDirector* director = tryGetDirector(audioUser);
+    if (!director)
+        return;
+
+    BgmPlayInfo* playInfo = alBgmFunction::tryFindBgmPlayInfo(director->getBgmDataBase(), playName);
+    if (!playInfo)
+        return;
+
+    BgmLine* line = director->getBgmLineByLineName(playInfo->lineName);
+    if (line)
+        line->replacePlayInfoResourceName(playName, resourceName);
+}
+
+bool isEnableRhythmAnim(const IUseAudioKeeper* audioUser, const char*) {
+    BgmRhythmSyncDirector* director = tryGetRhythmSyncDirector(audioUser);
+    return director && director->isEnableRhythmAnim();
+}
+
+bool isTriggerBeat(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    return detector && detector->isTriggerBeat();
+}
+
+bool isTriggerBackBeat(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    return detector && detector->isTriggerBackBeat();
+}
+
+bool isTriggerMeasureTop(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    return detector && detector->isTriggerMeasureTop();
+}
+
+f32 getBpm(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getBpm();
+}
+
+f32 getBeatRate(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getBeatRate();
+}
+
+f32 getCurBeat(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getCurBeat();
+}
+
+f32 getCurBeatOnMeasure(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getCurBeatOnMeasure();
+}
+
+f32 getLoopStartBeat(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getLoopStartBeat();
+}
+
+f32 getLoopEndBeat(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getLoopEndBeat();
+}
+
+f32 getFramePerMeasure(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1.0f;
+    return detector->getFramePerMeasure();
+}
+
+s32 getBeatPerMeasure(const IUseAudioKeeper* audioUser) {
+    BgmRhythmDetector* detector = tryGetRhythmDetector(audioUser);
+    if (!detector)
+        return -1;
+    return detector->getBeatPerMeasure();
+}
+
+bool isChangeActiveBgmResourceName(const IUseAudioKeeper* audioUser) {
+    BgmRhythmSyncDirector* director = tryGetRhythmSyncDirector(audioUser);
+    return director && director->isChangeActiveResourceName();
+}
+
+bool tryRegistTargetBgmResourceName(const IUseAudioKeeper* audioUser, const char* resourceName) {
+    BgmRhythmSyncDirector* director = tryGetRhythmSyncDirector(audioUser);
+    return director && director->tryRegistTargetResourceName(resourceName);
+}
+
+void muteOnRunningLineTrack(IUseAudioKeeper*, u32, bool) {}
+
+void muteOffRunningLineTrack(IUseAudioKeeper*, u32, bool) {}
+
+BgmDataBase* BgmDataBase::create(const char* archiveName, const char*) {
+    if (!isExistArchive(archiveName))
+        return nullptr;
+
+    Resource* resource = alAudioSystemFunction::tryGetAudioStationedResource(archiveName, nullptr);
+    return new BgmDataBase(resource, nullptr);
+}
+
+// NONMATCHING: https://decomp.me/scratch/KWqbv
+BgmDataBase::BgmDataBase(Resource* resource, Resource* localizedResource) {
+    Resource* mainResource = resource;
+    BgmDataBase* dataBase = this;
+    Resource* localResource = localizedResource;
+    dataBase->mBgmCombinedLineInfoList = nullptr;
+    dataBase->mBgmPlayInfoList = nullptr;
+    dataBase->mBgmResourceInfoList = nullptr;
+    dataBase->mBgmResourceCategoryInfoList = nullptr;
+    dataBase->mBgmStageInfoList = nullptr;
+    dataBase->mBgmSituationInfoList = nullptr;
+    dataBase->mBgmUserInfoList = nullptr;
+    dataBase->mBgmDemoSyncedProcInfoList = nullptr;
+
+    AudioInfoListWithParts<BgmCombinedLineInfo>* combinedLineInfoList = nullptr;
+    if (mainResource->isExistFile("BgmLineInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmLineInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "CombinedLineInfoList"))
+            combinedLineInfoList = createAudioInfoList<BgmCombinedLineInfo>(listIter, 0);
+    }
+    dataBase->mBgmCombinedLineInfoList = combinedLineInfoList;
+
+    AudioInfoListWithParts<BgmPlayInfo>* playInfoList = nullptr;
+    if (mainResource->isExistFile("BgmPlayInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmPlayInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "PlayInfoList"))
+            playInfoList = createAudioInfoList<BgmPlayInfo>(listIter, 0);
+    }
+    dataBase->mBgmPlayInfoList = playInfoList;
+
+    AudioInfoListWithParts<BgmResourceInfo>* resourceInfoList = nullptr;
+    if (mainResource->isExistFile("BgmResourceInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmResourceInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "ResourceInfoList")) {
+            u32 size = listIter.getSize();
+            resourceInfoList = new AudioInfoListWithParts<BgmResourceInfo>;
+            resourceInfoList->init(size, 0);
+            resourceInfoList->setLinearSearch(true);
+
+            u32 resourceId = 0;
+            if (size != 0) {
+                for (u32 i = 0; i < size; i++) {
+                    ByamlIter infoIter;
+                    listIter.tryGetIterByIndex(&infoIter, i);
+                    BgmResourceInfo* info = BgmResourceInfo::createInfo(infoIter);
+                    if (info) {
+                        info->resourceId = resourceId;
+                        resourceId++;
+                        resourceInfoList->setInfo(info);
+                    }
+                }
+            }
+
+            resourceInfoList->sort();
+        }
+    }
+    dataBase->mBgmResourceInfoList = resourceInfoList;
+
+    AudioInfoListWithParts<BgmResourceCategoryInfo>* resourceCategoryInfoList = nullptr;
+    if (mainResource->isExistFile("BgmResourceCategoryInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmResourceCategoryInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "ResourceCategoryInfoList"))
+            resourceCategoryInfoList = createAudioInfoList<BgmResourceCategoryInfo>(listIter, 0);
+    }
+    dataBase->mBgmResourceCategoryInfoList = resourceCategoryInfoList;
+
+    AudioInfoListWithParts<BgmStageInfo>* stageInfoList = nullptr;
+    if (mainResource->isExistFile("BgmStageInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmStageInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "StageInfoList")) {
+            if (localResource && localResource->isExistFile("BgmStageInfoList.byml")) {
+                ByamlIter localizedRootIter(localResource->getByml("BgmStageInfoList"));
+                ByamlIter localizedListIter;
+                if (localizedRootIter.tryGetIterByKey(&localizedListIter, "StageInfoList"))
+                    stageInfoList =
+                        createAudioInfoList<BgmStageInfo>(listIter, localizedListIter, 0, 0);
+                else
+                    stageInfoList = createAudioInfoList<BgmStageInfo>(listIter, 0);
+            } else {
+                stageInfoList = createAudioInfoList<BgmStageInfo>(listIter, 0);
+            }
+        }
+    }
+    dataBase->mBgmStageInfoList = stageInfoList;
+
+    AudioInfoListWithParts<BgmSituationInfo>* situationInfoList = nullptr;
+    if (mainResource->isExistFile("BgmSituationInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmSituationInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "SituationInfoList"))
+            situationInfoList = createAudioInfoList<BgmSituationInfo>(listIter, 0);
+    }
+    dataBase->mBgmSituationInfoList = situationInfoList;
+
+    s32 entryNum = mainResource->getEntryNum("/");
+    AudioInfoListWithParts<BgmUserInfo>* userInfoList = new AudioInfoListWithParts<BgmUserInfo>;
+    userInfoList->setLinearSearch(false);
+    userInfoList->init(entryNum, 0);
+
+    for (s32 i = 0; i < entryNum; i++) {
+        sead::FixedSafeString<128> fileName;
+        mainResource->getEntryName(&fileName, "/", i);
+
+        const char* name = fileName.cstr();
+        if (isEqualString(name, "BgmLineInfoList.byml") ||
+            isEqualString(name, "BgmPlayInfoList.byml") ||
+            isEqualString(name, "BgmResourceInfoList.byml") ||
+            isEqualString(name, "BgmResourceCategoryInfoList.byml") ||
+            isEqualString(name, "BgmSituationInfoList.byml") ||
+            isEqualString(name, "BgmStageInfoList.byml"))
+            continue;
+
+        ByamlIter iter(static_cast<const u8*>(mainResource->getOtherFile(fileName)));
+        fileName.removeSuffix(".byml");
+        BgmUserInfo* info = BgmUserInfo::createInfo(iter, fileName);
+        userInfoList->setInfo(info);
+    }
+
+    sead::PtrArray<const BgmUserInfo>* userList = userInfoList->getListForSort();
+    if (userList->size() < 10)
+        userList->sort(BgmUserInfo::compareInfo);
+    else
+        userList->heapSort(BgmUserInfo::compareInfo);
+
+    sead::PtrArray<AudioInfoList<BgmUserInfo>>* userParts = userInfoList->getParts();
+    if (userParts)
+        for (s32 i = 0; i < userParts->size(); i++)
+            userParts->at(i)->sort();
+    dataBase->mBgmUserInfoList = userInfoList;
+
+    AudioInfoListWithParts<BgmDemoSyncedProcInfo>* demoSyncedProcInfoList = nullptr;
+    if (mainResource->isExistFile("BgmDemoSyncedProcInfoList.byml")) {
+        ByamlIter rootIter(mainResource->getByml("BgmDemoSyncedProcInfoList"));
+        ByamlIter listIter;
+        if (rootIter.tryGetIterByKey(&listIter, "DemoSyncedProcInfoList"))
+            demoSyncedProcInfoList = createAudioInfoList<BgmDemoSyncedProcInfo>(listIter, 0);
+    }
+    if (demoSyncedProcInfoList) {
+        for (s32 i = 0; i < demoSyncedProcInfoList->getSize(); i++) {
+            const BgmDemoSyncedProcInfo* info = demoSyncedProcInfoList->getInfoAt(i);
+            if (info->isPartsProc || !info->partsProcNameList)
+                continue;
+
+            for (s32 j = 0; j < info->partsProcNameList->size(); j++) {
+                const char* partsName = info->partsProcNameList->at(j);
+                const BgmDemoSyncedProcInfo* partsInfo = nullptr;
+                const sead::PtrArray<const BgmDemoSyncedProcInfo>* list =
+                    demoSyncedProcInfoList->getList();
+
+                if (demoSyncedProcInfoList->isLinearSearch()) {
+                    s32 size = list->size();
+                    for (s32 k = 0; k < size; k++) {
+                        const BgmDemoSyncedProcInfo* findInfo = list->at(k);
+                        if (strcmp(findInfo->name, partsName) == 0) {
+                            partsInfo = findInfo;
+                            break;
+                        }
+                    }
+                } else {
+                    s32 index = -1;
+                    s32 size = list->size();
+                    if (size > 0) {
+                        s32 start = 0;
+                        s32 end = size - 1;
+                        while (start < end) {
+                            s32 mid = (start + end) / 2;
+                            s32 compare = AudioInfoList<BgmDemoSyncedProcInfo>::compareInfoAndKey(
+                                list->at(mid), partsName);
+                            if (compare == 0) {
+                                index = mid;
+                                break;
+                            }
+                            if (compare < 0)
+                                start = mid + 1;
+                            else
+                                end = mid;
+                        }
+                        if (index < 0 && AudioInfoList<BgmDemoSyncedProcInfo>::compareInfoAndKey(
+                                             list->at(start), partsName) == 0)
+                            index = start;
+                    }
+                    if (index >= 0)
+                        partsInfo = list->at(index);
+                }
+
+                if (!partsInfo) {
+                    s32 partsSize = demoSyncedProcInfoList->getPartsSize();
+                    for (s32 k = 0; k < partsSize; k++) {
+                        const AudioInfoList<BgmDemoSyncedProcInfo>* partsList =
+                            demoSyncedProcInfoList->getPartsListAt(k);
+                        list = partsList->getList();
+
+                        if (partsList->isLinearSearch()) {
+                            s32 size = list->size();
+                            for (s32 l = 0; l < size; l++) {
+                                const BgmDemoSyncedProcInfo* findInfo = list->at(l);
+                                if (strcmp(findInfo->name, partsName) == 0) {
+                                    partsInfo = findInfo;
+                                    break;
+                                }
+                            }
+                        } else {
+                            s32 index = -1;
+                            s32 size = list->size();
+                            if (size > 0) {
+                                s32 start = 0;
+                                s32 end = size - 1;
+                                while (start < end) {
+                                    s32 mid = (start + end) / 2;
+                                    s32 compare =
+                                        AudioInfoList<BgmDemoSyncedProcInfo>::compareInfoAndKey(
+                                            list->at(mid), partsName);
+                                    if (compare == 0) {
+                                        index = mid;
+                                        break;
+                                    }
+                                    if (compare < 0)
+                                        start = mid + 1;
+                                    else
+                                        end = mid;
+                                }
+                                if (index < 0 &&
+                                    AudioInfoList<BgmDemoSyncedProcInfo>::compareInfoAndKey(
+                                        list->at(start), partsName) == 0)
+                                    index = start;
+                            }
+                            if (index >= 0)
+                                partsInfo = list->at(index);
+                        }
+
+                        if (partsInfo)
+                            break;
+                    }
+                }
+
+                if (!partsInfo)
+                    continue;
+
+                if (info->demoProcInfoList && partsInfo->demoProcInfoList)
+                    info->demoProcInfoList->addParts(partsInfo->demoProcInfoList);
+                if (info->demoEndProcInfoList && partsInfo->demoEndProcInfoList)
+                    info->demoEndProcInfoList->addParts(partsInfo->demoEndProcInfoList);
+            }
+        }
+    }
+    dataBase->mBgmDemoSyncedProcInfoList = demoSyncedProcInfoList;
+}
+
+template s32 AudioInfoList<BgmDemoSyncedProcInfo>::compareInfoAndKey(const BgmDemoSyncedProcInfo*,
+                                                                     const char*);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmLineFunction.h
+++ b/lib/al/Library/Bgm/BgmLineFunction.h
@@ -5,24 +5,154 @@
 #include <math/seadVector.h>
 
 namespace al {
+class AudioInfoListCreateFunctorBase;
+template <typename T>
+class AudioInfoListWithParts;
 class BgmDirector;
 class BgmSituationDirector;
 class Bgm3DParamsController;
 class BgmLine;
 class BgmMultiPlayingController;
+struct BgmCombinedLineInfo;
+struct BgmPlayInfo;
+struct BgmResourceInfo;
+struct BgmResourceCategoryInfo;
+struct BgmStageInfo;
+struct BgmSituationInfo;
+struct BgmUserInfo;
+struct BgmDemoSyncedProcInfo;
 struct BgmPlayingRequest;
 class FunctorBase;
 class IBgmParamsChanger;
 class IUseAudioKeeper;
 class LiveActor;
 class Resource;
+class ByamlIter;
+struct BgmDemoProcInfo;
+struct BgmEnableSituationInfo;
+struct BgmResourceSpecificInfo;
+struct BgmResourceSuffixControlInfo;
+struct BgmResourceSuffixInfo;
+struct BgmStartTriggerSituationInfo;
 
 class BgmDataBase {
 public:
-    static BgmDataBase* create(const char*, const char*);
+    static BgmDataBase* create(const char* archiveName, const char* suffix);
 
-    BgmDataBase(const Resource*, const Resource*);
+    BgmDataBase(Resource* resource, Resource* localizedResource);
+
+    AudioInfoListWithParts<BgmCombinedLineInfo>* getBgmCombinedLineInfoList() const {
+        return mBgmCombinedLineInfoList;
+    }
+
+    AudioInfoListWithParts<BgmPlayInfo>* getBgmPlayInfoList() const { return mBgmPlayInfoList; }
+
+    AudioInfoListWithParts<BgmResourceInfo>* getBgmResourceInfoList() const {
+        return mBgmResourceInfoList;
+    }
+
+    AudioInfoListWithParts<BgmResourceCategoryInfo>* getBgmResourceCategoryInfoList() const {
+        return mBgmResourceCategoryInfoList;
+    }
+
+    AudioInfoListWithParts<BgmStageInfo>* getBgmStageInfoList() const { return mBgmStageInfoList; }
+
+    AudioInfoListWithParts<BgmSituationInfo>* getBgmSituationInfoList() const {
+        return mBgmSituationInfoList;
+    }
+
+    AudioInfoListWithParts<BgmUserInfo>* getBgmUserInfoList() const { return mBgmUserInfoList; }
+
+    AudioInfoListWithParts<BgmDemoSyncedProcInfo>* getBgmDemoSyncedProcInfoList() const {
+        return mBgmDemoSyncedProcInfoList;
+    }
+
+private:
+    AudioInfoListWithParts<BgmCombinedLineInfo>* mBgmCombinedLineInfoList;
+    AudioInfoListWithParts<BgmPlayInfo>* mBgmPlayInfoList;
+    AudioInfoListWithParts<BgmResourceInfo>* mBgmResourceInfoList;
+    AudioInfoListWithParts<BgmResourceCategoryInfo>* mBgmResourceCategoryInfoList;
+    AudioInfoListWithParts<BgmStageInfo>* mBgmStageInfoList;
+    AudioInfoListWithParts<BgmSituationInfo>* mBgmSituationInfoList;
+    AudioInfoListWithParts<BgmUserInfo>* mBgmUserInfoList;
+    AudioInfoListWithParts<BgmDemoSyncedProcInfo>* mBgmDemoSyncedProcInfoList;
 };
+
+static_assert(sizeof(BgmDataBase) == 0x40);
+
+struct BgmCombinedLineInfo {
+    static BgmCombinedLineInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmCombinedLineInfo* lhs, const BgmCombinedLineInfo* rhs);
+
+    const char* name = nullptr;
+};
+
+struct BgmPlayInfo {
+    static BgmPlayInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmPlayInfo* lhs, const BgmPlayInfo* rhs);
+
+    const char* name = nullptr;
+    const char* lineName = nullptr;
+};
+
+struct BgmResourceInfo {
+    static BgmResourceInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmResourceInfo* lhs, const BgmResourceInfo* rhs);
+
+    const char* name = nullptr;
+    const char* _8 = nullptr;
+    const char* categoryName = nullptr;
+    BgmResourceSpecificInfo* resourceSpecificInfo = nullptr;
+    AudioInfoListWithParts<BgmResourceSuffixInfo>* resourceSuffixInfoList = nullptr;
+    AudioInfoListWithParts<BgmEnableSituationInfo>* enableSituationInfoList = nullptr;
+    AudioInfoListWithParts<BgmStartTriggerSituationInfo>* startTriggerSituationInfoList = nullptr;
+    BgmResourceSuffixControlInfo* resourceSuffixControlInfo = nullptr;
+    bool isEnableRegionJump = false;
+    bool isDisableAudioEffect = false;
+    bool isEnableNwRender = false;
+    u8 _43 = 0;
+    u32 resourceId = 0;
+};
+
+static_assert(sizeof(BgmResourceInfo) == 0x48);
+
+struct BgmResourceCategoryInfo {
+    static BgmResourceCategoryInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmResourceCategoryInfo* lhs, const BgmResourceCategoryInfo* rhs);
+
+    const char* name = nullptr;
+};
+
+struct BgmStageInfo {
+    static BgmStageInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmStageInfo* lhs, const BgmStageInfo* rhs);
+
+    const char* name = nullptr;
+};
+
+struct BgmSituationInfo {
+    static BgmSituationInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmSituationInfo* lhs, const BgmSituationInfo* rhs);
+
+    const char* name = nullptr;
+};
+
+struct BgmDemoSyncedProcInfo {
+    static BgmDemoSyncedProcInfo* createInfo(const ByamlIter& iter);
+    static s32 compareInfo(const BgmDemoSyncedProcInfo* lhs, const BgmDemoSyncedProcInfo* rhs);
+
+    const char* name = nullptr;
+    bool isEnableEvent = false;
+    bool isPartsProc = false;
+    u8 _a[6] = {};
+    sead::PtrArray<const char>* partsProcNameList = nullptr;
+    bool isDisableLineChange = false;
+    u8 _19[7] = {};
+    AudioInfoListWithParts<BgmDemoProcInfo>* demoProcInfoList = nullptr;
+    AudioInfoListWithParts<BgmDemoProcInfo>* demoEndProcInfoList = nullptr;
+};
+
+static_assert(sizeof(BgmDemoSyncedProcInfo) == 0x30);
 
 BgmDirector* getBgmDirector(const IUseAudioKeeper*);
 BgmDirector* tryGetBgmDirector(const IUseAudioKeeper*);

--- a/lib/al/Library/Bgm/BgmLineKeeper.h
+++ b/lib/al/Library/Bgm/BgmLineKeeper.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+namespace al {
+class AudioBusSendController;
+class BgmDataBase;
+class BgmLine;
+class BgmParamsChanger;
+class SeadAudioPlayer;
+struct BgmCombinedLineInfo;
+struct BgmLineInfo;
+struct BgmMusicalInfo;
+struct BgmPlayingRequest;
+class BgmPlayPointRecorder;
+class IBgmParamsChanger;
+template <typename T>
+class AudioInfoListWithParts;
+
+class BgmLineKeeper {
+public:
+    BgmLineKeeper();
+
+    void init(const BgmDataBase* dataBase,
+              const AudioInfoListWithParts<BgmMusicalInfo>* musicalInfoList,
+              SeadAudioPlayer* seadAudioPlayer, const char* userName, const char* lineName,
+              s32 lineNum, sead::PtrArray<BgmParamsChanger>* paramsChangers);
+    void reset(const char* userName, s32 lineNum);
+    void update();
+    void tryChangeActiveLine();
+    void clearPlayData();
+    void clearPlayPointRecord();
+    void startBgm(const BgmPlayingRequest& request);
+    void prepareBgm(const BgmPlayingRequest& request);
+    void stopBgm(const char* playName, s32 fadeFrame);
+    void pauseBgm(const char* playName, s32 fadeFrame);
+    void resumeBgm(const char* playName, s32 fadeFrame);
+    bool isPlayingBgm();
+    bool isPlayingBgm(const char* playName);
+    bool isRunningBgm(const char* playName);
+    bool isPauseActiveBgmLine();
+    void pauseBgmIfFadeOut(s32 fadeFrame);
+    void resumeBgmIfFadeOut(s32 fadeFrame);
+    void stopAllBgmLine(s32 fadeFrame, bool isForce);
+    void tryStopAllBgmLine(s32 fadeFrame);
+    void tryPauseBgmIfNotPlaying(const char* playName, s32 fadeFrame);
+    void tryPauseBgmIfLowPriority(const char* playName, s32 fadeFrame);
+    void startSituation(const sead::FixedPtrArray<IBgmParamsChanger, 5>& paramsChangers);
+    void endSituation(const sead::FixedPtrArray<IBgmParamsChanger, 5>& paramsChangers);
+    s32 getBgmLineNum() const;
+    BgmLine* getBgmLine(s32 index) const;
+    BgmLine* getPlayingBgmLine(const char* playName) const;
+    BgmLine* getActiveBgmLine() const;
+    BgmLine* getBgmLineByLineName(const char* lineName) const;
+    s32 getBgmLineIndex(const char* lineName) const;
+    void setAudioBusSendController(AudioBusSendController* controller);
+
+private:
+    u8 _0[0x40] = {};
+};
+
+static_assert(sizeof(BgmLineKeeper) == 0x40);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmMultiPlayingController.h
+++ b/lib/al/Library/Bgm/BgmMultiPlayingController.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class BgmMultiPlayingController {
+public:
+    struct PlayParams {
+        u8 _0[0x18] = {};
+    };
+
+    BgmMultiPlayingController();
+
+    void use();
+    void removeAllMultiBgmPlayingInfo();
+    void activate(const PlayParams& params, s32 fadeFrame, bool isForce);
+    void deactivate(bool isForce, s32 fadeFrame);
+    void update();
+    void tryAddMultiBgmPlayingInfo(const char* playName, s32 fadeFrame, bool isForce);
+    void tryRemoveMultiBgmPlayingInfo(const char* playName);
+    void enableMultiBgmPlayingInfo(const char* playName);
+    void disableMultiBgmPlayingInfo(const char* playName);
+
+private:
+    u8 _0[0x40] = {};
+};
+
+static_assert(sizeof(BgmMultiPlayingController::PlayParams) == 0x18);
+static_assert(sizeof(BgmMultiPlayingController) == 0x40);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmPlayEventController.h
+++ b/lib/al/Library/Bgm/BgmPlayEventController.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVectorFwd.h>
+
+#include "Library/Area/IUseAreaObj.h"
+#include "Library/Audio/IUseAudioKeeper.h"
+
+namespace al {
+class AreaObjDirector;
+class AudioKeeper;
+class BgmPlayObj;
+class PlayerHolder;
+
+class BgmPlayEventController : public IUseAudioKeeper, public IUseAreaObj {
+public:
+    BgmPlayEventController(AudioKeeper* audioKeeper);
+
+    void init3D(AreaObjDirector* areaObjDirector);
+    void update();
+    void setChangeAreaParams(const char* playName, bool isChangeArea, bool isForceStart);
+    void tryStartBgmByChangeArea(bool isChangeArea, s32 startFrame, bool isForceStart);
+    void setStopAreaParams();
+    void tryStartBgmAfterStopAreaMove(bool isChangeArea, BgmPlayObj* obj, bool isForceStart);
+    void stopBgmByStopArea(bool isForceStop);
+    void updateWithoutEventStart();
+    void finalize();
+    void setPlayerHolder(const PlayerHolder* playerHolder);
+    bool tryRegistBgmPlayObj(BgmPlayObj* obj);
+    void reset();
+    const char* getBgmPlayNameInCurPosition(bool isStopArea);
+    const char* getBgmPlayNameInTargetPosition(const sead::Vector3f& position);
+    void tryStartAndStopBgmInCurPosition(bool isStopArea, bool isForceStart);
+    bool isInBgmStopArea(const char* playName);
+    bool checkWhetherItCanStartBgm(const char* playName);
+    void startBgm(bool isForceStart);
+
+    AudioKeeper* getAudioKeeper() const override;
+    AreaObjDirector* getAreaObjDirector() const override;
+
+private:
+    u8 _10[0x98];
+};
+
+static_assert(sizeof(BgmPlayEventController) == 0xa8);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmPlayingRequest.h
+++ b/lib/al/Library/Bgm/BgmPlayingRequest.h
@@ -6,6 +6,12 @@ namespace al {
 struct BgmPlayingRequest {
     BgmPlayingRequest(const char* name) : bgmName(name) {}
 
+    BgmPlayingRequest(const char* name, const char* suffix, const char* resourceName, s32 fadeFrame,
+                      s32 startFrame, s32 unk20, s32 unk24, s32 unk28, bool unk2c, bool unk2d,
+                      bool unk2e, bool unk2f)
+        : bgmName(name), _8(suffix), _10(resourceName), _18(fadeFrame), _1c(startFrame), _20(unk20),
+          _24(unk24), _28(unk28), _2c(unk2c), _2d(unk2d), _2e(unk2e), _2f(unk2f) {}
+
     const char* bgmName = nullptr;
     const char* _8 = nullptr;
     const char* _10 = nullptr;

--- a/lib/al/Library/Bgm/BgmRhythmDetector.h
+++ b/lib/al/Library/Bgm/BgmRhythmDetector.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Bgm/BgmResourceCategoryInfo.h"
+
+namespace al {
+struct BgmResourceSpecificInfo;
+struct BgmRhythmInfo;
+struct BgmSampleDataInfo;
+template <typename T>
+class AudioInfoListWithParts;
+
+class BgmRhythmDetector {
+public:
+    BgmRhythmDetector();
+
+    void init(AudioInfoListWithParts<BgmRhythmInfo>* rhythmInfoList,
+              AudioInfoListWithParts<BgmBpmInfo>* bpmInfoList,
+              AudioInfoListWithParts<BgmTimeSignatureInfo>* timeSignatureInfoList,
+              f32 beatStartOffsetTime, BgmResourceSpecificInfo* resourceSpecificInfo,
+              s64 samplePosition, const BgmSampleDataInfo& sampleDataInfo);
+    void update(s64 samplePosition);
+    void calcParams(s64 samplePosition);
+    void setRhythmInfoList(AudioInfoListWithParts<BgmRhythmInfo>* rhythmInfoList,
+                           AudioInfoListWithParts<BgmBpmInfo>* bpmInfoList,
+                           AudioInfoListWithParts<BgmTimeSignatureInfo>* timeSignatureInfoList,
+                           f32 beatStartOffsetTime);
+    void resetRhythmInfoList();
+    void forceUninitialized();
+
+    bool isTriggerBeat() const { return mIsTriggerBeat; }
+
+    bool isTriggerBackBeat() const { return mIsTriggerBackBeat; }
+
+    bool isTriggerMeasureTop() const { return mIsTriggerMeasureTop; }
+
+    f32 getBpm() const { return mCurrentBpmInfo ? mCurrentBpmInfo->bpm : -1.0; }
+
+    f32 getBeatRate() const { return mBeatRate; }
+
+    f32 getCurBeat() const { return mCurBeat; }
+
+    f32 getCurBeatOnMeasure() const { return mCurBeatOnMeasure; }
+
+    f32 getLoopStartBeat() const { return mLoopStartBeat; }
+
+    f32 getLoopEndBeat() const { return mLoopEndBeat; }
+
+    f32 getFramePerMeasure() const { return mFramePerMeasure; }
+
+    s32 getBeatPerMeasure() const { return mBeatPerMeasure; }
+
+private:
+    s32 _0 = -1;
+    u8 _4 = 0;
+    bool mIsTriggerBeat = false;
+    u8 _6 = 0;
+    bool mIsTriggerBackBeat = false;
+    bool mIsTriggerMeasureTop = false;
+    u8 _9[0x43] = {};
+    f32 mBeatRate = -1.0;
+    f32 mCurBeat = -1.0;
+    f32 mCurBeatOnMeasure = -1.0;
+    u8 _58[4] = {};
+    f32 mFramePerMeasure = -1.0;
+    s32 mBeatPerMeasure = -1;
+    u8 _64[0xc] = {};
+    BgmBpmInfo* mCurrentBpmInfo = nullptr;
+    u8 _78[4] = {};
+    f32 mLoopStartBeat = -1.0;
+    f32 mLoopEndBeat = -1.0;
+};
+
+static_assert(sizeof(BgmRhythmDetector) == 0x88);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmRhythmSyncDirector.h
+++ b/lib/al/Library/Bgm/BgmRhythmSyncDirector.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+namespace al {
+class BgmRhythmDetector;
+class IUseActiveBgmLine;
+
+class BgmRhythmSyncDirector {
+public:
+    BgmRhythmSyncDirector(IUseActiveBgmLine* activeBgmLine);
+
+    void update();
+    bool tryRegistTargetResourceName(const char* resourceName);
+
+    bool isEnableRhythmAnim() const { return mIsEnableRhythmAnim; }
+
+    bool isChangeActiveResourceName() const { return mIsChangeActiveResourceName; }
+
+    BgmRhythmDetector* getActiveRhythmDetector() const { return mActiveRhythmDetector; }
+
+private:
+    IUseActiveBgmLine* mActiveBgmLine = nullptr;
+    void* mCurrentRhythmDetector = nullptr;
+    s32 mTargetResourceIndex = -1;
+    bool mIsEnableRhythmAnim = false;
+    bool mIsChangeActiveResourceName = false;
+    u8 _16[2] = {};
+    sead::PtrArray<const char*>* mTargetResourceNames = nullptr;
+    BgmRhythmDetector* mActiveRhythmDetector = nullptr;
+};
+
+static_assert(sizeof(BgmRhythmSyncDirector) == 0x28);
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmSituationDirector.h
+++ b/lib/al/Library/Bgm/BgmSituationDirector.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+namespace al {
+class BgmDataBase;
+class BgmDirector;
+
+class BgmSituationDirector {
+public:
+    BgmSituationDirector(BgmDataBase* dataBase);
+
+    void update();
+    void forceEndSituation(BgmDirector* director);
+    void tryAddHoldUpSituation(const char* situationName);
+    void tryAddForceEndSituation(const char* situationName);
+    void tryRemoveHoldUpSituation(const char* situationName);
+    void tryRemoveForceEndSituation(const char* situationName);
+    void clear();
+    void startHoldUpSituation(BgmDirector* director);
+    void startSituation(const char* situationName, bool isApply, bool isForce, bool isForceStart);
+    void endSituation(const char* situationName, bool isApply, bool isForce);
+    void disableSituationChange();
+    void enableSituationChange(bool isForce);
+    const char* getActiveSituationName(s32 index) const;
+    const char* getDeactiveSituationName(s32 index) const;
+    void takeBgmSituationSnapShot();
+    void applyBgmSituationSnapShot();
+    void applyNoAppliedSituationRecord();
+
+    s32 getActiveSituationNum() const { return mActiveSituations->size(); }
+
+    s32 getDeactiveSituationNum() const { return mDeactiveSituations->size(); }
+
+    bool isDisableSituationChange() const { return mIsDisableSituationChange; }
+
+private:
+    u8 _0[0x18] = {};
+    sead::PtrArray<const char*>* mActiveSituations = nullptr;
+    sead::PtrArray<const char*>* mDeactiveSituations = nullptr;
+    u8 _28[0x28] = {};
+    bool mIsDisableSituationChange = false;
+    u8 _51[7] = {};
+    u8 _58[0x38] = {};
+};
+
+static_assert(sizeof(BgmSituationDirector) == 0x90);
+
+}  // namespace al

--- a/lib/al/Project/Bgm/Bgm.h
+++ b/lib/al/Project/Bgm/Bgm.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class Bgm {
+public:
+    const char* getRunningResourceName();
+    s64 getCurSamplePosition() const;
+};
+
+}  // namespace al


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1225)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1d634d7 - 440c988)

📈 **Matched code**: 14.80% (+0.09%, +11380 bytes)

<details>
<summary>✅ 105 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmStageInfo>* al::createAudioInfoList<al::BgmStageInfo>(al::ByamlIter const&, al::ByamlIter const&, int, bool)` | +372 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmCombinedLineInfo>* al::createAudioInfoList<al::BgmCombinedLineInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmPlayInfo>* al::createAudioInfoList<al::BgmPlayInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmResourceCategoryInfo>* al::createAudioInfoList<al::BgmResourceCategoryInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmStageInfo>* al::createAudioInfoList<al::BgmStageInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmSituationInfo>* al::createAudioInfoList<al::BgmSituationInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineInfo` | `al::AudioInfoListWithParts<al::BgmDemoSyncedProcInfo>* al::createAudioInfoList<al::BgmDemoSyncedProcInfo>(al::ByamlIter const&, int)` | +332 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::tryPauseBgmIfDifferBgmArea(al::LiveActor const*, sead::Vector3<float> const&, int)` | +292 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startAndStopBgmInCurPosition(al::IUseAudioKeeper const*, bool)` | +176 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::getBgmResourceNameInCurPosition(al::IUseAudioKeeper const*, bool)` | +168 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::prepareBgmWithAreaCheck(al::IUseAudioKeeper const*)` | +168 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startBgm(al::IUseAudioKeeper const*, char const*, int, int)` | +160 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startBgmWithSuffix(al::IUseAudioKeeper const*, char const*, char const*, int, int)` | +160 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isPlayingActiveBgm(al::IUseAudioKeeper const*, char const*)` | +160 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startBgm(al::IUseAudioKeeper const*, al::BgmPlayingRequest const&, bool, bool)` | +156 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isStartedBgmSituation(al::IUseAudioKeeper const*, char const*)` | +156 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::changeBgm3DParams(al::IUseAudioKeeper const*, float, float, float, float, bool)` | +140 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::replaceBgmPlayInfoResourceName(al::IUseAudioKeeper const*, char const*, char const*)` | +128 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::getBeatPerMeasure(al::IUseAudioKeeper const*)` | +128 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isTriggerBeat(al::IUseAudioKeeper const*)` | +124 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isTriggerBackBeat(al::IUseAudioKeeper const*)` | +124 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isTriggerMeasureTop(al::IUseAudioKeeper const*)` | +124 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isPlayingResourceCategoryBgm(al::IUseAudioKeeper const*, char const*)` | +120 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::clearBgmDataForStepOverScene(al::IUseAudioKeeper const*)` | +120 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startBgmSituation(al::IUseAudioKeeper const*, sead::PtrArray<al::IBgmParamsChanger>*, char const*, bool, bool)` | +116 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::BgmDataBase::create(char const*, char const*)` | +116 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::startBgmSituation(al::IUseAudioKeeper const*, char const*, bool, bool)` | +108 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::forceStartBgmSituation(al::IUseAudioKeeper const*, char const*, bool, bool)` | +108 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::endBgmSituation(al::IUseAudioKeeper const*, sead::PtrArray<al::IBgmParamsChanger>*, char const*, bool)` | +108 | 0.00% | 100.00% |
| `Library/Bgm/BgmLineFunction` | `al::isActivateBgm3DController(al::IUseAudioKeeper const*)` | +104 | 0.00% | 100.00% |

...and 75 more new matches
</details>


<!-- decomp.dev report end -->