### PR TITLE
Player: Implement `PlayerExternalVelocity`

### DIFF
--- a/src/Player/PlayerExternalVelocity.cpp
+++ b/src/Player/PlayerExternalVelocity.cpp
@@ -1,0 +1,172 @@
+#include "Player/PlayerExternalVelocity.h"
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/Controller/PadRumbleFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/Math/MathUtil.h"
+
+#include "Util/AreaUtil.h"
+#include "Util/ExternalForceKeeper.h"
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/SensorMsgFunction.h"
+
+// NON_MATCHING: Different optimization https://decomp.me/scratch/Tjb13
+PlayerExternalVelocity::PlayerExternalVelocity(const al::LiveActor* actor,
+                                               const IUsePlayerCollision* collision,
+                                               const sead::Vector3f* trans)
+    : mActor(actor), mCollision(collision), mTrans(trans) {
+    mExternalForceKeeper = new ExternalForceKeeper();
+}
+
+bool PlayerExternalVelocity::receiveMsgPlayer(const al::SensorMsg* msg, al::HitSensor* self,
+                                              al::HitSensor* other) {
+    sead::Vector3f snapForce = {0.0f, 0.0f, 0.0f};
+    if (rs::tryGetObjSnapForce(&snapForce, msg)) {
+        mSnapForce = snapForce;
+        return true;
+    }
+
+    return receiveMsgCap(msg, self, other);
+}
+
+bool PlayerExternalVelocity::receiveMsgCap(const al::SensorMsg* msg, al::HitSensor* self,
+                                           al::HitSensor* other) {
+    return mExternalForceKeeper->receiveMsg(msg, self, other);
+}
+
+void PlayerExternalVelocity::requestApplyLastGroundInertia() {
+    mGroundInertiaType = 1;
+}
+
+void PlayerExternalVelocity::cancelAndFeedbackLastGroundInertia(al::LiveActor* actor, f32 strength,
+                                                                bool isFrontOnly) {
+    sead::Vector3f intertia = mLastGroundInertia;
+    mTotalVelocity -= mLastGroundInertia;
+    mLastGroundInertia = {0.0f, 0.0f, 0.0f};
+    mGroundInertiaType = 0;
+
+    al::verticalizeVec(&intertia, al::getGravity(mActor), intertia);
+
+    sead::Vector3f inertiaDir = {0.0f, 0.0f, 0.0f};
+    if (!al::tryNormalizeOrZero(&inertiaDir, intertia))
+        return;
+
+    if (isFrontOnly) {
+        sead::Vector3f frontDir = {0.0f, 0.0f, 0.0f};
+        al::calcFrontDir(&frontDir, mActor);
+        al::verticalizeVec(&frontDir, al::getGravity(mActor), frontDir);
+
+        if (al::tryNormalizeOrZero(&frontDir))
+            strength *= sead::Mathf::clampMin(frontDir.dot(inertiaDir), 0.0f);
+    }
+
+    al::addVelocity(actor, strength * intertia);
+}
+
+void PlayerExternalVelocity::update() {
+    mTotalVelocity = {0.0f, 0.0f, 0.0f};
+
+    bool isOnGround = false;
+    if (mCollision)
+        isOnGround = rs::isOnGround(mActor, mCollision);
+    else
+        isOnGround = al::isExistActorCollider(mActor) && al::isOnGround(mActor, 0);
+
+    f32 sensitivity = isOnGround ? mSensitivity.x : mSensitivity.y;
+    f32 drag = isOnGround ? mExternalDrag.x : mExternalDrag.y;
+
+    mExternalForceKeeper->calcForce(&mExternalForce);
+    mExternalForceKeeper->reset();
+
+    mExternalVelocity *= drag;
+    mExternalVelocity += mExternalForce * sensitivity;
+
+    if (mExternalVelocity.length() < 0.1f)
+        mExternalVelocity = {0.0f, 0.0f, 0.0f};
+
+    updatePadRumbleExternalForce();
+
+    mAreaVelocity *= isOnGround ? mAreaDrag.x : mAreaDrag.y;
+
+    sead::Vector3f velocity = {0.0f, 0.0f, 0.0f};
+    rs::calcExtForceAreaVelocity(&velocity, mActor, al::getTrans(mActor), mAreaVelocity,
+                                 al::getVelocity(mActor));
+
+    mAreaVelocity += velocity;
+    if (mAreaVelocity.length() < 0.1f)
+        mAreaVelocity = {0.0f, 0.0f, 0.0f};
+
+    updateLastGroundForce(isOnGround);
+
+    mTotalVelocity.set(mLastGroundInertia);
+    mTotalVelocity += mExternalVelocity;
+    mTotalVelocity += mAreaVelocity;
+}
+
+void PlayerExternalVelocity::updatePadRumbleExternalForce() {
+    if (!mTrans)
+        return;
+
+    f32 distance = mExternalVelocity.length();
+    if (al::isNearZero(distance)) {
+        if (mIsRumbleActive) {
+            mIsRumbleActive = false;
+            alPadRumbleFunction::stopPadRumbleLoop(mActor, "【ループ】ジー（強）", mTrans);
+        }
+        return;
+    }
+
+    distance = al::easeIn(al::calcRate01(distance, 0.0f, 50.0f));
+    if (!mIsRumbleActive) {
+        mIsRumbleActive = true;
+        alPadRumbleFunction::startPadRumbleLoopNo3D(mActor, "【ループ】ジー（強）", mTrans);
+    }
+
+    f32 volume = distance * 0.35f;
+    f32 pitch = sead::Mathf::clampMin(distance * -0.25f + 1.0f, 0.1f);
+
+    alPadRumbleFunction::changePadRumbleLoopVolmue(mActor, "【ループ】ジー（強）", mTrans, volume,
+                                                   volume);
+    alPadRumbleFunction::changePadRumbleLoopPitch(mActor, "【ループ】ジー（強）", mTrans, pitch,
+                                                  pitch);
+}
+
+void PlayerExternalVelocity::updateLastGroundForce(bool isOnGround) {
+    if (!mCollision)
+        return;
+
+    mLastGroundInertia = {0.0f, 0.0f, 0.0f};
+    if (isOnGround) {
+        al::calcForceMovePowerExceptNormal(
+            &mMovePowerForce, rs::getCollidedGroundCollisionParts(mCollision),
+            rs::getCollidedGroundPos(mCollision), rs::getCollidedGroundNormal(mCollision));
+        return;
+    }
+
+    if (mGroundInertiaType < 1)
+        mMovePowerForce = {0.0f, 0.0f, 0.0f};
+    else
+        mLastGroundInertia.set(mMovePowerForce);
+
+    mGroundInertiaType = al::converge(mGroundInertiaType, 0, 1);
+}
+
+void PlayerExternalVelocity::reset() {
+    mExternalForceKeeper->reset();
+    mExternalForce = {0.0f, 0.0f, 0.0f};
+    mSnapForce = {0.0f, 0.0f, 0.0f};
+    mAreaVelocity = {0.0f, 0.0f, 0.0f};
+    mTotalVelocity = {0.0f, 0.0f, 0.0f};
+    mExternalVelocity = {0.0f, 0.0f, 0.0f};
+}
+
+bool PlayerExternalVelocity::isExistForce() const {
+    return !al::isNearZero(mAreaVelocity) || !al::isNearZero(mExternalForce) ||
+           !al::isNearZero(mExternalVelocity);
+}
+
+bool PlayerExternalVelocity::isExistSnapForce() const {
+    return !al::isNearZero(mSnapForce);
+}

--- a/src/Player/PlayerExternalVelocity.cpp
+++ b/src/Player/PlayerExternalVelocity.cpp
@@ -36,20 +36,20 @@ bool PlayerExternalVelocity::receiveMsgCap(const al::SensorMsg* msg, al::HitSens
 }
 
 void PlayerExternalVelocity::requestApplyLastGroundInertia() {
-    mGroundInertiaType = 1;
+    mApplyLastGroundInertiaFrames = 1;
 }
 
 void PlayerExternalVelocity::cancelAndFeedbackLastGroundInertia(al::LiveActor* actor, f32 strength,
                                                                 bool isFrontOnly) {
-    sead::Vector3f intertia = mLastGroundInertia;
+    sead::Vector3f inertia = mLastGroundInertia;
     mTotalVelocity -= mLastGroundInertia;
     mLastGroundInertia = {0.0f, 0.0f, 0.0f};
-    mGroundInertiaType = 0;
+    mApplyLastGroundInertiaFrames = 0;
 
-    al::verticalizeVec(&intertia, al::getGravity(mActor), intertia);
+    al::verticalizeVec(&inertia, al::getGravity(mActor), inertia);
 
-    sead::Vector3f inertiaDir = {0.0f, 0.0f, 0.0f};
-    if (!al::tryNormalizeOrZero(&inertiaDir, intertia))
+    sead::Vector3f inertiaHDir = {0.0f, 0.0f, 0.0f};
+    if (!al::tryNormalizeOrZero(&inertiaHDir, inertia))
         return;
 
     if (isFrontOnly) {
@@ -58,10 +58,10 @@ void PlayerExternalVelocity::cancelAndFeedbackLastGroundInertia(al::LiveActor* a
         al::verticalizeVec(&frontDir, al::getGravity(mActor), frontDir);
 
         if (al::tryNormalizeOrZero(&frontDir))
-            strength *= sead::Mathf::clampMin(frontDir.dot(inertiaDir), 0.0f);
+            strength *= sead::Mathf::clampMin(frontDir.dot(inertiaHDir), 0.0f);
     }
 
-    al::addVelocity(actor, strength * intertia);
+    al::addVelocity(actor, strength * inertia);
 }
 
 void PlayerExternalVelocity::update() {
@@ -73,8 +73,8 @@ void PlayerExternalVelocity::update() {
     else
         isOnGround = al::isExistActorCollider(mActor) && al::isOnGround(mActor, 0);
 
-    f32 sensitivity = isOnGround ? mSensitivity.x : mSensitivity.y;
-    f32 drag = isOnGround ? mExternalDrag.x : mExternalDrag.y;
+    f32 sensitivity = mSensitivity.getValue(isOnGround);
+    f32 drag = mExternalDrag.getValue(isOnGround);
 
     mExternalForceKeeper->calcForce(&mExternalForce);
     mExternalForceKeeper->reset();
@@ -87,7 +87,7 @@ void PlayerExternalVelocity::update() {
 
     updatePadRumbleExternalForce();
 
-    mAreaVelocity *= isOnGround ? mAreaDrag.x : mAreaDrag.y;
+    mAreaVelocity *= mAreaDrag.getValue(isOnGround);
 
     sead::Vector3f velocity = {0.0f, 0.0f, 0.0f};
     rs::calcExtForceAreaVelocity(&velocity, mActor, al::getTrans(mActor), mAreaVelocity,
@@ -144,12 +144,12 @@ void PlayerExternalVelocity::updateLastGroundForce(bool isOnGround) {
         return;
     }
 
-    if (mGroundInertiaType < 1)
+    if (mApplyLastGroundInertiaFrames < 1)
         mMovePowerForce = {0.0f, 0.0f, 0.0f};
     else
         mLastGroundInertia.set(mMovePowerForce);
 
-    mGroundInertiaType = al::converge(mGroundInertiaType, 0, 1);
+    mApplyLastGroundInertiaFrames = al::converge(mApplyLastGroundInertiaFrames, 0, 1);
 }
 
 void PlayerExternalVelocity::reset() {

--- a/src/Player/PlayerExternalVelocity.cpp
+++ b/src/Player/PlayerExternalVelocity.cpp
@@ -12,11 +12,10 @@
 #include "Util/PlayerCollisionUtil.h"
 #include "Util/SensorMsgFunction.h"
 
-// NON_MATCHING: Different optimization https://decomp.me/scratch/Tjb13
 PlayerExternalVelocity::PlayerExternalVelocity(const al::LiveActor* actor,
                                                const IUsePlayerCollision* collision,
                                                const sead::Vector3f* trans)
-    : mActor(actor), mCollision(collision), mTrans(trans) {
+    : mActor(actor), mCollision(collision), mTrans(trans), mAreaDrag(mExternalDrag) {
     mExternalForceKeeper = new ExternalForceKeeper();
 }
 

--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -1,33 +1,52 @@
 #pragma once
 
+#include <basis/seadTypes.h>
 #include <math/seadVector.h>
 
 namespace al {
+class HitSensor;
 class LiveActor;
-}
+class SensorMsg;
+}  // namespace al
+
 class ExternalForceKeeper;
 class IUsePlayerCollision;
 
 class PlayerExternalVelocity {
 public:
+    PlayerExternalVelocity(const al::LiveActor* actor, const IUsePlayerCollision* collision,
+                           const sead::Vector3f* trans);
+
+    bool receiveMsgPlayer(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other);
+    bool receiveMsgCap(const al::SensorMsg* msg, al::HitSensor* self, al::HitSensor* other);
+    void requestApplyLastGroundInertia();
+    void cancelAndFeedbackLastGroundInertia(al::LiveActor* actor, f32 strength, bool isFrontOnly);
+    void update();
+    void updatePadRumbleExternalForce();
+    void updateLastGroundForce(bool isOnGround);
+    void reset();
     bool isExistForce() const;
     bool isExistSnapForce() const;
 
 private:
-    ExternalForceKeeper* mExternalForceKeeper;
-    sead::Vector3f _8;
-    sead::Vector3f _14;
-    sead::Vector3f _20;
-    const al::LiveActor* mActor;
-    const IUsePlayerCollision* mCollision;
-    const sead::Vector3f* _38;
-    bool _40;
-    sead::Vector3f _44;
-    f32 _50[6];
-    sead::Vector3f mSnapForce;
-    s32 mApplyLastGroundInertia;
-    sead::Vector3f _80;
-    sead::Vector3f _8c;
+    ExternalForceKeeper* mExternalForceKeeper = nullptr;
+    sead::Vector3f mExternalVelocity = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mAreaVelocity = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mTotalVelocity = {0.0f, 0.0f, 0.0f};
+    const al::LiveActor* mActor = nullptr;
+    const IUsePlayerCollision* mCollision = nullptr;
+    const sead::Vector3f* mTrans = nullptr;
+    bool mIsRumbleActive = false;
+    sead::Vector3f mExternalForce = {0.0f, 0.0f, 0.0f};
+
+    sead::Vector2f mExternalDrag = {0.95f, 0.955f};
+    sead::Vector2f mAreaDrag = {0.95f, 0.955f};
+    sead::Vector2f mSensitivity = {0.275f, 0.275f};
+
+    sead::Vector3f mSnapForce = {0.0f, 0.0f, 0.0f};
+    s32 mGroundInertiaType = 0;
+    sead::Vector3f mMovePowerForce = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mLastGroundInertia = {0.0f, 0.0f, 0.0f};
 };
 
 static_assert(sizeof(PlayerExternalVelocity) == 0x98);

--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -33,14 +33,14 @@ private:
     sead::Vector3f mExternalVelocity = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mAreaVelocity = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mTotalVelocity = {0.0f, 0.0f, 0.0f};
-    const al::LiveActor* mActor = nullptr;
-    const IUsePlayerCollision* mCollision = nullptr;
-    const sead::Vector3f* mTrans = nullptr;
+    const al::LiveActor* mActor;
+    const IUsePlayerCollision* mCollision;
+    const sead::Vector3f* mTrans;
     bool mIsRumbleActive = false;
     sead::Vector3f mExternalForce = {0.0f, 0.0f, 0.0f};
 
     sead::Vector2f mExternalDrag = {0.95f, 0.955f};
-    sead::Vector2f mAreaDrag = {0.95f, 0.955f};
+    sead::Vector2f mAreaDrag;
     sead::Vector2f mSensitivity = {0.275f, 0.275f};
 
     sead::Vector3f mSnapForce = {0.0f, 0.0f, 0.0f};

--- a/src/Player/PlayerExternalVelocity.h
+++ b/src/Player/PlayerExternalVelocity.h
@@ -29,6 +29,13 @@ public:
     bool isExistSnapForce() const;
 
 private:
+    struct FloatParam {
+        f32 onGround;
+        f32 offGround;
+
+        f32 getValue(bool isOnGround) const { return isOnGround ? onGround : offGround; }
+    };
+
     ExternalForceKeeper* mExternalForceKeeper = nullptr;
     sead::Vector3f mExternalVelocity = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mAreaVelocity = {0.0f, 0.0f, 0.0f};
@@ -39,12 +46,12 @@ private:
     bool mIsRumbleActive = false;
     sead::Vector3f mExternalForce = {0.0f, 0.0f, 0.0f};
 
-    sead::Vector2f mExternalDrag = {0.95f, 0.955f};
-    sead::Vector2f mAreaDrag;
-    sead::Vector2f mSensitivity = {0.275f, 0.275f};
+    FloatParam mExternalDrag = {0.95f, 0.955f};
+    FloatParam mAreaDrag;
+    FloatParam mSensitivity = {0.275f, 0.275f};
 
     sead::Vector3f mSnapForce = {0.0f, 0.0f, 0.0f};
-    s32 mGroundInertiaType = 0;
+    s32 mApplyLastGroundInertiaFrames = 0;
     sead::Vector3f mMovePowerForce = {0.0f, 0.0f, 0.0f};
     sead::Vector3f mLastGroundInertia = {0.0f, 0.0f, 0.0f};
 };


### PR DESCRIPTION
~~The constructor is not matching not sure why~~. But the important math stuff is finally matching. I'm not really happy with variable names are they a force? velocity? inertia?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1270)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f980b6 - 41016de)

📈 **Matched code**: 15.21% (+0.02%, +1972 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::update()` | +604 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::updatePadRumbleExternalForce()` | +360 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::cancelAndFeedbackLastGroundInertia(al::LiveActor*, float, bool)` | +332 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::updateLastGroundForce(bool)` | +184 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::PlayerExternalVelocity(al::LiveActor const*, IUsePlayerCollision const*, sead::Vector3<float> const*)` | +132 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::receiveMsgPlayer(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +132 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::isExistForce() const` | +104 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::reset()` | +64 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::isExistSnapForce() const` | +40 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::requestApplyLastGroundInertia()` | +12 | 0.00% | 100.00% |
| `Player/PlayerExternalVelocity` | `PlayerExternalVelocity::receiveMsgCap(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->