### PR TITLE
Project/Scene: Implement `SceneCreator`

### DIFF
--- a/lib/al/Library/Thread/FunctorV1M.h
+++ b/lib/al/Library/Thread/FunctorV1M.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Thread/FunctorV0M.h"
+
+namespace al {
+template <class T, class F, class A>
+class FunctorV1M : public FunctorBase {
+public:
+    inline FunctorV1M() = default;
+
+    inline FunctorV1M(T objPointer, F functPointer, A argument)
+        : mObjPointer(objPointer), mFunctPointer(functPointer), mArgument(argument) {}
+
+    inline FunctorV1M(const FunctorV1M<T, F, A>& objPointer) = default;
+
+    void operator()() const override { (mObjPointer->*mFunctPointer)(mArgument); }
+
+    FunctorV1M<T, F, A>* clone() const override { return new FunctorV1M<T, F, A>(*this); }
+
+private:
+    T mObjPointer = nullptr;
+    F mFunctPointer = nullptr;
+    A mArgument;
+};
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.cpp
+++ b/lib/al/Project/Memory/SceneHeapSetter.cpp
@@ -1,0 +1,15 @@
+#include "Project/Memory/SceneHeapSetter.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Library/System/SystemKit.h"
+#include "Project/Memory/MemorySystem.h"
+
+#include "System/ProjectInterface.h"
+
+namespace al {
+SceneHeapSetter::SceneHeapSetter()
+    : sead::ScopedCurrentHeapSetter(
+          alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()),
+      mSceneHeap(alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()) {}
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <heap/seadHeapMgr.h>
+
 namespace al {
 
-class SceneHeapSetter {
+class SceneHeapSetter : public sead::ScopedCurrentHeapSetter {
 public:
-    SceneHeapSetter();
+    explicit SceneHeapSetter();
+
+    sead::Heap* getSceneHeap() const { return mSceneHeap; }
+
+private:
+    sead::Heap* mSceneHeap = nullptr;
 };
 
 }  // namespace al

--- a/lib/al/Project/Scene/SceneCreator.cpp
+++ b/lib/al/Project/Scene/SceneCreator.cpp
@@ -1,0 +1,89 @@
+#include "Project/Scene/SceneCreator.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Scene/Scene.h"
+#include "Library/Scene/SceneFactory.h"
+#include "Library/Thread/AsyncFunctorThread.h"
+#include "Library/Thread/FunctorV1M.h"
+#include "Project/Memory/SceneHeapSetter.h"
+#include "Project/Scene/SceneInitInfo.h"
+
+namespace al {
+using InitFunctor = FunctorV1M<Scene*, void (Scene::*)(const SceneInitInfo&), const SceneInitInfo&>;
+
+SceneCreator::SceneCreator(const GameSystemInfo* gameSystemInfo, GameDataHolderBase* gameDataHolder,
+                           ScreenCaptureExecutor* screenCaptureExecutor,
+                           alSceneFunction::SceneFactory* sceneFactory,
+                           AudioDirector* audioDirector)
+    : mGameSystemInfo(gameSystemInfo), mGameDataHolder(gameDataHolder),
+      mScreenCaptureExecutor(screenCaptureExecutor), mSceneFactory(sceneFactory),
+      mAudioDirector(audioDirector) {}
+
+Scene* SceneCreator::createScene(const char* sceneFactoryEntry, const char* stageName,
+                                 s32 scenarioNo, const char* sceneName,
+                                 bool initializeOnSeparateThread, s32 threadPriority) {
+    createSceneHeap(stageName, false);
+    SceneHeapSetter heapSetter;
+    alSceneFunction::SceneCreatorFunction func = nullptr;
+    mSceneFactory->getEntryIndex(&func, sceneFactoryEntry);
+    Scene* scene = func();
+    SceneInitInfo* initInfo =
+        new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                          scenarioNo, sceneName, mAudioDirector);
+    if (initializeOnSeparateThread)
+        mInitializeThread =
+            createAndStartInitializeThread(heapSetter.getSceneHeap(), threadPriority,
+                                           InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    else
+        scene->init(*initInfo);
+    return scene;
+}
+
+void SceneCreator::setSceneAndThreadInit(Scene* scene, const char* stageName, s32 scenarioNo,
+                                         const char* sceneName, s32 threadPriority,
+                                         sead::Heap* heap) {
+    if (heap) {
+        sead::ScopedCurrentHeapSetter heapSetter(heap);
+        SceneInitInfo* initInfo =
+            new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                              scenarioNo, sceneName, mAudioDirector);
+        mInitializeThread = createAndStartInitializeThread(
+            heap, threadPriority, InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    } else {
+        SceneHeapSetter heapSetter;
+        SceneInitInfo* initInfo =
+            new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                              scenarioNo, sceneName, mAudioDirector);
+        mInitializeThread =
+            createAndStartInitializeThread(heapSetter.getSceneHeap(), threadPriority,
+                                           InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    }
+}
+
+void SceneCreator::setSceneAndInit(Scene* scene, const char* stageName, s32 scenarioNo,
+                                   const char* sceneName) {
+    SceneHeapSetter heapSetter;
+    SceneInitInfo* initInfo =
+        new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                          scenarioNo, sceneName, mAudioDirector);
+    scene->init(*initInfo);
+}
+
+bool SceneCreator::tryEndInitThread() {
+    if (!isExistInitThread())
+        return true;
+
+    if (tryWaitDoneAndDestroyInitializeThread(mInitializeThread)) {
+        mInitializeThread = nullptr;
+        return true;
+    }
+
+    return false;
+}
+
+bool SceneCreator::isExistInitThread() const {
+    return mInitializeThread;
+}
+}  // namespace al

--- a/lib/al/Project/Scene/SceneCreator.h
+++ b/lib/al/Project/Scene/SceneCreator.h
@@ -16,20 +16,21 @@ class Scene;
 
 class SceneCreator {
 public:
-    SceneCreator(const GameSystemInfo*, GameDataHolderBase*, ScreenCaptureExecutor*,
-                 alSceneFunction::SceneFactory*, AudioDirector*);
-    void createScene(const char*, const char*, s32, const char*, bool, s32);
+    SceneCreator(const GameSystemInfo* gameSystemInfo, GameDataHolderBase* gameDataHolder,
+                 ScreenCaptureExecutor* screenCaptureExecutor,
+                 alSceneFunction::SceneFactory* sceneFactory, AudioDirector* audioDirector);
+    Scene* createScene(const char*, const char*, s32, const char*, bool, s32);
     void setSceneAndThreadInit(Scene*, const char*, s32, const char*, s32, sead::Heap*);
     void setSceneAndInit(Scene*, const char*, s32, const char*);
     bool tryEndInitThread();
-    bool isExistInitThread();
+    bool isExistInitThread() const;
 
 private:
-    GameSystemInfo* mGameSystemInfo;
+    const GameSystemInfo* mGameSystemInfo;
     GameDataHolderBase* mGameDataHolder;
     ScreenCaptureExecutor* mScreenCaptureExecutor;
     alSceneFunction::SceneFactory* mSceneFactory;
-    InitializeThread* mInitializeThread;
+    InitializeThread* mInitializeThread = nullptr;
     AudioDirector* mAudioDirector;
 };
 


### PR DESCRIPTION
depends on #1227

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1228)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6583c24 - f9e2c36)

📈 **Matched code**: 14.77% (+0.01%, +1144 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Scene/SceneCreator` | `al::SceneCreator::setSceneAndThreadInit(al::Scene*, char const*, int, char const*, int, sead::Heap*)` | +360 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::createScene(char const*, char const*, int, char const*, bool, int)` | +316 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::setSceneAndInit(al::Scene*, char const*, int, char const*)` | +164 | 0.00% | 100.00% |
| `Library/Memory/SceneHeapSetter` | `al::SceneHeapSetter::SceneHeapSetter()` | +88 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::clone() const` | +84 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::tryEndInitThread()` | +60 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::operator()() const` | +36 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::SceneCreator(al::GameSystemInfo const*, al::GameDataHolderBase*, al::ScreenCaptureExecutor*, alSceneFunction::SceneFactory*, al::AudioDirector*)` | +16 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::isExistInitThread() const` | +16 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::~FunctorV1M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->