### PR TITLE
Library/Event: Implement `EventFlowEventData`

### DIFF
--- a/lib/al/Library/Event/EventFlowEventData.cpp
+++ b/lib/al/Library/Event/EventFlowEventData.cpp
@@ -5,8 +5,8 @@
 
 namespace al {
 
-EventFlowEventData::EventFlowEventData(const char* name, const EventFlowNodeInitInfo& info) {
-    mName = name;
+EventFlowEventData::EventFlowEventData(const char* name, const EventFlowNodeInitInfo& info)
+    : mName(name) {
     mParamIter = new ByamlIter();
     tryGetParamIter(mParamIter, info);
 }

--- a/lib/al/Library/Event/EventFlowEventData.cpp
+++ b/lib/al/Library/Event/EventFlowEventData.cpp
@@ -1,0 +1,14 @@
+#include "Library/Event/EventFlowEventData.h"
+
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/Yaml/ByamlIter.h"
+
+namespace al {
+
+EventFlowEventData::EventFlowEventData(const char* name, const EventFlowNodeInitInfo& info) {
+    mName = name;
+    mParamIter = new ByamlIter();
+    tryGetParamIter(mParamIter, info);
+}
+
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowEventData.h
+++ b/lib/al/Library/Event/EventFlowEventData.h
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace al {
+class ByamlIter;
+class EventFlowNodeInitInfo;
+
+class EventFlowEventData {
+public:
+    EventFlowEventData(const char* name, const EventFlowNodeInitInfo& info);
+
+private:
+    const char* mName;
+    ByamlIter* mParamIter = nullptr;
+};
+
+static_assert(sizeof(EventFlowEventData) == 0x10);
+
+}  // namespace al


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#2165

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1261)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a3f94b0 - 615bdd7)

📈 **Matched code**: 15.15% (+0.00%, +72 bytes)

<details>
<summary>✅ 1 new match</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Event/EventFlowEventData` | `al::EventFlowEventData::EventFlowEventData(char const*, al::EventFlowNodeInitInfo const&)` | +72 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->