### PR TITLE
MapObj: Implement `TalkMessageInfoDirector`

### DIFF
--- a/src/Layout/ProjectReplaceTagProcessor.h
+++ b/src/Layout/ProjectReplaceTagProcessor.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class IUseMessageSystem;
+class IUseSceneObjHolder;
+class MessageTag;
+
+class ReplaceTagProcessorBase {
+public:
+    virtual s32 replacePictureGroup(char16* out, const MessageTag& tag) const;
+};
+}  // namespace al
+
+class ProjectReplaceTagProcessor : public al::ReplaceTagProcessorBase {
+public:
+    explicit ProjectReplaceTagProcessor(const al::IUseSceneObjHolder* user);
+
+private:
+    const al::IUseSceneObjHolder* mSceneObjHolder = nullptr;
+};
+
+static_assert(sizeof(ProjectReplaceTagProcessor) == 0x10);

--- a/src/MapObj/CapMessageKeeper.h
+++ b/src/MapObj/CapMessageKeeper.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadEnum.h>
+
+namespace al {
+class IUseSceneObjHolder;
+class Resource;
+}  // namespace al
+class CapMessageEnableChecker;
+
+class CapMessageKeeper {
+public:
+    SEAD_ENUM_EX(CapMsgType, PlayerInIceWaterFirst = 0 , PlayerSinkSandFirst = 1 ,
+                 CatchBombCatchFirst = 32 , PackunFireChokeCap = 34 ,
+                 PackunFireRescueCap = 35 , WorldWarpOutFirst = 40 ,
+                 WorldWarpOutAgain = 60 , CorkNearFirst = 81 , CorkNearLaunchedFirst = 82 ,
+                 CorkNearSecond = 83 , WorldWarpLookFirst = 84 , CollectCoinGetFirst = 85 ,
+                 ShineChipGetFirst = 88 , KakkuHideFirst = 89 , MoonRockLookFirst = 96 ,
+                 MoonRockLookFirstMoonWorld = 97 , MoonRockLookMoonWorld = 98 ,
+                 CatupultLookFirst = 99 , CatupultAfterShootFirst = 100 ,
+                 GrowFlowerSeedLookFirst = 101 , GrowFlowerPotAfterImplant = 103 ,
+                 GrowFlowerPotAfterImplantWater = 104 , MoonGetSpecial1 = 105 ,
+                 MoonGetSpecial2 = 106 , IntroducePowerStar = 107 ,
+                 WorldWarpCloseLookFirst = 115 , MoonRockLookLongTime = 116 , CapThrow = 250);
+
+    CapMessageKeeper();
+
+    void createAndReadYamlAll();
+    bool isShowCapMsg(const al::IUseSceneObjHolder* user, s32 type);
+    bool isShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* user, const CapMsgType& type);
+    bool tryShowSaveCapMsg(const al::IUseSceneObjHolder* user, const CapMsgType& type, bool low);
+    bool tryShowCapMsgPrivate(const al::IUseSceneObjHolder* user, const CapMsgType& type,
+                              const char* label, s32 delay, bool isLow, bool isStage);
+    bool tryCheckShowCapMsg(const al::IUseSceneObjHolder* user, const CapMsgType& type,
+                            CapMessageEnableChecker* checker, bool isLow);
+    void saveCapMsg(const al::IUseSceneObjHolder* user, s32 type);
+    bool tryShowCapMsgPriorityLow(const al::IUseSceneObjHolder* user, const CapMsgType& type,
+                                  s32 delay, s32 waitFrame);
+    bool tryReadYamlOne(const al::Resource* resource, const char* label, s32* delay,
+                        s32* waitFrame);
+    bool tryShowCapMsgCurrentWorld(const al::IUseSceneObjHolder* user, const CapMsgType& type);
+    void saveCapMsgCurrentWorld(const al::IUseSceneObjHolder* user, const CapMsgType& type);
+    void saveCapMsg(const al::IUseSceneObjHolder* user, const char* label);
+    s32* getCapMessageParam(const CapMsgType& type);
+
+private:
+    void* mParamList = nullptr;
+    s32 mDelay = -1;
+    s32 mWaitFrame = -1;
+    void* _10 = nullptr;
+    s32 _18 = 0;
+    u32 _1c = 0;
+};
+
+static_assert(sizeof(CapMessageKeeper) == 0x20);
+
+namespace CapMessageKeeperFuncrion {
+CapMessageKeeper* getCapMsgKeeper(const al::IUseSceneObjHolder* user);
+}

--- a/src/MapObj/TalkMessageInfoDirector.cpp
+++ b/src/MapObj/TalkMessageInfoDirector.cpp
@@ -1,0 +1,772 @@
+#include "MapObj/TalkMessageInfoDirector.h"
+
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Message/LanguageUtil.h"
+#include "Library/Message/MessageHolder.h"
+#include "Library/Nerve/NerveKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+#include "Library/Scene/SceneUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Layout/ProjectReplaceTagProcessor.h"
+#include "MapObj/CapMessageKeeper.h"
+#include "MapObj/TalkMessageInfoDirectorStateAppearMessage.h"
+#include "MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h"
+#include "MapObj/TalkMessageInfoMessageParam.h"
+#include "MapObj/TalkMessageInfoMoon.h"
+#include "MapObj/TalkMessageInfoParam.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/GameDataUtil.h"
+#include "Util/StageInputFunction.h"
+
+namespace alSeFunction {
+void startSituation(const al::IUseAudioKeeper* user, const char* name, s32 unk);
+void endSituation(const al::IUseAudioKeeper* user, const char* name, s32 unk);
+}  // namespace alSeFunction
+
+namespace {
+NERVE_IMPL(TalkMessageInfoDirector, Watch);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessage);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessageLow);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessageDemo);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessageBoss);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessageMoon);
+NERVE_IMPL(TalkMessageInfoDirector, AppearMessageMinigame);
+NERVE_IMPL(TalkMessageInfoDirector, AppearWaitEndMessage);
+NERVE_IMPL(TalkMessageInfoDirector, EndForce);
+NERVE_IMPL(TalkMessageInfoDirector, Appear);
+NERVE_IMPL(TalkMessageInfoDirector, FollowText);
+NERVE_IMPL(TalkMessageInfoDirector, Wait);
+NERVE_IMPL(TalkMessageInfoDirector, Disappear);
+NERVE_IMPL(TalkMessageInfoDirector, Delay);
+NERVES_MAKE_NOSTRUCT(TalkMessageInfoDirector, Watch, AppearMessage, AppearMessageLow,
+                     AppearMessageDemo, AppearMessageBoss, AppearMessageMoon, AppearMessageMinigame,
+                     AppearWaitEndMessage, EndForce, Appear, FollowText, Wait, Disappear, Delay);
+}  // namespace
+
+TalkMessageInfoDirector::TalkMessageInfoDirector() {
+    for (s32 i = 0; i < 32; ++i)
+        mInfoParams[i] = nullptr;
+}
+
+void TalkMessageInfoDirector::init(const al::ActorInitInfo& info,
+                                   al::SceneObjHolder* sceneObjHolder) {
+    mSceneObjHolder = sceneObjHolder;
+    mNerveKeeper = new al::NerveKeeper(this, &Watch, 7);
+    mLayout = new al::SimpleLayoutAppearWaitEnd("帽子メッセージ レイアウト", "TalkMessageInfo",
+                                                al::getLayoutInitInfo(info), nullptr, false);
+    al::initLayoutTextPaneAnimator(mLayout, "TxtMessage");
+    al::setSeSourceVolume(mLayout, 1.0f);
+    al::startAction(mLayout, "Loop", "Loop");
+    mAudioKeeper = alAudioKeeperFunction::createAudioKeeper(info.audioDirector, nullptr, nullptr);
+    mStateAppearMessage = new TalkMessageInfoDirectorStateAppearMessage(this, mLayout);
+    mStateAppearWaitEndMessage =
+        new TalkMessageInfoDirectorStateAppearWaitEndMessage(this, mLayout);
+    al::initNerveState(this, mStateAppearMessage, &AppearMessage, "[state]システムメッセージ出現");
+    al::addNerveState(this, mStateAppearMessage, &AppearMessageLow,
+                      "[state]システムメッセージ(優先度：低)出現");
+    al::addNerveState(this, mStateAppearMessage, &AppearMessageDemo, "[state]メッセージ表示(デモ)");
+    al::addNerveState(this, mStateAppearMessage, &AppearMessageBoss,
+                      "[state]システムメッセージ(ボス)");
+    al::addNerveState(this, mStateAppearMessage, &AppearMessageMoon,
+                      "[state]ムーン通知(配置) 出現");
+    al::addNerveState(this, mStateAppearMessage, &AppearMessageMinigame,
+                      "[state]システムメッセージ(ミニゲーム)");
+    al::initNerveState(this, mStateAppearWaitEndMessage, &AppearWaitEndMessage,
+                       "[state]メッセージ表示(プログラムで開始・終了)");
+    mCapMessageKeeper = new CapMessageKeeper();
+}
+
+void TalkMessageInfoDirector::execute() {
+    if (al::isNerve(this, &AppearMessageBoss) || al::isNerve(this, &AppearMessageMinigame)) {
+        mNerveKeeper->update();
+        return;
+    }
+
+    if (!mIsPlayCapMessage) {
+        if (al::isNerve(this, &AppearMessageDemo) || al::isNerve(this, &EndForce))
+            mNerveKeeper->update();
+        return;
+    }
+
+    s32 bestIdx = findInAreaTalkMessageInfoIdx();
+    TalkMessageInfoParam* param = nullptr;
+    if (bestIdx >= 0)
+        param = mInfoParams[bestIdx];
+
+    if (param != nullptr && param->isShowDisableCap()) {
+        if (!GameDataFunction::isEnableCap(GameDataHolderAccessor(this))) {
+            mNerveKeeper->update();
+            return;
+        }
+
+        param->onAppearEnd();
+        if (isActiveCapMessage(nullptr) || isDelayCapMessage(nullptr))
+            endForce();
+        return;
+    }
+
+    if (GameDataFunction::isEnableCap(GameDataHolderAccessor(this)))
+        mNerveKeeper->update();
+}
+
+s32 TalkMessageInfoDirector::findInAreaTalkMessageInfoIdx() const {
+    s32 bestPriority = -999999;
+    s32 bestIdx = -1;
+    for (s32 i = 0; i < mInfoParamCount; ++i) {
+        if (mInfoParams[i]->isEnableAppear() && bestPriority < mInfoParams[i]->getPriority()) {
+            bestPriority = mInfoParams[i]->getPriority();
+            bestIdx = i;
+        }
+    }
+    return bestIdx;
+}
+
+bool TalkMessageInfoDirector::isActiveCapMessage(const char* labelName) const {
+    bool isMessage = false;
+    if (al::isNerve(this, &AppearMessage) || al::isNerve(this, &AppearMessageMoon) ||
+        al::isNerve(this, &AppearMessageDemo) || al::isNerve(this, &AppearMessageBoss) ||
+        al::isNerve(this, &AppearMessageMinigame)) {
+        // BUG: This does nothing?
+        al::isNerve(this, &AppearWaitEndMessage);
+
+        isMessage = true;
+    } else {
+        bool isLow = al::isNerve(this, &AppearMessageLow);
+        bool isWaitEnd = al::isNerve(this, &AppearWaitEndMessage);
+        if (isLow)
+            isMessage = true;
+        else if (isWaitEnd) {
+            if (mStateAppearWaitEndMessage->isActiveCapMessage())
+                return true;
+        } else if (labelName == nullptr) {
+            if (al::isNerve(this, &Appear) || al::isNerve(this, &FollowText) ||
+                al::isNerve(this, &Wait) || al::isNerve(this, &Disappear))
+                return true;
+            return false;
+        }
+    }
+    if (isMessage && mStateAppearMessage->isActiveCapMessage(labelName))
+        return true;
+    return false;
+}
+
+bool TalkMessageInfoDirector::isDelayCapMessage(const char* labelName) const {
+    bool isMessage =
+        al::isNerve(this, &AppearMessage) || al::isNerve(this, &AppearMessageMoon) ||
+        al::isNerve(this, &AppearMessageDemo) || al::isNerve(this, &AppearMessageBoss) ||
+        al::isNerve(this, &AppearMessageMinigame) || al::isNerve(this, &AppearMessageLow);
+
+    if (labelName == nullptr)
+        return al::isNerve(this, &Delay);
+    if (isMessage)
+        return mStateAppearMessage->isDelayCapMessage(labelName);
+    return false;
+}
+
+void TalkMessageInfoDirector::endForce() {
+    if (al::isNerve(this, &AppearMessageBoss) || al::isNerve(this, &EndForce))
+        return;
+
+    if (al::isNerve(this, &AppearMessage) || al::isNerve(this, &AppearMessageDemo))
+        mStateAppearMessage->kill();
+    al::setNerve(this, &EndForce);
+}
+
+void TalkMessageInfoDirector::exeWatch() {
+    mCurrentInfoParamIdx = findInAreaTalkMessageInfoIdx();
+    if (mCurrentInfoParamIdx != -1) {
+        TalkMessageInfoParam* param = nullptr;
+        if (mCurrentInfoParamIdx >= 0 && mCurrentInfoParamIdx < mInfoParamCount)
+            param = mInfoParams[mCurrentInfoParamIdx];
+        param->onAppear();
+        if (param->getDelayFrame() >= 1)
+            al::setNerve(this, &Delay);
+        else
+            al::setNerve(this, &Appear);
+    }
+}
+
+void TalkMessageInfoDirector::setNerveMessage() {
+    TalkMessageInfoParam* param = nullptr;
+    if (mCurrentInfoParamIdx >= 0 && mCurrentInfoParamIdx < mInfoParamCount)
+        param = mInfoParams[mCurrentInfoParamIdx];
+    param->onAppear();
+    if (param->getDelayFrame() >= 1)
+        al::setNerve(this, &Delay);
+    else
+        al::setNerve(this, &Appear);
+}
+
+void TalkMessageInfoDirector::exeDelay() {
+    TalkMessageInfoParam* current = nullptr;
+    if (mCurrentInfoParamIdx >= 0 && mCurrentInfoParamIdx < mInfoParamCount)
+        current = mInfoParams[mCurrentInfoParamIdx];
+    s32 nextIdx = findInAreaTalkMessageInfoIdx();
+    if (nextIdx != -1 && mCurrentInfoParamIdx != nextIdx) {
+        getInfoParam()->onAppearEnd();
+        mCurrentInfoParamIdx = nextIdx;
+        TalkMessageInfoParam* next = nullptr;
+        if (mCurrentInfoParamIdx >= 0 && mCurrentInfoParamIdx < mInfoParamCount)
+            next = mInfoParams[mCurrentInfoParamIdx];
+        next->onAppear();
+        if (next->getDelayFrame() >= 1)
+            al::setNerve(this, &Delay);
+        else
+            al::setNerve(this, &Appear);
+        return;
+    }
+
+    if (!current->isInArea() && current->isDelayCancel()) {
+        al::setNerve(this, &Watch);
+        return;
+    }
+
+    if (mInfoParams[mCurrentInfoParamIdx]->isRequestEndForce()) {
+        al::setNerve(this, &EndForce);
+        return;
+    }
+
+    if (al::isGreaterEqualStep(this, current->getDelayFrame()))
+        al::setNerve(this, &Appear);
+}
+
+TalkMessageInfoParam* TalkMessageInfoDirector::getInfoParam() const {
+    if (mCurrentInfoParamIdx < 0 || mCurrentInfoParamIdx >= mInfoParamCount)
+        return nullptr;
+    return mInfoParams[mCurrentInfoParamIdx];
+}
+
+// NONMATCHING: https://decomp.me/scratch/uBpVm
+bool TalkMessageInfoDirector::changeTalkMessageIdx() {
+    s32 bestPriority = -999999;
+    s32 idx = -1;
+    for (s32 i = 0; i < mInfoParamCount; i++) {
+        if (mInfoParams[i]->isEnableAppear() && bestPriority < mInfoParams[i]->getPriority()) {
+            bestPriority = mInfoParams[i]->getPriority();
+            idx = i;
+        }
+    }
+
+    if (idx != -1 && mCurrentInfoParamIdx != idx) {
+        TalkMessageInfoParam* current = getInfoParam();
+        current->onAppearEnd();
+        mCurrentInfoParamIdx = idx;
+        return true;
+    }
+    return false;
+}
+
+void TalkMessageInfoDirector::exeAppear() {
+    if (al::isFirstStep(this)) {
+        al::appearLayoutIfDead(mLayout);
+        al::setPaneString(mLayout, "TxtMessage", mInfoParams[mCurrentInfoParamIdx]->getMessage(),
+                          0);
+        al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+        const char16* message = mInfoParams[mCurrentInfoParamIdx]->getMessage();
+        ProjectReplaceTagProcessor processor(layout);
+        al::startTextPaneAnim(layout, message, nullptr, &processor);
+        al::startAction(mLayout, "Appear", nullptr);
+        TalkMessageInfoParam* param = nullptr;
+        if (mCurrentInfoParamIdx >= 0 && mCurrentInfoParamIdx < mInfoParamCount)
+            param = mInfoParams[mCurrentInfoParamIdx];
+        param->invalidateClipping();
+        mCurrentPage = 0;
+        al::startBgmSituation(this, "AppearCapMessage", false, true);
+        alSeFunction::startSituation(mLayout, "キャップメッセージ", -1);
+    }
+
+    if (mInfoParams[mCurrentInfoParamIdx]->isRequestEndForce()) {
+        al::setNerve(this, &EndForce);
+        return;
+    }
+
+    if (al::isActionEnd(mLayout, nullptr))
+        al::setNerve(this, &FollowText);
+}
+
+void TalkMessageInfoDirector::exeFollowText() {
+    if (al::isFirstStep(this)) {
+        if (!al::isActionPlaying(mLayout, "Wait", nullptr))
+            al::startAction(mLayout, "Wait", nullptr);
+    }
+
+    if (mInfoParams[mCurrentInfoParamIdx]->isRequestEndForce()) {
+        al::setNerve(this, &EndForce);
+        return;
+    }
+
+    if (al::isEndTextPaneAnim(mLayout, false))
+        al::setNerve(this, &Wait);
+}
+
+void TalkMessageInfoDirector::exeWait() {
+    if (mInfoParams[mCurrentInfoParamIdx]->isRequestEndForce()) {
+        al::setNerve(this, &EndForce);
+        return;
+    }
+
+    s32 waitFrame =
+        calcWaitFrame(mInfoParams[mCurrentInfoParamIdx]->getMessageParam(), mCurrentPage);
+    if (rs::isKidsMode(mLayout))
+        waitFrame <<= 1;
+
+    if (al::isGreaterEqualStep(this, waitFrame)) {
+        ProjectReplaceTagProcessor processor(mLayout);
+        if (al::tryChangeNextPage(mLayout, nullptr, &processor)) {
+            ++mCurrentPage;
+            al::setNerve(this, &FollowText);
+            return;
+        }
+
+        s32 idx = mCurrentInfoParamIdx;
+        TalkMessageInfoParam* param = mInfoParams[idx];
+        if (!param->isKeepDisp())
+            al::setNerve(this, &Disappear);
+        else {
+            TalkMessageInfoParam* enableParam = nullptr;
+            if (idx >= 0 && idx < mInfoParamCount)
+                enableParam = param;
+            if (!enableParam->isEnableAppear())
+                al::setNerve(this, &EndForce);
+        }
+    }
+}
+
+s32 TalkMessageInfoDirector::calcWaitFrame(const TalkMessageInfoMessageParam* messageParam,
+                                           s32 page) const {
+    s32 language = al::getLanguageCode();
+    s32 speed = language == 1 ? 4 : 8;
+    if (language == 0)
+        speed = 8;
+    return speed * messageParam->getCharNum(page);
+}
+
+void TalkMessageInfoDirector::exeDisappear() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mLayout, "End", nullptr);
+        al::endBgmSituation(this, "AppearCapMessage", false);
+        alSeFunction::endSituation(mLayout, "キャップメッセージ", -1);
+    }
+
+    if (!al::isActionEnd(mLayout, nullptr))
+        return;
+
+    TalkMessageInfoParam* param = getInfoParam();
+    param->onAppearEnd();
+    mLayout->kill();
+
+    s32 idx = mCurrentInfoParamIdx;
+    param = nullptr;
+    bool shouldKill = false;
+    if (idx >= 0) {
+        TalkMessageInfoParam* rawParam = mInfoParams[idx];
+        u32 endActionType = rawParam->getEndActionType() - 1;
+        if (idx >= mInfoParamCount)
+            param = nullptr;
+        else
+            param = rawParam;
+        if (endActionType <= 1)
+            shouldKill = true;
+    } else {
+        TalkMessageInfoParam* rawParam = param;
+        s32 endActionType = rawParam->getEndActionType();
+        param = rawParam;
+        if (!(endActionType <= 0 || endActionType >= 3))
+            shouldKill = true;
+    }
+
+    if (shouldKill) {
+        param->kill();
+        al::setNerve(this, &Watch);
+        return;
+    }
+
+    if (!param->isInArea()) {
+        al::setNerve(this, &Watch);
+        return;
+    }
+
+    s32 nextIdx = findInAreaTalkMessageInfoIdx();
+    if (nextIdx != -1) {
+        if (mCurrentInfoParamIdx != nextIdx) {
+            TalkMessageInfoParam* current = getInfoParam();
+            current->onAppearEnd();
+            mCurrentInfoParamIdx = nextIdx;
+            setNerveMessage();
+        }
+    }
+}
+
+void TalkMessageInfoDirector::exeEndForce() {
+    TalkMessageInfoParam* param = tryGetInfoParam();
+    if (al::isFirstStep(this) && param != nullptr)
+        param->onAppearEnd();
+
+    if (updateEndForceCommon()) {
+        if (param != nullptr) {
+            s32 endActionType = param->getEndActionType();
+            if (endActionType >= 1 && endActionType <= 2)
+                param->kill();
+        }
+        al::setNerve(this, &Watch);
+    }
+}
+
+TalkMessageInfoParam* TalkMessageInfoDirector::tryGetInfoParam() const {
+    if (mCurrentInfoParamIdx < 0 || mCurrentInfoParamIdx >= mInfoParamCount)
+        return nullptr;
+    return mInfoParams[mCurrentInfoParamIdx];
+}
+
+bool TalkMessageInfoDirector::updateEndForceCommon() {
+    if (al::isFirstStep(this)) {
+        if (!al::isActionPlaying(mLayout, "End", nullptr))
+            al::startAction(mLayout, "End", nullptr);
+    }
+
+    if (al::isActionEnd(mLayout, nullptr) || al::isDead(mLayout)) {
+        al::killLayoutIfActive(mLayout);
+        return true;
+    }
+    return false;
+}
+
+void TalkMessageInfoDirector::exeAppearMessage() {
+    if (al::isFirstStep(this)) {
+        mStateAppearMessage->appear();
+        al::startBgmSituation(this, "AppearCapMessage", false, true);
+        alSeFunction::startSituation(mLayout, "キャップメッセージ", -1);
+    }
+
+    if (mStateAppearMessage->isActiveCapMessage(nullptr)) {
+        const char* labelName = mStateAppearMessage->getLabelName();
+        if (labelName != nullptr) {
+            CapMessageKeeper::CapMsgType moonGetSpecial1(
+                CapMessageKeeper::CapMsgType::MoonGetSpecial1);
+            CapMessageKeeper::CapMsgType moonGetSpecial2(
+                CapMessageKeeper::CapMsgType::MoonGetSpecial2);
+            if (al::isEqualString(labelName, moonGetSpecial1.text()) ||
+                al::isEqualString(labelName, moonGetSpecial2.text()))
+                mCapMessageKeeper->saveCapMsg(this, labelName);
+        }
+    }
+
+    if (al::updateNerveStateAndNextNerve(this, &Watch)) {
+        al::endBgmSituation(this, "AppearCapMessage", false);
+        alSeFunction::endSituation(mLayout, "キャップメッセージ", -1);
+    }
+}
+
+void TalkMessageInfoDirector::exeAppearMessageLow() {
+    if (al::isFirstStep(this)) {
+        mStateAppearMessage->appear();
+        al::startBgmSituation(this, "AppearCapMessage", false, true);
+        alSeFunction::startSituation(mLayout, "キャップメッセージ", -1);
+    }
+
+    if (al::updateNerveStateAndNextNerve(this, &Watch)) {
+        al::endBgmSituation(this, "AppearCapMessage", false);
+        alSeFunction::endSituation(mLayout, "キャップメッセージ", -1);
+    }
+
+    s32 idx = findInAreaTalkMessageInfoIdx();
+    if (idx != -1) {
+        mCurrentInfoParamIdx = idx;
+        al::endBgmSituation(this, "AppearCapMessage", false);
+        alSeFunction::endSituation(mLayout, "キャップメッセージ", -1);
+        al::setNerve(this, &EndForce);
+    }
+}
+
+void TalkMessageInfoDirector::exeAppearMessageDemo() {
+    if (al::isFirstStep(this))
+        mStateAppearMessage->appear();
+    al::updateNerveStateAndNextNerve(this, &Watch);
+}
+
+void TalkMessageInfoDirector::exeAppearMessageBoss() {
+    if (al::isFirstStep(this))
+        mStateAppearMessage->appear();
+    al::updateNerveStateAndNextNerve(this, &Watch);
+}
+
+void TalkMessageInfoDirector::exeAppearMessageMinigame() {
+    if (al::isFirstStep(this))
+        mStateAppearMessage->appear();
+    al::updateNerveStateAndNextNerve(this, &Watch);
+}
+
+void TalkMessageInfoDirector::exeAppearMessageMoon() {
+    if (al::isFirstStep(this)) {
+        mStateAppearMessage->setDelay(45);
+        mStateAppearMessage->appear();
+    }
+    al::updateNerveStateAndNextNerve(this, &Watch);
+}
+
+void TalkMessageInfoDirector::exeAppearWaitEndMessage() {
+    if (al::isFirstStep(this))
+        mStateAppearWaitEndMessage->appear();
+    al::updateNerveStateAndNextNerve(this, &Watch);
+}
+
+void TalkMessageInfoDirector::registerTalkMessageInfoParam(TalkMessageInfoParam* param) {
+    mInfoParams[mInfoParamCount] = param;
+    ++mInfoParamCount;
+}
+
+void TalkMessageInfoDirector::tryCreateCapMessageList(const al::StageInfo* stageInfo,
+                                                      const al::ActorInitInfo& info) {
+    if (!GameDataFunction::checkIsNewWorldInAlreadyGoWorld(GameDataHolderAccessor(this)))
+        return;
+
+    al::PlacementInfo listInfo;
+    if (!al::tryGetPlacementInfoAndCount(&listInfo, &mMoonInfoCount, stageInfo, "CapMessageList"))
+        return;
+
+    mMoonInfos = new TalkMessageInfoMoon*[mMoonInfoCount];
+    for (s32 i = 0; i < mMoonInfoCount; ++i) {
+        al::PlacementInfo placementInfo;
+        al::getPlacementInfoByIndex(&placementInfo, listInfo, i);
+        if (al::isObjectName(placementInfo, "TalkMessageInfoPointMoon")) {
+            const char* displayName;
+            al::getDisplayName(&displayName, placementInfo);
+            TalkMessageInfoMoon* moonInfo = new TalkMessageInfoMoon(displayName);
+            mMoonInfos[i] = moonInfo;
+            mMoonInfos[i]->initPlacement(info, placementInfo);
+        }
+    }
+}
+
+void TalkMessageInfoDirector::startPlayCapMessage() {
+    mIsPlayCapMessage = true;
+}
+
+void TalkMessageInfoDirector::endPlayCapMessage() {
+    mIsPlayCapMessage = false;
+    if (al::isNerve(this, &AppearMessageBoss) || al::isNerve(this, &EndForce))
+        return;
+
+    if (al::isNerve(this, &AppearMessage) || al::isNerve(this, &AppearMessageMoon) ||
+        al::isNerve(this, &AppearMessageDemo) || al::isNerve(this, &AppearMessageBoss) ||
+        al::isNerve(this, &AppearMessageMinigame) || al::isNerve(this, &AppearMessageLow) ||
+        tryGetInfoParam() != nullptr)
+        al::setNerve(this, &EndForce);
+}
+
+void TalkMessageInfoDirector::startMessageContinue(const char* labelName) {
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    const char16* message = al::getSystemMessageString(layout, "CapMessage", labelName);
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    al::setNerve(this, &AppearWaitEndMessage);
+    al::setNerve(this, &AppearWaitEndMessage);
+}
+
+void TalkMessageInfoDirector::setNerveAppearWaitEndSystemMessage(const char* categoryName,
+                                                                 const char* labelName) {
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    const char16* message = al::getSystemMessageString(layout, categoryName, labelName);
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    al::setNerve(this, &AppearWaitEndMessage);
+}
+
+void TalkMessageInfoDirector::endMessageContinue() {
+    if (al::isNerve(this, &AppearWaitEndMessage))
+        mStateAppearWaitEndMessage->end();
+}
+
+bool TalkMessageInfoDirector::trySetNerveAppearMessageLow(const char* categoryName,
+                                                          const char* labelName, s32 waitFrame,
+                                                          s32 delay) {
+    if (!GameDataFunction::isEnableCap(GameDataHolderAccessor(this)) ||
+        !al::isExistLabelInSystemMessage(mLayout, "CapMessage", labelName) ||
+        al::isNerve(this, &Delay) || al::isNerve(this, &Appear) || al::isNerve(this, &FollowText) ||
+        al::isNerve(this, &Wait) || al::isNerve(this, &AppearMessage) ||
+        al::isNerve(this, &AppearMessageMoon) || al::isNerve(this, &AppearMessageDemo) ||
+        al::isNerve(this, &AppearMessageBoss) || al::isNerve(this, &AppearMessageMinigame) ||
+        al::isNerve(this, &AppearMessageLow))
+        return false;
+
+    const char16* message = al::getSystemMessageString(mLayout, categoryName, labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(waitFrame);
+    mStateAppearMessage->setDelay(delay);
+    mStateAppearMessage->setLabelName(labelName);
+    al::setNerve(this, &AppearMessageLow);
+    return true;
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageCommon(const char* categoryName,
+                                                          const char* labelName, s32 waitFrame,
+                                                          s32 delay, const al::Nerve* nerve,
+                                                          bool isStageMessage) {
+    const char16* message = nullptr;
+    if (isStageMessage)
+        message = al::getStageMessageString(mLayout, categoryName, labelName);
+    else
+        message = al::getSystemMessageString(mLayout, categoryName, labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(waitFrame);
+    mStateAppearMessage->setDelay(delay);
+    mStateAppearMessage->setLabelName(labelName);
+    al::setNerve(this, nerve);
+}
+
+void TalkMessageInfoDirector::trySetNerveAppearMessageMoon() {
+    if (al::isNerve(this, &AppearMessageMoon))
+        return;
+
+    TalkMessageInfoMoon* bestMoon = nullptr;
+    for (s32 i = 0; i < mMoonInfoCount; ++i) {
+        TalkMessageInfoMoon* moonInfo = mMoonInfos[i];
+        moonInfo->update();
+        if (moonInfo->isRequest()) {
+            moonInfo->accepted();
+            if (bestMoon == nullptr || bestMoon->getPriority() < moonInfo->getPriority())
+                bestMoon = moonInfo;
+        }
+    }
+
+    if (bestMoon == nullptr)
+        return;
+
+    const char* labelName = bestMoon->getLabelName();
+    const char16* message = al::getSystemMessageString(mLayout, "CapMessage", labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(90);
+    mStateAppearMessage->setDelay(45);
+    mStateAppearMessage->setLabelName("(GetMoonSpecial)");
+    al::setNerve(this, &AppearMessageMoon);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageMoon(const char* categoryName,
+                                                        const char* labelName) {
+    const char16* message = al::getSystemMessageString(mLayout, categoryName, labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(90);
+    mStateAppearMessage->setDelay(45);
+    mStateAppearMessage->setLabelName("(GetMoonSpecial)");
+    al::setNerve(this, &AppearMessageMoon);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessage(const char* categoryName, const char* labelName,
+                                                    s32 waitFrame, s32 delay, bool isDemo,
+                                                    bool isStageMessage) {
+    if (isDemo)
+        setNerveAppearMessageCommon(categoryName, labelName, waitFrame, delay, &AppearMessageDemo,
+                                    isStageMessage);
+    else
+        setNerveAppearMessageCommon(categoryName, labelName, waitFrame, delay, &AppearMessage,
+                                    isStageMessage);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageBoss(const char* categoryName,
+                                                        const char* labelName, s32 waitFrame,
+                                                        s32 delay, bool isStageMessage) {
+    if (rs::isSeparatePlay(mLayout))
+        return;
+
+    const char16* message = nullptr;
+    if (isStageMessage)
+        message = al::getStageMessageString(mLayout, categoryName, labelName);
+    else
+        message = al::getSystemMessageString(mLayout, categoryName, labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(waitFrame);
+    mStateAppearMessage->setDelay(delay);
+    mStateAppearMessage->setLabelName(labelName);
+    al::setNerve(this, &AppearMessageBoss);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageMinigame(const char* categoryName,
+                                                            const char* labelName, s32 waitFrame,
+                                                            s32 delay) {
+    const char16* message = al::getSystemMessageString(mLayout, categoryName, labelName);
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(waitFrame);
+    mStateAppearMessage->setDelay(delay);
+    mStateAppearMessage->setLabelName(labelName);
+    al::setNerve(this, &AppearMessageMinigame);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageMoonLowText(const char16* message,
+                                                               const char* labelName) {
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, message, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(90);
+    mStateAppearMessage->setDelay(45);
+    mStateAppearMessage->setLabelName("(GetMoonSpecial)");
+    al::setNerve(this, &AppearMessageMoon);
+}
+
+void TalkMessageInfoDirector::setNerveAppearMessageMoonNum(const char* categoryName,
+                                                           const char* labelName, s32 num) {
+    sead::WFixedSafeString<256>* moonNumText = &mMoonNumText;
+    al::SimpleLayoutAppearWaitEnd* layout = mLayout;
+    const al::IUseMessageSystem* messageSystem = layout;
+    const char16* message = al::getSystemMessageString(messageSystem, categoryName, labelName);
+    al::replaceMessageTagScore(moonNumText, messageSystem, message, num, "Moon");
+    const char16* replacedMessage = moonNumText->cstr();
+    layout = mLayout;
+    ProjectReplaceTagProcessor processor(layout);
+    al::startTextPaneAnim(layout, replacedMessage, nullptr, &processor);
+    mStateAppearMessage->setWaitFrame(90);
+    mStateAppearMessage->setDelay(45);
+    mStateAppearMessage->setLabelName("(GetMoonSpecial)");
+    al::setNerve(this, &AppearMessageMoon);
+}
+
+void TalkMessageFunction::registerTalkMessageInfoParam(
+    TalkMessageInfoParam* param, const al::IUseSceneObjHolder* sceneObjHolder) {
+    getTalkMessageInfoDirector(sceneObjHolder)->registerTalkMessageInfoParam(param);
+}
+
+TalkMessageInfoDirector*
+TalkMessageFunction::getTalkMessageInfoDirector(const al::IUseSceneObjHolder* sceneObjHolder) {
+    return nullptr;
+}
+
+bool TalkMessageFunction::isExistTalkMessageInfoDirector(
+    const al::IUseSceneObjHolder* sceneObjHolder) {
+    return false;
+}
+
+al::NerveKeeper* TalkMessageInfoDirector::getNerveKeeper() const {
+    return mNerveKeeper;
+}
+
+al::SceneObjHolder* TalkMessageInfoDirector::getSceneObjHolder() const {
+    return mSceneObjHolder;
+}
+
+al::AudioKeeper* TalkMessageInfoDirector::getAudioKeeper() const {
+    return mAudioKeeper;
+}

--- a/src/MapObj/TalkMessageInfoDirector.h
+++ b/src/MapObj/TalkMessageInfoDirector.h
@@ -1,0 +1,120 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Audio/IUseAudioKeeper.h"
+#include "Library/Execute/IUseExecutor.h"
+#include "Library/HostIO/HioNode.h"
+#include "Library/Nerve/IUseNerve.h"
+#include "Library/Scene/ISceneObj.h"
+#include "Library/Scene/IUseSceneObjHolder.h"
+
+namespace al {
+struct ActorInitInfo;
+class AudioKeeper;
+class Nerve;
+class NerveKeeper;
+class SceneObjHolder;
+class SimpleLayoutAppearWaitEnd;
+class StageInfo;
+}  // namespace al
+class CapMessageKeeper;
+class TalkMessageInfoDirectorStateAppearMessage;
+class TalkMessageInfoDirectorStateAppearWaitEndMessage;
+class TalkMessageInfoMessageParam;
+class TalkMessageInfoMoon;
+class TalkMessageInfoParam;
+
+class TalkMessageInfoDirector : public al::HioNode,
+                                public al::IUseNerve,
+                                public al::ISceneObj,
+                                public al::IUseSceneObjHolder,
+                                public al::IUseExecutor,
+                                public al::IUseAudioKeeper {
+public:
+    TalkMessageInfoDirector();
+
+    al::NerveKeeper* getNerveKeeper() const override;
+    void execute() override;
+    al::SceneObjHolder* getSceneObjHolder() const override;
+    al::AudioKeeper* getAudioKeeper() const override;
+
+    void init(const al::ActorInitInfo& info, al::SceneObjHolder* sceneObjHolder);
+    s32 findInAreaTalkMessageInfoIdx() const;
+    bool isActiveCapMessage(const char* labelName) const;
+    bool isDelayCapMessage(const char* labelName) const;
+    void endForce();
+
+    void exeWatch();
+    void setNerveMessage();
+    void exeDelay();
+    TalkMessageInfoParam* getInfoParam() const;
+    bool changeTalkMessageIdx();
+    void exeAppear();
+    void exeFollowText();
+    void exeWait();
+    s32 calcWaitFrame(const TalkMessageInfoMessageParam* messageParam, s32 page) const;
+    void exeDisappear();
+    void exeEndForce();
+    TalkMessageInfoParam* tryGetInfoParam() const;
+    bool updateEndForceCommon();
+
+    void exeAppearMessage();
+    void exeAppearMessageLow();
+    void exeAppearMessageDemo();
+    void exeAppearMessageBoss();
+    void exeAppearMessageMinigame();
+    void exeAppearMessageMoon();
+    void exeAppearWaitEndMessage();
+
+    void registerTalkMessageInfoParam(TalkMessageInfoParam* param);
+    void tryCreateCapMessageList(const al::StageInfo* stageInfo, const al::ActorInitInfo& info);
+    void startPlayCapMessage();
+    void endPlayCapMessage();
+    void startMessageContinue(const char* labelName);
+    void setNerveAppearWaitEndSystemMessage(const char* categoryName, const char* labelName);
+    void endMessageContinue();
+    bool trySetNerveAppearMessageLow(const char* categoryName, const char* labelName, s32 waitFrame,
+                                     s32 delay);
+    void setNerveAppearMessageCommon(const char* categoryName, const char* labelName, s32 waitFrame,
+                                     s32 delay, const al::Nerve* nerve, bool isStageMessage);
+    void trySetNerveAppearMessageMoon();
+    void setNerveAppearMessageMoon(const char* categoryName, const char* labelName);
+    void setNerveAppearMessage(const char* categoryName, const char* labelName, s32 waitFrame,
+                               s32 delay, bool isDemo, bool isStageMessage);
+    void setNerveAppearMessageBoss(const char* categoryName, const char* labelName, s32 waitFrame,
+                                   s32 delay, bool isStageMessage);
+    void setNerveAppearMessageMinigame(const char* categoryName, const char* labelName,
+                                       s32 waitFrame, s32 delay);
+    void setNerveAppearMessageMoonLowText(const char16* message, const char* labelName);
+    void setNerveAppearMessageMoonNum(const char* categoryName, const char* labelName, s32 num);
+
+private:
+    TalkMessageInfoParam* mInfoParams[32];
+    s32 mInfoParamCount = 0;
+    s32 mCurrentInfoParamIdx = -1;
+    TalkMessageInfoMoon** mMoonInfos = nullptr;
+    s32 mMoonInfoCount = 0;
+    al::SimpleLayoutAppearWaitEnd* mLayout = nullptr;
+    s32 mCurrentPage = 0;
+    TalkMessageInfoDirectorStateAppearMessage* mStateAppearMessage = nullptr;
+    void* _158 = nullptr;
+    TalkMessageInfoDirectorStateAppearWaitEndMessage* mStateAppearWaitEndMessage = nullptr;
+    al::NerveKeeper* mNerveKeeper = nullptr;
+    al::SceneObjHolder* mSceneObjHolder = nullptr;
+    bool mIsPlayCapMessage = true;
+    u8 _179[7];
+    CapMessageKeeper* mCapMessageKeeper = nullptr;
+    al::AudioKeeper* mAudioKeeper = nullptr;
+    sead::WFixedSafeString<256> mMoonNumText;
+};
+
+static_assert(sizeof(TalkMessageInfoDirector) == 0x3A8);
+
+namespace TalkMessageFunction {
+void registerTalkMessageInfoParam(TalkMessageInfoParam* param,
+                                  const al::IUseSceneObjHolder* sceneObjHolder);
+TalkMessageInfoDirector* getTalkMessageInfoDirector(const al::IUseSceneObjHolder* sceneObjHolder);
+bool isExistTalkMessageInfoDirector(const al::IUseSceneObjHolder* sceneObjHolder);
+}  // namespace TalkMessageFunction

--- a/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.h
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearMessage.h
@@ -1,0 +1,42 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class SimpleLayoutAppearWaitEnd;
+}  // namespace al
+class TalkMessageInfoDirector;
+
+class TalkMessageInfoDirectorStateAppearMessage
+    : public al::HostStateBase<TalkMessageInfoDirector> {
+public:
+    TalkMessageInfoDirectorStateAppearMessage(TalkMessageInfoDirector* director,
+                                              al::SimpleLayoutAppearWaitEnd* layout);
+
+    void init() override;
+    void appear() override;
+    void kill() override;
+
+    void exeAppearWait();
+    void exeAppear();
+    void exeFollowText();
+    void exeWait();
+    void exeEnd();
+    void setWaitFrame(s32 waitFrame);
+    void setDelay(s32 delay);
+    void setLabelName(const char* labelName);
+    const char* getLabelName() const;
+    bool isActiveCapMessage(const char* labelName) const;
+    bool isDelayCapMessage(const char* labelName) const;
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mLayout = nullptr;
+    s32 mWaitFrame = 90;
+    s32 mDelay = 0;
+    al::StringTmp<128> mLabelName;
+};
+
+static_assert(sizeof(TalkMessageInfoDirectorStateAppearMessage) == 0xC8);

--- a/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h
+++ b/src/MapObj/TalkMessageInfoDirectorStateAppearWaitEndMessage.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class SimpleLayoutAppearWaitEnd;
+}  // namespace al
+class TalkMessageInfoDirector;
+
+class TalkMessageInfoDirectorStateAppearWaitEndMessage
+    : public al::HostStateBase<TalkMessageInfoDirector> {
+public:
+    TalkMessageInfoDirectorStateAppearWaitEndMessage(TalkMessageInfoDirector* director,
+                                                     al::SimpleLayoutAppearWaitEnd* layout);
+
+    void appear() override;
+    void kill() override;
+
+    void exeAppear();
+    void exeWait();
+    void exeEnd();
+    void end();
+    bool isActiveCapMessage() const;
+
+private:
+    al::SimpleLayoutAppearWaitEnd* mLayout = nullptr;
+};
+
+static_assert(sizeof(TalkMessageInfoDirectorStateAppearWaitEndMessage) == 0x28);

--- a/src/MapObj/TalkMessageInfoMessageParam.h
+++ b/src/MapObj/TalkMessageInfoMessageParam.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class IUseMessageSystem;
+}  // namespace al
+
+class TalkMessageInfoMessageParam {
+public:
+    TalkMessageInfoMessageParam(const al::IUseMessageSystem* messageSystem, const char16* message,
+                                const char* label);
+    void setting(const al::IUseMessageSystem* messageSystem, const char16* message);
+    s32 getCharNum(s32 page) const;
+
+private:
+    s32 mPageCount = 0;
+    s32* mCharNums = nullptr;
+};
+
+static_assert(sizeof(TalkMessageInfoMessageParam) == 0x10);

--- a/src/MapObj/TalkMessageInfoMoon.h
+++ b/src/MapObj/TalkMessageInfoMoon.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class PlacementInfo;
+}  // namespace al
+
+class TalkMessageInfoMoon : public al::LiveActor {
+public:
+    TalkMessageInfoMoon(const char* displayName);
+
+    void initPlacement(const al::ActorInitInfo& info, const al::PlacementInfo& placementInfo);
+    void update();
+    bool isRequest() const;
+    void accepted();
+
+    const char* getLabelName() const { return mLabelName; }
+
+    s32 getPriority() const { return mPriority; }
+
+private:
+    const char* mLabelName = nullptr;
+    s32 mPriority = -1;
+    s32 _114 = -1;
+    u16 _118 = 0;
+    u8 _11a[6] = {};
+    void* _120 = nullptr;
+    void* _128 = nullptr;
+};
+
+static_assert(sizeof(TalkMessageInfoMoon) == 0x130);

--- a/src/MapObj/TalkMessageInfoParam.h
+++ b/src/MapObj/TalkMessageInfoParam.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Message/IUseMessageSystem.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class LiveActor;
+class MessageSystem;
+class SensorMsg;
+}  // namespace al
+
+class TalkMessageInfoMessageParam;
+
+class TalkMessageInfoParam : public al::IUseHioNode, public al::IUseMessageSystem {
+public:
+    TalkMessageInfoParam(al::LiveActor* actor, const bool* listenFlag, const bool* inAreaFlag,
+                         bool showDisableCap);
+
+    void initState(const al::ActorInitInfo& info, const char16* message);
+    void listenOn();
+    void listenOff();
+    void listenKill();
+    void listenAppear();
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    void kill();
+    void invalidateClipping();
+    bool isEnableAppear() const;
+    bool isInArea() const;
+    void onAppear();
+    void onAppearEnd();
+    bool isShowDisableCap() const;
+    const al::MessageSystem* getMessageSystem() const override;
+
+    const char16* getMessage() const { return mMessage; }
+
+    bool isRequestEndForce() const { return mIsRequestEndForce; }
+
+    s32 getPriority() const { return mPriority; }
+
+    bool isKeepDisp() const { return mIsKeepDisp; }
+
+    bool isDelayCancel() const { return mIsDelayCancel; }
+
+    s32 getDelayFrame() const { return mDelayFrame; }
+
+    s32 getEndActionType() const { return mEndActionType; }
+
+    TalkMessageInfoMessageParam* getMessageParam() const { return mMessageParam; }
+
+private:
+    al::LiveActor* mActor = nullptr;
+    const char16* mMessage = nullptr;
+    bool mIsRequestEndForce = false;
+    u8 _19[3] = {};
+    s32 mPriority = 0;
+    u16 _20 = 0;
+    u8 _22[6] = {};
+    const bool* mListenFlag = nullptr;
+    const bool* mInAreaFlag = nullptr;
+    u8 _38 = 1;
+    bool mIsKeepDisp = false;
+    bool mIsDelayCancel = true;
+    u8 _3b = 0;
+    s32 mDelayFrame = 0;
+    u8 _40[0x20] = {};
+    s32 mEndActionType = 0;
+    bool mIsShowDisableCap = false;
+    u8 _65[3] = {};
+    s32 _68 = 0;
+    u16 _6c = 0;
+    u8 _6e[2] = {};
+    void* _70 = nullptr;
+    TalkMessageInfoMessageParam* mMessageParam = nullptr;
+};
+
+static_assert(sizeof(TalkMessageInfoParam) == 0x80);
+
+namespace rs {
+const char* getColor(const TalkMessageInfoParam* param);
+}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1239)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (38dcd61 - 57ad29e)

📈 **Matched code**: 14.95% (+0.08%, +10476 bytes)

<details>
<summary>✅ 74 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeAppearMessage()` | +600 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeDisappear()` | +560 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::init(al::ActorInitInfo const&, al::SceneObjHolder*)` | +480 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::execute()` | +460 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::trySetNerveAppearMessageLow(char const*, char const*, int, int)` | +444 | 0.00% | 100.00% |
| `MapObj/CapMessageKeeper` | `CapMessageKeeper::CapMsgType::text_(int)` | +428 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeDelay()` | +400 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeAppear()` | +384 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeAppearMessageLow()` | +372 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeWait()` | +340 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::isActiveCapMessage(char const*) const` | +320 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::tryCreateCapMessageList(al::StageInfo const*, al::ActorInitInfo const&)` | +308 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::trySetNerveAppearMessageMoon()` | +304 | 0.00% | 100.00% |
| `MapObj/CapMessageKeeper` | `sead::FixedSafeString<757>::operator=(sead::SafeStringBase<char> const&)` | +240 | 0.00% | 100.00% |
| `MapObj/CapMessageKeeper` | `sead::FixedSafeStringBase<char, 757>::operator=(sead::SafeStringBase<char> const&)` | +240 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeWatch()` | +240 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageBoss(char const*, char const*, int, int, bool)` | +240 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::isDelayCapMessage(char const*) const` | +236 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageMoonNum(char const*, char const*, int)` | +228 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::endPlayCapMessage()` | +216 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::TalkMessageInfoDirector()` | +208 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageCommon(char const*, char const*, int, int, al::Nerve const*, bool)` | +204 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageMinigame(char const*, char const*, int, int)` | +188 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeFollowText()` | +184 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageMoon(char const*, char const*)` | +172 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::updateEndForceCommon()` | +164 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::startMessageContinue(char const*)` | +160 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::exeEndForce()` | +152 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::setNerveAppearMessageMoonLowText(char16_t const*, char const*)` | +152 | 0.00% | 100.00% |
| `MapObj/TalkMessageInfoDirector` | `(anonymous namespace)::TalkMessageInfoDirectorNrvEndForce::execute(al::NerveKeeper*) const` | +152 | 0.00% | 100.00% |

...and 44 more new matches
</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TalkMessageInfoDirector` | `TalkMessageInfoDirector::changeTalkMessageIdx()` | +49 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->