### PR TITLE
Sequence: Implement `HakoniwaStateDemoEnding`

### DIFF
--- a/lib/al/Library/Nerve/NerveStateBase.h
+++ b/lib/al/Library/Nerve/NerveStateBase.h
@@ -40,6 +40,9 @@ public:
 
     T* getHost() const { return mHost; }
 
+protected:
+    T** getHostPtr() { return &mHost; }
+
 private:
     T* mHost;
 };

--- a/lib/al/Library/Play/Layout/WipeHolder.h
+++ b/lib/al/Library/Play/Layout/WipeHolder.h
@@ -24,12 +24,19 @@ public:
     bool isOpenEnd() const;
     bool isCloseWipe(const char* name) const;
 
+    bool isClose() const { return mIsClose; }
+
 private:
     s32 mMaxWipeCount;
     s32 mWipeCount;
-    void* _8;
+    s32 mCurrentWipeIndex;
+    u32 _c;
     WipeSimple** mWipes;
-    void* filler[4];
+    bool mIsClose;
+    u8 _19[7];
+    void* _20;
+    void* _28;
+    s32 _30;
 };
 }  // namespace al
 

--- a/lib/al/Library/Scene/Scene.h
+++ b/lib/al/Library/Scene/Scene.h
@@ -83,6 +83,8 @@ public:
 
     DrawSystemInfo* getDrawSystemInfo() const { return mDrawSystemInfo; }
 
+    bool isAlive() const { return mIsAlive; }
+
 private:
     bool mIsAlive = false;
     sead::FixedSafeString<0x40> mName;

--- a/lib/al/Library/Sequence/Sequence.h
+++ b/lib/al/Library/Sequence/Sequence.h
@@ -6,13 +6,24 @@
 #include "Library/Nerve/NerveExecutor.h"
 #include "Library/Sequence/IUseSceneCreator.h"
 
+namespace sead {
+class Heap;
+}  // namespace sead
+
+namespace alSceneFunction {
+class SceneFactory;
+}  // namespace alSceneFunction
+
 namespace al {
 struct GameSystemInfo;
 struct DrawSystemInfo;
 struct SequenceInitInfo;
 struct AudioSystemInfo;
+struct AudioDirectorInitInfo;
+class GameDataHolderBase;
 class AudioDirector;
 class Scene;
+class ScreenCaptureExecutor;
 
 class Sequence : public NerveExecutor, public IUseAudioKeeper, public IUseSceneCreator {
 public:
@@ -43,6 +54,10 @@ public:
 
     DrawSystemInfo* getDrawInfo() const { return mDrawSystemInfo; }
 
+    AudioDirector* getAudioDirector() const { return mAudioDirector; }
+
+    void setNextScene(Scene* scene) { mNextScene = scene; }
+
 private:
     sead::FixedSafeString<0x40> mName;
     Scene* mCurrentScene = nullptr;
@@ -53,4 +68,25 @@ private:
     DrawSystemInfo* mDrawSystemInfo = nullptr;
     bool mIsAlive = true;
 };
+
+void initSceneCreator(IUseSceneCreator* sceneCreator, const SequenceInitInfo& initInfo,
+                      GameDataHolderBase* gameDataHolder, AudioDirector* audioDirector,
+                      ScreenCaptureExecutor* screenCaptureExecutor,
+                      alSceneFunction::SceneFactory* sceneFactory);
+Scene* createSceneAndInit(IUseSceneCreator* sceneCreator, const char* stageName,
+                          const char* sceneName, s32 scenarioNo, const char* sequenceParam);
+void createSceneAndUseInitThread(IUseSceneCreator* sceneCreator, const char* stageName,
+                                 s32 priority, const char* sceneName, s32 scenarioNo,
+                                 const char* sequenceParam);
+void setSceneAndInit(IUseSceneCreator* sceneCreator, Scene* scene, const char* stageName,
+                     s32 scenarioNo, const char* sequenceParam);
+void setSceneAndUseInitThread(IUseSceneCreator* sceneCreator, Scene* scene, s32 priority,
+                              const char* stageName, s32 scenarioNo, const char* sequenceParam,
+                              sead::Heap* heap);
+bool tryEndSceneInitThread(IUseSceneCreator* sceneCreator);
+bool isExistSceneInitThread(const IUseSceneCreator* sceneCreator);
+void initAudioDirector(Sequence* sequence, AudioSystemInfo* audioSystemInfo,
+                       AudioDirectorInitInfo& initInfo);
+void setSequenceAudioKeeperToSceneSeDirector(Sequence* sequence, Scene* scene);
+void setSequenceNameForActorPickTool(Sequence* sequence, Scene* scene);
 }  // namespace al

--- a/src/Scene/EndingScene.h
+++ b/src/Scene/EndingScene.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <prim/seadSafeString.h>
+
+#include "Library/Scene/Scene.h"
+
+namespace al {
+struct ActorInitInfo;
+class LayoutInitInfo;
+struct SceneInitInfo;
+class StageInfo;
+class WipeHolder;
+}  // namespace al
+
+class EndingScene : public al::Scene {
+public:
+    explicit EndingScene(al::WipeHolder* wipeHolder);
+
+    void init(const al::SceneInitInfo& initInfo) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void drawMain() const override;
+
+    void exePlay();
+    bool isLoadEnd() const;
+    void exeSkipProc();
+    void initLayout(const al::LayoutInitInfo& layoutInitInfo);
+    void initPlacement(const al::ActorInitInfo& actorInitInfo);
+    void initPlacementSky(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    void initPlacementDemo(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    void initPlacementObject(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo,
+                             const char* placementKey);
+
+    void setLoadEnd(bool isLoadEnd) { mIsLoadEnd = isLoadEnd; }
+
+private:
+    sead::FixedSafeString<64> mStageName;
+    u8 _130[0x10];
+    bool mIsLoadEnd = false;
+    u8 _141[7];
+    void* _148 = nullptr;
+    s32 _150 = 1;
+    u8 _154[4];
+    void* _158 = nullptr;
+    s32 _160 = 0;
+    u8 _164[4];
+    void* _168 = nullptr;
+    void* _170 = nullptr;
+    void* _178 = nullptr;
+    void* _180 = nullptr;
+    al::WipeHolder* mWipeHolder = nullptr;
+};
+
+static_assert(sizeof(EndingScene) == 0x190, "EndingScene size");

--- a/src/Scene/StaffRollScene.h
+++ b/src/Scene/StaffRollScene.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Message/IUseMessageSystem.h"
+#include "Library/Scene/Scene.h"
+
+namespace al {
+struct ActorInitInfo;
+class LayoutInitInfo;
+class MessageSystem;
+class Nerve;
+struct SceneInitInfo;
+class StageInfo;
+class WipeHolder;
+}  // namespace al
+
+class StaffRollScene : public al::Scene, public al::IUseMessageSystem {
+public:
+    explicit StaffRollScene(al::WipeHolder* wipeHolder);
+
+    void init(const al::SceneInitInfo& initInfo) override;
+    void appear() override;
+    void kill() override;
+    void control() override;
+    void drawMain() const override;
+    const al::MessageSystem* getMessageSystem() const override;
+
+    void initRollLineData();
+    void exeTitleLogo();
+    void exeRollLine();
+    void initCurrentRollLines();
+    void initSlideShowFrame();
+    void updateRollLine();
+    void updateSlideShow();
+    void tryChangeToSkipConfirm(const al::Nerve* nextNerve);
+    void exeThank();
+    void dropAllRollLine();
+    void exeShowPicture();
+    void exeRight();
+    void exeConfirm();
+    void exeSkipProc();
+    void exeSkipWipe();
+    void killRollLine();
+    s32 getMyNerveStep() const;
+    void initLayout(const al::LayoutInitInfo& layoutInitInfo);
+    f32 calcNameRollTimeRate(f32 rate);
+    void dropCurrentToStock();
+    void initPlacement(const al::ActorInitInfo& actorInitInfo);
+    void initPlacementSky(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    void initPlacementObject(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo,
+                             const char* placementKey);
+    void initPlacementDemo(const al::StageInfo* stageInfo, const al::ActorInitInfo& actorInitInfo);
+    bool isCanSkip();
+
+private:
+    const al::MessageSystem* mMessageSystem = nullptr;
+    al::WipeHolder* mWipeHolder = nullptr;
+    u8 _f0[0x6160];
+};
+
+static_assert(sizeof(StaffRollScene) == 0x6250, "StaffRollScene size");

--- a/src/Sequence/HakoniwaStateDeleteScene.h
+++ b/src/Sequence/HakoniwaStateDeleteScene.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+#include "Library/Sequence/Sequence.h"
+
+class WorldResourceLoader;
+
+namespace al {
+class AsyncFunctorThread;
+class Scene;
+}  // namespace al
+
+class HakoniwaStateDeleteScene : public al::HostStateBase<al::Sequence> {
+public:
+    HakoniwaStateDeleteScene(al::Sequence* sequence, WorldResourceLoader* resourceLoader);
+
+    void appear() override;
+    void kill() override;
+
+    void deleteScene();
+    void start(al::Scene* scene, bool destroyResource, bool finalizeAudio, s32 stopSeFrame);
+    void exePrepare();
+    void exeFinalizeAudio();
+    void exeDeleteScene();
+
+private:
+    al::Scene* mScene = nullptr;
+    al::AsyncFunctorThread* mDeleteSceneThread = nullptr;
+    bool mIsDestroyResource = false;
+    bool mIsFinalizeAudio = false;
+    s32 mStopSeFrame = 0;
+    WorldResourceLoader* mResourceLoader = nullptr;
+};
+
+static_assert(sizeof(HakoniwaStateDeleteScene) == 0x40, "HakoniwaStateDeleteScene size");

--- a/src/Sequence/HakoniwaStateDemoEnding.cpp
+++ b/src/Sequence/HakoniwaStateDemoEnding.cpp
@@ -1,0 +1,235 @@
+#include "Sequence/HakoniwaStateDemoEnding.h"
+
+#include <heap/seadHeap.h>
+#include <nn/oe.h>
+#include <thread/seadThread.h>
+
+#include "Library/Audio/System/AudioKeeperFunction.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/Memory/HeapUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/WipeHolder.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/Scene/Scene.h"
+#include "Library/Screen/ScreenFunction.h"
+#include "Library/Sequence/Sequence.h"
+#include "Project/Memory/SceneHeapSetter.h"
+
+#include "Scene/EndingScene.h"
+#include "Scene/StaffRollScene.h"
+#include "Sequence/HakoniwaSequence.h"
+#include "Sequence/HakoniwaStateDeleteScene.h"
+#include "Sequence/WorldResourceLoader.h"
+#include "System/GameDataFunction.h"
+
+const s32 cDefaultPriority = sead::Thread::cDefaultPriority;
+const s32 cPriority = cDefaultPriority + 3;
+
+namespace {
+NERVE_IMPL(HakoniwaStateDemoEnding, Load);
+NERVE_IMPL(HakoniwaStateDemoEnding, EndEnding);
+NERVE_IMPL(HakoniwaStateDemoEnding, End);
+NERVE_IMPL(HakoniwaStateDemoEnding, LoadWorldResource);
+NERVE_IMPL(HakoniwaStateDemoEnding, LoadWorldResourceSecond);
+NERVE_IMPL(HakoniwaStateDemoEnding, DemoEnding);
+NERVE_IMPL(HakoniwaStateDemoEnding, LoadStaffRoll);
+NERVE_IMPL(HakoniwaStateDemoEnding, DemoStaffRoll);
+
+NERVES_MAKE_NOSTRUCT(HakoniwaStateDemoEnding, Load, DemoEnding, LoadStaffRoll, DemoStaffRoll);
+NERVES_MAKE_STRUCT(HakoniwaStateDemoEnding, LoadWorldResource, EndEnding, End,
+                   LoadWorldResourceSecond);
+}  // namespace
+
+HakoniwaStateDemoEnding::HakoniwaStateDemoEnding(HakoniwaSequence* sequence,
+                                                 al::WipeHolder* wipeHolder,
+                                                 al::ScreenCaptureExecutor* screenCaptureExecutor,
+                                                 HakoniwaStateDeleteScene* stateDeleteScene,
+                                                 WorldResourceLoader* resourceLoader,
+                                                 GameDataHolder* gameDataHolder)
+    : al::HostStateBase<HakoniwaSequence>("エンディングデモ", sequence), mWipeHolder(wipeHolder),
+      mScreenCaptureExecutor(screenCaptureExecutor), mStateDeleteScene(stateDeleteScene),
+      mResourceLoader(resourceLoader), mGameDataHolder(gameDataHolder) {}
+
+HakoniwaStateDemoEnding::~HakoniwaStateDemoEnding() {
+    if (nn::oe::IsUserInactivityDetectionTimeExtended()) {
+        nn::oe::SetUserInactivityDetectionTimeExtended(false);
+        nn::oe::IsUserInactivityDetectionTimeExtended();
+    }
+
+    if (mCurrentScene)
+        delete mCurrentScene;
+    mCurrentScene = nullptr;
+}
+
+void HakoniwaStateDemoEnding::init() {
+    initNerve(&NrvHakoniwaStateDemoEnding.LoadWorldResource, 2);
+    al::addNerveState(this, mStateDeleteScene, &NrvHakoniwaStateDemoEnding.EndEnding,
+                      "シーン破棄[エンディング]");
+    al::addNerveState(this, mStateDeleteScene, &NrvHakoniwaStateDemoEnding.End,
+                      "シーン破棄[スタッフロール]");
+}
+
+void HakoniwaStateDemoEnding::appear() {
+    al::NerveStateBase::appear();
+    nn::oe::SetUserInactivityDetectionTimeExtended(true);
+
+    if (mResourceLoader->getLoadWorldId() == GameDataFunction::getWorldIndexMoon())
+        al::setNerve(this, &NrvHakoniwaStateDemoEnding.LoadWorldResource);
+    else
+        al::setNerve(this, &NrvHakoniwaStateDemoEnding.LoadWorldResourceSecond);
+}
+
+void HakoniwaStateDemoEnding::kill() {
+    nn::oe::SetUserInactivityDetectionTimeExtended(false);
+    al::NerveStateBase::kill();
+}
+
+void HakoniwaStateDemoEnding::exeLoadWorldResource() {
+    if (al::isFirstStep(this))
+        mResourceLoader->requestLoadWorldHomeStageResource(GameDataFunction::getWorldIndexMoon(),
+                                                           1);
+
+    if (mResourceLoader->isEndLoadWorldResource())
+        al::setNerve(this, &Load);
+}
+
+void HakoniwaStateDemoEnding::exeLoadWorldResourceSecond() {
+    if (al::isFirstStep(this))
+        mResourceLoader->requestLoadWorldResource(GameDataFunction::getWorldIndexMoon());
+
+    if (mResourceLoader->isEndLoadWorldResource())
+        al::setNerve(this, &NrvHakoniwaStateDemoEnding.LoadWorldResource);
+}
+
+void HakoniwaStateDemoEnding::exeLoad() {
+    HakoniwaSequence** sequence;
+
+    if (al::isFirstStep(this)) {
+        const char* stageName = "DemoEndingStage";
+        al::createSceneHeap(stageName, true);
+        al::setCurrentCategoryName("シーン");
+
+        {
+            al::SceneHeapSetter heapSetter;
+
+            EndingScene* scene = new EndingScene(mWipeHolder);
+            mCurrentScene = scene;
+            scene->setLoadEnd(true);
+
+            sequence = getHostPtr();
+            alAudioSystemFunction::resetDataDependedStage((*sequence)->getAudioDirector(),
+                                                          stageName, 1);
+            al::setSceneAndUseInitThread(*sequence, mCurrentScene, cPriority, stageName, 1,
+                                         "Sequence=ProductSequence", nullptr);
+        }
+    } else {
+        sequence = getHostPtr();
+    }
+
+    if (al::tryEndSceneInitThread(*sequence)) {
+        al::setSequenceAudioKeeperToSceneSeDirector(*sequence, mCurrentScene);
+        mScreenCaptureExecutor->offDraw();
+        mCurrentScene->appear();
+        (*sequence)->setNextScene(mCurrentScene);
+
+        if (!mWipeHolder->isOpenEnd())
+            mWipeHolder->startOpen(-1);
+
+        al::getSceneHeap()->adjust();
+        al::setSequenceNameForActorPickTool(*sequence, mCurrentScene);
+        al::setNerve(this, &DemoEnding);
+    }
+}
+
+void HakoniwaStateDemoEnding::exeDemoEnding() {
+    getHost()->updatePadSystem();
+
+    if (!mCurrentScene->isAlive()) {
+        mScreenCaptureExecutor->requestCapture(true, 0);
+        al::setNerve(this, &NrvHakoniwaStateDemoEnding.EndEnding);
+    }
+}
+
+void HakoniwaStateDemoEnding::exeEndEnding() {
+    if (al::isFirstStep(this)) {
+        mStateDeleteScene->start(mCurrentScene, true, false, 0);
+        al::stopBgm(getHost(), "Ending", -1);
+    }
+
+    if (al::updateNerveState(this)) {
+        mCurrentScene = nullptr;
+        if (!GameDataFunction::isGameClear(mGameDataHolder))
+            mResourceLoader->tryDestroyWorldResource();
+        al::setNerve(this, &LoadStaffRoll);
+    }
+}
+
+void HakoniwaStateDemoEnding::exeLoadStaffRoll() {
+    HakoniwaSequence** sequence;
+
+    if (al::isFirstStep(this)) {
+        const char* stageName = "StaffRollStage";
+        al::createSceneHeap(stageName, true);
+        al::setCurrentCategoryName("シーン");
+
+        {
+            al::SceneHeapSetter heapSetter;
+
+            mCurrentScene = new StaffRollScene(mWipeHolder);
+
+            sequence = getHostPtr();
+            alAudioSystemFunction::resetDataDependedStage((*sequence)->getAudioDirector(),
+                                                          stageName, 1);
+            al::setSceneAndUseInitThread(*sequence, mCurrentScene, cPriority, stageName, 1,
+                                         "Sequence=ProductSequence", nullptr);
+        }
+    } else {
+        sequence = getHostPtr();
+    }
+
+    if (al::tryEndSceneInitThread(*sequence)) {
+        al::setSequenceAudioKeeperToSceneSeDirector(*sequence, mCurrentScene);
+        mScreenCaptureExecutor->offDraw();
+        mCurrentScene->appear();
+        (*sequence)->setNextScene(mCurrentScene);
+        al::getSceneHeap()->adjust();
+        al::setSequenceNameForActorPickTool(*sequence, mCurrentScene);
+
+        if (!GameDataFunction::isGameClear(mGameDataHolder)) {
+            mResourceLoader->tryDestroyWorldResource();
+            mResourceLoader->requestLoadWorldHomeStageResource(
+                GameDataFunction::getWorldIndexPeach(), 2);
+        }
+
+        if (!mWipeHolder->isOpenEnd())
+            mWipeHolder->startOpen(-1);
+
+        al::setNerve(this, &DemoStaffRoll);
+    }
+}
+
+void HakoniwaStateDemoEnding::exeDemoStaffRoll() {
+    getHost()->updatePadSystem();
+
+    if (!mCurrentScene->isAlive()) {
+        mScreenCaptureExecutor->requestCapture(true, 0);
+
+        if (!mWipeHolder->isClose())
+            mWipeHolder->startClose("FadeBlack", -1);
+
+        al::setNerve(this, &NrvHakoniwaStateDemoEnding.End);
+    }
+}
+
+void HakoniwaStateDemoEnding::exeEnd() {
+    if (al::isFirstStep(this)) {
+        mStateDeleteScene->start(mCurrentScene, true, false, 0);
+        return;
+    }
+
+    if (al::updateNerveState(this)) {
+        mCurrentScene = nullptr;
+        kill();
+    }
+}

--- a/src/Sequence/HakoniwaStateDemoEnding.h
+++ b/src/Sequence/HakoniwaStateDemoEnding.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Nerve/NerveStateBase.h"
+
+#include "System/GameDataHolderAccessor.h"
+
+class GameDataHolder;
+class HakoniwaSequence;
+class HakoniwaStateDeleteScene;
+class WorldResourceLoader;
+
+namespace al {
+class Scene;
+class ScreenCaptureExecutor;
+class WipeHolder;
+}  // namespace al
+
+class HakoniwaStateDemoEnding : public al::HostStateBase<HakoniwaSequence> {
+public:
+    HakoniwaStateDemoEnding(HakoniwaSequence* sequence, al::WipeHolder* wipeHolder,
+                            al::ScreenCaptureExecutor* screenCaptureExecutor,
+                            HakoniwaStateDeleteScene* stateDeleteScene,
+                            WorldResourceLoader* resourceLoader, GameDataHolder* gameDataHolder);
+    ~HakoniwaStateDemoEnding() override;
+
+    void init() override;
+    void appear() override;
+    void kill() override;
+
+    void exeLoadWorldResource();
+    void exeLoadWorldResourceSecond();
+    void exeLoad();
+    void exeDemoEnding();
+    void exeEndEnding();
+    void exeLoadStaffRoll();
+    void exeDemoStaffRoll();
+    void exeEnd();
+
+private:
+    al::Scene* mCurrentScene = nullptr;
+    al::WipeHolder* mWipeHolder = nullptr;
+    al::ScreenCaptureExecutor* mScreenCaptureExecutor = nullptr;
+    HakoniwaStateDeleteScene* mStateDeleteScene = nullptr;
+    WorldResourceLoader* mResourceLoader = nullptr;
+    GameDataHolderAccessor mGameDataHolder;
+};
+
+static_assert(sizeof(HakoniwaStateDemoEnding) == 0x50, "HakoniwaStateDemoEnding size");


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1260)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 335debb)

📈 **Matched code**: 15.16% (+0.02%, +2564 bytes)

<details>
<summary>✅ 23 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeLoadStaffRoll()` | +412 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeLoad()` | +376 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeEndEnding()` | +152 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::HakoniwaStateDemoEnding(HakoniwaSequence*, al::WipeHolder*, al::ScreenCaptureExecutor*, HakoniwaStateDeleteScene*, WorldResourceLoader*, GameDataHolder*)` | +120 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeDemoStaffRoll()` | +120 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvDemoStaffRoll::execute(al::NerveKeeper*) const` | +120 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvEnd::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeEnd()` | +108 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::~HakoniwaStateDemoEnding()` | +100 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvLoadWorldResource::execute(al::NerveKeeper*) const` | +100 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeLoadWorldResource()` | +96 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvLoadWorldResourceSecond::execute(al::NerveKeeper*) const` | +96 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::~HakoniwaStateDemoEnding()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::init()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::appear()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeLoadWorldResourceSecond()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::exeDemoEnding()` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvDemoEnding::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `HakoniwaStateDemoEnding::kill()` | +44 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `_GLOBAL__sub_I_HakoniwaStateDemoEnding.cpp` | +32 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvLoad::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvEndEnding::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Sequence/HakoniwaStateDemoEnding` | `(anonymous namespace)::HakoniwaStateDemoEndingNrvLoadStaffRoll::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->