### PR TITLE
Library/Event: Implement `EventFlowNodeJoin`

### DIFF
--- a/lib/al/Library/Event/EventFlowNodeJoin.cpp
+++ b/lib/al/Library/Event/EventFlowNodeJoin.cpp
@@ -1,0 +1,11 @@
+#include "Library/Event/EventFlowNodeJoin.h"
+
+#include "Library/Event/EventFlowFunction.h"
+
+namespace al {
+
+void EventFlowNodeJoin::init(const EventFlowNodeInitInfo& info) {
+    initEventFlowNode(this, info);
+}
+
+}  // namespace al

--- a/lib/al/Library/Event/EventFlowNodeJoin.h
+++ b/lib/al/Library/Event/EventFlowNodeJoin.h
@@ -9,4 +9,6 @@ public:
 
     void init(const EventFlowNodeInitInfo& info) override;
 };
+
+static_assert(sizeof(EventFlowNodeJoin) == 0x68);
 }  // namespace al

--- a/lib/al/Library/Event/EventFlowNodeJoin.h
+++ b/lib/al/Library/Event/EventFlowNodeJoin.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "Library/Event/EventFlowNode.h"
+
+namespace al {
+class EventFlowNodeJoin : public EventFlowNode {
+public:
+    EventFlowNodeJoin(const char* name) : EventFlowNode(name) {}
+
+    void init(const EventFlowNodeInitInfo& info) override;
+};
+}  // namespace al

--- a/src/Scene/ProjectEventFlowNodeFactory.cpp
+++ b/src/Scene/ProjectEventFlowNodeFactory.cpp
@@ -2,6 +2,7 @@
 
 #include "Library/Event/CreateEventFlowNode.h"
 #include "Library/Event/EventFlowNodeActionLoop.h"
+#include "Library/Event/EventFlowNodeJoin.h"
 
 const al::NameToCreator<al::EventFlowNodeCreatorFunction> sProjectEventFlowNodeFactoryEntries[] = {
     {"ActionLoop", al::createEventFlowNode<al::EventFlowNodeActionLoop>},
@@ -74,7 +75,7 @@ const al::NameToCreator<al::EventFlowNodeCreatorFunction> sProjectEventFlowNodeF
     {"IsEnableSearchAmiibo", nullptr},
     {"IsTalkAmiiboHelp", nullptr},
     {"KakkuTurn", nullptr},
-    {"Join", nullptr},
+    {"Join", al::createEventFlowNode<al::EventFlowNodeJoin>},
     {"JumpEntry", nullptr},
     {"MessageBalloon", nullptr},
     {"MessageTalk", nullptr},


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#1723

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1262)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a3f94b0 - 1753c56)

📈 **Matched code**: 15.15% (+0.00%, +84 bytes)

<details>
<summary>✅ 2 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Scene/ProjectEventFlowNodeFactory` | `al::EventFlowNode* al::createEventFlowNode<al::EventFlowNodeJoin>(char const*)` | +80 | 0.00% | 100.00% |
| `Library/Event/EventFlowNodeJoin` | `al::EventFlowNodeJoin::init(al::EventFlowNodeInitInfo const&)` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->