### PR TITLE
Library/Item: Implement `ActorItemInfo`

### DIFF
--- a/lib/al/Library/Item/ActorItemInfo.cpp
+++ b/lib/al/Library/Item/ActorItemInfo.cpp
@@ -1,0 +1,27 @@
+#include "Library/Item/ActorItemInfo.h"
+
+#include "Library/Base/StringUtil.h"
+
+namespace al {
+
+ActorItemInfo::ActorItemInfo(const char* name, const char* timing, const char* factor, s32 value) {
+    mName = name;
+    mTiming = timing;
+    mFactor = factor;
+    _18 = 0;
+    mValue = value;
+}
+
+bool ActorItemInfo::isEqualTiming(const char* timing) const {
+    if (timing != nullptr && mTiming != nullptr)
+        return isEqualString(timing, mTiming);
+    return timing == nullptr && mTiming == nullptr;
+}
+
+bool ActorItemInfo::isEqualFactor(const char* factor) const {
+    if (factor != nullptr && mFactor != nullptr)
+        return isEqualString(factor, mFactor);
+    return factor == nullptr && mFactor == nullptr;
+}
+
+}  // namespace al

--- a/lib/al/Library/Item/ActorItemInfo.h
+++ b/lib/al/Library/Item/ActorItemInfo.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+class ActorItemInfo {
+public:
+    ActorItemInfo(const char* name, const char* timing, const char* factor, s32 value);
+
+    bool isEqualTiming(const char* timing) const;
+    bool isEqualFactor(const char* factor) const;
+
+private:
+    const char* mName;
+    const char* mTiming;
+    const char* mFactor;
+    s32 _18;
+    s32 mValue;
+};
+
+static_assert(sizeof(ActorItemInfo) == 0x20);
+
+}  // namespace al


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#2234

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1258)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 79fb237)

📈 **Matched code**: 15.15% (+0.00%, +96 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Unknown/ActorItemInfo` | `al::ActorItemInfo::isEqualTiming(char const*) const` | +40 | 0.00% | 100.00% |
| `Unknown/ActorItemInfo` | `al::ActorItemInfo::isEqualFactor(char const*) const` | +40 | 0.00% | 100.00% |
| `Unknown/ActorItemInfo` | `al::ActorItemInfo::ActorItemInfo(char const*, char const*, char const*, int)` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->