### PR TITLE
 Library/Sequence: Implement `SequenceUtil`

### DIFF
--- a/lib/al/Library/Bgm/BgmDirectorInitInfo.h
+++ b/lib/al/Library/Bgm/BgmDirectorInitInfo.h
@@ -6,7 +6,7 @@ namespace al {
 struct BgmDirectorInitInfo {
     BgmDirectorInitInfo() {}
 
-    bool field_0 = false;
-    const char* field_8 = nullptr;
+    bool isScene = false;
+    const char* name = nullptr;
 };
 }  // namespace al

--- a/lib/al/Library/Scene/SceneUtil.cpp
+++ b/lib/al/Library/Scene/SceneUtil.cpp
@@ -695,8 +695,8 @@ AudioDirector* initAudioDirectorImpl(Scene* scene, const SceneInitInfo& sceneInf
     if (audioDirectorInfo.seDirectorInitInfo.playerCount < 1)
         audioDirectorInfo.seDirectorInitInfo.playerCount = 40;
 
-    audioDirectorInfo.bgmDirectorInitInfo.field_0 = true;
-    audioDirectorInfo.bgmDirectorInitInfo.field_8 = "Scene";
+    audioDirectorInfo.bgmDirectorInitInfo.isScene = true;
+    audioDirectorInfo.bgmDirectorInitInfo.name = "Scene";
     audioDirectorInfo.duckingName = "DuckingForScene";
 
     AudioDirector* audioDirector = new AudioDirector();

--- a/lib/al/Library/Se/Function/SeFunction.h
+++ b/lib/al/Library/Se/Function/SeFunction.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace al {
+class AudioKeeper;
+class SeKeeper;
+class IUseAudioKeeper;
+}  // namespace al
+
+namespace alSeFunction {
+al::SeKeeper* tryGetSeKeeper(const al::IUseAudioKeeper* user);
+}

--- a/lib/al/Library/Se/SeDirector.h
+++ b/lib/al/Library/Se/SeDirector.h
@@ -1,0 +1,94 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Audio/System/AudioSystemInfo.h"
+#include "Library/Se/SeDirectorInitInfo.h"
+
+namespace al {
+class AudioDirector;
+struct SeDirectorInitInfo;
+struct AudioSystemInfo;
+class IUseActiveBgmLine;
+class SePlayerGroupKeeper;
+class SeListenerKeeper;
+class MeInfoKeeper;
+class SeMaterialInfoKeeper;
+class SeCategoryHolder;
+class SeSituationKeeper;
+class SeStageInfo;
+class SeSourceKeeper;
+class SeBarrierKeeper;
+class SeLoopSequencer;
+class SeDuckingController;
+class SeDataBase;
+class SeKeeper;
+class PadRumbleDirector;
+class SeListener;
+class AreaObjDirector;
+class PlayerHolder;
+class SeRequestParam;
+class SeEmitter;
+class AudioBusSendController;
+class MeInfo;
+
+class SeDirector {
+public:
+    SeDirector();
+
+    void init(const AudioDirector* audioDirector, const SeDirectorInitInfo& initInfo,
+              const char* stageName, s32 scenarioNo, const AudioSystemInfo* audioSystemInfo,
+              MeInfoKeeper* meInfoKeeper, const IUseActiveBgmLine* activeBgmLineUser);
+    void init3D(const SeDirectorInitInfo& initInfo);
+    void initAfterInitPlacement(AreaObjDirector* areaObjDirector);
+    void finalize();
+    void update();
+
+    void notifyIsModeHandheld(bool inHandheld);
+    void addRequest(SeRequestParam* requestParam, const char*, s32, bool);
+    void notifiedUpdateMaterial(SeEmitter* emitter, const char*, s32);
+    void pauseSystem(bool, const char* pauseReason, u32);
+    void startSituation(const char* situationName, s32, s32, s32);
+    void endSituation(const char* situationName, s32);
+    void checkIsActiveSituation(const char* situationName) const;
+    void requestPlayLoopSeSequence(const char*, const MeInfo*, s32);
+
+    void setPlayerHolder(const PlayerHolder* playerHolder);
+    void setAudioBusSendController(AudioBusSendController* audioBusSendController);
+    SeListener* getListener(s32 index) const;
+    SeDataBase* getSeDataBase();
+    bool isSystemPaused() const;
+    f32 getDuckingVolume() const;
+    const char* getStageEffectName() const;
+
+    void setUpperLevelKeeper(SeKeeper* keeper) { mUpperLevelKeeper = keeper; }
+
+private:
+    SePlayerGroupKeeper* mPlayerGroupKeeper;
+    SeListenerKeeper* mListenerKeeper;
+    MeInfoKeeper* mMeInfoKeeper;
+    SeMaterialInfoKeeper* mSeMaterialInfoKeeper;
+    s32 mListenerCount;
+    SeCategoryHolder* mCategoryHolder;
+    SeSituationKeeper* mSituationKeeper;
+    SeStageInfo* mStageInfo;
+    const char* mStageEffectName;
+    SeSourceKeeper* mSourceKeeper;
+    SeBarrierKeeper* mBarrierKeeper;
+    SeLoopSequencer* mLoopSequencer;
+    SeDuckingController* mDuckingController;
+    SeDataBase* mDatabase;
+    void* _70;
+    f32 mVolume;
+    SeKeeper* mUpperLevelKeeper;
+    const char** mPauseReasons;
+    s32 mPauseReasonCount;
+    bool* _98;  // true when less than 3 sound channels are available
+    bool* mIsStereoOutput;
+    const char** _a8;
+    s32 _b0;
+    PadRumbleDirector* mPadRumbleDirector;
+};
+
+static_assert(sizeof(SeDirector) == 0xc0);
+}  // namespace al

--- a/lib/al/Library/Sequence/IUseSceneCreator.h
+++ b/lib/al/Library/Sequence/IUseSceneCreator.h
@@ -7,7 +7,7 @@ class IUseSceneCreator {
 public:
     virtual ~IUseSceneCreator();
 
-    virtual void setSceneCreator(SceneCreator* creator) = 0;
     virtual SceneCreator* getSceneCreator() const = 0;
+    virtual void setSceneCreator(SceneCreator* creator) = 0;
 };
 }  // namespace al

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -43,6 +43,8 @@ public:
 
     DrawSystemInfo* getDrawInfo() const { return mDrawSystemInfo; }
 
+    void setAudioDirector(AudioDirector* audioDirector) { mAudioDirector = audioDirector; }
+
 private:
     sead::FixedSafeString<0x40> mName;
     Scene* mCurrentScene = nullptr;

--- a/lib/al/Library/Sequence/SequenceInitInfo.cpp
+++ b/lib/al/Library/Sequence/SequenceInitInfo.cpp
@@ -1,0 +1,6 @@
+#include "Library/Sequence/SequenceInitInfo.h"
+
+namespace al {
+SequenceInitInfo::SequenceInitInfo(const GameSystemInfo* gameSystemInfo)
+    : gameSystemInfo(gameSystemInfo) {}
+}  // namespace al

--- a/lib/al/Library/Sequence/SequenceInitInfo.h
+++ b/lib/al/Library/Sequence/SequenceInitInfo.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace al {
+struct GameSystemInfo;
+
+struct SequenceInitInfo {
+    SequenceInitInfo(const GameSystemInfo* gameSystemInfo);
+
+    const GameSystemInfo* gameSystemInfo;
+};
+}  // namespace al

--- a/lib/al/Library/Sequence/SequenceUtil.cpp
+++ b/lib/al/Library/Sequence/SequenceUtil.cpp
@@ -1,0 +1,92 @@
+#include "Library/Sequence/SequenceUtil.h"
+
+#include "Library/Audio/AudioDirector.h"
+#include "Library/Audio/AudioDirectorInitInfo.h"
+#include "Library/Scene/Scene.h"
+#include "Library/Se/Function/SeFunction.h"
+#include "Library/Se/SeDirector.h"
+#include "Library/Sequence/IUseSceneCreator.h"
+#include "Library/Sequence/Sequence.h"
+#include "Library/Sequence/SequenceInitInfo.h"
+#include "Project/Scene/SceneCreator.h"
+
+namespace al {
+
+void initSceneCreator(IUseSceneCreator* user, const SequenceInitInfo& initInfo,
+                      GameDataHolderBase* gameDataHolder, AudioDirector* audioDirector,
+                      ScreenCaptureExecutor* screenCaptureExecutor,
+                      alSceneFunction::SceneFactory* sceneFactory) {
+    SceneCreator* sceneCreator =
+        new SceneCreator(initInfo.gameSystemInfo, gameDataHolder, screenCaptureExecutor,
+                         sceneFactory, audioDirector);
+    user->setSceneCreator(sceneCreator);
+}
+
+void createSceneAndInit(IUseSceneCreator* user, const char* sceneFactoryEntry,
+                        const char* stageName, s32 scenarioNo, const char* sceneName) {
+    user->getSceneCreator()->createScene(sceneFactoryEntry, stageName, scenarioNo, sceneName, false,
+                                         -1);
+}
+
+void createSceneAndUseInitThread(IUseSceneCreator* user, const char* sceneFactoryEntry,
+                                 s32 threadPriority, const char* stageName, s32 scenarioNo,
+                                 const char* sceneName) {
+    user->getSceneCreator()->createScene(sceneFactoryEntry, stageName, scenarioNo, sceneName, true,
+                                         threadPriority);
+}
+
+void setSceneAndInit(IUseSceneCreator* user, Scene* scene, const char* stageName, s32 scenarioNo,
+                     const char* sceneName) {
+    user->getSceneCreator()->setSceneAndInit(scene, stageName, scenarioNo, sceneName);
+}
+
+void setSceneAndUseInitThread(IUseSceneCreator* user, Scene* scene, s32 threadPriority,
+                              const char* stageName, s32 scenarioNo, const char* sceneName,
+                              sead::Heap* heap) {
+    user->getSceneCreator()->setSceneAndThreadInit(scene, stageName, scenarioNo, sceneName,
+                                                   threadPriority, heap);
+}
+
+bool tryEndSceneInitThread(IUseSceneCreator* user) {
+    return user->getSceneCreator()->tryEndInitThread();
+}
+
+bool isExistSceneInitThread(const IUseSceneCreator* user) {
+    return user->getSceneCreator()->isExistInitThread();
+}
+
+void initAudioDirector(Sequence* sequence, AudioSystemInfo* audioSystemInfo,
+                       AudioDirectorInitInfo& initInfo) {
+    if (!sequence)
+        return;
+    initInfo.audioSystemInfo = audioSystemInfo;
+    initInfo.demoDirector = nullptr;
+    if (initInfo.curStage)
+        initInfo.curStage = nullptr;
+    if (initInfo.scenarioNo)
+        initInfo.scenarioNo = 0;
+    if (initInfo.seDirectorInitInfo.maxRequests <= 0)
+        initInfo.seDirectorInitInfo.maxRequests = 30;
+    if (initInfo.seDirectorInitInfo.playerCount <= 0)
+        initInfo.seDirectorInitInfo.playerCount = 20;
+    initInfo.bgmDirectorInitInfo.name = "Sequence";
+    initInfo.duckingName = "DuckingForSequence";
+    AudioDirector* audioDirector = new AudioDirector();
+    audioDirector->init(initInfo);
+    sequence->setAudioDirector(audioDirector);
+}
+
+void setSequenceAudioKeeperToSceneSeDirector(Sequence* sequence, Scene* scene) {
+    if (!scene->getAudioDirector())
+        return;
+    SeDirector* seDirector = scene->getAudioDirector()->getSeDirector();
+    if (!seDirector)
+        return;
+
+    SeKeeper* seKeeper = alSeFunction::tryGetSeKeeper(sequence);
+    if (seKeeper)
+        seDirector->setUpperLevelKeeper(seKeeper);
+}
+
+void setSequenceNameForActorPickTool(Sequence* sequence, Scene* scene) {}
+}  // namespace al

--- a/lib/al/Library/Sequence/SequenceUtil.h
+++ b/lib/al/Library/Sequence/SequenceUtil.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <heap/seadHeap.h>
+
+namespace alSceneFunction {
+class SceneFactory;
+}
+
+namespace al {
+class IUseSceneCreator;
+struct SequenceInitInfo;
+class GameDataHolderBase;
+class AudioDirector;
+class ScreenCaptureExecutor;
+class Scene;
+class Sequence;
+struct AudioSystemInfo;
+struct AudioDirectorInitInfo;
+
+void initSceneCreator(IUseSceneCreator* user, const SequenceInitInfo& initInfo,
+                      GameDataHolderBase* gameDataHolder, AudioDirector* audioDirector,
+                      ScreenCaptureExecutor* screenCaptureExecutor,
+                      alSceneFunction::SceneFactory* sceneFactory);
+void createSceneAndInit(IUseSceneCreator* user, const char* sceneFactoryEntry,
+                        const char* stageName, s32 scenarioNo, const char* sceneName);
+void createSceneAndUseInitThread(IUseSceneCreator* user, const char* sceneFactoryEntry,
+                                 s32 threadPriority, const char* stageName, s32 scenarioNo,
+                                 const char* sceneName);
+void setSceneAndInit(IUseSceneCreator* user, Scene* scene, const char* stageName, s32 scenarioNo,
+                     const char* sceneName);
+void setSceneAndUseInitThread(IUseSceneCreator* user, Scene* scene, s32 threadPriority,
+                              const char* stageName, s32 scenarioNo, const char* sceneName,
+                              sead::Heap* heap);
+bool tryEndSceneInitThread(IUseSceneCreator* user);
+bool isExistSceneInitThread(const IUseSceneCreator* user);
+void initAudioDirector(Sequence* sequence, AudioSystemInfo* audioSystemInfo,
+                       AudioDirectorInitInfo& initInfo);
+void setSequenceAudioKeeperToSceneSeDirector(Sequence* sequence, Scene* scene);
+void setSequenceNameForActorPickTool(Sequence* sequence, Scene* scene);
+}  // namespace al

--- a/lib/al/Library/Thread/FunctorV1M.h
+++ b/lib/al/Library/Thread/FunctorV1M.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "Library/Thread/FunctorV0M.h"
+
+namespace al {
+template <class T, class F, class A>
+class FunctorV1M : public FunctorBase {
+public:
+    inline FunctorV1M() = default;
+
+    inline FunctorV1M(T objPointer, F functPointer, A argument)
+        : mObjPointer(objPointer), mFunctPointer(functPointer), mArgument(argument) {}
+
+    inline FunctorV1M(const FunctorV1M<T, F, A>& objPointer) = default;
+
+    void operator()() const override { (mObjPointer->*mFunctPointer)(mArgument); }
+
+    FunctorV1M<T, F, A>* clone() const override { return new FunctorV1M<T, F, A>(*this); }
+
+private:
+    T mObjPointer = nullptr;
+    F mFunctPointer = nullptr;
+    A mArgument;
+};
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.cpp
+++ b/lib/al/Project/Memory/SceneHeapSetter.cpp
@@ -1,0 +1,15 @@
+#include "Project/Memory/SceneHeapSetter.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Library/System/SystemKit.h"
+#include "Project/Memory/MemorySystem.h"
+
+#include "System/ProjectInterface.h"
+
+namespace al {
+SceneHeapSetter::SceneHeapSetter()
+    : sead::ScopedCurrentHeapSetter(
+          alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()),
+      mSceneHeap(alProjectInterface::getSystemKit()->getMemorySystem()->getSceneHeap()) {}
+}  // namespace al

--- a/lib/al/Project/Memory/SceneHeapSetter.h
+++ b/lib/al/Project/Memory/SceneHeapSetter.h
@@ -1,10 +1,17 @@
 #pragma once
 
+#include <heap/seadHeapMgr.h>
+
 namespace al {
 
-class SceneHeapSetter {
+class SceneHeapSetter : public sead::ScopedCurrentHeapSetter {
 public:
-    SceneHeapSetter();
+    explicit SceneHeapSetter();
+
+    sead::Heap* getSceneHeap() const { return mSceneHeap; }
+
+private:
+    sead::Heap* mSceneHeap = nullptr;
 };
 
 }  // namespace al

--- a/lib/al/Project/Scene/SceneCreator.cpp
+++ b/lib/al/Project/Scene/SceneCreator.cpp
@@ -1,0 +1,89 @@
+#include "Project/Scene/SceneCreator.h"
+
+#include <heap/seadHeapMgr.h>
+
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Scene/Scene.h"
+#include "Library/Scene/SceneFactory.h"
+#include "Library/Thread/AsyncFunctorThread.h"
+#include "Library/Thread/FunctorV1M.h"
+#include "Project/Memory/SceneHeapSetter.h"
+#include "Project/Scene/SceneInitInfo.h"
+
+namespace al {
+using InitFunctor = FunctorV1M<Scene*, void (Scene::*)(const SceneInitInfo&), const SceneInitInfo&>;
+
+SceneCreator::SceneCreator(const GameSystemInfo* gameSystemInfo, GameDataHolderBase* gameDataHolder,
+                           ScreenCaptureExecutor* screenCaptureExecutor,
+                           alSceneFunction::SceneFactory* sceneFactory,
+                           AudioDirector* audioDirector)
+    : mGameSystemInfo(gameSystemInfo), mGameDataHolder(gameDataHolder),
+      mScreenCaptureExecutor(screenCaptureExecutor), mSceneFactory(sceneFactory),
+      mAudioDirector(audioDirector) {}
+
+Scene* SceneCreator::createScene(const char* sceneFactoryEntry, const char* stageName,
+                                 s32 scenarioNo, const char* sceneName,
+                                 bool initializeOnSeparateThread, s32 threadPriority) {
+    createSceneHeap(stageName, false);
+    SceneHeapSetter heapSetter;
+    alSceneFunction::SceneCreatorFunction func = nullptr;
+    mSceneFactory->getEntryIndex(&func, sceneFactoryEntry);
+    Scene* scene = func();
+    SceneInitInfo* initInfo =
+        new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                          scenarioNo, sceneName, mAudioDirector);
+    if (initializeOnSeparateThread)
+        mInitializeThread =
+            createAndStartInitializeThread(heapSetter.getSceneHeap(), threadPriority,
+                                           InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    else
+        scene->init(*initInfo);
+    return scene;
+}
+
+void SceneCreator::setSceneAndThreadInit(Scene* scene, const char* stageName, s32 scenarioNo,
+                                         const char* sceneName, s32 threadPriority,
+                                         sead::Heap* heap) {
+    if (heap) {
+        sead::ScopedCurrentHeapSetter heapSetter(heap);
+        SceneInitInfo* initInfo =
+            new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                              scenarioNo, sceneName, mAudioDirector);
+        mInitializeThread = createAndStartInitializeThread(
+            heap, threadPriority, InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    } else {
+        SceneHeapSetter heapSetter;
+        SceneInitInfo* initInfo =
+            new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                              scenarioNo, sceneName, mAudioDirector);
+        mInitializeThread =
+            createAndStartInitializeThread(heapSetter.getSceneHeap(), threadPriority,
+                                           InitFunctor(scene, &Scene::initializeAsync, *initInfo));
+    }
+}
+
+void SceneCreator::setSceneAndInit(Scene* scene, const char* stageName, s32 scenarioNo,
+                                   const char* sceneName) {
+    SceneHeapSetter heapSetter;
+    SceneInitInfo* initInfo =
+        new SceneInitInfo(mGameSystemInfo, mGameDataHolder, mScreenCaptureExecutor, stageName,
+                          scenarioNo, sceneName, mAudioDirector);
+    scene->init(*initInfo);
+}
+
+bool SceneCreator::tryEndInitThread() {
+    if (!isExistInitThread())
+        return true;
+
+    if (tryWaitDoneAndDestroyInitializeThread(mInitializeThread)) {
+        mInitializeThread = nullptr;
+        return true;
+    }
+
+    return false;
+}
+
+bool SceneCreator::isExistInitThread() const {
+    return mInitializeThread;
+}
+}  // namespace al

--- a/lib/al/Project/Scene/SceneCreator.h
+++ b/lib/al/Project/Scene/SceneCreator.h
@@ -16,20 +16,21 @@ class Scene;
 
 class SceneCreator {
 public:
-    SceneCreator(const GameSystemInfo*, GameDataHolderBase*, ScreenCaptureExecutor*,
-                 alSceneFunction::SceneFactory*, AudioDirector*);
-    void createScene(const char*, const char*, s32, const char*, bool, s32);
+    SceneCreator(const GameSystemInfo* gameSystemInfo, GameDataHolderBase* gameDataHolder,
+                 ScreenCaptureExecutor* screenCaptureExecutor,
+                 alSceneFunction::SceneFactory* sceneFactory, AudioDirector* audioDirector);
+    Scene* createScene(const char*, const char*, s32, const char*, bool, s32);
     void setSceneAndThreadInit(Scene*, const char*, s32, const char*, s32, sead::Heap*);
     void setSceneAndInit(Scene*, const char*, s32, const char*);
     bool tryEndInitThread();
-    bool isExistInitThread();
+    bool isExistInitThread() const;
 
 private:
-    GameSystemInfo* mGameSystemInfo;
+    const GameSystemInfo* mGameSystemInfo;
     GameDataHolderBase* mGameDataHolder;
     ScreenCaptureExecutor* mScreenCaptureExecutor;
     alSceneFunction::SceneFactory* mSceneFactory;
-    InitializeThread* mInitializeThread;
+    InitializeThread* mInitializeThread = nullptr;
     AudioDirector* mAudioDirector;
 };
 


### PR DESCRIPTION
depends on #1228

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1229)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6583c24 - 9f1b068)

📈 **Matched code**: 14.78% (+0.02%, +1920 bytes)

<details>
<summary>✅ 21 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Scene/SceneCreator` | `al::SceneCreator::setSceneAndThreadInit(al::Scene*, char const*, int, char const*, int, sead::Heap*)` | +360 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::createScene(char const*, char const*, int, char const*, bool, int)` | +316 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::setSceneAndInit(al::Scene*, char const*, int, char const*)` | +164 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::initAudioDirector(al::Sequence*, al::AudioSystemInfo*, al::AudioDirectorInitInfo&)` | +164 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::initSceneCreator(al::IUseSceneCreator*, al::SequenceInitInfo const&, al::GameDataHolderBase*, al::AudioDirector*, al::ScreenCaptureExecutor*, alSceneFunction::SceneFactory*)` | +124 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::setSceneAndUseInitThread(al::IUseSceneCreator*, al::Scene*, int, char const*, int, char const*, sead::Heap*)` | +100 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::createSceneAndUseInitThread(al::IUseSceneCreator*, char const*, int, char const*, int, char const*)` | +96 | 0.00% | 100.00% |
| `Library/Memory/SceneHeapSetter` | `al::SceneHeapSetter::SceneHeapSetter()` | +88 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::clone() const` | +84 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::createSceneAndInit(al::IUseSceneCreator*, char const*, char const*, int, char const*)` | +84 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::setSceneAndInit(al::IUseSceneCreator*, al::Scene*, char const*, int, char const*)` | +76 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::setSequenceAudioKeeperToSceneSeDirector(al::Sequence*, al::Scene*)` | +64 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::tryEndInitThread()` | +60 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::operator()() const` | +36 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::tryEndSceneInitThread(al::IUseSceneCreator*)` | +28 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::isExistSceneInitThread(al::IUseSceneCreator const*)` | +28 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::SceneCreator(al::GameSystemInfo const*, al::GameDataHolderBase*, al::ScreenCaptureExecutor*, alSceneFunction::SceneFactory*, al::AudioDirector*)` | +16 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::SceneCreator::isExistInitThread() const` | +16 | 0.00% | 100.00% |
| `Library/Sequence/SequenceInitInfo` | `al::SequenceInitInfo::SequenceInitInfo(al::GameSystemInfo const*)` | +8 | 0.00% | 100.00% |
| `Project/Scene/SceneCreator` | `al::FunctorV1M<al::Scene*, void (al::Scene::*)(al::SceneInitInfo const&), al::SceneInitInfo const&>::~FunctorV1M()` | +4 | 0.00% | 100.00% |
| `Library/Sequence/SequenceUtil` | `al::setSequenceNameForActorPickTool(al::Sequence*, al::Scene*)` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->