### PR TITLE
Enemy: Implement `Killer`

### DIFF
--- a/lib/al/Library/Light/LightKeeper.h
+++ b/lib/al/Library/Light/LightKeeper.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <basis/seadTypes.h>
+
 namespace al {
 class LiveActor;
 

--- a/lib/al/Library/Light/LightKeeper.h
+++ b/lib/al/Library/Light/LightKeeper.h
@@ -1,0 +1,9 @@
+#pragma once
+
+namespace al {
+class LiveActor;
+
+bool isActivePrePassLight(const LiveActor*, const char*);
+bool isExistPrePassLight(const LiveActor*, const char*);
+void killPrePassLight(const LiveActor*, const char*, s32);
+}  // namespace al

--- a/lib/al/Library/Light/LightKeeper.h
+++ b/lib/al/Library/Light/LightKeeper.h
@@ -6,4 +6,5 @@ class LiveActor;
 bool isActivePrePassLight(const LiveActor*, const char*);
 bool isExistPrePassLight(const LiveActor*, const char*);
 void killPrePassLight(const LiveActor*, const char*, s32);
+void appearPrePassLight(const LiveActor*, const char*, s32);
 }  // namespace al

--- a/src/Enemy/EnemyStateDamageCap.h
+++ b/src/Enemy/EnemyStateDamageCap.h
@@ -26,7 +26,7 @@ public:
     void exeWait();
     void exeDamageCap();
 
-    const EnemyCap* getEnemyCap() { return mEnemyCap; };
+    EnemyCap* getEnemyCap() const { return mEnemyCap; };
 
 private:
     EnemyCap* mEnemyCap = nullptr;

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -1,14 +1,13 @@
 #include "Enemy/Killer.h"
 
-#include "Enemy/EnemyStateDamageCap.h"
-#include "Enemy/KillerStateHack.h"
-#include "EnemyStateHackStart.h"
 #include "Library/Base/StringUtil.h"
 #include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Item/ItemUtil.h"
 #include "Library/Light/LightKeeper.h"
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorAnimFunction.h"
 #include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
 #include "Library/LiveActor/ActorFlagFunction.h"
 #include "Library/LiveActor/ActorInitUtil.h"
 #include "Library/LiveActor/ActorModelFunction.h"
@@ -18,9 +17,17 @@
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
+#include "Library/Player/PlayerUtil.h"
 #include "Library/Se/SeFunction.h"
 #include "Library/Shadow/ActorShadowUtil.h"
+
+#include "Enemy/EnemyCap.h"
+#include "Enemy/EnemyStateDamageCap.h"
+#include "Enemy/EnemyStateHackStart.h"
+#include "Enemy/KillerStateHack.h"
 #include "System/GameDataFunction.h"
+#include "Util/ItemUtil.h"
+#include "Util/PlayerUtil.h"
 #include "Util/SensorMsgFunction.h"
 #include "Util/SpecialBuildUtil.h"
 
@@ -161,8 +168,173 @@ void Killer::explode() {
     al::setNerve(this, &NrvKiller.Explode);
 }
 
-// bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self)
-// {}
+bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if ((al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
+         al::isNerve(this, &NrvKiller.Launch) || al::isNerve(this, &NrvKiller.Explode) ||
+         al::isNerve(this, &NrvKiller.FallDown)) &&
+        rs::isMsgPlayerDisregardHomingAttack(message)) {
+        return true;
+    }
+
+    if (rs::isMsgCapCancelLockOn(message))
+        return true;
+
+    if (al::isDead(this))
+        return false;
+
+    if (al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
+        al::isNerve(this, &NrvKiller.Launch)) {
+        if (mIsMagnum && rs::isMsgCapReflect(message)) {
+            rs::requestHitReactionToAttacker(message, self, other);
+
+            return true;
+        }
+
+        return false;
+    }
+
+    if (al::isNerve(this, &NrvKiller.Explode))
+        return false;
+
+    if (al::isNerve(this, &NrvKiller.FallDown))
+        return false;
+
+    if (al::isSensorName(self, "AttackMagnum"))
+        return false;
+
+    if (al::isNerve(this, &NrvKiller.Hack)) {
+        if (mKillerStateHack->receiveMsgHackEnd(message, other, self)) {
+            if (rs::isModeE3MovieRom())
+                EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
+
+            _120 = 20;
+            al::endBgmSituation(this, "Capture", false);
+            al::hideSilhouetteModelIfShow(this);
+            _134 = false;
+
+            if (!al::isNerve(this, &NrvKiller.Explode))
+                al::setNerve(this, &NrvKiller.AfterHack);
+
+            return true;
+        }
+
+        if (mKillerStateHack->receiveMsgHackEndExplode(message, other, self)) {
+            if (!mIsMagnum && mKillerStateHack->isEnableExplode()) {
+                _134 = false;
+                explode();
+            }
+
+            return true;
+        }
+    }
+
+    if ((rs::isMsgCapStartLockOn(message) || rs::isMsgCapKeepLockOn(message)) &&
+        !mEnemyStateDamageCap->isCapOn()) {
+        if (!al::isNerve(this, &NrvKiller.DamageCap) || al::isGreaterEqualStep(this, 8))
+            return true;
+    }
+
+    if (mKillerStateHack->receiveMsgInitCapTargetInfo(message))
+        return true;
+
+    if (mKillerStateHack->receiveMsgHackStart(message, other, self)) {
+        al::onCollide(this);
+        al::setVelocityZero(this);
+        resetAliveCountAndAnim();
+        al::startBgmSituation(this, "Capture", false);
+
+        if (_135) {
+            _11c = mIsMagnum ? 1850.0f : 900.0f;
+            al::startVisAnim(this, "HackOff");
+            al::startMclAnim(this, "HackOff");
+            _135 = false;
+        }
+
+        al::showModelIfHide(this);
+        al::setNerve(this, &NrvKiller.Hack);
+
+        return true;
+    }
+
+    if (rs::isMsgKillerMagnumAttack(message)) {
+        if (!al::isNerve(this, &NrvKiller.Hack) || !mIsMagnum)
+            explode();
+
+        return true;
+    }
+
+    if (rs::isMsgCactusNeedleAttack(message)) {
+        if (!mIsMagnum)
+            explode();
+
+        return false;
+    }
+
+    if (rs::isMsgSandGeyserRaise(message)) {
+        if (!mIsMagnum)
+            explode();
+
+        return true;
+    }
+
+    if (al::isMsgExplosion(message) || rs::isMsgBlowDown(message)) {
+        rs::requestHitReactionToAttacker(message, self, other);
+
+        if (!mIsMagnum)
+            explode();
+
+        return true;
+    }
+
+    if (mIsMagnum && al::tryReceiveMsgPushAndAddVelocityH(this, message, other, self, 1.0f))
+        return true;
+
+    if (al::isNerve(this, &NrvKiller.Hack))
+        return mKillerStateHack->receiveMsg(message, other, self);
+
+    if (mKillerStateHack->receiveMsgNpcScareByEnemy(message))
+        return true;
+
+    if (rs::isMsgKillerMagnumHackAttack(message)) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        explode();
+        al::appearItem(this);
+
+        return true;
+    }
+
+    if (mEnemyStateDamageCap->tryReceiveMsgCapBlow(message, other, self)) {
+        al::setNerve(this, &NrvKiller.DamageCap);
+
+        return true;
+    }
+
+    if (rs::isMsgKillByShineGet(message)) {
+        kill();
+
+        return true;
+    }
+
+    if (rs::isMsgMeganeAttack(message)) {
+        explode();
+
+        return true;
+    }
+
+    if (!rs::isMsgPlayerAndCapObjHipDropReflectAll(message) && !rs::isMsgPressDown(message))
+        return false;
+
+    if (_120 <= 0) {
+        rs::requestHitReactionToAttacker(message, self, other);
+        rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
+        al::setNerve(this, &NrvKiller.FallDown);
+
+        return true;
+    }
+
+    return false;
+}
 
 void Killer::resetAliveCountAndAnim() {
     if (!_135)
@@ -242,4 +414,179 @@ void Killer::forceExplode() {
 
 bool Killer::isHack() const {
     return al::isNerve(this, &NrvKiller.Hack);
+}
+
+void Killer::exeAppear() {
+    if (al::isFirstStep(this)) {
+        al::offCollide(this);
+
+        if (mIsCapKoopa && !_137)
+            al::hideModelIfShow(mEnemyStateDamageCap->getEnemyCap());
+    }
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvKiller.StandBy);
+}
+
+void Killer::exeStandBy() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "StandBy");
+}
+
+void Killer::exeLaunch() {
+    if (al::isFirstStep(this) && mIsCapKoopa && !_137) {
+        al::showModelIfHide(mEnemyStateDamageCap->getEnemyCap());
+        al::startAction(mEnemyStateDamageCap->getEnemyCap(), "AppearKillerMagnum");
+    }
+
+    applyVelocityDamp();
+
+    if (al::isGreaterEqualStep(this, mIsMagnum ? 40 : 25)) {
+        al::onCollide(this);
+        al::setNerve(this, &NrvKiller.Fly);
+    }
+}
+
+void Killer::applyVelocityDamp() {
+    al::addVelocityToFront(this, mIsMagnum ? 1.72f : 0.63f);
+    al::scaleVelocity(this, mIsMagnum ? 0.90f : 0.95f);
+}
+
+bool FUN_7100146a14(Killer*, bool);
+
+void Killer::exeFly() {
+    if (al::isFirstStep(this)) {
+        _134 = true;
+        al::startAction(this, "FlyWait");
+        al::tryStartSe(this, "PgMoveEnemyMeLv");
+    }
+
+    al::LiveActor* player = al::tryFindNearestPlayerActor(this);
+    if (player && !rs::isPlayer2D(this)) {
+        const sead::Vector3f& playerTrans = al::getTrans(player);
+        f32 distance = al::calcDistance(this, playerTrans);
+        f32 fVar5 = mIsMagnum ? 0.4f : 2.4f;
+
+        if (distance < (mIsMagnum ? 700.0f : 1100.0f))
+            fVar5 *= distance / (mIsMagnum ? 700.0f : 1100.0f);
+
+        al::turnToTarget(this, playerTrans, fVar5);
+    }
+
+    applyVelocityDamp();
+
+    if (FUN_7100146a14(this, mIsMagnum))
+        explode();
+}
+
+bool FUN_7100146a14(Killer* killer, bool isMagnum) {
+    al::HitSensor* wallSensor = al::tryGetCollidedWallSensor(killer);
+    if (wallSensor) {
+        if (al::getCollidedWallNormal(killer).dot(al::getVelocity(killer)) > -0.2f)
+            return false;
+
+        if (al::sendMsgExplosion(wallSensor, al::getHitSensor(killer, "Attack"), nullptr) &&
+            isMagnum)
+            return false;
+
+        return true;
+    }
+
+    if (al::isOnGround(killer, 0) &&
+        al::calcAngleDegree(sead::Vector3f::ey, al::getCollidedGroundNormal(killer)) > 44.0f) {
+        al::sendMsgExplosion(al::getCollidedGroundSensor(killer),
+                             al::getHitSensor(killer, "Attack"), nullptr);
+
+        return true;
+    }
+
+    return false;
+}
+
+void Killer::exeExplode() {
+    if (al::isFirstStep(this)) {
+        al::hideSilhouetteModelIfShow(this);
+        al::validateHitSensor(this, "Explosion");
+        al::validateHitSensor(this, "ExplosionToPlayer");
+        al::setVelocityZero(this);
+        al::startAction(this, "Explosion");
+        al::hideModelIfShow(this);
+    }
+
+    f32 rate = al::calcNerveRate(this, 5);
+    al::setSensorRadius(this, "Explosion", al::lerpValue(0.0, 200.0, rate));
+    al::setSensorRadius(this, "ExplosionToPlayer", al::lerpValue(0.0, 100.0, rate));
+
+    if (al::isGreaterEqualStep(this, 5)) {
+        mEnemyStateDamageCap->makeActorDeadCap();
+        al::setSensorRadius(this, "Explosion", 0.0);
+        al::setSensorRadius(this, "ExplosionToPlayer", 0.0);
+        al::invalidateHitSensor(this, "Explosion");
+        al::invalidateHitSensor(this, "ExplosionToPlayer");
+        kill();
+    }
+}
+
+void Killer::exeDamageCap() {
+    if (al::isFirstStep(this))
+        al::setVelocityZero(this);
+
+    if (al::updateNerveState(this) && (!mIsMagnum || al::isGreaterEqualStep(this, 50)))
+        al::setNerve(this, &NrvKiller.Fly);
+}
+
+void Killer::exeHack() {
+    if (al::isFirstStep(this))
+        _134 = false;
+
+    if (!al::updateNerveState(this)) {
+        if (!FUN_7100146a14(this, mIsMagnum))
+            return;
+
+        al::startVisAnim(this, "HackOff");
+        al::startMclAnim(this, "HackOff");
+    }
+
+    explode();
+}
+
+void Killer::exeAfterHack() {
+    if (al::isFirstStep(this)) {
+        al::startVisAnim(this, "HackOff");
+        al::startMclAnim(this, "Default");
+        al::startAction(this, "HackEnd");
+        al::tryStartSe(this, "PgMoveEnemyMeLv");
+        EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
+        al::invalidateClipping(this);
+    }
+
+    applyVelocityDamp();
+
+    if (al::isActionPlaying(this, "HackEnd") && al::isActionEnd(this))
+        al::startAction(this, "FlyWait");
+
+    if (al::isGreaterEqualStep(this, mIsMagnum ? 180 : 280)) {
+        _134 = true;
+        al::setNerve(this, &NrvKiller.Fly);
+    } else if (FUN_7100146a14(this, mIsMagnum)) {
+        explode();
+    }
+}
+
+void Killer::exeFallDown() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "FallDown");
+        al::setVelocityZero(this);
+        al::addVelocityToGravity(this, -20.0f);
+    }
+
+    al::addVelocityToGravity(this, 1.75f);
+    al::scaleVelocity(this, mIsMagnum ? 0.90f : 0.95f);
+
+    if (al::isActionEnd(this) || al::isOnGround(this, 0)) {
+        al::startHitReaction(this, "死亡");
+        al::appearItem(this);
+        mEnemyStateDamageCap->makeActorDeadCap();
+        kill();
+    }
 }

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -1,0 +1,190 @@
+#include "Enemy/Killer.h"
+
+#include "Enemy/EnemyStateDamageCap.h"
+#include "Enemy/KillerStateHack.h"
+#include "EnemyStateHackStart.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Light/LightKeeper.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Se/SeFunction.h"
+#include "System/GameDataFunction.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(Killer, Fly)
+NERVE_IMPL(Killer, DamageCap)
+NERVE_IMPL(Killer, Hack)
+NERVE_IMPL(Killer, FallDown)
+NERVE_IMPL(Killer, Explode)
+NERVE_IMPL(Killer, AfterHack)
+NERVE_IMPL(Killer, Appear)
+NERVE_IMPL(Killer, StandBy)
+NERVE_IMPL(Killer, Launch)
+
+NERVES_MAKE_STRUCT(Killer, Fly, DamageCap, Hack, FallDown, Explode, AfterHack, Appear, StandBy,
+                   Launch)
+}  // namespace
+
+Killer::Killer(const char* name) : al::LiveActor(name) {}
+
+void Killer::init(const al::ActorInitInfo& info) {
+    if (!mIsMagnum)
+        al::initActorWithArchiveName(this, info, "Killer", nullptr);
+    else
+        al::initActorWithArchiveName(this, info, "KillerMagnum", nullptr);
+
+    al::initNerve(this, &NrvKiller.Fly, 3);
+    mEnemyStateDamageCap = new EnemyStateDamageCap(this);
+
+    if (!_137) {
+        if (mIsMagnum || al::isEqualString(GameDataFunction::getCurrentStageName(this),
+                                           "MoonWorldCaptureParadeStage")) {
+            mIsCapKoopa = true;
+        }
+
+        if (mIsCapKoopa) {
+            mEnemyStateDamageCap->createEnemyCap(info, "EnemyCapKoopa");
+            mEnemyStateDamageCap->makeActorDeadCap();
+        } else {
+            mEnemyStateDamageCap->createEnemyCap(info, "EnemyCapKiller");
+            mEnemyStateDamageCap->makeActorDeadCap();
+        }
+    }
+
+    al::initNerveState(this, mEnemyStateDamageCap, &NrvKiller.DamageCap, "帽子ふきとび");
+    mKillerStateHack = new KillerStateHack(this, mIsMagnum, _138);
+    al::initNerveState(this, mKillerStateHack, &NrvKiller.Hack, "キャプチャ");
+    al::setSensorRadius(this, "Explosion", 0.0f);
+    al::setSensorRadius(this, "ExplosionToPlayer", 0.0f);
+    al::invalidateHitSensor(this, "Explosion");
+    al::invalidateHitSensor(this, "ExplosionToPlayer");
+
+    if (al::isExistPrePassLight(this, "Front") && al::isActivePrePassLight(this, "Front"))
+        al::killPrePassLight(this, "Front", -1);
+
+    al::setSeUserSyncParamPtr(this, &_130, "回転角");
+
+    makeActorAlive();
+}
+
+void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
+        al::isNerve(this, &NrvKiller.Launch)) {
+        if (mIsMagnum)
+            rs::sendMsgPushToPlayer(other, self);
+
+        return;
+    }
+
+    if (al::isNerve(this, &NrvKiller.FallDown))
+        return;
+
+    if (_13c < 1 && rs::sendMsgKillerAttackNoExplode(other, self)) {
+        _13c = 40;
+
+        return;
+    }
+
+    if (al::isNerve(this, &NrvKiller.Hack) &&
+        mKillerStateHack->attackSensorCheckExplode(self, other)) {
+        explode();
+    }
+
+    if (al::isSensorName(self, "AttackMagnum")) {
+        if (mIsMagnum)
+            rs::sendMsgKillerMagnumAttack(other, self);
+
+        return;
+    }
+
+    if (al::isNerve(this, &NrvKiller.Explode)) {
+        if (al::isSensorPlayer(other)) {
+            if (_134 && al::isSensorName(self, "ExplosionToPlayer"))
+                al::sendMsgExplosion(other, self, nullptr);
+        } else if (al::isSensorName(self, "Explosion")) {
+            al::sendMsgExplosion(other, self, nullptr);
+        }
+
+        return;
+    }
+
+    if (al::isSensorEnemyAttack(self)) {
+        if (al::sendMsgExplosion(other, self, nullptr) && !mIsMagnum) {
+            explode();
+
+            return;
+        }
+
+        if (al::sendMsgPush(other, self)) {
+            if (!mIsMagnum)
+                explode();
+
+            return;
+        }
+    }
+
+    if (al::isSensorEnemyAttack(self) && al::isSensorPlayer(other)) {
+        if (!al::isNerve(this, &NrvKiller.AfterHack) && _134 &&
+            al::sendMsgExplosion(other, self, nullptr)) {
+            explode();
+
+            return;
+        }
+
+        rs::sendMsgPushToPlayer(other, self);
+    }
+}
+
+void Killer::explode() {
+    if (al::isNerve(this, &NrvKiller.Hack)) {
+        if (!mKillerStateHack->isEnableExplode())
+            return;
+
+        mKillerStateHack->endHackExplode();
+        al::endBgmSituation(this, "Capture", false);
+        al::hideSilhouetteModelIfShow(this);
+    }
+
+    al::tryStopSe(this, "PgMoveEnemyMeLv", -1, nullptr);
+    al::setNerve(this, &NrvKiller.Explode);
+}
+
+// bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self)
+// {}
+
+void Killer::resetAliveCountAndAnim() {
+    if (!_135)
+        return;
+
+    _11c = _118;
+    al::startVisAnim(this, "HackOff");
+    al::startMclAnim(this, "HackOff");
+}
+
+// void Killer::control() {}
+
+void Killer::appearBy2D(const sead::Vector3f& position, const sead::Vector3f& velocity,
+                        const sead::Quatf& rotation, s32 param_4) {
+    al::resetPosition(this, position);
+    al::setQuat(this, rotation);
+    appearInit();
+    al::setVelocity(this, velocity);
+    al::startAction(this, "FlyWait");
+    al::startVisAnim(this, "HackOff");
+    EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
+    _118 = param_4;
+    _11c = _118;
+    al::setNerve(this, &NrvKiller.Fly);
+    appear();
+    al::invalidateClipping(this);
+}

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -14,6 +14,7 @@
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
 #include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
@@ -45,6 +46,8 @@ NERVE_IMPL(Killer, Launch)
 NERVES_MAKE_STRUCT(Killer, Fly, DamageCap, Hack, FallDown, Explode, AfterHack, Appear, StandBy,
                    Launch)
 }  // namespace
+
+const sead::Vector3f g_71018a084 = {0.0f, 0.0f, 100.0f};
 
 Killer::Killer(const char* name) : al::LiveActor(name) {}
 
@@ -345,7 +348,82 @@ void Killer::resetAliveCountAndAnim() {
     al::startMclAnim(this, "HackOff");
 }
 
-// void Killer::control() {}
+void Killer::control() {
+    if (!al::isNerve(this, &NrvKiller.Hack) && _138) {
+        if (al::isAlive(al::getSubActor(this, "キラーアイライト")))
+            al::getSubActor(this, "キラーアイライト")->kill();
+
+        if (al::isExistPrePassLight(this, "Front") && al::isActivePrePassLight(this, "Front"))
+            al::killPrePassLight(this, "Front", -1);
+    }
+
+    if (_13c > 0)
+        _13c--;
+
+    sead::Vector3f front;
+    al::calcFrontDir(&front, this);
+
+    if (!al::isNerve(this, &NrvKiller.Hack) || !mKillerStateHack->isStarting()) {
+        f32 angle = al::calcAngleOnPlaneDegree(front, _124, sead::Vector3f::ey);
+        f32 rate;
+        if (!mIsMagnum)
+            rate = 1.2f;
+        else if (al::isNerve(this, &NrvKiller.Hack))
+            rate = 2.0f;
+        else
+            rate = 0.7f;
+
+        angle *= rate;
+
+        _130 = (_130 + angle) * 0.9f;
+        sead::Quatf quat;
+        al::makeQuatFrontUp(&quat, front, sead::Vector3f::ey);
+        al::setQuat(this, quat);
+        // TODO: check axis because Y is strange here
+        al::rotateQuatLocalDirDegree(this, static_cast<s32>(al::Axis::Y), _130);
+    }
+
+    _124.set(front);
+
+    if (_120 > 0)
+        _120--;
+
+    if (al::isNerve(this, &NrvKiller.Explode) || al::isNerve(this, &NrvKiller.FallDown) ||
+        al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
+        (al::isNerve(this, &NrvKiller.Hack) && mKillerStateHack->isStarting()))
+        return;
+
+    if (al::isNerve(this, &NrvKiller.Hack)) {
+        if (_11c > 180.0f)
+            if (!mIsMagnum)
+                _11c -= sead::Mathf::min(al::getVelocity(this).length() / 10.8f, 3.8f);
+            else
+                _11c -= sead::Mathf::min(al::getVelocity(this).length() / 18.4f, 3.15f);
+        else
+            _11c--;
+
+        if (_138) {
+            sead::Vector3f trans;
+            al::calcTransLocalOffset(&trans, this, g_71018a084);
+            al::setTrans(al::getSubActor(this, "キラーアイライト"), trans);
+            al::setQuat(al::getSubActor(this, "キラーアイライト"), al::getQuat(this));
+            if (al::isExistPrePassLight(this, "Front") && !al::isActivePrePassLight(this, "Front"))
+                al::appearPrePassLight(this, "Front", -1);
+        }
+    } else {
+        _11c--;
+    }
+
+    if (_11c <= 180.0f) {
+        al::tryStartMclAnimIfNotPlaying(this, "SignExplosion");
+
+        if (al::isNerve(this, &NrvKiller.Hack))
+            al::holdSe(this, "ExplodeSign");
+    }
+
+    if (_11c <= 0.0f)
+        explode();
+}
 
 void Killer::appearBy2D(const sead::Vector3f& position, const sead::Vector3f& velocity,
                         const sead::Quatf& rotation, s32 param_4) {

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -86,7 +86,7 @@ void Killer::init(const al::ActorInitInfo& info) {
     if (al::isExistPrePassLight(this, "Front") && al::isActivePrePassLight(this, "Front"))
         al::killPrePassLight(this, "Front", -1);
 
-    al::setSeUserSyncParamPtr(this, &_130, "回転角");
+    al::setSeUserSyncParamPtr(this, &mRotationAngle, "回転角");
 
     makeActorAlive();
 }
@@ -121,7 +121,7 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 
     if (al::isNerve(this, &NrvKiller.Explode)) {
         if (al::isSensorPlayer(other)) {
-            if (_134 && al::isSensorName(self, "ExplosionToPlayer"))
+            if (mHasExplosion && al::isSensorName(self, "ExplosionToPlayer"))
                 al::sendMsgExplosion(other, self, nullptr);
         } else if (al::isSensorName(self, "Explosion")) {
             al::sendMsgExplosion(other, self, nullptr);
@@ -146,7 +146,7 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     }
 
     if (al::isSensorEnemyAttack(self) && al::isSensorPlayer(other)) {
-        if (!al::isNerve(this, &NrvKiller.AfterHack) && _134 &&
+        if (!al::isNerve(this, &NrvKiller.AfterHack) && mHasExplosion &&
             al::sendMsgExplosion(other, self, nullptr)) {
             explode();
 
@@ -213,7 +213,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
             _120 = 20;
             al::endBgmSituation(this, "Capture", false);
             al::hideSilhouetteModelIfShow(this);
-            _134 = false;
+            mHasExplosion = false;
 
             if (!al::isNerve(this, &NrvKiller.Explode))
                 al::setNerve(this, &NrvKiller.AfterHack);
@@ -223,7 +223,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
 
         if (mKillerStateHack->receiveMsgHackEndExplode(message, other, self)) {
             if (!mIsMagnum && mKillerStateHack->isEnableExplode()) {
-                _134 = false;
+                mHasExplosion = false;
                 explode();
             }
 
@@ -247,7 +247,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
         al::startBgmSituation(this, "Capture", false);
 
         if (_135) {
-            _11c = mIsMagnum ? 1850.0f : 900.0f;
+            mExplosionTime = mIsMagnum ? 1850.0f : 900.0f;
             al::startVisAnim(this, "HackOff");
             al::startMclAnim(this, "HackOff");
             _135 = false;
@@ -343,7 +343,7 @@ void Killer::resetAliveCountAndAnim() {
     if (!_135)
         return;
 
-    _11c = _118;
+    mExplosionTime = mAliveFrame;
     al::startVisAnim(this, "HackOff");
     al::startMclAnim(this, "HackOff");
 }
@@ -364,7 +364,7 @@ void Killer::control() {
     al::calcFrontDir(&front, this);
 
     if (!al::isNerve(this, &NrvKiller.Hack) || !mKillerStateHack->isStarting()) {
-        f32 angle = al::calcAngleOnPlaneDegree(front, _124, sead::Vector3f::ey);
+        f32 angle = al::calcAngleOnPlaneDegree(front, mFrontDir, sead::Vector3f::ey);
         f32 rate;
         if (!mIsMagnum)
             rate = 1.2f;
@@ -375,15 +375,15 @@ void Killer::control() {
 
         angle *= rate;
 
-        _130 = (_130 + angle) * 0.9f;
+        mRotationAngle = (mRotationAngle + angle) * 0.9f;
         sead::Quatf quat;
         al::makeQuatFrontUp(&quat, front, sead::Vector3f::ey);
         al::setQuat(this, quat);
         // TODO: check axis because Y is strange here
-        al::rotateQuatLocalDirDegree(this, static_cast<s32>(al::Axis::Y), _130);
+        al::rotateQuatLocalDirDegree(this, static_cast<s32>(al::Axis::Y), mRotationAngle);
     }
 
-    _124.set(front);
+    mFrontDir.set(front);
 
     if (_120 > 0)
         _120--;
@@ -394,13 +394,13 @@ void Killer::control() {
         return;
 
     if (al::isNerve(this, &NrvKiller.Hack)) {
-        if (_11c > 180.0f)
+        if (mExplosionTime > 180.0f)
             if (!mIsMagnum)
-                _11c -= sead::Mathf::min(al::getVelocity(this).length() / 10.8f, 3.8f);
+                mExplosionTime -= sead::Mathf::min(al::getVelocity(this).length() / 10.8f, 3.8f);
             else
-                _11c -= sead::Mathf::min(al::getVelocity(this).length() / 18.4f, 3.15f);
+                mExplosionTime -= sead::Mathf::min(al::getVelocity(this).length() / 18.4f, 3.15f);
         else
-            _11c--;
+            mExplosionTime--;
 
         if (mIsUseCaptureLight) {
             sead::Vector3f trans;
@@ -411,22 +411,22 @@ void Killer::control() {
                 al::appearPrePassLight(this, "Front", -1);
         }
     } else {
-        _11c--;
+        mExplosionTime--;
     }
 
-    if (_11c <= 180.0f) {
+    if (mExplosionTime <= 180.0f) {
         al::tryStartMclAnimIfNotPlaying(this, "SignExplosion");
 
         if (al::isNerve(this, &NrvKiller.Hack))
             al::holdSe(this, "ExplodeSign");
     }
 
-    if (_11c <= 0.0f)
+    if (mExplosionTime <= 0.0f)
         explode();
 }
 
 void Killer::appearBy2D(const sead::Vector3f& position, const sead::Vector3f& velocity,
-                        const sead::Quatf& rotation, s32 param_4) {
+                        const sead::Quatf& rotation, s32 aliveFrame) {
     al::resetPosition(this, position);
     al::setQuat(this, rotation);
     appearInit();
@@ -434,8 +434,8 @@ void Killer::appearBy2D(const sead::Vector3f& position, const sead::Vector3f& ve
     al::startAction(this, "FlyWait");
     al::startVisAnim(this, "HackOff");
     EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
-    _118 = param_4;
-    _11c = _118;
+    mAliveFrame = aliveFrame;
+    mExplosionTime = mAliveFrame;
     al::setNerve(this, &NrvKiller.Fly);
     appear();
     al::invalidateClipping(this);
@@ -447,14 +447,14 @@ void Killer::appearInit() {
     al::showModelIfHide(this);
     resetAliveCountAndAnim();
 
-    _134 = true;
+    mHasExplosion = true;
     _135 = true;
-    al::calcFrontDir(&_124, this);
-    _130 = 0.0;
+    al::calcFrontDir(&mFrontDir, this);
+    mRotationAngle = 0.0;
     sead::Quatf quat;
-    al::makeQuatFrontUp(&quat, _124, sead::Vector3f::ey);
+    al::makeQuatFrontUp(&quat, mFrontDir, sead::Vector3f::ey);
     al::setQuat(this, quat);
-    al::calcFrontDir(&_124, this);
+    al::calcFrontDir(&mFrontDir, this);
     al::hideSilhouetteModelIfShow(this);
 }
 
@@ -479,9 +479,9 @@ void Killer::standByAppear(const sead::Vector3f& position, const sead::Quatf& ro
     al::invalidateClipping(this);
 }
 
-void Killer::launch(s32 param_1) {
-    _118 = param_1;
-    _11c = _118;
+void Killer::launch(s32 aliveFrame) {
+    mAliveFrame = aliveFrame;
+    mExplosionTime = mAliveFrame;
     al::startAction(this, "FlyWaitStart");
     al::setNerve(this, &NrvKiller.Launch);
 }
@@ -534,7 +534,7 @@ bool FUN_7100146a14(Killer*, bool);
 
 void Killer::exeFly() {
     if (al::isFirstStep(this)) {
-        _134 = true;
+        mHasExplosion = true;
         al::startAction(this, "FlyWait");
         al::tryStartSe(this, "PgMoveEnemyMeLv");
     }
@@ -615,7 +615,7 @@ void Killer::exeDamageCap() {
 
 void Killer::exeHack() {
     if (al::isFirstStep(this))
-        _134 = false;
+        mHasExplosion = false;
 
     if (!al::updateNerveState(this)) {
         if (!FUN_7100146a14(this, mIsMagnum))
@@ -644,7 +644,7 @@ void Killer::exeAfterHack() {
         al::startAction(this, "FlyWait");
 
     if (al::isGreaterEqualStep(this, mIsMagnum ? 180 : 280)) {
-        _134 = true;
+        mHasExplosion = true;
         al::setNerve(this, &NrvKiller.Fly);
     } else if (FUN_7100146a14(this, mIsMagnum)) {
         explode();

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -77,8 +77,8 @@ void Killer::init(const al::ActorInitInfo& info) {
     }
 
     al::initNerveState(this, mEnemyStateDamageCap, &NrvKiller.DamageCap, "帽子ふきとび");
-    mKillerStateHack = new KillerStateHack(this, mIsMagnum, mIsUseCaptureLight);
-    al::initNerveState(this, mKillerStateHack, &NrvKiller.Hack, "キャプチャ");
+    mStateHack = new KillerStateHack(this, mIsMagnum, mIsUseCaptureLight);
+    al::initNerveState(this, mStateHack, &NrvKiller.Hack, "キャプチャ");
     al::setSensorRadius(this, "Explosion", 0.0f);
     al::setSensorRadius(this, "ExplosionToPlayer", 0.0f);
     al::invalidateHitSensor(this, "Explosion");
@@ -104,13 +104,13 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     if (al::isNerve(this, &NrvKiller.FallDown))
         return;
 
-    if (_13c < 1 && rs::sendMsgKillerAttackNoExplode(other, self)) {
-        _13c = 40;
+    if (mAttackCooldown < 1 && rs::sendMsgKillerAttackNoExplode(other, self)) {
+        mAttackCooldown = 40;
 
         return;
     }
 
-    if (isHack() && mKillerStateHack->attackSensorCheckExplode(self, other))
+    if (isHack() && mStateHack->attackSensorCheckExplode(self, other))
         explode();
 
     if (al::isSensorName(self, "AttackMagnum")) {
@@ -122,7 +122,7 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 
     if (al::isNerve(this, &NrvKiller.Explode)) {
         if (al::isSensorPlayer(other)) {
-            if (mHasExplosion && al::isSensorName(self, "ExplosionToPlayer"))
+            if (mCanExplode && al::isSensorName(self, "ExplosionToPlayer"))
                 al::sendMsgExplosion(other, self, nullptr);
         } else if (al::isSensorName(self, "Explosion")) {
             al::sendMsgExplosion(other, self, nullptr);
@@ -147,7 +147,7 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
     }
 
     if (al::isSensorEnemyAttack(self) && al::isSensorPlayer(other)) {
-        if (!al::isNerve(this, &NrvKiller.AfterHack) && mHasExplosion &&
+        if (!al::isNerve(this, &NrvKiller.AfterHack) && mCanExplode &&
             al::sendMsgExplosion(other, self, nullptr)) {
             explode();
 
@@ -160,10 +160,10 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 
 void Killer::explode() {
     if (isHack()) {
-        if (!mKillerStateHack->isEnableExplode())
+        if (!mStateHack->isEnableExplode())
             return;
 
-        mKillerStateHack->endHackExplode();
+        mStateHack->endHackExplode();
         al::endBgmSituation(this, "Capture", false);
         al::hideSilhouetteModelIfShow(this);
     }
@@ -207,14 +207,14 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
         return false;
 
     if (isHack()) {
-        if (mKillerStateHack->receiveMsgHackEnd(message, other, self)) {
+        if (mStateHack->receiveMsgHackEnd(message, other, self)) {
             if (rs::isModeE3MovieRom())
                 EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
 
-            _120 = 20;
+            mHackEndImmuneTime = 20;
             al::endBgmSituation(this, "Capture", false);
             al::hideSilhouetteModelIfShow(this);
-            mHasExplosion = false;
+            mCanExplode = false;
 
             if (!al::isNerve(this, &NrvKiller.Explode))
                 al::setNerve(this, &NrvKiller.AfterHack);
@@ -222,9 +222,9 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
             return true;
         }
 
-        if (mKillerStateHack->receiveMsgHackEndExplode(message, other, self)) {
-            if (!mIsMagnum && mKillerStateHack->isEnableExplode()) {
-                mHasExplosion = false;
+        if (mStateHack->receiveMsgHackEndExplode(message, other, self)) {
+            if (!mIsMagnum && mStateHack->isEnableExplode()) {
+                mCanExplode = false;
                 explode();
             }
 
@@ -238,20 +238,20 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
             return true;
     }
 
-    if (mKillerStateHack->receiveMsgInitCapTargetInfo(message))
+    if (mStateHack->receiveMsgInitCapTargetInfo(message))
         return true;
 
-    if (mKillerStateHack->receiveMsgHackStart(message, other, self)) {
+    if (mStateHack->receiveMsgHackStart(message, other, self)) {
         al::onCollide(this);
         al::setVelocityZero(this);
         resetAliveCountAndAnim();
         al::startBgmSituation(this, "Capture", false);
 
-        if (_135) {
+        if (mIsFirstCapture) {
             mExplosionTime = mIsMagnum ? 1850.0f : 900.0f;
             al::startVisAnim(this, "HackOff");
             al::startMclAnim(this, "HackOff");
-            _135 = false;
+            mIsFirstCapture = false;
         }
 
         al::showModelIfHide(this);
@@ -294,9 +294,9 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
         return true;
 
     if (isHack())
-        return mKillerStateHack->receiveMsg(message, other, self);
+        return mStateHack->receiveMsg(message, other, self);
 
-    if (mKillerStateHack->receiveMsgNpcScareByEnemy(message))
+    if (mStateHack->receiveMsgNpcScareByEnemy(message))
         return true;
 
     if (rs::isMsgKillerMagnumHackAttack(message)) {
@@ -327,7 +327,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     }
 
     if ((rs::isMsgPlayerAndCapObjHipDropReflectAll(message) || rs::isMsgPressDown(message)) &&
-        _120 <= 0) {
+        mHackEndImmuneTime <= 0) {
         rs::requestHitReactionToAttacker(message, self, other);
         rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
         al::setNerve(this, &NrvKiller.FallDown);
@@ -339,7 +339,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
 }
 
 void Killer::resetAliveCountAndAnim() {
-    if (!_135)
+    if (!mIsFirstCapture)
         return;
 
     mExplosionTime = mAliveFrame;
@@ -356,15 +356,15 @@ void Killer::control() {
             al::killPrePassLight(this, "Front", -1);
     }
 
-    if (_13c > 0)
-        _13c--;
+    if (mAttackCooldown > 0)
+        mAttackCooldown--;
 
     sead::Vector3f front;
     al::calcFrontDir(&front, this);
 
     // adds roll based on current horizontal rotation speed
-    if (!isHack() || !mKillerStateHack->isStarting()) {
-        f32 angle = al::calcAngleOnPlaneDegree(front, mFrontDir, sead::Vector3f::ey);
+    if (!isHack() || !mStateHack->isStarting()) {
+        f32 angle = al::calcAngleOnPlaneDegree(front, mLastFrontDir, sead::Vector3f::ey);
         f32 rate;
         if (!mIsMagnum)
             rate = 1.2f;
@@ -382,14 +382,14 @@ void Killer::control() {
         al::rotateQuatLocalDirDegree(this, 2 /* axis Z */, mRotationAngle);
     }
 
-    mFrontDir.set(front);
+    mLastFrontDir.set(front);
 
-    if (_120 > 0)
-        _120--;
+    if (mHackEndImmuneTime > 0)
+        mHackEndImmuneTime--;
 
     if (al::isNerve(this, &NrvKiller.Explode) || al::isNerve(this, &NrvKiller.FallDown) ||
         al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
-        (isHack() && mKillerStateHack->isStarting()))
+        (isHack() && mStateHack->isStarting()))
         return;
 
     if (isHack()) {
@@ -446,14 +446,14 @@ void Killer::appearInit() {
     al::showModelIfHide(this);
     resetAliveCountAndAnim();
 
-    mHasExplosion = true;
-    _135 = true;
-    al::calcFrontDir(&mFrontDir, this);
+    mCanExplode = true;
+    mIsFirstCapture = true;
+    al::calcFrontDir(&mLastFrontDir, this);
     mRotationAngle = 0.0f;
     sead::Quatf quat;
-    al::makeQuatFrontUp(&quat, mFrontDir, sead::Vector3f::ey);
+    al::makeQuatFrontUp(&quat, mLastFrontDir, sead::Vector3f::ey);
     al::setQuat(this, quat);
-    al::calcFrontDir(&mFrontDir, this);
+    al::calcFrontDir(&mLastFrontDir, this);
     al::hideSilhouetteModelIfShow(this);
 }
 
@@ -529,34 +529,7 @@ void Killer::applyVelocityDamp() {
     al::scaleVelocity(this, mIsMagnum ? 0.90f : 0.95f);
 }
 
-static bool isExplodeCollision(Killer* killer, bool isMagnum);
-
-void Killer::exeFly() {
-    if (al::isFirstStep(this)) {
-        mHasExplosion = true;
-        al::startAction(this, "FlyWait");
-        al::tryStartSe(this, "PgMoveEnemyMeLv");
-    }
-
-    al::LiveActor* player = al::tryFindNearestPlayerActor(this);
-    if (player && !rs::isPlayer2D(this)) {
-        const sead::Vector3f& playerTrans = al::getTrans(player);
-        f32 distance = al::calcDistance(this, playerTrans);
-        f32 turnDegrees = mIsMagnum ? 0.4f : 2.4f;
-
-        if (distance < (mIsMagnum ? 700.0f : 1100.0f))
-            turnDegrees *= distance / (mIsMagnum ? 700.0f : 1100.0f);
-
-        al::turnToTarget(this, playerTrans, turnDegrees);
-    }
-
-    applyVelocityDamp();
-
-    if (isExplodeCollision(this, mIsMagnum))
-        explode();
-}
-
-bool isExplodeCollision(Killer* killer, bool isMagnum) {
+static bool isExplodeCollision(Killer* killer, bool isMagnum) {
     al::HitSensor* wallSensor = al::tryGetCollidedWallSensor(killer);
     if (wallSensor) {
         if (al::getCollidedWallNormal(killer).dot(al::getVelocity(killer)) > -0.2f)
@@ -578,6 +551,31 @@ bool isExplodeCollision(Killer* killer, bool isMagnum) {
     }
 
     return false;
+}
+
+void Killer::exeFly() {
+    if (al::isFirstStep(this)) {
+        mCanExplode = true;
+        al::startAction(this, "FlyWait");
+        al::tryStartSe(this, "PgMoveEnemyMeLv");
+    }
+
+    al::LiveActor* player = al::tryFindNearestPlayerActor(this);
+    if (player && !rs::isPlayer2D(this)) {
+        const sead::Vector3f& playerTrans = al::getTrans(player);
+        f32 distance = al::calcDistance(this, playerTrans);
+        f32 turnDegrees = mIsMagnum ? 0.4f : 2.4f;
+
+        if (distance < (mIsMagnum ? 700.0f : 1100.0f))
+            turnDegrees *= distance / (mIsMagnum ? 700.0f : 1100.0f);
+
+        al::turnToTarget(this, playerTrans, turnDegrees);
+    }
+
+    applyVelocityDamp();
+
+    if (isExplodeCollision(this, mIsMagnum))
+        explode();
 }
 
 void Killer::exeExplode() {
@@ -614,7 +612,7 @@ void Killer::exeDamageCap() {
 
 void Killer::exeHack() {
     if (al::isFirstStep(this))
-        mHasExplosion = false;
+        mCanExplode = false;
 
     if (al::updateNerveState(this)) {
         explode();
@@ -645,7 +643,7 @@ void Killer::exeAfterHack() {
         al::startAction(this, "FlyWait");
 
     if (al::isGreaterEqualStep(this, mIsMagnum ? 180 : 280)) {
-        mHasExplosion = true;
+        mCanExplode = true;
         al::setNerve(this, &NrvKiller.Fly);
     } else if (isExplodeCollision(this, mIsMagnum)) {
         explode();

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -52,11 +52,12 @@ const sead::Vector3f gLightOffset = {0.0f, 0.0f, 100.0f};
 Killer::Killer(const char* name) : al::LiveActor(name) {}
 
 void Killer::init(const al::ActorInitInfo& info) {
-    if (!mIsMagnum)
-        al::initActorWithArchiveName(this, info, "Killer", nullptr);
-    else
+    if (mIsMagnum)
         al::initActorWithArchiveName(this, info, "KillerMagnum", nullptr);
+    else
+        al::initActorWithArchiveName(this, info, "Killer", nullptr);
 
+    // NOTE: reserves space for 3 substates, but only adds 2
     al::initNerve(this, &NrvKiller.Fly, 3);
     mEnemyStateDamageCap = new EnemyStateDamageCap(this);
 
@@ -205,7 +206,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     if (al::isSensorName(self, "AttackMagnum"))
         return false;
 
-    if (al::isNerve(this, &NrvKiller.Hack)) {
+    if (isHack()) {
         if (mKillerStateHack->receiveMsgHackEnd(message, other, self)) {
             if (rs::isModeE3MovieRom())
                 EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
@@ -260,7 +261,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     }
 
     if (rs::isMsgKillerMagnumAttack(message)) {
-        if (!al::isNerve(this, &NrvKiller.Hack) || !mIsMagnum)
+        if (!isHack() || !mIsMagnum)
             explode();
 
         return true;
@@ -292,7 +293,7 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
     if (mIsMagnum && al::tryReceiveMsgPushAndAddVelocityH(this, message, other, self, 1.0f))
         return true;
 
-    if (al::isNerve(this, &NrvKiller.Hack))
+    if (isHack())
         return mKillerStateHack->receiveMsg(message, other, self);
 
     if (mKillerStateHack->receiveMsgNpcScareByEnemy(message))
@@ -325,10 +326,8 @@ bool Killer::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::
         return true;
     }
 
-    if (!rs::isMsgPlayerAndCapObjHipDropReflectAll(message) && !rs::isMsgPressDown(message))
-        return false;
-
-    if (_120 <= 0) {
+    if ((rs::isMsgPlayerAndCapObjHipDropReflectAll(message) || rs::isMsgPressDown(message)) &&
+        _120 <= 0) {
         rs::requestHitReactionToAttacker(message, self, other);
         rs::setAppearItemFactorAndOffsetByMsg(this, message, other);
         al::setNerve(this, &NrvKiller.FallDown);
@@ -349,7 +348,7 @@ void Killer::resetAliveCountAndAnim() {
 }
 
 void Killer::control() {
-    if (!al::isNerve(this, &NrvKiller.Hack) && mIsUseCaptureLight) {
+    if (!isHack() && mIsUseCaptureLight) {
         if (al::isAlive(al::getSubActor(this, "キラーアイライト")))
             al::getSubActor(this, "キラーアイライト")->kill();
 
@@ -363,12 +362,13 @@ void Killer::control() {
     sead::Vector3f front;
     al::calcFrontDir(&front, this);
 
-    if (!al::isNerve(this, &NrvKiller.Hack) || !mKillerStateHack->isStarting()) {
+    // adds roll based on current horizontal rotation speed
+    if (!isHack() || !mKillerStateHack->isStarting()) {
         f32 angle = al::calcAngleOnPlaneDegree(front, mFrontDir, sead::Vector3f::ey);
         f32 rate;
         if (!mIsMagnum)
             rate = 1.2f;
-        else if (al::isNerve(this, &NrvKiller.Hack))
+        else if (isHack())
             rate = 2.0f;
         else
             rate = 0.7f;
@@ -389,10 +389,10 @@ void Killer::control() {
 
     if (al::isNerve(this, &NrvKiller.Explode) || al::isNerve(this, &NrvKiller.FallDown) ||
         al::isNerve(this, &NrvKiller.Appear) || al::isNerve(this, &NrvKiller.StandBy) ||
-        (al::isNerve(this, &NrvKiller.Hack) && mKillerStateHack->isStarting()))
+        (isHack() && mKillerStateHack->isStarting()))
         return;
 
-    if (al::isNerve(this, &NrvKiller.Hack)) {
+    if (isHack()) {
         if (mExplosionTime > 180.0f)
             if (!mIsMagnum)
                 mExplosionTime -= sead::Mathf::min(al::getVelocity(this).length() / 10.8f, 3.8f);
@@ -416,7 +416,7 @@ void Killer::control() {
     if (mExplosionTime <= 180.0f) {
         al::tryStartMclAnimIfNotPlaying(this, "SignExplosion");
 
-        if (al::isNerve(this, &NrvKiller.Hack))
+        if (isHack())
             al::holdSe(this, "ExplodeSign");
     }
 
@@ -529,7 +529,7 @@ void Killer::applyVelocityDamp() {
     al::scaleVelocity(this, mIsMagnum ? 0.90f : 0.95f);
 }
 
-bool FUN_7100146a14(Killer*, bool);
+static bool isExplodeCollision(Killer* killer, bool isMagnum);
 
 void Killer::exeFly() {
     if (al::isFirstStep(this)) {
@@ -542,21 +542,21 @@ void Killer::exeFly() {
     if (player && !rs::isPlayer2D(this)) {
         const sead::Vector3f& playerTrans = al::getTrans(player);
         f32 distance = al::calcDistance(this, playerTrans);
-        f32 fVar5 = mIsMagnum ? 0.4f : 2.4f;
+        f32 turnDegrees = mIsMagnum ? 0.4f : 2.4f;
 
         if (distance < (mIsMagnum ? 700.0f : 1100.0f))
-            fVar5 *= distance / (mIsMagnum ? 700.0f : 1100.0f);
+            turnDegrees *= distance / (mIsMagnum ? 700.0f : 1100.0f);
 
-        al::turnToTarget(this, playerTrans, fVar5);
+        al::turnToTarget(this, playerTrans, turnDegrees);
     }
 
     applyVelocityDamp();
 
-    if (FUN_7100146a14(this, mIsMagnum))
+    if (isExplodeCollision(this, mIsMagnum))
         explode();
 }
 
-bool FUN_7100146a14(Killer* killer, bool isMagnum) {
+bool isExplodeCollision(Killer* killer, bool isMagnum) {
     al::HitSensor* wallSensor = al::tryGetCollidedWallSensor(killer);
     if (wallSensor) {
         if (al::getCollidedWallNormal(killer).dot(al::getVelocity(killer)) > -0.2f)
@@ -616,15 +616,17 @@ void Killer::exeHack() {
     if (al::isFirstStep(this))
         mHasExplosion = false;
 
-    if (!al::updateNerveState(this)) {
-        if (!FUN_7100146a14(this, mIsMagnum))
-            return;
+    if (al::updateNerveState(this)) {
+        explode();
 
-        al::startVisAnim(this, "HackOff");
-        al::startMclAnim(this, "HackOff");
+        return;
     }
 
-    explode();
+    if (isExplodeCollision(this, mIsMagnum)) {
+        al::startVisAnim(this, "HackOff");
+        al::startMclAnim(this, "HackOff");
+        explode();
+    }
 }
 
 void Killer::exeAfterHack() {
@@ -645,7 +647,7 @@ void Killer::exeAfterHack() {
     if (al::isGreaterEqualStep(this, mIsMagnum ? 180 : 280)) {
         mHasExplosion = true;
         al::setNerve(this, &NrvKiller.Fly);
-    } else if (FUN_7100146a14(this, mIsMagnum)) {
+    } else if (isExplodeCollision(this, mIsMagnum)) {
         explode();
     }
 }

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -47,7 +47,7 @@ NERVES_MAKE_STRUCT(Killer, Fly, DamageCap, Hack, FallDown, Explode, AfterHack, A
                    Launch)
 }  // namespace
 
-const sead::Vector3f g_71018a084 = {0.0f, 0.0f, 100.0f};
+const sead::Vector3f gLightOffset = {0.0f, 0.0f, 100.0f};
 
 Killer::Killer(const char* name) : al::LiveActor(name) {}
 
@@ -60,7 +60,7 @@ void Killer::init(const al::ActorInitInfo& info) {
     al::initNerve(this, &NrvKiller.Fly, 3);
     mEnemyStateDamageCap = new EnemyStateDamageCap(this);
 
-    if (!_137) {
+    if (!mIsNoCap) {
         if (mIsMagnum || al::isEqualString(GameDataFunction::getCurrentStageName(this),
                                            "MoonWorldCaptureParadeStage")) {
             mIsCapKoopa = true;
@@ -76,7 +76,7 @@ void Killer::init(const al::ActorInitInfo& info) {
     }
 
     al::initNerveState(this, mEnemyStateDamageCap, &NrvKiller.DamageCap, "帽子ふきとび");
-    mKillerStateHack = new KillerStateHack(this, mIsMagnum, _138);
+    mKillerStateHack = new KillerStateHack(this, mIsMagnum, mIsUseCaptureLight);
     al::initNerveState(this, mKillerStateHack, &NrvKiller.Hack, "キャプチャ");
     al::setSensorRadius(this, "Explosion", 0.0f);
     al::setSensorRadius(this, "ExplosionToPlayer", 0.0f);
@@ -349,7 +349,7 @@ void Killer::resetAliveCountAndAnim() {
 }
 
 void Killer::control() {
-    if (!al::isNerve(this, &NrvKiller.Hack) && _138) {
+    if (!al::isNerve(this, &NrvKiller.Hack) && mIsUseCaptureLight) {
         if (al::isAlive(al::getSubActor(this, "キラーアイライト")))
             al::getSubActor(this, "キラーアイライト")->kill();
 
@@ -402,9 +402,9 @@ void Killer::control() {
         else
             _11c--;
 
-        if (_138) {
+        if (mIsUseCaptureLight) {
             sead::Vector3f trans;
-            al::calcTransLocalOffset(&trans, this, g_71018a084);
+            al::calcTransLocalOffset(&trans, this, gLightOffset);
             al::setTrans(al::getSubActor(this, "キラーアイライト"), trans);
             al::setQuat(al::getSubActor(this, "キラーアイライト"), al::getQuat(this));
             if (al::isExistPrePassLight(this, "Front") && !al::isActivePrePassLight(this, "Front"))
@@ -498,7 +498,7 @@ void Killer::exeAppear() {
     if (al::isFirstStep(this)) {
         al::offCollide(this);
 
-        if (mIsCapKoopa && !_137)
+        if (mIsCapKoopa && !mIsNoCap)
             al::hideModelIfShow(mEnemyStateDamageCap->getEnemyCap());
     }
 
@@ -512,7 +512,7 @@ void Killer::exeStandBy() {
 }
 
 void Killer::exeLaunch() {
-    if (al::isFirstStep(this) && mIsCapKoopa && !_137) {
+    if (al::isFirstStep(this) && mIsCapKoopa && !mIsNoCap) {
         al::showModelIfHide(mEnemyStateDamageCap->getEnemyCap());
         al::startAction(mEnemyStateDamageCap->getEnemyCap(), "AppearKillerMagnum");
     }

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -379,8 +379,7 @@ void Killer::control() {
         sead::Quatf quat;
         al::makeQuatFrontUp(&quat, front, sead::Vector3f::ey);
         al::setQuat(this, quat);
-        // TODO: check axis because Y is strange here
-        al::rotateQuatLocalDirDegree(this, static_cast<s32>(al::Axis::Y), mRotationAngle);
+        al::rotateQuatLocalDirDegree(this, 2 /* axis Z */, mRotationAngle);
     }
 
     mFrontDir.set(front);
@@ -450,7 +449,7 @@ void Killer::appearInit() {
     mHasExplosion = true;
     _135 = true;
     al::calcFrontDir(&mFrontDir, this);
-    mRotationAngle = 0.0;
+    mRotationAngle = 0.0f;
     sead::Quatf quat;
     al::makeQuatFrontUp(&quat, mFrontDir, sead::Vector3f::ey);
     al::setQuat(this, quat);
@@ -592,13 +591,13 @@ void Killer::exeExplode() {
     }
 
     f32 rate = al::calcNerveRate(this, 5);
-    al::setSensorRadius(this, "Explosion", al::lerpValue(0.0, 200.0, rate));
-    al::setSensorRadius(this, "ExplosionToPlayer", al::lerpValue(0.0, 100.0, rate));
+    al::setSensorRadius(this, "Explosion", al::lerpValue(0.0f, 200.0f, rate));
+    al::setSensorRadius(this, "ExplosionToPlayer", al::lerpValue(0.0f, 100.0f, rate));
 
     if (al::isGreaterEqualStep(this, 5)) {
         mEnemyStateDamageCap->makeActorDeadCap();
-        al::setSensorRadius(this, "Explosion", 0.0);
-        al::setSensorRadius(this, "ExplosionToPlayer", 0.0);
+        al::setSensorRadius(this, "Explosion", 0.0f);
+        al::setSensorRadius(this, "ExplosionToPlayer", 0.0f);
         al::invalidateHitSensor(this, "Explosion");
         al::invalidateHitSensor(this, "ExplosionToPlayer");
         kill();

--- a/src/Enemy/Killer.cpp
+++ b/src/Enemy/Killer.cpp
@@ -9,16 +9,20 @@
 #include "Library/LiveActor/ActorActionFunction.h"
 #include "Library/LiveActor/ActorAnimFunction.h"
 #include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
 #include "Library/LiveActor/ActorInitUtil.h"
 #include "Library/LiveActor/ActorModelFunction.h"
 #include "Library/LiveActor/ActorMovementFunction.h"
 #include "Library/LiveActor/ActorPoseUtil.h"
 #include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
 #include "Library/Nerve/NerveSetupUtil.h"
 #include "Library/Nerve/NerveUtil.h"
 #include "Library/Se/SeFunction.h"
+#include "Library/Shadow/ActorShadowUtil.h"
 #include "System/GameDataFunction.h"
 #include "Util/SensorMsgFunction.h"
+#include "Util/SpecialBuildUtil.h"
 
 namespace {
 NERVE_IMPL(Killer, Fly)
@@ -95,10 +99,8 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
         return;
     }
 
-    if (al::isNerve(this, &NrvKiller.Hack) &&
-        mKillerStateHack->attackSensorCheckExplode(self, other)) {
+    if (isHack() && mKillerStateHack->attackSensorCheckExplode(self, other))
         explode();
-    }
 
     if (al::isSensorName(self, "AttackMagnum")) {
         if (mIsMagnum)
@@ -146,7 +148,7 @@ void Killer::attackSensor(al::HitSensor* self, al::HitSensor* other) {
 }
 
 void Killer::explode() {
-    if (al::isNerve(this, &NrvKiller.Hack)) {
+    if (isHack()) {
         if (!mKillerStateHack->isEnableExplode())
             return;
 
@@ -187,4 +189,57 @@ void Killer::appearBy2D(const sead::Vector3f& position, const sead::Vector3f& ve
     al::setNerve(this, &NrvKiller.Fly);
     appear();
     al::invalidateClipping(this);
+}
+
+void Killer::appearInit() {
+    al::startVisAnim(this, "HackOff");
+    al::startMclAnim(this, "HackOff");
+    al::showModelIfHide(this);
+    resetAliveCountAndAnim();
+
+    _134 = true;
+    _135 = true;
+    al::calcFrontDir(&_124, this);
+    _130 = 0.0;
+    sead::Quatf quat;
+    al::makeQuatFrontUp(&quat, _124, sead::Vector3f::ey);
+    al::setQuat(this, quat);
+    al::calcFrontDir(&_124, this);
+    al::hideSilhouetteModelIfShow(this);
+}
+
+void Killer::standByAppear(const sead::Vector3f& position, const sead::Quatf& rotation) {
+    al::resetPosition(this, position);
+    al::setQuat(this, rotation);
+    appearInit();
+    mEnemyStateDamageCap->resetCap();
+    al::startAction(this, "Appear");
+    al::startVisAnim(this, "HackOff");
+
+    if (rs::isModeE3MovieRom()) {
+        al::invalidateShadow(this);
+        al::offDepthShadowModel(this);
+        al::validateDepthShadowMap(this);
+    } else {
+        EnemyStateHackFunction::endHackSwitchShadow(this, nullptr);
+    }
+
+    al::setNerve(this, &NrvKiller.Appear);
+    appear();
+    al::invalidateClipping(this);
+}
+
+void Killer::launch(s32 param_1) {
+    _118 = param_1;
+    _11c = _118;
+    al::startAction(this, "FlyWaitStart");
+    al::setNerve(this, &NrvKiller.Launch);
+}
+
+void Killer::forceExplode() {
+    explode();
+}
+
+bool Killer::isHack() const {
+    return al::isNerve(this, &NrvKiller.Hack);
 }

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -48,8 +48,8 @@ private:
     bool _134 = true;
     bool _135 = true;
     bool mIsMagnum = false;
-    bool _137 = false;
-    bool _138 = false;
+    bool mIsNoCap = false;
+    bool mIsUseCaptureLight = false;
     bool mIsCapKoopa = false;
     s32 _13c = 0;
 };

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -33,7 +33,7 @@ public:
     void exeFly();
     void exeExplode();
     void exeDamageCap();
-    void exeHack();
+    __attribute__((noinline)) void exeHack();
     void exeAfterHack();
     void exeFallDown();
 

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -33,7 +33,7 @@ public:
     void exeFly();
     void exeExplode();
     void exeDamageCap();
-    __attribute__((noinline)) void exeHack();
+    void exeHack();
     void exeAfterHack();
     void exeFallDown();
 

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -39,19 +39,19 @@ public:
 
 private:
     EnemyStateDamageCap* mEnemyStateDamageCap = nullptr;
-    KillerStateHack* mKillerStateHack = nullptr;
+    KillerStateHack* mStateHack = nullptr;
     s32 mAliveFrame = 1200;
     f32 mExplosionTime = 1200.0f;
-    s32 _120 = 0;
-    sead::Vector3f mFrontDir = sead::Vector3f::zero;
+    s32 mHackEndImmuneTime = 0;
+    sead::Vector3f mLastFrontDir = sead::Vector3f::zero;
     f32 mRotationAngle = 0.0f;
-    bool mHasExplosion = true;
-    bool _135 = true;
+    bool mCanExplode = true;
+    bool mIsFirstCapture = true;
     bool mIsMagnum = false;
     bool mIsNoCap = false;
     bool mIsUseCaptureLight = false;
     bool mIsCapKoopa = false;
-    s32 _13c = 0;
+    s32 mAttackCooldown = 0;
 };
 
 static_assert(sizeof(Killer) == 0x140);

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -20,10 +20,10 @@ public:
     void explode();
     void resetAliveCountAndAnim();
     void appearBy2D(const sead::Vector3f& position, const sead::Vector3f& velocity,
-                    const sead::Quatf& rotation, s32);
+                    const sead::Quatf& rotation, s32 aliveFrame);
     void appearInit();
     void standByAppear(const sead::Vector3f& position, const sead::Quatf& rotation);
-    void launch(s32);
+    void launch(s32 aliveFrame);
     void forceExplode();
     void applyVelocityDamp();
 
@@ -40,12 +40,12 @@ public:
 private:
     EnemyStateDamageCap* mEnemyStateDamageCap = nullptr;
     KillerStateHack* mKillerStateHack = nullptr;
-    s32 _118 = 1200;
-    f32 _11c = 1200.0f;
+    s32 mAliveFrame = 1200;
+    f32 mExplosionTime = 1200.0f;
     s32 _120 = 0;
-    sead::Vector3f _124 = sead::Vector3f::zero;
-    f32 _130 = 0.0f;
-    bool _134 = true;
+    sead::Vector3f mFrontDir = sead::Vector3f::zero;
+    f32 mRotationAngle = 0.0f;
+    bool mHasExplosion = true;
     bool _135 = true;
     bool mIsMagnum = false;
     bool mIsNoCap = false;

--- a/src/Enemy/Killer.h
+++ b/src/Enemy/Killer.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class EnemyStateDamageCap;
+class KillerStateHack;
+
+class Killer : public al::LiveActor {
+public:
+    Killer(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void control() override;
+
+    bool isHack() const;
+
+    void explode();
+    void resetAliveCountAndAnim();
+    void appearBy2D(const sead::Vector3f& position, const sead::Vector3f& velocity,
+                    const sead::Quatf& rotation, s32);
+    void appearInit();
+    void standByAppear(const sead::Vector3f& position, const sead::Quatf& rotation);
+    void launch(s32);
+    void forceExplode();
+    void applyVelocityDamp();
+
+    void exeAppear();
+    void exeStandBy();
+    void exeLaunch();
+    void exeFly();
+    void exeExplode();
+    void exeDamageCap();
+    void exeHack();
+    void exeAfterHack();
+    void exeFallDown();
+
+private:
+    EnemyStateDamageCap* mEnemyStateDamageCap = nullptr;
+    KillerStateHack* mKillerStateHack = nullptr;
+    s32 _118 = 1200;
+    f32 _11c = 1200.0f;
+    s32 _120 = 0;
+    sead::Vector3f _124 = sead::Vector3f::zero;
+    f32 _130 = 0.0f;
+    bool _134 = true;
+    bool _135 = true;
+    bool mIsMagnum = false;
+    bool _137 = false;
+    bool _138 = false;
+    bool mIsCapKoopa = false;
+    s32 _13c = 0;
+};
+
+static_assert(sizeof(Killer) == 0x140);

--- a/src/Enemy/KillerStateHack.h
+++ b/src/Enemy/KillerStateHack.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+class KillerStateHack : public al::ActorStateBase {
+public:
+    KillerStateHack(al::LiveActor*, bool, bool);
+
+    bool attackSensorCheckExplode(al::HitSensor*, al::HitSensor*);
+    bool isEnableExplode() const;
+    void endHackExplode();
+
+private:
+    s8 padding[0x58 - sizeof(al::ActorStateBase)];
+};
+
+static_assert(sizeof(KillerStateHack) == 0x58);

--- a/src/Enemy/KillerStateHack.h
+++ b/src/Enemy/KillerStateHack.h
@@ -11,18 +11,25 @@ class KillerStateHack : public al::ActorStateBase {
 public:
     KillerStateHack(al::LiveActor*, bool, bool);
 
-    bool attackSensorCheckExplode(al::HitSensor* self, al::HitSensor* other);
-    bool isEnableExplode() const;
-    bool isStarting() const;
+    void appear() override;
+    void kill() override;
+
     void endHackExplode();
-    bool receiveMsgHackEnd(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
-    bool receiveMsgHackEndExplode(const al::SensorMsg* message, al::HitSensor* other,
-                                  al::HitSensor* self);
+    bool receiveMsgInitCapTargetInfo(const al::SensorMsg* message);
+    bool receiveMsgNpcScareByEnemy(const al::SensorMsg* message);
     bool receiveMsgHackStart(const al::SensorMsg* message, al::HitSensor* other,
                              al::HitSensor* self);
     bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
-    bool receiveMsgInitCapTargetInfo(const al::SensorMsg* message);
-    bool receiveMsgNpcScareByEnemy(const al::SensorMsg* message);
+    bool receiveMsgHackEndExplode(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self);
+    bool receiveMsgHackEnd(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    bool attackSensorCheckExplode(al::HitSensor* self, al::HitSensor* other);
+    bool isStarting() const;
+    bool isEnableExplode() const;
+    bool isBoosting() const;
+    bool isTurbo() const;
+    void exeStart();
+    void exeFly();
 
 private:
     s8 padding[0x58 - sizeof(al::ActorStateBase)];

--- a/src/Enemy/KillerStateHack.h
+++ b/src/Enemy/KillerStateHack.h
@@ -6,9 +6,17 @@ class KillerStateHack : public al::ActorStateBase {
 public:
     KillerStateHack(al::LiveActor*, bool, bool);
 
-    bool attackSensorCheckExplode(al::HitSensor*, al::HitSensor*);
+    bool attackSensorCheckExplode(al::HitSensor* self, al::HitSensor* other);
     bool isEnableExplode() const;
     void endHackExplode();
+    bool receiveMsgHackEnd(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    bool receiveMsgHackEndExplode(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self);
+    bool receiveMsgHackStart(const al::SensorMsg* message, al::HitSensor* other,
+                             al::HitSensor* self);
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    bool receiveMsgInitCapTargetInfo(const al::SensorMsg* message);
+    bool receiveMsgNpcScareByEnemy(const al::SensorMsg* message);
 
 private:
     s8 padding[0x58 - sizeof(al::ActorStateBase)];

--- a/src/Enemy/KillerStateHack.h
+++ b/src/Enemy/KillerStateHack.h
@@ -8,6 +8,7 @@ public:
 
     bool attackSensorCheckExplode(al::HitSensor* self, al::HitSensor* other);
     bool isEnableExplode() const;
+    bool isStarting() const;
     void endHackExplode();
     bool receiveMsgHackEnd(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
     bool receiveMsgHackEndExplode(const al::SensorMsg* message, al::HitSensor* other,

--- a/src/Enemy/KillerStateHack.h
+++ b/src/Enemy/KillerStateHack.h
@@ -2,6 +2,11 @@
 
 #include "Library/Nerve/NerveStateBase.h"
 
+namespace al {
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
 class KillerStateHack : public al::ActorStateBase {
 public:
     KillerStateHack(al::LiveActor*, bool, bool);

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -3,13 +3,12 @@
 import argparse
 import csv
 import os
-import stat
 import re
+import stat
 import subprocess
 from functools import cache
 
 from common import setup_common as setup
-from common.util import utils
 
 # ------
 # CHECKS
@@ -17,6 +16,7 @@ from common.util import utils
 
 issueFound = False
 runAllChecks = False
+
 
 def FAIL(message, line, path):
     print("Offending file:", os.path.relpath(path, os.getcwd()))
@@ -26,11 +26,13 @@ def FAIL(message, line, path):
     global issueFound
     issueFound = True
 
+
 def CHECK(cond, line, message, path):
     if not cond(line):
         FAIL(message, line, path)
         return True
     return False
+
 
 # Common
 
@@ -94,6 +96,7 @@ def common_no_namespace_qualifiers(c, path):
         if not runAllChecks:
             exit(1)
 
+
 @cache
 def get_includes():
     def get_files(path):
@@ -131,6 +134,7 @@ def get_includes():
     game_includes = game_files
 
     return angled_includes, al_includes, game_includes
+
 
 def common_include_order(c, path, is_header):
     lines = c.split("\n")
@@ -213,8 +217,10 @@ def common_include_order(c, path, is_header):
 
     CHECK(lambda a: order in [-1, -2, -3, -4], "not applicable", "Empty line expected after includes!", path)
 
+
 def common_newline_eof(c, path):
     CHECK(lambda a: a == "", c.split("\n")[-1], "Files should end with a newline!", path)
+
 
 def common_sead_types(c, path):
     FORBIDDEN_TYPES = ["int", "float", "short", "long", "double", "char16_t"]
@@ -236,22 +242,26 @@ def common_sead_types(c, path):
                     line, path)
                 return
 
+
 def common_void_params(c, path):
     for line in c.splitlines():
         if "(void);" in line or "(void) {" in line or "(void) const" in line:
             FAIL("Function parameters should be empty instead of \"(void)\"!", line, path)
             return
 
+
 def common_this_prefix(c, path):
     for line in c.splitlines():
         if 'this->' in line:
             FAIL("this-> is not allowed!", line, path)
+
 
 def common_consistent_float_literals(c, path):
     for line in c.splitlines():
         index = line.find(".f")
         if index != -1 and not line[index + 2].isalpha():
             FAIL(" '.f' is not allowed, use '.0f' instead!", line, path)
+
 
 def common_sead_math_template(c, path):
     for line in c.splitlines():
@@ -269,6 +279,7 @@ def common_sead_math_template(c, path):
             if "BitUtil" in line:
                 continue
             FAIL("Use short sead types: sead::Vector3f, sead::Mathi and similar!", line, path)
+
 
 def common_string_finder(c, path):
     string_table = get_string_table()
@@ -300,7 +311,8 @@ def common_string_finder(c, path):
                     found = True
                     break
             if not found:
-                FAIL("String not found in binary: \""+match+"\"", line, path)
+                FAIL("String not found in binary: \"" + match + "\"", line, path)
+
 
 def common_const_reference(c, path):
     for line in c.splitlines():
@@ -331,12 +343,16 @@ def common_const_reference(c, path):
         if re.search(r"(?<!const)[( ][\w_:]+(<[\w_:]+[\*&]?>)?&", line):
             FAIL("References must be const!", line, path)
 
+
 def common_self_other(c, path, is_header):
     lines = c.splitlines()
     for i, line in enumerate(lines):
-        if (("attackSensor(" in line and "void HitSensor" not in line) or "receiveMsg(" in line) and (is_header or "::" in line) and (("self" not in line and "self" not in lines[i + 1]) or "other" not in line) and "Library/HitSensor/HitSensorKeeper.h" not in path and "Library/Event/EventFlowExecutor.h" not in path:
+        if (("attackSensor(" in line and "void HitSensor" not in line) or "receiveMsg(" in line) and (
+                is_header or "::" in line) and (("self" not in line and "self" not in lines[
+            i + 1]) or "other" not in line) and "Library/HitSensor/HitSensorKeeper.h" not in path and "Library/Event/EventFlowExecutor.h" not in path:
             FAIL("'attackSensor' and 'receiveMsg' should have 'self' and 'other' params!", line, path)
             return
+
 
 # Header files
 
@@ -394,8 +410,8 @@ def header_sorted_visibility(c, path):
         if not runAllChecks:
             exit(1)
 
-def header_check_line(line, path, visibility, should_start_class, is_in_struct):
 
+def header_check_line(line, path, visibility, should_start_class, is_in_struct):
     if is_in_struct:
         if re.search(r"\w+[\*&]*\s+m[A-Z]", line):
             FAIL("Struct member variables should be formatted as noPrefixCamelCase!", line, path)
@@ -427,7 +443,8 @@ def header_check_line(line, path, visibility, should_start_class, is_in_struct):
             CHECK(lambda a: not function_name.endswith("_"), line,
                   "Functions ending with an underscore are either protected or private!", path)
     elif visibility == 2:  # private
-        if line == "};" or line == "" or line == "union {" or line.startswith("struct") or line.startswith("enum"): return
+        if line == "};" or line == "" or line == "union {" or line.startswith("struct") or line.startswith(
+                "enum"): return
         newline = line
         if line.startswith("static_assert") or "template" in line:
             return
@@ -461,27 +478,35 @@ def header_check_line(line, path, visibility, should_start_class, is_in_struct):
             CHECK(lambda a: allowed_name, line, "Member variables must be prefixed with `m`!", path)
 
         if var_type == "bool":
-            BOOL_PREFIXES = ["mIs", "mHas", "mAlways"]
+            BOOL_PREFIXES = ["mIs", "mHas", "mAlways", "mCan"]
             allowed_name = any(
                 [var_name.startswith(p) and (var_name[len(p)].isupper() or var_name[len(p)].isdigit()) for p in
                  BOOL_PREFIXES]) or any([var_name.startswith(p) for p in PREFIXES])
             if path.endswith("ByamlWriterData.h") and var_name == "mValue": return
-            CHECK(lambda a: allowed_name, line, "Boolean member variables must start with `mIs` or `mHas`!", path)
+            CHECK(lambda a: allowed_name, line,
+                  "Boolean member variables must start with one of " + ", ".join(f"`{p}`" for p in BOOL_PREFIXES) + "!",
+                  path)
+
 
 def header_no_offset_comments(c, path):
     for line in c.splitlines():
         if "// 0x" in line or "// _" in line:
             FAIL("Offset comments are not allowed in headers!", line, path)
 
+
 def header_lowercase_member_offset_vars(c, path):
     for line in c.splitlines():
-        if re.search(r"\s(field|gap|filler|pad|padding)?_[0-9a-z]*[A-Z]", line) and "," not in line and not line.endswith(");"):
-            CHECK(lambda a: "#define" in a, line, "Characters in the names of offset variables need to be lowercase!", path)
+        if re.search(r"\s(field|gap|filler|pad|padding)?_[0-9a-z]*[A-Z]",
+                     line) and "," not in line and not line.endswith(");"):
+            CHECK(lambda a: "#define" in a, line, "Characters in the names of offset variables need to be lowercase!",
+                  path)
+
 
 def header_bool_getter_name_prefix(c, path):
     for line in c.splitlines():
         if re.search(r"bool\s(?!(is|has|get_))\w+\(\)\s*const\s*{", line):
             FAIL("Boolean getter names should be prefix with `is` or `has`", line, path)
+
 
 # Source files
 
@@ -490,16 +515,21 @@ def source_no_raw_auto(c, path):
         if "auto" in line and not "auto*" in line and not "auto&" in line and not " it " in line and "node " not in line and ".end()" not in line and "autoGet" not in line:
             FAIL("Raw use of auto isn't allowed! Please use auto* or auto& instead", line, path)
 
+
 def source_no_nerve_make(c, path):
     for line in c.splitlines():
         if "NERVE_MAKE(" in line:
             FAIL("Use of NERVE_MAKE is not allowed. Use NERVES_MAKE_[NO]STRUCT instead.", line, path)
             return
 
+
 def source_always_inline_macro(c, path):
     for line in c.splitlines():
         if "__attribute__((always_inline)) inline" in line:
-            FAIL("Explicitly using `__attribute__((always_inline)) inline` is not allowed. Use ALWAYS_INLINE from Library/Base/Macros.h instead", line, path)
+            FAIL(
+                "Explicitly using `__attribute__((always_inline)) inline` is not allowed. Use ALWAYS_INLINE from Library/Base/Macros.h instead",
+                line, path)
+
 
 # -----
 # UTILS
@@ -521,6 +551,7 @@ def check_source(c, path):
     common_consistent_float_literals(c, path)
     source_always_inline_macro(c, path)
 
+
 def check_header(c, path):
     common_newline_eof(c, path)
     common_no_namespace_qualifiers(c, path)
@@ -537,6 +568,7 @@ def check_header(c, path):
     common_consistent_float_literals(c, path)
     header_bool_getter_name_prefix(c, path)
 
+
 def _check_file_content(content, file_str):
     if file_str.endswith('.h'):
         check_header(content, file_str)
@@ -544,6 +576,7 @@ def _check_file_content(content, file_str):
         check_source(content, file_str)
     else:
         FAIL("Must only contain .h and .cpp files!", "NOT APPLICABLE", file_str)
+
 
 def check_file(file_str):
     st = os.stat(file_str)
@@ -554,6 +587,7 @@ def check_file(file_str):
     content = file.read()
     file.close()
     _check_file_content(content, file_str)
+
 
 def read_csv_file(path):
     if not os.path.isfile(path):
@@ -568,11 +602,14 @@ def read_csv_file(path):
 
     return rows;
 
+
 @cache
 def get_string_table():
     return read_csv_file(project_root / 'data' / "data_strings.csv");
 
+
 project_root = setup.ROOT
+
 
 def main():
     parser = argparse.ArgumentParser(
@@ -589,10 +626,11 @@ def main():
     runAllChecks = args.all
 
     if not args.run_clang_format and not args.ci:
-        print("Warning: Input files not being formatted correctly may cause false fails for some checks, to automatically run clang-format use '--run-clang-format' (or '-F')")
+        print(
+            "Warning: Input files not being formatted correctly may cause false fails for some checks, to automatically run clang-format use '--run-clang-format' (or '-F')")
         print()
 
-    for dir in [project_root/'lib'/'al', project_root/'src']:
+    for dir in [project_root / 'lib' / 'al', project_root / 'src']:
         for root, _, files in os.walk(dir):
             for file in files:
                 if os.path.basename(file) == ".DS_Store":
@@ -602,8 +640,10 @@ def main():
                 if args.run_clang_format:
                     subprocess.check_call(['clang-format', '-i', file_str])
                 if args.ci:
-                    if subprocess.run(['clang-format', file_str, '--dry-run', '--Werror'], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL).returncode != 0:
-                        print("Warning: file", os.path.relpath(file_str, os.getcwd()), "wasn't formatted correctly with clang-format, this may cause the line numbers to be incorrect")
+                    if subprocess.run(['clang-format', file_str, '--dry-run', '--Werror'], stdout=subprocess.DEVNULL,
+                                      stderr=subprocess.DEVNULL).returncode != 0:
+                        print("Warning: file", os.path.relpath(file_str, os.getcwd()),
+                              "wasn't formatted correctly with clang-format, this may cause the line numbers to be incorrect")
                         print()
                         result = subprocess.run(['clang-format', file_str], capture_output=True, text=True)
                         if result.returncode == 0:
@@ -614,6 +654,7 @@ def main():
     if issueFound:
         exit(1)
     print("No issues found!")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR add `Killer` implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1247)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ece395d - 35b82d0)

📈 **Matched code**: 15.34% (+0.06%, +7176 bytes)

<details>
<summary>✅ 34 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Enemy/Killer` | `Killer::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +1300 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::control()` | +992 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::init(al::ActorInitInfo const&)` | +560 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::attackSensor(al::HitSensor*, al::HitSensor*)` | +536 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeExplode()` | +352 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeAfterHack()` | +332 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeFly()` | +300 | 0.00% | 100.00% |
| `Enemy/Killer` | `isExplodeCollision(Killer*, bool)` | +292 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::Killer(char const*)` | +208 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::appearInit()` | +204 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::Killer(char const*)` | +196 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeLaunch()` | +196 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeFallDown()` | +192 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::explode()` | +184 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::standByAppear(sead::Vector3<float> const&, sead::Quat<float> const&)` | +184 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::appearBy2D(sead::Vector3<float> const&, sead::Vector3<float> const&, sead::Quat<float> const&, int)` | +176 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeHack()` | +116 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvAppear::execute(al::NerveKeeper*) const` | +116 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeAppear()` | +112 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvDamageCap::execute(al::NerveKeeper*) const` | +108 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeDamageCap()` | +104 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::resetAliveCountAndAnim()` | +88 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::launch(int)` | +68 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::applyVelocityDamp()` | +68 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvStandBy::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::exeStandBy()` | +60 | 0.00% | 100.00% |
| `Enemy/Killer` | `Killer::isHack() const` | +16 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvFly::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvHack::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Enemy/Killer` | `(anonymous namespace)::KillerNrvFallDown::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

...and 4 more new matches
</details>


<!-- decomp.dev report end -->