### PR TITLE
Item: Implement `YoshiFruitShineHolder`

### DIFF
--- a/src/Item/YoshiFruitShineHolder.cpp
+++ b/src/Item/YoshiFruitShineHolder.cpp
@@ -1,0 +1,42 @@
+#include "Item/YoshiFruitShineHolder.h"
+
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "Item/Shine.h"
+#include "Util/ItemUtil.h"
+
+YoshiFruitShineHolder::YoshiFruitShineHolder(const char* name) : al::LiveActor(name) {}
+
+void YoshiFruitShineHolder::init(const al::ActorInitInfo& info) {
+    al::initActorSceneInfo(this, info);
+
+    s32 shineNum = al::calcLinkChildNum(info, "ShineFromFruit");
+    mAppearedCount = 0;
+    mShines.allocBuffer(shineNum, nullptr);
+
+    for (s32 i = 0; i < shineNum; i++) {
+        Shine* shine = rs::initLinkShine(info, "ShineFromFruit", i);
+        mShines.pushBack(shine);
+        if (shine->isGot())
+            mAppearedCount++;
+    }
+
+    rs::registerFruitShineHolder(this);
+    makeActorAlive();
+}
+
+void YoshiFruitShineHolder::updateHintPos(const sead::Vector3f& pos) {
+    for (Shine& shine : mShines)
+        rs::updateHintTrans(&shine, pos);
+}
+
+al::LiveActor* YoshiFruitShineHolder::appearShineFromFruit(const sead::Vector3f& pos) {
+    Shine* shine = mShines[mAppearedCount];
+
+    al::resetPosition(shine, pos);
+    shine->appearStatic();
+    mAppearedCount++;
+    return shine;
+}

--- a/src/Item/YoshiFruitShineHolder.cpp
+++ b/src/Item/YoshiFruitShineHolder.cpp
@@ -32,7 +32,7 @@ void YoshiFruitShineHolder::updateHintPos(const sead::Vector3f& pos) {
         rs::updateHintTrans(&shine, pos);
 }
 
-al::LiveActor* YoshiFruitShineHolder::appearShineFromFruit(const sead::Vector3f& pos) {
+Shine* YoshiFruitShineHolder::appearShineFromFruit(const sead::Vector3f& pos) {
     Shine* shine = mShines[mAppearedCount];
 
     al::resetPosition(shine, pos);

--- a/src/Item/YoshiFruitShineHolder.h
+++ b/src/Item/YoshiFruitShineHolder.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class Shine;
+
+class YoshiFruitShineHolder : public al::LiveActor {
+public:
+    YoshiFruitShineHolder(const char* name);
+
+    void init(const al::ActorInitInfo& info) override;
+    void updateHintPos(const sead::Vector3f& pos);
+    al::LiveActor* appearShineFromFruit(const sead::Vector3f& pos);
+
+private:
+    sead::PtrArray<Shine> mShines;
+    s32 mAppearedCount = 0;
+};
+
+static_assert(sizeof(YoshiFruitShineHolder) == 0x120);
+
+namespace rs {
+void registerFruitShineHolder(YoshiFruitShineHolder*);
+}  // namespace rs

--- a/src/Item/YoshiFruitShineHolder.h
+++ b/src/Item/YoshiFruitShineHolder.h
@@ -18,7 +18,7 @@ public:
 
     void init(const al::ActorInitInfo& info) override;
     void updateHintPos(const sead::Vector3f& pos);
-    al::LiveActor* appearShineFromFruit(const sead::Vector3f& pos);
+    Shine* appearShineFromFruit(const sead::Vector3f& pos);
 
 private:
     sead::PtrArray<Shine> mShines;
@@ -26,7 +26,3 @@ private:
 };
 
 static_assert(sizeof(YoshiFruitShineHolder) == 0x120);
-
-namespace rs {
-void registerFruitShineHolder(YoshiFruitShineHolder*);
-}  // namespace rs

--- a/src/Util/ItemUtil.h
+++ b/src/Util/ItemUtil.h
@@ -11,6 +11,7 @@ class HitSensor;
 class SensorMsg;
 }  // namespace al
 class Shine;
+class YoshiFruitShineHolder;
 
 namespace rs {
 // TODO: Replace this with SEAD_ENUM_EX when its ValueArray constructor matches
@@ -61,6 +62,7 @@ bool isAliveShine(const Shine* shine);
 bool isMainShine(const Shine* shine);
 
 void updateHintTrans(const Shine* shine, const sead::Vector3f& trans);
+void registerFruitShineHolder(YoshiFruitShineHolder* holder);
 void appearShineAndJoinBossDemo(Shine* shine, const char* name, const sead::Quatf& quat,
                                 const sead::Vector3f& trans);
 void endShineBossDemo(Shine* shine);


### PR DESCRIPTION
Closes MonsterDruide1/OdysseyDecompTracker#475

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1266)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c889da8 - 0a0edf8)

📈 **Matched code**: 15.17% (+0.01%, +660 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/YoshiFruitShineHolder` | `YoshiFruitShineHolder::init(al::ActorInitInfo const&)` | +228 | 0.00% | 100.00% |
| `Item/YoshiFruitShineHolder` | `YoshiFruitShineHolder::YoshiFruitShineHolder(char const*)` | +140 | 0.00% | 100.00% |
| `Item/YoshiFruitShineHolder` | `YoshiFruitShineHolder::YoshiFruitShineHolder(char const*)` | +128 | 0.00% | 100.00% |
| `Item/YoshiFruitShineHolder` | `YoshiFruitShineHolder::appearShineFromFruit(sead::Vector3<float> const&)` | +92 | 0.00% | 100.00% |
| `Item/YoshiFruitShineHolder` | `YoshiFruitShineHolder::updateHintPos(sead::Vector3<float> const&)` | +72 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->