### PR TITLE
Item: Implement `YoshiFruitWatcher`

### DIFF
--- a/src/Item/YoshiFruitShineHolder.h
+++ b/src/Item/YoshiFruitShineHolder.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class Shine;
+
+class YoshiFruitShineHolder : public al::LiveActor {
+public:
+    YoshiFruitShineHolder(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void updateHintPos(const sead::Vector3f& pos);
+    Shine* appearShineFromFruit(const sead::Vector3f& pos);
+
+    s32 getGotShineNum() const { return mGotShineNum; }
+
+private:
+    sead::PtrArray<Shine> mShines;
+    s32 mGotShineNum = 0;
+};
+
+static_assert(sizeof(YoshiFruitShineHolder) == 0x120);

--- a/src/Item/YoshiFruitWatcher.cpp
+++ b/src/Item/YoshiFruitWatcher.cpp
@@ -1,0 +1,262 @@
+#include "Item/YoshiFruitWatcher.h"
+
+#include <math/seadVector.h>
+
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Screen/ScreenFunction.h"
+
+#include "Item/Shine.h"
+#include "Item/YoshiFruitShineHolder.h"
+#include "Player/Yoshi.h"
+#include "System/GameDataUtil.h"
+#include "System/SaveObjInfo.h"
+#include "Util/DemoUtil.h"
+#include "Util/PlayerUtil.h"
+
+namespace {
+NERVE_IMPL(YoshiFruitWatcher, Wait);
+NERVE_IMPL(YoshiFruitWatcher, DemoRequest);
+NERVE_IMPL(YoshiFruitWatcher, GaugeAppear);
+NERVE_IMPL(YoshiFruitWatcher, GaugeWait);
+NERVE_IMPL(YoshiFruitWatcher, GaugeEnd);
+NERVE_IMPL(YoshiFruitWatcher, DemoGauge);
+NERVE_IMPL(YoshiFruitWatcher, DemoShine);
+
+NERVES_MAKE_NOSTRUCT(YoshiFruitWatcher, DemoRequest, DemoGauge, DemoShine, Wait, GaugeAppear,
+                     GaugeEnd, GaugeWait);
+
+}  // namespace
+
+YoshiFruitWatcher::YoshiFruitWatcher() : al::LiveActor("ヨッシーフルーツ監視者") {
+    mFruits.allocBuffer(100, nullptr);
+    mGetFruitSaveInfos.allocBuffer(100, nullptr);
+}
+
+void YoshiFruitWatcher::initAfterPlacementSceneObj(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+    al::initExecutorWatchObj(this, info);
+    al::initNerve(this, &Wait, 0);
+    // The original dispatches the scene-name virtual here before creating the gauge layout.
+    getSceneObjName();
+
+    mGaugeLayout = new al::LayoutActor("ヨッシーフルーツゲージ");
+    al::initLayoutActor(mGaugeLayout, al::getLayoutInitInfo(info), "GaugeYoshi", nullptr);
+
+    if (mCurrentHackYoshi)
+        mShineHolder->updateHintPos(al::getTrans(mCurrentHackYoshi));
+
+    makeActorAlive();
+}
+
+const char* YoshiFruitWatcher::getSceneObjName() const {
+    return "ヨッシーフルーツ監視者";
+}
+
+void YoshiFruitWatcher::registerShineHolder(YoshiFruitShineHolder* shineHolder) {
+    mShineHolder = shineHolder;
+}
+
+bool YoshiFruitWatcher::registerFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo) {
+    mFruits.pushBack(fruit);
+
+    if (rs::isGetYoshiFruit(saveObjInfo)) {
+        mGetFruitNum++;
+        return false;
+    }
+
+    return true;
+}
+
+void YoshiFruitWatcher::noticeCurrentHackYoshi(Yoshi* yoshi) {
+    mCurrentHackYoshi = yoshi;
+}
+
+void YoshiFruitWatcher::noticeGetFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo) {
+    mGetFruitNum++;
+    mGetFruitSaveInfos.pushBack(saveObjInfo);
+
+    if (mShineHolder->getGotShineNum() < mGetFruitNum / 10) {
+        al::startFreezeGaugeAction(mGaugeLayout, 10.0f, 0.0f, 10.0f, "Gauge", "Gauge");
+        al::setNerve(this, &GaugeAppear);
+        return;
+    }
+
+    if (al::isNerve(this, &GaugeAppear))
+        return;
+
+    al::startFreezeGaugeAction(mGaugeLayout, mGetFruitNum % 10, 0.0f, 10.0f, "Gauge", "Gauge");
+    saveGetFruit();
+
+    if (al::isNerve(this, &GaugeEnd))
+        return;
+
+    if (al::isNerve(this, &GaugeWait)) {
+        al::setNerve(this, &GaugeWait);
+        return;
+    }
+
+    al::setNerve(this, &GaugeEnd);
+}
+
+void YoshiFruitWatcher::saveGetFruit() {
+    s32 lastIndex = mGetFruitSaveInfos.size() - 1;
+    if (lastIndex >= 0)
+        for (u64 i = 0;; i++) {
+            SaveObjInfo* saveObjInfo = static_cast<u32>(mGetFruitSaveInfos.size()) <= i ?
+                                           nullptr :
+                                           mGetFruitSaveInfos.data()[i];
+            rs::getYoshiFruit(saveObjInfo);
+            if (lastIndex == static_cast<s32>(i))
+                break;
+        }
+
+    mGetFruitSaveInfos.clear();
+}
+
+void YoshiFruitWatcher::control() {
+    if (mCurrentHackYoshi)
+        mShineHolder->updateHintPos(al::getTrans(mCurrentHackYoshi));
+}
+
+void YoshiFruitWatcher::exeWait() {}
+
+void YoshiFruitWatcher::exeGaugeAppear() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mGaugeLayout, "Appear", nullptr);
+        al::appearLayoutIfDead(mGaugeLayout);
+    }
+
+    al::LayoutActor* gaugeLayout = mGaugeLayout;
+    const al::LiveActor* hostActor = this;
+    sead::Vector3f worldPos = {0.0f, 0.0f, 0.0f};
+    rs::calcPlayerFollowLayoutWorldPos(&worldPos, hostActor);
+    sead::Vector2f layoutPos = {0.0f, 0.0f};
+    al::calcLayoutPosFromWorldPos(&layoutPos, hostActor, worldPos);
+    al::setLocalTrans(gaugeLayout, layoutPos);
+
+    if (al::isActionEnd(mGaugeLayout, nullptr))
+        al::setNerve(this, &GaugeWait);
+}
+
+void YoshiFruitWatcher::exeGaugeWait() {
+    if (al::isFirstStep(this))
+        al::startAction(mGaugeLayout, "Wait", nullptr);
+
+    al::LayoutActor* gaugeLayout = mGaugeLayout;
+    const al::LiveActor* hostActor = this;
+    sead::Vector3f worldPos = {0.0f, 0.0f, 0.0f};
+    rs::calcPlayerFollowLayoutWorldPos(&worldPos, hostActor);
+    sead::Vector2f layoutPos = {0.0f, 0.0f};
+    al::calcLayoutPosFromWorldPos(&layoutPos, hostActor, worldPos);
+    al::setLocalTrans(gaugeLayout, layoutPos);
+
+    if (!al::isLessStep(this, 120))
+        al::setNerve(this, &DemoRequest);
+}
+
+void YoshiFruitWatcher::exeGaugeEnd() {
+    if (al::isFirstStep(this))
+        al::startAction(mGaugeLayout, "End", nullptr);
+
+    al::LayoutActor* gaugeLayout = mGaugeLayout;
+    const al::LiveActor* hostActor = this;
+    sead::Vector3f worldPos = {0.0f, 0.0f, 0.0f};
+    rs::calcPlayerFollowLayoutWorldPos(&worldPos, hostActor);
+    sead::Vector2f layoutPos = {0.0f, 0.0f};
+    al::calcLayoutPosFromWorldPos(&layoutPos, hostActor, worldPos);
+    al::setLocalTrans(gaugeLayout, layoutPos);
+
+    if (al::isActionEnd(mGaugeLayout, nullptr)) {
+        mGaugeLayout->kill();
+        al::setNerve(this, &Wait);
+    }
+}
+
+void YoshiFruitWatcher::exeDemoRequest() {
+    if (rs::requestStartDemoNormal(this, false))
+        al::setNerve(this, &DemoGauge);
+}
+
+void YoshiFruitWatcher::exeDemoGauge() {
+    if (al::isFirstStep(this)) {
+        al::startAction(mGaugeLayout, "Complete", nullptr);
+        al::appearLayoutIfDead(mGaugeLayout);
+
+        if (mCurrentHackYoshi)
+            mCurrentHackYoshi->startFruitShineGetDemo();
+    }
+
+    {
+        const al::LiveActor* hostActor = this;
+        al::LayoutActor* gaugeLayout = mGaugeLayout;
+        sead::Vector3f worldPos = {0.0f, 0.0f, 0.0f};
+        rs::calcPlayerFollowLayoutWorldPos(&worldPos, this);
+        sead::Vector2f layoutPos = {0.0f, 0.0f};
+        al::calcLayoutPosFromWorldPos(&layoutPos, hostActor, worldPos);
+        al::setLocalTrans(gaugeLayout, layoutPos);
+    }
+
+    if (!al::isActionEnd(mGaugeLayout, nullptr))
+        return;
+
+    sead::Vector3f playerPos = rs::getPlayerPos(this);
+    sead::Vector2f paneTrans = {0.0f, 0.0f};
+    al::calcPaneTrans(&paneTrans, mGaugeLayout, "PicGauge00");
+
+    sead::Vector3f shinePos = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f playerPosOffset = playerPos + sead::Vector3f::ey * 200.0f;
+    al::calcWorldPosFromLayoutPos(&shinePos, this, paneTrans, playerPosOffset);
+
+    mDemoShine = mShineHolder->appearShineFromFruit(shinePos);
+    mGaugeLayout->kill();
+    rs::addDemoActor(mDemoShine, false);
+    al::setNerve(this, &DemoShine);
+}
+
+void YoshiFruitWatcher::exeDemoShine() {
+    if (!mDemoShine->isEndAppear())
+        return;
+
+    if (!al::isGreaterEqualStep(this, 120))
+        return;
+
+    saveGetFruit();
+    rs::requestEndDemoNormal(this);
+    al::startFreezeGaugeAction(mGaugeLayout, mGetFruitNum % 10, 0.0f, 10.0f, "Gauge", "Gauge");
+    mDemoShine->getDirectWithDemo();
+
+    if (mGetFruitNum % 10 != 0)
+        al::setNerve(this, &GaugeEnd);
+    else
+        al::setNerve(this, &Wait);
+}
+
+namespace rs {
+bool registerFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo) {
+    YoshiFruitWatcher* watcher = al::createSceneObj<YoshiFruitWatcher>(fruit);
+    return watcher->registerFruit(fruit, saveObjInfo);
+}
+
+void registerFruitShineHolder(YoshiFruitShineHolder* shineHolder) {
+    YoshiFruitWatcher* watcher = al::createSceneObj<YoshiFruitWatcher>(shineHolder);
+    watcher->registerShineHolder(shineHolder);
+}
+
+void noticeCurrentHackYoshi(Yoshi* yoshi) {
+    if (al::isExistSceneObj<YoshiFruitWatcher>(yoshi))
+        al::getSceneObj<YoshiFruitWatcher>(yoshi)->noticeCurrentHackYoshi(yoshi);
+}
+
+void noticeGetFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo) {
+    al::getSceneObj<YoshiFruitWatcher>(fruit)->noticeGetFruit(fruit, saveObjInfo);
+}
+}  // namespace rs

--- a/src/Item/YoshiFruitWatcher.h
+++ b/src/Item/YoshiFruitWatcher.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class LayoutActor;
+}  // namespace al
+
+class SaveObjInfo;
+class Shine;
+class Yoshi;
+class YoshiFruitShineHolder;
+
+class YoshiFruitWatcher : public al::LiveActor, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_YoshiFruitWatcher;
+
+    YoshiFruitWatcher();
+
+    const char* getSceneObjName() const override;
+    void initAfterPlacementSceneObj(const al::ActorInitInfo& info) override;
+
+    void registerShineHolder(YoshiFruitShineHolder* shineHolder);
+    bool registerFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo);
+    void noticeCurrentHackYoshi(Yoshi* yoshi);
+    void noticeGetFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo);
+    void saveGetFruit();
+    void control() override;
+
+    void exeWait();
+    void exeGaugeAppear();
+    void exeGaugeWait();
+    void exeGaugeEnd();
+    void exeDemoRequest();
+    void exeDemoGauge();
+    void exeDemoShine();
+
+private:
+    sead::PtrArray<al::LiveActor> mFruits;
+    sead::PtrArray<SaveObjInfo> mGetFruitSaveInfos;
+    YoshiFruitShineHolder* mShineHolder = nullptr;
+    Yoshi* mCurrentHackYoshi = nullptr;
+    s32 mGetFruitNum = 0;
+    Shine* mDemoShine = nullptr;
+    al::LayoutActor* mGaugeLayout = nullptr;
+};
+
+static_assert(sizeof(YoshiFruitWatcher) == 0x158);
+
+namespace rs {
+bool registerFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo);
+void registerFruitShineHolder(YoshiFruitShineHolder* shineHolder);
+void noticeCurrentHackYoshi(Yoshi* yoshi);
+void noticeGetFruit(al::LiveActor* fruit, SaveObjInfo* saveObjInfo);
+}  // namespace rs


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1252)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 3ec0a37)

📈 **Matched code**: 15.17% (+0.03%, +3232 bytes)

<details>
<summary>✅ 34 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::noticeGetFruit(al::LiveActor*, SaveObjInfo*)` | +440 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeDemoGauge()` | +416 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeDemoShine()` | +304 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::YoshiFruitWatcher()` | +212 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeGaugeEnd()` | +208 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeGaugeAppear()` | +204 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::YoshiFruitWatcher()` | +200 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +192 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeGaugeWait()` | +180 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `rs::registerFruit(al::LiveActor*, SaveObjInfo*)` | +148 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::saveGetFruit()` | +108 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::registerFruit(al::LiveActor*, SaveObjInfo*)` | +104 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `rs::noticeCurrentHackYoshi(Yoshi*)` | +84 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvDemoRequest::execute(al::NerveKeeper*) const` | +68 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeDemoRequest()` | +64 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `rs::registerFruitShineHolder(YoshiFruitShineHolder*)` | +64 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `rs::noticeGetFruit(al::LiveActor*, SaveObjInfo*)` | +64 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::control()` | +56 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `non-virtual thunk to YoshiFruitWatcher::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `non-virtual thunk to YoshiFruitWatcher::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::registerShineHolder(YoshiFruitShineHolder*)` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::noticeCurrentHackYoshi(Yoshi*)` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `non-virtual thunk to YoshiFruitWatcher::~YoshiFruitWatcher()` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvGaugeAppear::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvGaugeWait::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvGaugeEnd::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvDemoGauge::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `(anonymous namespace)::YoshiFruitWatcherNrvDemoShine::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Item/YoshiFruitWatcher` | `YoshiFruitWatcher::exeWait()` | +4 | 0.00% | 100.00% |

...and 4 more new matches
</details>


<!-- decomp.dev report end -->