### PR TITLE
Library/Bgm: Implement `BgmChordDetector`

### DIFF
--- a/lib/al/Library/Bgm/BgmChordDetector.cpp
+++ b/lib/al/Library/Bgm/BgmChordDetector.cpp
@@ -1,0 +1,43 @@
+#include "Library/Bgm/BgmChordDetector.h"
+
+#include "Library/Audio/AudioInfo.h"
+
+#include "Project/Bgm/BgmInfo.h"
+
+namespace al {
+
+BgmChordDetector::BgmChordDetector() = default;
+
+void BgmChordDetector::init(const AudioInfoListWithParts<BgmChordInfo>* chordInfoList) {
+    mChordInfoList = chordInfoList;
+}
+
+void BgmChordDetector::update(f32 time) {
+    f32 offsetTime = time + 0.25f;
+    if (offsetTime < 0.0f)
+        return;
+
+    const AudioInfoListWithParts<BgmChordInfo>* list = mChordInfoList;
+    if (!list)
+        return;
+
+    mCurrentChordInfo = nullptr;
+
+    for (s32 i = 0; i < list->getSize(); i++) {
+        const BgmChordInfo* info = list->getInfoAt(i);
+        if (i > 0 && offsetTime < info->beat) {
+            mCurrentChordInfo = list->getInfoAt(i - 1);
+            if (mCurrentChordInfo)
+                return;
+            break;
+        }
+    }
+
+    mCurrentChordInfo = list->getInfoAt(list->getSize() - 1);
+}
+
+void BgmChordDetector::forceUninitialized() {
+    mChordInfoList = nullptr;
+}
+
+}  // namespace al

--- a/lib/al/Library/Bgm/BgmChordDetector.h
+++ b/lib/al/Library/Bgm/BgmChordDetector.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+template <typename T>
+class AudioInfoListWithParts;
+struct BgmChordInfo;
+
+class BgmChordDetector {
+public:
+    BgmChordDetector();
+
+    void init(const AudioInfoListWithParts<BgmChordInfo>* chordInfoList);
+    void update(f32 time);
+    void forceUninitialized();
+
+private:
+    const AudioInfoListWithParts<BgmChordInfo>* mChordInfoList = nullptr;
+    const BgmChordInfo* mCurrentChordInfo = nullptr;
+};
+
+static_assert(sizeof(BgmChordDetector) == 0x10);
+
+}  // namespace al


### PR DESCRIPTION
`al::BgmChordDetector::update(float)` isn't fully matching

Closes MonsterDruide1/OdysseyDecompTracker#1591

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1267)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (c889da8 - 5ec268f)

📈 **Matched code**: 15.16% (+0.00%, +24 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Bgm/BgmChordDetector` | `al::BgmChordDetector::BgmChordDetector()` | +8 | 0.00% | 100.00% |
| `Library/Bgm/BgmChordDetector` | `al::BgmChordDetector::init(al::AudioInfoListWithParts<al::BgmChordInfo> const*)` | +8 | 0.00% | 100.00% |
| `Library/Bgm/BgmChordDetector` | `al::BgmChordDetector::forceUninitialized()` | +8 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Bgm/BgmChordDetector` | `al::BgmChordDetector::update(float)` | +195 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->