### PR TITLE
MapObj: Implement `SimpleSignBoard`

### DIFF
--- a/src/MapObj/SimpleSignBoard.cpp
+++ b/src/MapObj/SimpleSignBoard.cpp
@@ -1,0 +1,43 @@
+#include "MapObj/SimpleSignBoard.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+SimpleSignBoard::SimpleSignBoard(const char* name) : al::LiveActor(name) {}
+
+void SimpleSignBoard::init(const al::ActorInitInfo& info) {
+    al::initActor(this, info);
+    SimpleSignBoardFunction::startSignAimVisAnimFromModelName(this, info);
+    makeActorAlive();
+}
+
+namespace SimpleSignBoardFunction {
+void startSignAimVisAnimFromModelName(al::LiveActor* actor, const al::ActorInitInfo& info) {
+    const char* modelName = nullptr;
+    alPlacementFunction::getModelName(&modelName, info);
+
+    f32 frame;
+    if (al::isEqualSubString(modelName, "LeftDown"))
+        frame = 7.0f;
+    else if (al::isEqualSubString(modelName, "LeftUp"))
+        frame = 6.0f;
+    else if (al::isEqualSubString(modelName, "RightDown"))
+        frame = 5.0f;
+    else if (al::isEqualSubString(modelName, "RightUp"))
+        frame = 4.0f;
+    else if (al::isEqualSubString(modelName, "Right"))
+        frame = 3.0f;
+    else if (al::isEqualSubString(modelName, "Left"))
+        frame = 2.0f;
+    else if (al::isEqualSubString(modelName, "Down"))
+        frame = 1.0f;
+    else if (al::isEqualSubString(modelName, "Up"))
+        frame = 0.0f;
+    else
+        frame = -1.0f;
+
+    al::startVisAnimAndSetFrameAndStop(actor, "SignAim", frame);
+}
+}  // namespace SimpleSignBoardFunction


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#2814

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1265)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3b0ff47 - 0e1eafb)

📈 **Matched code**: 15.17% (+0.00%, +596 bytes)

<details>
<summary>✅ 4 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/SimpleSignBoard` | `SimpleSignBoardFunction::startSignAimVisAnimFromModelName(al::LiveActor*, al::ActorInitInfo const&)` | +284 | 0.00% | 100.00% |
| `MapObj/SimpleSignBoard` | `SimpleSignBoard::SimpleSignBoard(char const*)` | +132 | 0.00% | 100.00% |
| `MapObj/SimpleSignBoard` | `SimpleSignBoard::SimpleSignBoard(char const*)` | +120 | 0.00% | 100.00% |
| `MapObj/SimpleSignBoard` | `SimpleSignBoard::init(al::ActorInitInfo const&)` | +60 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->