### PR TITLE
Player: Implement EquipmentInfo

### DIFF
--- a/src/Player/EquipmentInfo.cpp
+++ b/src/Player/EquipmentInfo.cpp
@@ -1,0 +1,26 @@
+#include "Player/EquipmentInfo.h"
+
+EquipmentInfo::EquipmentInfo(const al::LiveActor* actor) {
+    mActor = actor;
+    _8 = 0;
+    _c = 0;
+    _10 = 0.0f;
+}
+
+void EquipmentInfo::onNoCapThrow() {
+    _8 |= 1;
+}
+
+void EquipmentInfo::onForceDash(s32 param_1, f32 param_2) {
+    _8 |= 2;
+    _c = param_1;
+    _10 = param_2;
+}
+
+bool EquipmentInfo::isNoCapThrow() const {
+    return (_8 & 1) != 0;
+}
+
+bool EquipmentInfo::isForceDash() const {
+    return (_8 & 2) != 0;
+}

--- a/src/Player/EquipmentInfo.h
+++ b/src/Player/EquipmentInfo.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class EquipmentInfo {
+public:
+    EquipmentInfo(const al::LiveActor* actor);
+
+    void onNoCapThrow();
+    void onForceDash(s32, f32);
+    bool isNoCapThrow() const;
+    bool isForceDash() const;
+
+private:
+    const al::LiveActor* mActor;
+    u32 _8;
+    s32 _c;
+    f32 _10;
+};
+
+static_assert(sizeof(EquipmentInfo) == 0x18);


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#1146

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1257)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - d9fe957)

📈 **Matched code**: 15.14% (+0.00%, +72 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/EquipmentInfo` | `EquipmentInfo::onForceDash(int, float)` | +20 | 0.00% | 100.00% |
| `Player/EquipmentInfo` | `EquipmentInfo::onNoCapThrow()` | +16 | 0.00% | 100.00% |
| `Player/EquipmentInfo` | `EquipmentInfo::EquipmentInfo(al::LiveActor const*)` | +12 | 0.00% | 100.00% |
| `Player/EquipmentInfo` | `EquipmentInfo::isNoCapThrow() const` | +12 | 0.00% | 100.00% |
| `Player/EquipmentInfo` | `EquipmentInfo::isForceDash() const` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->