### PR TITLE
Project/Memory: Implement `SceneHeapSetter`

### DIFF
--- a/lib/al/Project/Memory/SceneHeapSetter.cpp
+++ b/lib/al/Project/Memory/SceneHeapSetter.cpp
@@ -1,0 +1,15 @@
+#include "Project/Memory/SceneHeapSetter.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Library/System/SystemKit.h"
+#include "Project/Memory/MemorySystem.h"
+
+#include "System/ProjectInterface.h"
+
+namespace al {
+SceneHeapSetter::SceneHeapSetter()
+    : sead::ScopedCurrentHeapSetter(
+          alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()),
+      mSceneHeap(alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()) {}
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <heap/seadHeapMgr.h>
+
 namespace al {
 
-class SceneHeapSetter {
+class SceneHeapSetter : public sead::ScopedCurrentHeapSetter {
 public:
-    SceneHeapSetter();
+    explicit SceneHeapSetter();
+
+    sead::Heap* getSceneHeap() const { return mSceneHeap; }
+
+private:
+    sead::Heap* mSceneHeap = nullptr;
 };
 
 }  // namespace al


### PR DESCRIPTION
depends on #1226

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1227)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6583c24 - 79ea3e9)

📈 **Matched code**: 14.76% (+0.00%, +88 bytes)

<details>
<summary>✅ 1 new match</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Memory/SceneHeapSetter` | `al::SceneHeapSetter::SceneHeapSetter()` | +88 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->