### PR TITLE
Library/Area: Fix `AreaObj::init`

### DIFF
--- a/lib/al/Library/Area/AreaObj.cpp
+++ b/lib/al/Library/Area/AreaObj.cpp
@@ -40,11 +40,11 @@ void AreaObj::init(const AreaInitInfo& info) {
     mAreaShape->setScale(scale);
 
     initStageSwitch(this, info.getStageSwitchDirector(), info);
-    if (listenStageSwitchOnOffAppear(this, AreaObjFunctor(this, &AreaObj::invalidate),
-                                     AreaObjFunctor(this, &AreaObj::validate)))
+    if (listenStageSwitchOnOffAppear(this, AreaObjFunctor(this, &AreaObj::validate),
+                                     AreaObjFunctor(this, &AreaObj::invalidate)))
         invalidate();
 
-    if (listenStageSwitchOnKill(this, AreaObjFunctor(this, &AreaObj::validate)))
+    if (listenStageSwitchOnKill(this, AreaObjFunctor(this, &AreaObj::invalidate)))
         validate();
 }
 


### PR DESCRIPTION
I'm playing with check tool and found this mistake.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1269)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a76cdfb - 589a498)

No changes

<!-- decomp.dev report end -->