### PR TITLE
all: Fix mismatches with newer toolchain

### DIFF
--- a/lib/al/Library/Audio/AudioDirector.h
+++ b/lib/al/Library/Audio/AudioDirector.h
@@ -50,7 +50,7 @@ public:
     void addAudiioFrameProccess(aal::IAudioFrameProcess* process);
     void removeAudiioFrameProccess(aal::IAudioFrameProcess* process);
     void* getAudioMaximizer() const;  // unknown return type
-    bool isPpausedSystem(const char* name) const;
+    bool isPpausedSystem(const char* name);
 
     void pauseSystem(bool, const char*, bool, f32, bool, bool, bool) override;
     AreaObjDirector* getAreaObjDirector() const override;

--- a/lib/al/Project/Anim/AnimInfo.h
+++ b/lib/al/Project/Anim/AnimInfo.h
@@ -12,7 +12,7 @@ struct AnimResInfo {
 
 class AnimInfoTable {
 public:
-    AnimInfoTable(u32);
+    AnimInfoTable(s32);
 
     const AnimResInfo& findAnimInfo(const char* name) const;
     bool tryFindAnimInfo(const char* name) const;

--- a/src/Area/RouteGuideArea.cpp
+++ b/src/Area/RouteGuideArea.cpp
@@ -14,7 +14,7 @@ void RouteGuideArea::init(const al::AreaInitInfo& info) {
     al::tryGetArg(&mIsGuide3D, info, "IsGuide3D");
     al::tryGetLinksTrans(&mTargetPosition, info, "TargetPosition");
     if (rs::isKidsMode(this))
-        rs::onRouteGuideSystem(this);
+        rs::createRouteGuideDirector(this);
 }
 
 void RouteGuideArea::calcGuidePos(sead::Vector3f* guidePos) const {

--- a/src/MapObj/PoleGrabCeil.cpp
+++ b/src/MapObj/PoleGrabCeil.cpp
@@ -87,7 +87,7 @@ void PoleGrabCeil::control() {
         }
 
         const sead::Vector3f& hitPos = alCollisionUtil::getCollisionHitPos(**hitInfo);
-        const sead::Vector3f& hitNormal = alCollisionUtil::getCollisionHitPos(**hitInfo);
+        const sead::Vector3f& hitNormal = alCollisionUtil::getCollisionHitNormal(**hitInfo);
         al::makeMtxUpNoSupportPos(&mSurfaceMatrix, hitNormal, hitPos);
         al::startHitReaction(mKeyMoveFollowTarget, "コリジョンヒット");
         return;

--- a/src/Player/PlayerRecoverySafetyPoint.cpp
+++ b/src/Player/PlayerRecoverySafetyPoint.cpp
@@ -256,7 +256,7 @@ void PlayerRecoverySafetyPoint::startRecovery(f32 height) {
     al::startAction(mTractorBubble, "Appear");
     updateRecoveryBubble();
 
-    if (mHackCap->isEnableRescuePlayer()) {
+    if (mHackCap->isRescuePlayer()) {
         al::LiveActor* hat = al::getSubActor(mTractorBubble, "装着帽子");
         hat->appear();
         al::startAction(hat, "LockOn");


### PR DESCRIPTION
Newer toolchain displays some errors that were previously ignored.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1272)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a76cdfb - 38a2f21)

No changes

<!-- decomp.dev report end -->