### PR TITLE
README: update discord invite to point to `#reverse-engineering`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [progress]: https://decomp.dev/MonsterDruide1/OdysseyDecomp
 [progress-badge]: https://img.shields.io/badge/dynamic/json?url=https://monsterdruide.one/OdysseyDecomp/progress.json&query=$.matching&suffix=%&label=decompiled&color=blue
 
-[discord]: https://discord.gg/uUecWhMHZy
+[discord]: https://discord.gg/cNbnu6SeGE
 [discord-badge]: https://img.shields.io/discord/774687602996936747?color=%237289DA&logo=discord&logoColor=%23FFFFFF
 
 This is a WIP decompilation of Super Mario Odyssey 1.0.0. The purpose of the project is to recreate a source code base for the game from scratch. For more information, you can get in touch with the team on the [SMO Modding Discord Server][discord].


### PR DESCRIPTION
Seems like it points to the General-VC at the moment - forcing people to join that channel when clicking on the invite link.

I guess it makes more sense to direct them to the `#reverse-engineering` channel by default - so this new invite link does that.

Yes, I made sure to do a non-expiring link 🙃

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1263)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (9f787bc - 8de4760)

No changes

<!-- decomp.dev report end -->