### PR TITLE
Library/Shadow: Implement `ActorShadowFunction`

### DIFF
--- a/lib/al/Library/Model/ModelCtrl.h
+++ b/lib/al/Library/Model/ModelCtrl.h
@@ -39,6 +39,15 @@ public:
 
     void setModelOcclusionQuery(ModelOcclusionQuery* query) { mModelOcclusionQuery = query; }
 
+    bool isDepthShadowModel() const {
+        u16 state = mDepthShadowModelState;
+        bool isSmallState = state < 0x100;
+        bool isActive = (state & 0xff) != 0;
+        return isSmallState ? isActive : false;
+    }
+
+    void setDepthShadowModel(bool isDepthShadowModel) { depthShadowModel = isDepthShadowModel; }
+
 private:
     nn::g3d::ModelObj* mModelObj;
     s32 _8;
@@ -49,7 +58,18 @@ private:
     GraphicsQualityInfo* mGraphicsQualityInfo;
     unsigned char padding2[514];
     ActorDitherAnimator* mActorDitherAnimator;
-    unsigned char padding3[36];
+    unsigned char padding3[8];
+
+    union {
+        struct {
+            bool depthShadowModel;
+            bool depthShadowModelMasked;
+        };
+
+        u16 mDepthShadowModelState;
+    };
+
+    unsigned char padding3b[26];
     s32 mCalcViewCore;
     s32 pad_3b0;
     unsigned char padding4[124];

--- a/lib/al/Library/Shader/ActorOcclusionKeeper.h
+++ b/lib/al/Library/Shader/ActorOcclusionKeeper.h
@@ -1,9 +1,64 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+#include <prim/seadSafeString.h>
+
 namespace al {
 class Resource;
 class GraphicsSystemInfo;
 class LiveActor;
+class MtxConnector;
+
+class OccSphere {
+public:
+    OccSphere();
+
+    void calcConnectPos(sead::Vector3f*) const;
+    void connectToHostJoint(const LiveActor*);
+    void tryCalcLightPosDir(sead::Vector3f*, const sead::Vector3f&) const;
+    void setEnable(bool);
+    void postUpdate();
+
+    bool isExistLightPosPtr() const { return mLightPosPtr != nullptr; }
+
+    void setLightPosPtr(const sead::Vector3f* lightPosPtr) { mLightPosPtr = lightPosPtr; }
+
+    void setAddOffset(const sead::Vector3f& offset) { mAddOffset.set(offset); }
+
+    bool isEnable() const { return mIsEnable; }
+
+    f32 getRadius() const { return mRadius; }
+
+    f32 getDoRange() const { return mDoRange; }
+
+    f32 getBoundingDistanceScale() const { return mBoundingDistanceScale; }
+
+    const sead::FixedSafeString<32>& getGroupName() const { return mGroupName; }
+
+    sead::FixedSafeString<32>* getGroupNamePtr() { return &mGroupName; }
+
+private:
+    u8 _0[0x90];
+    f32 mRadius;
+    u8 _94[0x5c];
+    f32 mDoRange;
+    u8 _f4[0xbc];
+    sead::FixedSafeString<32> mGroupName;
+    u8 _1e8[0x2c];
+    sead::Vector3f mAddOffset;
+    const sead::Vector3f* mLightPosPtr;
+    bool _228;
+    bool mIsEnable;
+    bool _22a;
+    u8 _22b;
+    f32 mBoundingDistanceScale;
+    f32 _230;
+    u8 _234[4];
+    MtxConnector* mMtxConnector;
+};
+
+static_assert(sizeof(OccSphere) == 0x240);
 
 class ActorOcclusionKeeper {
 public:
@@ -14,9 +69,16 @@ public:
     void requestKill();
     void updateAndRequest();
     void hideModel();
+    void calcDirectionalLight(sead::Vector3f*) const;
+    f32 calcSystemConeDegree() const;
+    OccSphere* getOccSphere(const char*);
+
+    void setIgnoreHostHide(bool isIgnoreHostHide) { mIsIgnoreHostHide = isIgnoreHostHide; }
 
 private:
-    void* _0[0x298 / 8];
+    void* _0[0x290 / 8];
+    bool mIsIgnoreHostHide;
+    u8 _291[7];
 };
 
 static_assert(sizeof(ActorOcclusionKeeper) == 0x298);

--- a/lib/al/Library/Shadow/ActorShadowFunction.cpp
+++ b/lib/al/Library/Shadow/ActorShadowFunction.cpp
@@ -1,0 +1,849 @@
+#include "Library/Shadow/ActorShadowFunction.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/Draw/GraphicsSystemInfo.h"
+#include "Library/Execute/ExecuteUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSceneInfo.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Model/ModelCtrl.h"
+#include "Library/Model/ModelKeeper.h"
+#include "Library/Shader/ActorOcclusionKeeper.h"
+#include "Library/Shadow/DepthShadowMapCtrl.h"
+#include "Library/Shadow/DepthShadowMapDirector.h"
+#include "Library/Shadow/ShadowDirector.h"
+#include "Library/Shadow/ShadowKeeper.h"
+#include "Library/Shadow/ShadowMaskCtrl.h"
+#include "Library/Shadow/ShadowMaskCube.h"
+#include "Library/Shadow/ShadowMaskDirector.h"
+
+namespace agl::sdw {
+void calcSphereDoBoundingConeDegree(sead::Vector3f*, f32*, const sead::Vector3f&,
+                                    const sead::Vector3f&, f32, f32, f32);
+}
+
+namespace ShadowMaskFunction {
+al::ShadowMaskDirector* getShadowMaskDirector(const al::LiveActor*);
+}
+
+namespace DepthShadowMapFunction {
+al::DepthShadowMapDirector* getDepthShadowMapDirector(const al::LiveActor*);
+}
+
+namespace {
+
+al::ShadowMaskCtrl* getShadowMaskCtrl(const al::LiveActor* actor) {
+    return actor->getShadowKeeper()->getShadowMaskCtrl();
+}
+
+al::DepthShadowMapCtrl* getDepthShadowMapCtrl(const al::LiveActor* actor) {
+    return actor->getShadowKeeper()->getDepthShadowMapCtrl();
+}
+
+al::ShadowMaskDirector* getShadowMaskDirector(const al::LiveActor* actor) {
+    return ShadowMaskFunction::getShadowMaskDirector(actor);
+}
+
+al::DepthShadowMapDirector* getDepthShadowMapDirector(const al::LiveActor* actor) {
+    return DepthShadowMapFunction::getDepthShadowMapDirector(actor);
+}
+
+al::ShadowMaskCube* getCubeMask(al::ShadowMaskBase* mask) {
+    // TODO: verify a cast-free typed lookup path for cube-only mask fields.
+    return static_cast<al::ShadowMaskCube*>(mask);
+}
+
+void showShadowMaskImpl(const al::LiveActor* actor, al::ShadowMaskBase* mask) {
+    if (mask->isHidden()) {
+        mask->setHidden(false);
+        if (mask->isValid())
+            getShadowMaskDirector(actor)->registerUpdateShadowMask(mask);
+    }
+}
+
+void hideShadowMaskImpl(const al::LiveActor* actor, al::ShadowMaskBase* mask) {
+    if (!mask->isHidden() && !mask->isIgnoreHide()) {
+        mask->setHidden(true);
+        if (mask->isValid())
+            getShadowMaskDirector(actor)->removeUpdateShadowMask(mask);
+    }
+}
+
+void validateShadowMaskImpl(const al::LiveActor* actor, al::ShadowMaskBase* mask) {
+    if (!mask->isValid()) {
+        mask->setValid(true);
+        if (!mask->isHidden())
+            getShadowMaskDirector(actor)->registerUpdateShadowMask(mask);
+    }
+}
+
+void invalidateShadowMaskImpl(const al::LiveActor* actor, al::ShadowMaskBase* mask) {
+    if (mask->isValid()) {
+        mask->setValid(false);
+        if (!mask->isHidden())
+            getShadowMaskDirector(actor)->removeUpdateShadowMask(mask);
+    }
+}
+
+void invalidateShadowMaskInCategory(const al::LiveActor* actor,
+                                    al::ShadowMaskDrawCategory drawCategory) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        al::ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory)) {
+            hideShadowMaskImpl(actor, mask);
+            mask->setValid(false);
+        }
+    }
+}
+
+void showDepthShadowMapImpl(const al::LiveActor* actor, al::DepthShadowMapInfo* map) {
+    if (map->isHidden()) {
+        map->setHidden(false);
+        if (map->isValid())
+            getDepthShadowMapDirector(actor)->registerUpdateDepthShadowMap(map);
+    }
+}
+
+void hideDepthShadowMapImpl(const al::LiveActor* actor, al::DepthShadowMapInfo* map) {
+    if (!map->isHidden()) {
+        map->setHidden(true);
+        if (map->isValid())
+            getDepthShadowMapDirector(actor)->removeUpdateDepthShadowMap(map);
+    }
+}
+
+void validateDepthShadowMapImpl(const al::LiveActor* actor, al::DepthShadowMapInfo* map) {
+    if (!map->isValid()) {
+        map->setValid(true);
+        if (!map->isHidden())
+            getDepthShadowMapDirector(actor)->registerUpdateDepthShadowMap(map);
+    }
+}
+
+void invalidateDepthShadowMapImpl(const al::LiveActor* actor, al::DepthShadowMapInfo* map) {
+    if (map->isValid()) {
+        map->setValid(false);
+        if (!map->isHidden())
+            getDepthShadowMapDirector(actor)->removeUpdateDepthShadowMap(map);
+    }
+}
+
+}  // namespace
+
+namespace al {
+
+bool isExistShadow(LiveActor* actor) {
+    ShadowMaskCtrl* shadowMaskCtrl = getShadowMaskCtrl(actor);
+    if (shadowMaskCtrl && shadowMaskCtrl->getShadowMaskNum() > 0)
+        return true;
+    return getDepthShadowMapCtrl(actor) != nullptr;
+}
+
+bool isExistShadowMaskCtrl(LiveActor* actor) {
+    return getShadowMaskCtrl(actor) != nullptr;
+}
+
+bool isExistShadowMask(LiveActor* actor, const char* maskName) {
+    ShadowMaskCtrl* shadowMaskCtrl = getShadowMaskCtrl(actor);
+    if (shadowMaskCtrl)
+        return shadowMaskCtrl->findShadowMask(maskName) != nullptr;
+    return false;
+}
+
+bool isExistDepthShadow(LiveActor* actor) {
+    const ModelCtrl* modelCtrl = actor->getModelKeeper()->getModelCtrl();
+    if (!modelCtrl)
+        return false;
+    return modelCtrl->isDepthShadowModel();
+}
+
+bool isExistDepthShadowMapCtrl(LiveActor* actor) {
+    return getDepthShadowMapCtrl(actor) != nullptr;
+}
+
+bool isExistAnyShadowCtrl(LiveActor* actor) {
+    return getShadowMaskCtrl(actor) != nullptr || getDepthShadowMapCtrl(actor) != nullptr;
+}
+
+bool isHideShadowMask(const LiveActor* actor) {
+    ShadowMaskCtrl* shadowMaskCtrl = getShadowMaskCtrl(actor);
+    if (shadowMaskCtrl)
+        return shadowMaskCtrl->isHide();
+    return false;
+}
+
+void hideShadow(LiveActor* actor) {
+    ShadowKeeper* shadowKeeper = actor->getShadowKeeper();
+    if (shadowKeeper)
+        shadowKeeper->hide();
+}
+
+void showShadow(LiveActor* actor) {
+    ShadowKeeper* shadowKeeper = actor->getShadowKeeper();
+    if (shadowKeeper)
+        shadowKeeper->show();
+}
+
+void showShadowMask(LiveActor* actor) {
+    getShadowMaskCtrl(actor)->show();
+}
+
+void showShadowMask(LiveActor* actor, ShadowMaskBase* mask) {
+    showShadowMaskImpl(actor, mask);
+}
+
+void showShadowMask(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        showShadowMaskImpl(actor, mask);
+}
+
+void showShadowMask(LiveActor* actor, ShadowMaskDrawCategory drawCategory) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory))
+            showShadowMaskImpl(actor, mask);
+    }
+}
+
+void hideShadowMask(LiveActor* actor) {
+    getShadowMaskCtrl(actor)->hide();
+}
+
+void hideShadowMask(LiveActor* actor, ShadowMaskBase* mask) {
+    hideShadowMaskImpl(actor, mask);
+}
+
+void hideShadowMask(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        hideShadowMaskImpl(actor, mask);
+}
+
+void hideShadowMask(LiveActor* actor, ShadowMaskDrawCategory drawCategory) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory))
+            hideShadowMaskImpl(actor, mask);
+    }
+}
+
+bool isHideShadowMask(LiveActor* actor, const char* maskName) {
+    return getShadowMaskCtrl(actor)->findShadowMask(maskName)->isHidden();
+}
+
+void showDepthShadowMap(LiveActor* actor, s32 mapIdx) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->getDepthShadowMapInfo(mapIdx);
+    showDepthShadowMapImpl(actor, map);
+}
+
+void showDepthShadowMap(const LiveActor* actor, DepthShadowMapInfo* map) {
+    showDepthShadowMapImpl(actor, map);
+}
+
+void showDepthShadowMap(LiveActor* actor, const char* mapName) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName);
+    showDepthShadowMapImpl(actor, map);
+}
+
+void hideDepthShadowMap(LiveActor* actor, s32 mapIdx) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->getDepthShadowMapInfo(mapIdx);
+    hideDepthShadowMapImpl(actor, map);
+}
+
+void hideDepthShadowMap(const LiveActor* actor, DepthShadowMapInfo* map) {
+    hideDepthShadowMapImpl(actor, map);
+}
+
+void hideDepthShadowMap(LiveActor* actor, const char* mapName) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName);
+    hideDepthShadowMapImpl(actor, map);
+}
+
+bool isHideDepthShadowMap(LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->isHidden();
+}
+
+bool isHideDepthShadowMap(LiveActor* actor, s32 mapIdx) {
+    return getDepthShadowMapCtrl(actor)->getDepthShadowMapInfo(mapIdx)->isHidden();
+}
+
+s32 getDepthShadowMapNum(LiveActor* actor) {
+    DepthShadowMapCtrl* ctrl = getDepthShadowMapCtrl(actor);
+    if (ctrl)
+        return ctrl->getDepthShadowMapNum();
+    return 0;
+}
+
+void validateShadowMask(LiveActor* actor) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        validateShadowMaskImpl(actor, mask);
+    }
+}
+
+void validateShadowMask(LiveActor* actor, ShadowMaskBase* mask) {
+    validateShadowMaskImpl(actor, mask);
+}
+
+void validateShadowMask(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        validateShadowMaskImpl(actor, mask);
+}
+
+void invalidateShadowMask(LiveActor* actor) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        invalidateShadowMaskImpl(actor, mask);
+    }
+}
+
+void invalidateShadowMask(LiveActor* actor, ShadowMaskBase* mask) {
+    invalidateShadowMaskImpl(actor, mask);
+}
+
+void invalidateShadowMask(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        invalidateShadowMaskImpl(actor, mask);
+}
+
+void validateDepthShadowMap(LiveActor* actor) {
+    for (s32 i = 0; i < getDepthShadowMapNum(actor); i++) {
+        DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->getDepthShadowMapInfo(i);
+        validateDepthShadowMapImpl(actor, map);
+    }
+}
+
+void validateDepthShadowMap(LiveActor* actor, DepthShadowMapInfo* map) {
+    validateDepthShadowMapImpl(actor, map);
+}
+
+void validateDepthShadowMap(LiveActor* actor, const char* mapName) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName);
+    validateDepthShadowMapImpl(actor, map);
+}
+
+void invalidateDepthShadowMap(LiveActor* actor) {
+    for (s32 i = 0; i < getDepthShadowMapNum(actor); i++) {
+        DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->getDepthShadowMapInfo(i);
+        invalidateDepthShadowMapImpl(actor, map);
+    }
+}
+
+void invalidateDepthShadowMap(LiveActor* actor, DepthShadowMapInfo* map) {
+    invalidateDepthShadowMapImpl(actor, map);
+}
+
+void invalidateDepthShadowMap(LiveActor* actor, const char* mapName) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName);
+    invalidateDepthShadowMapImpl(actor, map);
+}
+
+void invalidateShadowMask(LiveActor* actor, ShadowMaskDrawCategory drawCategory) {
+    invalidateShadowMaskInCategory(actor, drawCategory);
+}
+
+void invalidateShadowMaskIntensityAll(LiveActor* actor) {
+    invalidateShadowMaskInCategory(actor, ShadowMaskDrawCategory::シャドウ);
+    invalidateShadowMaskInCategory(actor, ShadowMaskDrawCategory::AO);
+    invalidateShadowMaskInCategory(actor, ShadowMaskDrawCategory::ライトスケール);
+    invalidateShadowMaskInCategory(actor, ShadowMaskDrawCategory::ライトバッファ加算);
+}
+
+void setShadowMaskFixed(LiveActor* actor, bool isFixed) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask)
+            mask->setShadowFixed(isFixed);
+    }
+}
+
+void setShadowMaskDropDir(LiveActor* actor, const sead::Vector3f& dropDir) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask)
+            mask->setDropDir(dropDir);
+    }
+}
+
+void setShadowMaskDropDir(LiveActor* actor, const sead::Vector3f& dropDir, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        mask->setDropDir(dropDir);
+}
+
+void setShadowMaskDropDirActorDown(LiveActor* actor) {
+    sead::Vector3f dropDir;
+    calcUpDir(&dropDir, actor);
+    ShadowMaskCtrl* ctrl = getShadowMaskCtrl(actor);
+    if (ctrl->getShadowMaskNum() < 1)
+        return;
+
+    f32 dropDirX = -dropDir.x;
+    f32 dropDirY = -dropDir.y;
+    f32 dropDirZ = -dropDir.z;
+    for (s32 i = 0;; i++) {
+        ShadowMaskBase* mask = ctrl->getShadowMask(i);
+        if (mask)
+            mask->setDropDir(dropDirX, dropDirY, dropDirZ);
+        ctrl = getShadowMaskCtrl(actor);
+        if (i + 1 >= ctrl->getShadowMaskNum())
+            break;
+    }
+}
+
+void setShadowMaskSize(LiveActor* actor, const char* maskName, const sead::Vector3f& size) {
+    f32 sizeX = size.x;
+    f32 sizeZ = size.z;
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (!mask)
+        return;
+
+    if (mask->getShadowMaskType() == ShadowMaskType::Sphere)
+        mask->setSizeX(sizeX);
+    else if (mask->getShadowMaskType() == ShadowMaskType::Cube) {
+        mask->setSizeX(sizeX);
+        getCubeMask(mask)->setSizeZ(sizeZ);
+    } else if (mask->getShadowMaskType() == ShadowMaskType::Cylinder)
+        mask->setSizeX(sizeX);
+}
+
+void setShadowMaskSize(LiveActor* actor, const char* maskName, f32 sizeX, f32, f32 sizeZ) {
+    f32 shadowSizeZ = sizeZ;
+    f32 shadowSizeX = sizeX;
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (!mask)
+        return;
+
+    if (mask->getShadowMaskType() == ShadowMaskType::Sphere)
+        mask->setSizeX(shadowSizeX);
+    else if (mask->getShadowMaskType() == ShadowMaskType::Cube) {
+        mask->setSizeX(shadowSizeX);
+        getCubeMask(mask)->setSizeZ(shadowSizeZ);
+    } else if (mask->getShadowMaskType() == ShadowMaskType::Cylinder)
+        mask->setSizeX(shadowSizeX);
+}
+
+void setShadowTextureOffset(LiveActor* actor, const char* maskName, f32 offsetX, f32 offsetY) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask && mask->getShadowMaskType() == ShadowMaskType::Cube)
+        getCubeMask(mask)->setTextureOffset(offsetX, offsetY);
+}
+
+void onShadowTextureScroll(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask && mask->getShadowMaskType() == ShadowMaskType::Cube)
+        getCubeMask(mask)->setTextureScroll(true);
+}
+
+void offShadowTextureScroll(LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask && mask->getShadowMaskType() == ShadowMaskType::Cube)
+        getCubeMask(mask)->setTextureScroll(false);
+}
+
+void calcShadowMaskSize(sead::Vector3f* size, LiveActor* actor, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+
+    if (mask->getShadowMaskType() == ShadowMaskType::Cube) {
+        size->x = mask->getSizeX();
+        size->y = 0.0f;
+        size->z = getCubeMask(mask)->getSizeZ();
+    } else if (mask->getShadowMaskType() == ShadowMaskType::Cylinder) {
+        f32 sizeX = mask->getSizeX();
+        size->z = sizeX;
+        size->y = 0.0f;
+        size->x = sizeX;
+    }
+}
+
+f32 getShadowMaskDropLength(const LiveActor* actor, const char* maskName) {
+    return getShadowMaskCtrl(actor)->findShadowMask(maskName)->getDropLength();
+}
+
+void setShadowMaskDropLength(LiveActor* actor, f32 dropLength) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask)
+            mask->setDropLength(dropLength);
+    }
+}
+
+void setShadowMaskDropLength(LiveActor* actor, f32 dropLength, const char* maskName) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        mask->setDropLength(dropLength);
+}
+
+void setShadowMaskDropLengthScaleWithDrawCategory(LiveActor* actor, f32 dropLengthScale,
+                                                  ShadowMaskDrawCategory drawCategory) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory))
+            mask->scaleDropLength(dropLengthScale);
+    }
+}
+
+void setShadowMaskDropLengthWithDrawCategory(LiveActor* actor, f32 dropLength,
+                                             ShadowMaskDrawCategory drawCategory) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory))
+            mask->setDropLength(dropLength);
+    }
+}
+
+void setShadowMaskDropLengthEvenWithTarget(ShadowMaskBase* targetMask, const char* maskName,
+                                           const sead::Vector3f& planeNormal) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(targetMask->getHost())->findShadowMask(maskName);
+    setShadowMaskDropLengthEvenWithTarget(targetMask, mask, planeNormal);
+}
+
+void setShadowMaskDropLengthEvenWithTarget(ShadowMaskBase* targetMask, const ShadowMaskBase* mask,
+                                           const sead::Vector3f& planeNormal) {
+    if (!mask || mask == targetMask)
+        return;
+
+    sead::Vector3f targetCenter;
+    f32 targetCenterX = targetMask->getDropLengthEvenCenterX();
+    targetCenter.x = targetCenterX;
+    f32 targetCenterY = targetMask->getDropLengthEvenCenterY();
+    targetCenter.y = targetCenterY;
+    f32 targetCenterZ = targetMask->getDropLengthEvenCenterZ();
+    targetCenter.z = targetCenterZ;
+
+    sead::Vector3f targetSize;
+    f32 targetSizeX = targetMask->getDropLengthEvenSizeX();
+    f32 targetSizeY = targetMask->getDropLengthEvenSizeY();
+    f32 targetSizeZ = targetMask->getDropLengthEvenSizeZ();
+    targetSize.x = targetSizeX;
+    targetSize.y = targetSizeY;
+    targetSize.z = targetSizeZ;
+    if (isNearZero(targetSize, 0.001f)) {
+        targetMask->setDropLength(0.0f);
+        return;
+    }
+
+    if (isNearZero(targetSize.dot(planeNormal), 0.001f)) {
+        targetMask->setDropLength(0.0f);
+        return;
+    }
+
+    targetCenter += targetSize * 0.5f;
+
+    sead::Vector3f maskPlanePoint;
+    f32 maskCenterX = mask->getDropLengthEvenCenterX();
+    f32 maskCenterY = mask->getDropLengthEvenCenterY();
+    f32 maskCenterZ = mask->getDropLengthEvenCenterZ();
+    f32 maskSizeX = mask->getDropLengthEvenSizeX();
+    f32 maskSizeY = mask->getDropLengthEvenSizeY();
+    f32 maskSizeZ = mask->getDropLengthEvenSizeZ();
+    f32 maskSizeHalfX = maskSizeX * 0.5f;
+    f32 maskSizeHalfY = maskSizeY * 0.5f;
+    f32 maskSizeHalfZ = maskSizeZ * 0.5f;
+    f32 maskPlaneX = maskCenterX - maskSizeHalfX;
+    maskPlanePoint.x = maskPlaneX;
+    f32 maskPlaneY = maskCenterY - maskSizeHalfY;
+    maskPlanePoint.y = maskPlaneY;
+    f32 maskPlaneZ = maskCenterZ - maskSizeHalfZ;
+    maskPlanePoint.z = maskPlaneZ;
+    sead::Vector3f maskSize(maskSizeX, maskSizeY, maskSizeZ);
+    (void)maskSize.length();
+
+    sead::Vector3f reverseTargetSize = -targetSize;
+    f32 distance =
+        calcDistanceVecToPlane(reverseTargetSize, targetCenter, planeNormal, maskPlanePoint);
+    if (!(distance < 0.0f))
+        targetMask->setDropLength(distance);
+}
+
+void setShadowMaskDropLengthEvenWithDrawCategory(LiveActor* actor,
+                                                 ShadowMaskDrawCategory drawCategory,
+                                                 const LiveActor* targetActor,
+                                                 const char* maskName) {
+    ShadowMaskBase* targetMask = getShadowMaskCtrl(targetActor)->findShadowMask(maskName);
+    ShadowMaskCtrl* ctrl = getShadowMaskCtrl(actor);
+    s32 lastIdx = ctrl->getShadowMaskNum() - 1;
+    if (lastIdx < 0)
+        return;
+
+    for (u64 i = 0;; i++) {
+        if (u64(u32(ctrl->getShadowMaskNum())) > i) {
+            ShadowMaskBase* mask = ctrl->getShadowMask(i);
+            if (mask && static_cast<s32>(mask->getDrawCategory()) == static_cast<s32>(drawCategory))
+                setShadowMaskDropLengthEvenWithTarget(mask, targetMask, sead::Vector3f::ey);
+        }
+        if (lastIdx == s32(i))
+            break;
+    }
+}
+
+void setShadowMaskDropLengthEvenPlaneNormal(const LiveActor* actor,
+                                            const sead::Vector3f& planeNormal) {
+    for (s32 i = 0; i < getShadowMaskCtrl(actor)->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = getShadowMaskCtrl(actor)->getShadowMask(i);
+        if (mask)
+            mask->setDropLengthPlaneNormal(planeNormal);
+    }
+}
+
+s32 getDepthShadowMapWidth(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->getWidth();
+}
+
+s32 getDepthShadowMapHeight(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->getHeight();
+}
+
+void setDepthShadowMapSize(const LiveActor* actor, s32 width, s32 height, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setShadowTextureSize(width,
+                                                                                           height);
+}
+
+f32 getDepthShadowMapLength(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->getLength();
+}
+
+void setDepthShadowMapLength(const LiveActor* actor, f32 length, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setLength(length);
+}
+
+void setDepthShadowMapLengthFromActorTransFlag(const LiveActor* actor, bool isSetShadowLength,
+                                               const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setLengthFromActorTrans(
+        isSetShadowLength);
+}
+
+void setDepthShadowMapBoundingBox(const LiveActor* actor, const sead::Vector3f& boundMin,
+                                  const sead::Vector3f& boundMax, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setBoundingBox(boundMin,
+                                                                                     boundMax);
+}
+
+void setDepthShadowMapMaskTypeNone(const LiveActor* actor, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setMaskType(0);
+}
+
+void setDepthShadowMapMaskTypeSelf(const LiveActor* actor, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setMaskType(1);
+}
+
+void setEnableDepthShadowMapBottomGradation(const LiveActor* actor, const char* mapName,
+                                            bool isEnableBottomGradation) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setEnableBottomGradation(
+        isEnableBottomGradation);
+}
+
+bool isEnableDepthShadowMapBottomGradation(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)
+        ->tryFindDepthShadowMapInfo(mapName)
+        ->isEnableBottomGradation();
+}
+
+void setDepthShadowMapBottomGradationLength(const LiveActor* actor, const char* mapName,
+                                            f32 length) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setBottomGradationLength(
+        length);
+}
+
+f32 getDepthShadowMapBottomGradationLength(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)
+        ->tryFindDepthShadowMapInfo(mapName)
+        ->getBottomGradationLength();
+}
+
+bool isAppendSubActorDepthShadowMap(const LiveActor* actor) {
+    return getDepthShadowMapCtrl(actor)->isAppendSubActor();
+}
+
+f32 getShadowMaskDropLengthMax(const LiveActor* actor) {
+    ShadowMaskCtrl* ctrl = getShadowMaskCtrl(actor);
+    f32 maxDropLength = 0.0f;
+    for (s32 i = 0; i < ctrl->getShadowMaskNum(); i++) {
+        ShadowMaskBase* mask = ctrl->getShadowMask(i);
+        if (maxDropLength < mask->getDropLength())
+            maxDropLength = mask->getDropLength();
+    }
+    return maxDropLength;
+}
+
+void setShadowMaskColor(const LiveActor* actor, const char* maskName, const sead::Color4f& color) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        mask->setColor(color);
+}
+
+const sead::Color4f& getShadowMaskColor(const LiveActor* actor, const char* maskName) {
+    return getShadowMaskCtrl(actor)->findShadowMask(maskName)->getColor();
+}
+
+void setShadowMaskIntensity(const LiveActor* actor, const char* maskName, f32 intensity) {
+    ShadowMaskBase* mask = getShadowMaskCtrl(actor)->findShadowMask(maskName);
+    if (mask)
+        mask->setIntensity(intensity);
+}
+
+f32 getShadowMaskIntensity(const LiveActor* actor, const char* maskName) {
+    return getShadowMaskCtrl(actor)->findShadowMask(maskName)->getIntensity();
+}
+
+f32 getShadowMaskTextureFixedScale(const LiveActor* actor, const char* maskName) {
+    return getCubeMask(getShadowMaskCtrl(actor)->findShadowMask(maskName))->getTextureFixedScale();
+}
+
+void setShadowMaskTextureFixedScale(const LiveActor* actor, const char* maskName, f32 scale) {
+    getCubeMask(getShadowMaskCtrl(actor)->findShadowMask(maskName))->setTextureFixedScale(scale);
+}
+
+const sead::Vector3f& getShadowMaskOffset(const LiveActor* actor, const char* maskName) {
+    return getShadowMaskCtrl(actor)->findShadowMask(maskName)->getOffset();
+}
+
+void setShadowMaskOffset(const LiveActor* actor, const sead::Vector3f& offset,
+                         const char* maskName) {
+    getShadowMaskCtrl(actor)->findShadowMask(maskName)->setOffset(offset);
+}
+
+bool isExistOcclusionLightPosPtr(const LiveActor* actor, const char* occSphereName) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        return occSphere->isExistLightPosPtr();
+    return false;
+}
+
+void setOcclusionLightPosPtr(const LiveActor* actor, const char* occSphereName,
+                             const sead::Vector3f* lightPosPtr) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        occSphere->setLightPosPtr(lightPosPtr);
+}
+
+void setOcclusionAddOffset(const LiveActor* actor, const char* occSphereName,
+                           const sead::Vector3f& offset) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        occSphere->setAddOffset(offset);
+}
+
+void enableOcclusion(const LiveActor* actor, const char* occSphereName) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        occSphere->setEnable(true);
+}
+
+void disableOcclusion(const LiveActor* actor, const char* occSphereName) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        occSphere->setEnable(false);
+}
+
+bool isEnableOcclusion(const LiveActor* actor, const char* occSphereName) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (occSphere)
+        return occSphere->isEnable();
+    return false;
+}
+
+void calcSphereDoBoundingInfo(sead::Vector3f* outDir, sead::Vector3f* lightDir, f32* outDistance,
+                              f32* coneDegree, const LiveActor* actor, const char* occSphereName,
+                              f32 scale) {
+    ActorOcclusionKeeper* occlusionKeeper = actor->getActorOcclusionKeeper();
+    if (!occlusionKeeper)
+        return;
+
+    OccSphere* occSphere = occlusionKeeper->getOccSphere(occSphereName);
+    if (!occSphere)
+        return;
+
+    occlusionKeeper->calcDirectionalLight(lightDir);
+
+    sead::Vector3f connectPos;
+    occSphere->calcConnectPos(&connectPos);
+    occSphere->tryCalcLightPosDir(lightDir, connectPos);
+
+    f32 systemConeDegree = occlusionKeeper->calcSystemConeDegree();
+    *coneDegree = systemConeDegree * scale;
+    agl::sdw::calcSphereDoBoundingConeDegree(outDir, outDistance, *lightDir, connectPos,
+                                             occSphere->getRadius(), occSphere->getDoRange(),
+                                             *coneDegree);
+    *outDistance *= occSphere->getBoundingDistanceScale();
+}
+
+void calcOcclusionSpherePos(sead::Vector3f* pos, const LiveActor* actor,
+                            const char* occSphereName) {
+    ActorOcclusionKeeper* occlusionKeeper = actor->getActorOcclusionKeeper();
+    if (occlusionKeeper) {
+        OccSphere* occSphere = occlusionKeeper->getOccSphere(occSphereName);
+        if (occSphere)
+            occSphere->calcConnectPos(pos);
+    }
+}
+
+void changeOcclusionGroup(const LiveActor* actor, const char* occSphereName,
+                          const char* groupName) {
+    OccSphere* occSphere = actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+    if (!occSphere)
+        return;
+
+    if (groupName)
+        occSphere->getGroupNamePtr()->format(groupName);
+    else
+        *occSphere->getGroupNamePtr() = sead::SafeString::cEmptyString;
+}
+
+OccSphere* getOcclusionSphere(const LiveActor* actor, const char* occSphereName) {
+    return actor->getActorOcclusionKeeper()->getOccSphere(occSphereName);
+}
+
+void setOcclusionIgnoreHostHide(const LiveActor* actor, bool isIgnoreHostHide) {
+    ActorOcclusionKeeper* occlusionKeeper = actor->getActorOcclusionKeeper();
+    if (occlusionKeeper)
+        occlusionKeeper->setIgnoreHostHide(isIgnoreHostHide);
+}
+
+bool findIsInShade(const LiveActor* actor, const sead::Vector3f& pos) {
+    return actor->getSceneInfo()
+        ->graphicsSystemInfo->getShadowDirector()
+        ->getDepthShadowMapDirector()
+        ->findIsInShade(pos);
+}
+
+void requestDepthShadowMapLightDir(const LiveActor* actor, const sead::Vector3f& lightDir,
+                                   const char* mapName) {
+    DepthShadowMapInfo* map = getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName);
+    map->setRequestLightDir(true);
+    map->setLightDir(lightDir);
+}
+
+void resetRequestDepthShadowMapLightDir(const LiveActor* actor, const char* mapName) {
+    getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->setRequestLightDir(false);
+}
+
+bool isRequestDepthShadowMapLightDir(const LiveActor* actor, const char* mapName) {
+    return getDepthShadowMapCtrl(actor)->tryFindDepthShadowMapInfo(mapName)->isRequestLightDir();
+}
+
+void onDepthShadowModel(LiveActor* actor) {
+    actor->getModelKeeper()->getModelCtrl()->setDepthShadowModel(true);
+    alActorSystemFunction::updateExecutorDraw(actor);
+}
+
+void offDepthShadowModel(LiveActor* actor) {
+    actor->getModelKeeper()->getModelCtrl()->setDepthShadowModel(false);
+    alActorSystemFunction::updateExecutorDraw(actor);
+}
+
+void updateDepthShadowMapCtrlShapeVisible(LiveActor* actor) {
+    ShadowKeeper* shadowKeeper = actor->getShadowKeeper();
+    if (shadowKeeper) {
+        DepthShadowMapCtrl* depthShadowMapCtrl = shadowKeeper->getDepthShadowMapCtrl();
+        if (depthShadowMapCtrl)
+            depthShadowMapCtrl->updateShapeVisible(nullptr);
+    }
+}
+
+}  // namespace al

--- a/lib/al/Library/Shadow/ActorShadowFunction.h
+++ b/lib/al/Library/Shadow/ActorShadowFunction.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "Library/Shadow/ActorShadowUtil.h"

--- a/lib/al/Library/Shadow/DepthShadowMapCtrl.h
+++ b/lib/al/Library/Shadow/DepthShadowMapCtrl.h
@@ -11,33 +11,131 @@ class Resource;
 class ByamlIter;
 class GraphicsSystemInfo;
 class LiveActor;
+class DepthShadowMapCtrl;
 class DepthShadowMapInfo;
 class ModelDrawerDepthShadowMap;
 class ModelDrawerMask;
+
+class DepthShadowMapInfo {
+public:
+    DepthShadowMapInfo(const char*);
+
+    void setShadowTextureSize(s32, s32);
+    DepthShadowMapCtrl* getDepthShadowMapCtrl();
+
+    const char* getName() const { return mName; }
+
+    s32 getWidth() const { return mShadowTextureWidth; }
+
+    s32 getHeight() const { return mShadowTextureHeight; }
+
+    f32 getLength() const { return mLength; }
+
+    void setLength(f32 length) { mLength = length; }
+
+    void setLengthFromActorTrans(bool isLengthFromActorTrans) {
+        mIsLengthFromActorTrans = isLengthFromActorTrans;
+    }
+
+    void setLightDir(const sead::Vector3f& lightDir) { mLightDir.set(lightDir); }
+
+    void setRequestLightDir(bool isRequest) { mIsRequestLightDir = isRequest; }
+
+    bool isRequestLightDir() const { return mIsRequestLightDir; }
+
+    void setBoundingBox(const sead::Vector3f& boundMin, const sead::Vector3f& boundMax) {
+        mBoundingBoxMin.x = boundMin.x;
+        mBoundingBoxMin.y = boundMin.y;
+        mBoundingBoxMin.z = boundMin.z;
+        mBoundingBoxMax.x = boundMax.x;
+        mBoundingBoxMax.y = boundMax.y;
+        mBoundingBoxMax.z = boundMax.z;
+    }
+
+    void setMaskType(s32 maskType) { mMaskType = maskType; }
+
+    void setEnableBottomGradation(bool isEnable) { mIsEnableBottomGradation = isEnable; }
+
+    bool isEnableBottomGradation() const { return mIsEnableBottomGradation; }
+
+    void setBottomGradationLength(f32 length) { mBottomGradationLength = length; }
+
+    f32 getBottomGradationLength() const { return mBottomGradationLength; }
+
+    bool isHidden() const { return mIsHidden; }
+
+    void setHidden(bool isHidden) { mIsHidden = isHidden; }
+
+    bool isValid() const { return mIsValid; }
+
+    void setValid(bool isValid) { mIsValid = isValid; }
+
+private:
+    const char* mName;
+    s32 mShadowTextureWidth;
+    s32 mShadowTextureHeight;
+    s32 mBlurIteration;
+    f32 mLength;
+    bool mIsLengthFromActorTrans;
+    u8 _19[3];
+    sead::Vector3f mLightDir;
+    bool mIsRequestLightDir;
+    u8 _29[3];
+    sead::Vector3f mBoundingBoxMin;
+    sead::Vector3f mBoundingBoxMax;
+    s32 mMaskType;
+    bool _48;
+    u8 _49[3];
+    f32 _4c;
+    f32 _50;
+    f32 _54;
+    f32 _58;
+    s32 _5c;
+    s32 _60;
+    u16 _64;
+    u8 _66[2];
+    void* _68;
+    const char* mJointName;
+    bool mIsEnableBottomGradation;
+    u8 _79[3];
+    f32 mBottomGradationLength;
+    bool mIsHidden;
+    bool mIsValid;
+    u8 _82[2];
+    f32 _84;
+    bool _88;
+    u8 _89[7];
+    const LiveActor* mHostActor;
+    void* mShadowTextureInfo;
+};
+
+static_assert(sizeof(DepthShadowMapInfo) == 0xa0);
 
 class DepthShadowMapCtrl : public HioNode {
 public:
     DepthShadowMapCtrl(const Resource* resource);
     virtual ~DepthShadowMapCtrl();
 
-    void actorModelDrawDepth();
-    void actorModelDrawMask();
+    void actorModelDrawDepth() const;
+    void actorModelDrawMask() const;
     void appendDepthShadowMapInfo(const char*, s32, s32, s32, f32, bool, const sead::Vector3f&,
                                   bool, const sead::Vector3f&, const sead::Vector3f&, bool,
                                   const char*, s32, bool, f32, f32, f32, bool, bool, f32, s32, bool,
                                   bool, f32);
-    DepthShadowMapInfo* getDepthShadowMapInfo(s32 index);
-    u32 getDepthShadowMapNum();
+    DepthShadowMapInfo* getDepthShadowMapInfo(s32 index) const;
+    s32 getDepthShadowMapNum() const;
     void hide();
     void init(LiveActor* actor, const ByamlIter& iter);
     void initAfterPlacement(GraphicsSystemInfo* graphicsSystemInfo);
     void initWithoutIter(LiveActor* actor, s32);
     void show();
-    DepthShadowMapInfo* tryFindDepthShadowMapInfo(const char*);
+    DepthShadowMapInfo* tryFindDepthShadowMapInfo(const char*) const;
     void update();
     void updateShapeVisible(const LiveActor* actor);
 
     void setAppendSubActor(bool isAppendSubActor) { mIsAppendSubActor = isAppendSubActor; }
+
+    bool isAppendSubActor() const { return mIsAppendSubActor; }
 
 private:
     LiveActor* mLiveActor;

--- a/lib/al/Library/Shadow/DepthShadowMapDirector.h
+++ b/lib/al/Library/Shadow/DepthShadowMapDirector.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <math/seadVector.h>
 
 #include "Library/HostIO/HioNode.h"
 
 namespace al {
 class DepthShadowMapCtrl;
+class DepthShadowMapInfo;
 class ModelKeeper;
 
 class DepthShadowMapDirector : public HioNode {
@@ -14,6 +16,9 @@ public:
 
     void createDepthShadowMap(const DepthShadowMapCtrl*, const ModelKeeper*, const char*, s32, s32,
                               s32);
+    void registerUpdateDepthShadowMap(DepthShadowMapInfo*);
+    void removeUpdateDepthShadowMap(DepthShadowMapInfo*);
+    bool findIsInShade(const sead::Vector3f&) const;
 
     void declareUseDepthShadowMap(s32 num) { _68 += num; }
 

--- a/lib/al/Library/Shadow/ShadowMaskBase.h
+++ b/lib/al/Library/Shadow/ShadowMaskBase.h
@@ -9,7 +9,7 @@ namespace al {
 class LiveActor;
 class ByamlIter;
 class MtxConnector;
-enum class ShadowMaskType;
+enum class ShadowMaskType : s32 { None = 0, Sphere = 1, Cylinder = 2, Cube = 3 };
 
 SEAD_ENUM(ShadowMaskDrawCategory, シャドウ, AO, ライトスケール, ライトバッファ加算)
 
@@ -31,15 +31,87 @@ public:
     void setHost(const LiveActor*);
     void setDrawCategory(const char*);
 
+    const LiveActor* getHost() const { return mHost; }
+
     MtxConnector* getMtxConnector() const { return mMtxConnector; }
+
+    const char* getName() const { return mName; }
 
     ShadowMaskDrawCategory getDrawCategory() const { return mDrawCategory; }
 
+    void setShadowFixed(bool isFixed) { mIsShadowFixed = isFixed; }
+
+    bool isIgnoreHide() const { return mIsIgnoreHide; }
+
+    bool isValid() const { return mIsValid; }
+
+    void setValid(bool isValid) { mIsValid = isValid; }
+
+    bool isHidden() const { return mIsHidden; }
+
+    void setHidden(bool isHidden) { mIsHidden = isHidden; }
+
+    const sead::Vector3f& getDropDir() const { return mDropDir; }
+
+    void setDropDir(const sead::Vector3f& dropDir) {
+        mDropDir.x = dropDir.x;
+        mDropDir.y = dropDir.y;
+        mDropDir.z = dropDir.z;
+    }
+
+    void setDropDir(f32 x, f32 y, f32 z) {
+        mDropDir.x = x;
+        mDropDir.y = y;
+        mDropDir.z = z;
+    }
+
+    f32 getDropLength() const { return mDropLength; }
+
     void setDropLength(f32 dropLength) { mDropLength = dropLength; }
+
+    void scaleDropLength(f32 scale) { mDropLength *= scale; }
+
+    void setDropLengthPlaneNormal(const sead::Vector3f& planeNormal) {
+        mDropLengthPlaneNormal.x = planeNormal.x;
+        mDropLengthPlaneNormal.y = planeNormal.y;
+        mDropLengthPlaneNormal.z = planeNormal.z;
+    }
+
+    f32 getSizeX() const { return mSizeX; }
+
+    void setSizeX(f32 sizeX) { mSizeX = sizeX; }
+
+    sead::Vector3f getDropLengthEvenSize() const {
+        return {mDropLengthEvenSizeX, mDropLengthEvenSizeY, mDropLengthEvenSizeZ};
+    }
+
+    sead::Vector3f getDropLengthEvenCenter() const {
+        return {mDropLengthEvenCenterX, mDropLengthEvenCenterY, mDropLengthEvenCenterZ};
+    }
+
+    f32 getDropLengthEvenSizeX() const { return mDropLengthEvenSizeX; }
+
+    f32 getDropLengthEvenSizeY() const { return mDropLengthEvenSizeY; }
+
+    f32 getDropLengthEvenSizeZ() const { return mDropLengthEvenSizeZ; }
+
+    f32 getDropLengthEvenCenterX() const { return mDropLengthEvenCenterX; }
+
+    f32 getDropLengthEvenCenterY() const { return mDropLengthEvenCenterY; }
+
+    f32 getDropLengthEvenCenterZ() const { return mDropLengthEvenCenterZ; }
+
+    const sead::Vector3f& getOffset() const { return mOffset; }
 
     void setOffset(const sead::Vector3f& offset) { mOffset.set(offset); }
 
+    const sead::Color4f& getColor() const { return mColor; }
+
     void setColor(const sead::Color4f& color) { mColor = color; }
+
+    f32 getIntensity() const { return mColor.r; }
+
+    void setIntensity(f32 intensity) { mColor.r = intensity; }
 
     void setDrawCategory(ShadowMaskDrawCategory drawCategory) { mDrawCategory = drawCategory; }
 
@@ -48,10 +120,9 @@ private:
     MtxConnector* mMtxConnector;
     sead::Vector3f mOffset;
     sead::Color4f mColor;
-    sead::Vector3f _34;
+    sead::Vector3f mDropDir;
     f32 mDropLength;
-    s32 pad2;
-    void* _48[1];
+    sead::Vector3f mDropLengthPlaneNormal;
     const char* mName;
     bool mIsFixedIntensity;
     bool mIsFollowHostScale;
@@ -61,9 +132,25 @@ private:
     bool mIsShadowFixed;
     bool pad3[7];
     const char* mActorJointName;
-    void* _70[7];
+    u8 _70[2];
+    bool mIsValid;
+    bool mIsHidden;
+    u8 _74[4];
+    f32 mDropLengthEvenSizeX;
+    u8 _7c[4];
+    f32 mDropLengthEvenCenterX;
+    u8 _84[4];
+    f32 mDropLengthEvenSizeY;
+    u8 _8c[4];
+    f32 mDropLengthEvenCenterY;
+    u8 _94[4];
+    f32 mDropLengthEvenSizeZ;
+    u8 _9c[4];
+    f32 mDropLengthEvenCenterZ;
+    u8 _a4[4];
     sead::FixedSafeString<32> mSetHeightEvenTargetName;
     s32 _e0[3];
+    f32 mSizeX;
 };
 
 static_assert(sizeof(ShadowMaskBase) == 0xf0);

--- a/lib/al/Library/Shadow/ShadowMaskCastOvalCylinder.h
+++ b/lib/al/Library/Shadow/ShadowMaskCastOvalCylinder.h
@@ -16,11 +16,14 @@ public:
     void addMulti() override;
     ShadowMaskType getShadowMaskType() const override;
 
-    void calcOvalWrapMtxCylinder(sead::Matrix34f*, sead::Matrix34f, const sead::Vector3f&, f32);
+    void calcOvalWrapMtxCylinder(sead::Matrix34f*, sead::Matrix34f, const sead::Vector3f&,
+                                 f32) const;
 
     void init(const sead::Vector3f& scale, f32 dropLength, f32 expXZ, f32 expY, f32 distYBase,
               const sead::Vector3f& offset, const sead::Color4f& color) {
-        mScale = scale;
+        setSizeX(scale.x);
+        mScaleY = scale.y;
+        mScaleZ = scale.z;
         setDropLength(dropLength);
         mExpXZ = expXZ;
         mExpY = expY;
@@ -31,7 +34,8 @@ public:
     }
 
 private:
-    sead::Vector3f mScale;
+    f32 mScaleY;
+    f32 mScaleZ;
     void* _f8;
     s32 _100;
     f32 mExpXZ;

--- a/lib/al/Library/Shadow/ShadowMaskCtrl.h
+++ b/lib/al/Library/Shadow/ShadowMaskCtrl.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <container/seadPtrArray.h>
+#include <gfx/seadColor.h>
 #include <math/seadMatrix.h>
+#include <math/seadVector.h>
 
 namespace al {
 
@@ -18,18 +20,18 @@ class ShadowMaskCtrl {
 public:
     ShadowMaskCtrl(bool);
     void appendShadowMask(ShadowMaskBase*);
-    ShadowMaskBase* findShadowMask(const char*);
+    ShadowMaskBase* findShadowMask(const char*) const;
     void hide();
     bool init(LiveActor*, const ActorInitInfo&, const ByamlIter&);
     bool init(LiveActor*, s32);
     void initAfterPlacement();
     void initShadowMaskNum(s32);
     void invalidate();
-    bool isHide();
-    void setupShadowMaskCastOvalCylinderParam(ShadowMaskCastOvalCylinder*);
-    void setupShadowMaskCubeParam(ShadowMaskCube*);
-    void setupShadowMaskCylinderParam(ShadowMaskCylinder*);
-    void setupShadowMaskSphereParam(ShadowMaskSphere*);
+    bool isHide() const;
+    void setupShadowMaskCastOvalCylinderParam(ShadowMaskCastOvalCylinder*) const;
+    void setupShadowMaskCubeParam(ShadowMaskCube*) const;
+    void setupShadowMaskCylinderParam(ShadowMaskCylinder*) const;
+    void setupShadowMaskSphereParam(ShadowMaskSphere*) const;
     void show();
     void validate();
 
@@ -37,7 +39,30 @@ public:
 
     ShadowMaskBase* getShadowMask(s32 index) const { return mShadowMasks[index]; }
 
+    ShadowMaskBase* getShadowMask(u64 index) const { return mShadowMasks.data()[index]; }
+
 private:
+    struct ShadowMaskBaseInfo {
+        void setPtr();
+        void readIter(const ByamlIter&);
+
+        const char* name;
+        const char* shadowMaskType;
+        const char* actorJointName;
+        sead::Vector3f offset;
+        sead::Color4f color;
+        bool isApplyShadowIntensityUser;
+        u8 shadowIntensityUser;
+        bool isIgnoreHide;
+        bool isFollowHostScale;
+        const char* drawCategory;
+        bool isShadowFixed;
+        u8 _41[7];
+        const char* setHeightEvenTargetName;
+    };
+
+    static_assert(sizeof(ShadowMaskBaseInfo) == 0x50);
+
     sead::PtrArray<ShadowMaskBase> mShadowMasks;
     sead::Matrix34f mMtx;
     void* mLiveActor;

--- a/lib/al/Library/Shadow/ShadowMaskCube.h
+++ b/lib/al/Library/Shadow/ShadowMaskCube.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <gfx/seadColor.h>
+#include <math/seadVector.h>
 
 #include "Library/Shadow/ShadowMaskBase.h"
 
@@ -20,12 +21,24 @@ public:
 
     void tryInitTexture(const char*);
 
+    f32 getSizeZ() const { return mSizeZ; }
+
+    void setSizeZ(f32 sizeZ) { mSizeZ = sizeZ; }
+
+    f32 getTextureFixedScale() const { return mTextureFixedScale; }
+
+    void setTextureFixedScale(f32 scale) { mTextureFixedScale = scale; }
+
+    void setTextureOffset(f32 x, f32 y) { mTextureOffset.set(x, y); }
+
+    void setTextureScroll(bool isScroll) { mIsTextureScroll = isScroll; }
+
     // TODO: assign proper parameter names
     void init(f32 a1, f32 a2, f32 dropLength, const sead::Vector3f& a4, f32 a5,
               const sead::Vector3f& offset, const sead::Color4f& color) {
-        _ec = a1;
-        _f4 = a2;
-        _f0 = 1.0f;
+        setSizeX(a1);
+        mSizeZ = a2;
+        mSizeY = 1.0f;
         setDropLength(dropLength);
         _f8.set(a4);
         _104 = a5;
@@ -35,12 +48,21 @@ public:
     }
 
 private:
-    f32 _ec;
-    f32 _f0;
-    f32 _f4;
+    f32 mSizeY;
+    f32 mSizeZ;
     sead::Vector3f _f8;
     f32 _104;
-    void* _108[46];
+    void* _108[38];
+    void* _238;
+    void* _240;
+    sead::Vector2f mTextureOffset;
+    sead::Vector2f _250;
+    sead::Vector2f _258;
+    sead::Vector2f _260;
+    sead::Vector2f _268;
+    f32 mTextureFixedScale;
+    bool mIsTextureScroll;
+    u8 _275[3];
 };
 
 static_assert(sizeof(ShadowMaskCube) == 0x278);

--- a/lib/al/Library/Shadow/ShadowMaskCylinder.h
+++ b/lib/al/Library/Shadow/ShadowMaskCylinder.h
@@ -19,7 +19,7 @@ public:
     // TODO: assign proper parameter names
     void init(f32 a1, f32 dropLength, f32 a3, f32 a4, f32 a5, const sead::Vector3f& offset,
               const sead::Color4f& color) {
-        _ec = a1;
+        setSizeX(a1);
         _f4 = a1;
         _f0 = 1.0f;
         setDropLength(dropLength);
@@ -32,7 +32,6 @@ public:
     }
 
 private:
-    f32 _ec;
     f32 _f0;
     f32 _f4;
     void* _f8;

--- a/lib/al/Library/Shadow/ShadowMaskDirector.h
+++ b/lib/al/Library/Shadow/ShadowMaskDirector.h
@@ -6,6 +6,8 @@ class ShadowMaskBase;
 class ShadowMaskDirector {
 public:
     void registerShadowMask(ShadowMaskBase*);
+    void registerUpdateShadowMask(ShadowMaskBase*);
+    void removeUpdateShadowMask(ShadowMaskBase*);
 
 private:
     void* _0[0x8D8 / 8];

--- a/lib/al/Library/Shadow/ShadowMaskSphere.h
+++ b/lib/al/Library/Shadow/ShadowMaskSphere.h
@@ -17,7 +17,10 @@ public:
     ShadowMaskType getShadowMaskType() const override;
 
 private:
-    void* _f0[2];
+    f32 _f0;
+    bool _f4;
+    u8 _f5[3];
+    f32 _f8;
 };
 
 static_assert(sizeof(ShadowMaskSphere) == 0x100);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1245)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c4d724d - 43ab53b)

📈 **Matched code**: 15.19% (+0.06%, +7900 bytes)

<details>
<summary>✅ 101 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Shadow/ActorShadowFunction` | `al::invalidateShadowMaskIntensityAll(al::LiveActor*)` | +636 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropLengthEvenWithTarget(al::ShadowMaskBase*, al::ShadowMaskBase const*, sead::Vector3<float> const&)` | +432 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::calcSphereDoBoundingInfo(sead::Vector3<float>*, sead::Vector3<float>*, float*, float*, al::LiveActor const*, char const*, float)` | +204 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::invalidateShadowMask(al::LiveActor*, al::ShadowMaskDrawCategory)` | +196 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::hideShadowMask(al::LiveActor*, al::ShadowMaskDrawCategory)` | +192 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropLengthEvenWithDrawCategory(al::LiveActor*, al::ShadowMaskDrawCategory, al::LiveActor const*, char const*)` | +180 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::showShadowMask(al::LiveActor*, al::ShadowMaskDrawCategory)` | +172 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::validateShadowMask(al::LiveActor*)` | +156 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::invalidateShadowMask(al::LiveActor*)` | +152 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropDirActorDown(al::LiveActor*)` | +148 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskSize(al::LiveActor*, char const*, sead::Vector3<float> const&)` | +148 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskSize(al::LiveActor*, char const*, float, float, float)` | +148 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::validateDepthShadowMap(al::LiveActor*)` | +136 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::getShadowMaskDropLengthMax(al::LiveActor const*)` | +136 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::invalidateDepthShadowMap(al::LiveActor*)` | +132 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::calcShadowMaskSize(sead::Vector3<float>*, al::LiveActor*, char const*)` | +124 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropLengthScaleWithDrawCategory(al::LiveActor*, float, al::ShadowMaskDrawCategory)` | +124 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropLengthWithDrawCategory(al::LiveActor*, float, al::ShadowMaskDrawCategory)` | +116 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::hideShadowMask(al::LiveActor*, char const*)` | +104 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::validateShadowMask(al::LiveActor*, char const*)` | +100 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropDir(al::LiveActor*, sead::Vector3<float> const&)` | +100 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setShadowMaskDropLengthEvenPlaneNormal(al::LiveActor const*, sead::Vector3<float> const&)` | +100 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::hideDepthShadowMap(al::LiveActor*, int)` | +96 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::hideDepthShadowMap(al::LiveActor*, char const*)` | +96 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::invalidateShadowMask(al::LiveActor*, char const*)` | +96 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::setDepthShadowMapBoundingBox(al::LiveActor const*, sead::Vector3<float> const&, sead::Vector3<float> const&, char const*)` | +96 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::showShadowMask(al::LiveActor*, char const*)` | +92 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::showDepthShadowMap(al::LiveActor*, int)` | +92 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::showDepthShadowMap(al::LiveActor*, char const*)` | +92 | 0.00% | 100.00% |
| `Library/Shadow/ActorShadowFunction` | `al::validateDepthShadowMap(al::LiveActor*, char const*)` | +92 | 0.00% | 100.00% |

...and 71 more new matches
</details>


<!-- decomp.dev report end -->