### PR TITLE
Boss/BossKnuckle: Implement `BossKnuckleCounterGround`

### DIFF
--- a/src/Boss/BossKnuckle/BossKnuckleCounterGround.cpp
+++ b/src/Boss/BossKnuckle/BossKnuckleCounterGround.cpp
@@ -1,0 +1,279 @@
+#include "Boss/BossKnuckle/BossKnuckleCounterGround.h"
+
+#include <math/seadQuat.h>
+
+#include "Library/Item/ItemUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Util/ItemUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(BossKnuckleCounterGround, WaitOnGround);
+NERVE_IMPL(BossKnuckleCounterGround, Break);
+NERVE_IMPL(BossKnuckleCounterGround, Fall);
+NERVE_IMPL(BossKnuckleCounterGround, BeforeStart);
+NERVE_IMPL(BossKnuckleCounterGround, Sink);
+NERVES_MAKE_NOSTRUCT(BossKnuckleCounterGround, WaitOnGround, Break, Fall, BeforeStart, Sink);
+}  // namespace
+
+BossKnuckleCounterGround::BossKnuckleCounterGround(const char* name)
+    : al::LiveActor(name), mBreakActor(nullptr), mUnusedActor(nullptr), mLifeUpItem(nullptr),
+      mFallStartTrans(0.0f, 0.0f, 0.0f), mIsBreakOnGround(false), mIsBreakByIceConflict(false) {}
+
+void BossKnuckleCounterGround::init(const al::ActorInitInfo& initInfo) {
+    al::initActorWithArchiveName(this, initInfo, "BossKnuckleCounterGround", nullptr);
+    al::initNerve(this, &WaitOnGround, 0);
+
+    mBreakActor = new al::LiveActor("氷壊れ");
+    al::initChildActorWithArchiveNameNoPlacementInfo(mBreakActor, initInfo,
+                                                     "BossKnuckleCounterGroundBreak", nullptr);
+
+    bool hasLifeUp = false;
+    al::tryGetArg(&hasLifeUp, initInfo, "HasLifeUp");
+    if (hasLifeUp) {
+        mLifeUpItem = new al::LiveActor("ライフアップアイテム");
+        al::initChildActorWithArchiveNameNoPlacementInfo(mLifeUpItem, initInfo, "LifeUpItem",
+                                                         nullptr);
+        al::setTrans(mLifeUpItem, al::getTrans(this));
+        mLifeUpItem->makeActorAlive();
+        al::offCollide(mLifeUpItem);
+        rs::tryInitItem(this, rs::ItemType::LifeUpItem, initInfo, false);
+    }
+
+    mBreakActor->makeActorDead();
+    al::invalidateClipping(this);
+    makeActorAlive();
+}
+
+void BossKnuckleCounterGround::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isNerve(this, &Break))
+        return;
+
+    if (al::isSensorEnemyBody(other) && rs::sendMsgBossKnuckleCounter(other, self)) {
+        mIsBreakByIceConflict = false;
+        if (al::isAlive(this)) {
+            mIsBreakOnGround = al::isNerve(this, &WaitOnGround);
+            al::setNerve(this, &Break);
+        }
+    }
+
+    if (al::isNerve(this, &Fall)) {
+        if (al::sendMsgEnemyAttack(other, self)) {
+            mIsBreakByIceConflict = false;
+            al::startHitReaction(this, "氷衝突");
+            if (al::isAlive(this)) {
+                mIsBreakOnGround = al::isNerve(this, &WaitOnGround);
+                al::setNerve(this, &Break);
+            }
+        }
+
+        rs::sendMsgBossKnuckleIceFallToMummy(other, self);
+        rs::sendMsgBossKnuckleIceConflict(other, self);
+    }
+}
+
+void BossKnuckleCounterGround::doBreak() {
+    if (al::isAlive(this)) {
+        mIsBreakOnGround = al::isNerve(this, &WaitOnGround);
+        al::setNerve(this, &Break);
+    }
+}
+
+bool BossKnuckleCounterGround::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                          al::HitSensor* self) {
+    if (al::isMsgPlayerDisregard(message))
+        return true;
+
+    if (al::isNerve(this, &Break))
+        return false;
+
+    if (al::isNerve(this, &Fall))
+        return false;
+
+    if (!rs::isMsgBossKnuckleIceConflict(message))
+        return false;
+
+    if (al::isNerve(this, &WaitOnGround))
+        al::startHitReaction(this, "氷衝突（埋まり)");
+    else
+        al::startHitReaction(this, "氷衝突");
+
+    mIsBreakByIceConflict = true;
+    al::offCollide(this);
+    if (al::isAlive(this)) {
+        mIsBreakOnGround = al::isNerve(this, &WaitOnGround);
+        al::setNerve(this, &Break);
+    }
+
+    return true;
+}
+
+void BossKnuckleCounterGround::doFall(const sead::Vector3f& trans) {
+    al::offCollide(this);
+    al::invalidateCollisionParts(this);
+    al::showModelIfHide(this);
+    al::invalidateClipping(this);
+
+    mFallStartTrans.set(trans);
+    sead::Vector3f startTrans = trans;
+    startTrans.y += 1400.0f;
+    al::resetPosition(this, startTrans);
+    al::setUp(this, sead::Vector3f::ey);
+    al::setVelocityY(this, -20.0f);
+    al::validateShadow(this);
+    appear();
+    al::setNerve(this, &Fall);
+}
+
+void BossKnuckleCounterGround::doFallStartDemo() {
+    appear();
+    al::offCollide(this);
+    al::invalidateCollisionParts(this);
+    al::showModelIfHide(this);
+    al::invalidateClipping(this);
+
+    mFallStartTrans.set(al::getTrans(this));
+    mFallStartTrans.y += 200.0f;
+    sead::Vector3f startTrans = mFallStartTrans;
+    startTrans.y += 3500.0f;
+    al::resetPosition(this, startTrans);
+    al::setUp(this, sead::Vector3f::ey);
+    al::setVelocityY(this, -120.0f);
+
+    if (mLifeUpItem)
+        al::resetPosition(mLifeUpItem, startTrans + sead::Vector3f::ey * 105.0f);
+
+    al::setNerve(this, &Fall);
+}
+
+void BossKnuckleCounterGround::setBeforeStart() {
+    al::setNerve(this, &BeforeStart);
+}
+
+void BossKnuckleCounterGround::doWaitOnGround() {
+    al::startAction(this, "Sink");
+    al::setActionFrame(this, al::getActionFrameMax(this, "Sink"));
+    al::offCollide(this);
+    al::setUp(this, sead::Vector3f::ey);
+    al::invalidateShadow(this);
+
+    if (mLifeUpItem)
+        al::resetPosition(mLifeUpItem, al::getTrans(this) + sead::Vector3f::ey * 105.0f);
+
+    al::setNerve(this, &WaitOnGround);
+}
+
+bool BossKnuckleCounterGround::isBreak() const {
+    return al::isNerve(this, &Break);
+}
+
+bool BossKnuckleCounterGround::isBeforeStart() const {
+    return al::isNerve(this, &BeforeStart);
+}
+
+void BossKnuckleCounterGround::killAll() {
+    mBreakActor->kill();
+    if (mLifeUpItem)
+        mLifeUpItem->kill();
+    kill();
+}
+
+void BossKnuckleCounterGround::exeWaitOnGround() {
+    if (al::isFirstStep(this))
+        al::validateCollisionParts(this);
+}
+
+void BossKnuckleCounterGround::exeFall() {
+    if (al::isFirstStep(this)) {
+        al::onCollide(this);
+        al::startAction(this, "Wait");
+    }
+
+    al::turnFront(this, 4.0f);
+
+    if (mLifeUpItem)
+        al::setTrans(mLifeUpItem, al::getTrans(this) + sead::Vector3f::ey * 105.0f);
+
+    if (al::isOnGround(this, 0)) {
+        f32 groundOffset = al::getTrans(this).y - al::getColliderRadius(this) - mFallStartTrans.y;
+        if (al::isNearZeroOrLess(groundOffset)) {
+            al::reboundVelocityFromCollision(this, 0.0f, 0.0f, 1.0f);
+            al::offCollide(this);
+            al::setNerve(this, &Sink);
+        }
+    }
+}
+
+void BossKnuckleCounterGround::exeSink() {
+    if (al::isFirstStep(this)) {
+        al::startAction(this, "Sink");
+        al::setVelocityZero(this);
+        al::setVelocityY(this, -15.0f);
+        al::startHitReaction(this, "埋まり始め");
+    }
+
+    al::turnFront(this, 3.0f);
+
+    if (mLifeUpItem)
+        al::setTrans(mLifeUpItem, al::getTrans(this) + sead::Vector3f::ey * 105.0f);
+
+    if (al::isGreaterEqualStep(this, 26)) {
+        al::invalidateShadow(this);
+        al::setVelocityZero(this);
+        al::setNerve(this, &WaitOnGround);
+    }
+}
+
+void BossKnuckleCounterGround::exeBreak() {
+    if (al::isFirstStep(this)) {
+        if (!mIsBreakByIceConflict) {
+            al::setTrans(mBreakActor, al::getTrans(this));
+            al::copyPose(mBreakActor, this);
+            mBreakActor->makeActorAlive();
+            al::invalidateClipping(mBreakActor);
+            if (mIsBreakOnGround)
+                al::startAction(mBreakActor, "BreakGround");
+            else
+                al::startAction(mBreakActor, "BreakAir");
+            al::hideModelIfShow(this);
+            al::invalidateCollisionParts(this);
+        }
+
+        if (mLifeUpItem) {
+            const sead::Vector3f& trans = al::getTrans(this);
+            sead::Vector3f itemTrans =
+                sead::Vector3f::ey * 105.0f + sead::Vector3f::ey * 105.0f + trans;
+            const sead::Quatf& itemQuat = al::getQuat(mLifeUpItem);
+            al::appearItem(this, itemTrans, itemQuat, nullptr);
+            mLifeUpItem->kill();
+            mLifeUpItem = nullptr;
+        }
+    }
+
+    if (mIsBreakByIceConflict) {
+        kill();
+        return;
+    }
+
+    if (al::isActionEnd(mBreakActor) && al::isGreaterEqualStep(this, 1)) {
+        mIsBreakOnGround = false;
+        al::validateClipping(mBreakActor);
+        mBreakActor->kill();
+        kill();
+    }
+}
+
+void BossKnuckleCounterGround::exeBeforeStart() {}

--- a/src/Boss/BossKnuckle/BossKnuckleCounterGround.h
+++ b/src/Boss/BossKnuckle/BossKnuckleCounterGround.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class BossKnuckleCounterGround : public al::LiveActor {
+public:
+    BossKnuckleCounterGround(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void doBreak();
+    void doFall(const sead::Vector3f& trans);
+    void doFallStartDemo();
+    void setBeforeStart();
+    void doWaitOnGround();
+    bool isBreak() const;
+    bool isBeforeStart() const;
+    void killAll();
+    void exeWaitOnGround();
+    void exeFall();
+    void exeSink();
+    void exeBreak();
+    void exeBeforeStart();
+
+private:
+    al::LiveActor* mBreakActor;
+    al::LiveActor* mUnusedActor;
+    al::LiveActor* mLifeUpItem;
+    sead::Vector3f mFallStartTrans;
+    bool mIsBreakOnGround;
+    bool mIsBreakByIceConflict;
+};
+
+static_assert(sizeof(BossKnuckleCounterGround) == 0x130);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -36,6 +36,7 @@
 
 #include "Boss/BarrierField.h"
 #include "Boss/BossForest/BossForestWander.h"
+#include "Boss/BossKnuckle/BossKnuckleCounterGround.h"
 #include "Boss/Mofumofu/MofumofuScrap.h"
 #include "Camera/ScenarioStartCamera.h"
 #include "Demo/DemoPeachWedding.h"
@@ -191,7 +192,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"BossForestBlock", nullptr},
     {"BossForestWander", al::createActorFunction<BossForestWander>},
     {"BossKnuckle", nullptr},
-    {"BossKnuckleCounterGround", nullptr},
+    {"BossKnuckleCounterGround", al::createActorFunction<BossKnuckleCounterGround>},
     {"BossKnuckleFix", al::createActorFunction<BossKnuckleFix>},
     {"BossMagma", nullptr},
     {"BossRaid", nullptr},


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1253)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 1a0abf3)

📈 **Matched code**: 15.17% (+0.03%, +3204 bytes)

<details>
<summary>✅ 24 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::exeBreak()` | +384 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::init(al::ActorInitInfo const&)` | +364 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::doFallStartDemo()` | +304 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::exeFall()` | +288 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::attackSensor(al::HitSensor*, al::HitSensor*)` | +272 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +248 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::exeSink()` | +248 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::doWaitOnGround()` | +216 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::doFall(sead::Vector3<float> const&)` | +204 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::BossKnuckleCounterGround(char const*)` | +148 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::BossKnuckleCounterGround(char const*)` | +136 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::doBreak()` | +84 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::killAll()` | +76 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `(anonymous namespace)::BossKnuckleCounterGroundNrvWaitOnGround::execute(al::NerveKeeper*) const` | +56 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::exeWaitOnGround()` | +52 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<BossKnuckleCounterGround>(char const*)` | +52 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::isBreak() const` | +16 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::setBeforeStart()` | +12 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::isBeforeStart() const` | +12 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `(anonymous namespace)::BossKnuckleCounterGroundNrvBreak::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `(anonymous namespace)::BossKnuckleCounterGroundNrvFall::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `(anonymous namespace)::BossKnuckleCounterGroundNrvSink::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `BossKnuckleCounterGround::exeBeforeStart()` | +4 | 0.00% | 100.00% |
| `Boss/BossKnuckle/BossKnuckleCounterGround` | `(anonymous namespace)::BossKnuckleCounterGroundNrvBeforeStart::execute(al::NerveKeeper*) const` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->