### PR TITLE
Audio: Implement `ProjectSeNamedList`

### DIFF
--- a/src/Audio/ProjectSeNamedList.cpp
+++ b/src/Audio/ProjectSeNamedList.cpp
@@ -1,0 +1,36 @@
+#include "Audio/ProjectSeNamedList.h"
+
+static const char* const sMuteSeInPVList[] = {
+    "WsEmMeganeOnStart",
+    "WsEvMeganeOnStart",
+    "SeMoMeElecWireMoveLv",
+    "SeBmMeBossKnuckleHackMoveLv",
+    "SeBmMeBossKnuckleHackMoveFastLv",
+    "SeMoMeCapFlowerOpen",
+    "SeMoMeCapFlowerOpenAll",
+    "WsUiTalkUiAppearSquare",
+    "WsdSyMapWindowSubClose",
+    "RcWsdSyTestWindowClose",
+    "WsSyJumpingRopeCount",
+    "RcWsdSyTestWindowAppear",
+    "WsdSyTestWindowAppear",
+    "RcSeGmCsAppear",
+    "WsSyPlayerLifeAlertTrg",
+    "WsUiInvalid03",
+    "WsdSySelectButtonMove",
+    "WsUiSkip",
+    "WsNvCapManHeroTalkInfo_",
+    "SeBmMe",
+    "SeMoMe",
+    "SeEmMe",
+};
+
+ProjectSeNamedList::ProjectSeNamedList() = default;
+
+s32 ProjectSeNamedList::getMuteSeInPVListSize() {
+    return 0x16;
+}
+
+const char* const* ProjectSeNamedList::getMuteSeInPVList() {
+    return sMuteSeInPVList;
+}

--- a/src/Audio/ProjectSeNamedList.h
+++ b/src/Audio/ProjectSeNamedList.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class ProjectSeNamedList {
+public:
+    ProjectSeNamedList();
+
+    s32 getMuteSeInPVListSize();
+    const char* const* getMuteSeInPVList();
+};


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#23

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1259)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 072ad41)

📈 **Matched code**: 15.14% (+0.00%, +24 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Audio/ProjectSeNamedList` | `ProjectSeNamedList::getMuteSeInPVList()` | +12 | 0.00% | 100.00% |
| `Audio/ProjectSeNamedList` | `ProjectSeNamedList::getMuteSeInPVListSize()` | +8 | 0.00% | 100.00% |
| `Audio/ProjectSeNamedList` | `ProjectSeNamedList::ProjectSeNamedList()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->