### PR TITLE
MapObj: Implement `KuriboTowerSwitch`

### DIFF
--- a/src/MapObj/KuriboTowerSwitch.cpp
+++ b/src/MapObj/KuriboTowerSwitch.cpp
@@ -1,0 +1,157 @@
+#include "MapObj/KuriboTowerSwitch.h"
+
+#include <math/seadMathCalcCommon.h>
+#include <math/seadVector.h>
+
+#include "Library/Audio/System/SimpleAudioUser.h"
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorAnimFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/CollisionObj.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Se/SeFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(KuriboTowerSwitch, OffWait);
+NERVE_IMPL(KuriboTowerSwitch, On);
+NERVE_IMPL(KuriboTowerSwitch, OnWait);
+NERVE_IMPL(KuriboTowerSwitch, Disable);
+NERVE_IMPL(KuriboTowerSwitch, ReactionLand);
+
+NERVES_MAKE_STRUCT(KuriboTowerSwitch, OffWait, On, OnWait, Disable, ReactionLand);
+}  // namespace
+
+KuriboTowerSwitch::KuriboTowerSwitch(const char* name) : al::LiveActor(name) {}
+
+void KuriboTowerSwitch::init(const al::ActorInitInfo& initInfo) {
+    al::initActorWithArchiveName(this, initInfo, "KuriboTowerSwitch", nullptr);
+    al::initNerve(this, &NrvKuriboTowerSwitch.OffWait, 0);
+    mMtxConnector = al::createMtxConnector(this);
+    mCollisionObj = al::createCollisionObj(this, initInfo, "KuriboTowerSwitch_Body",
+                                           al::getHitSensor(this, "Collision"), "Move", nullptr);
+    mCollisionObj->makeActorAlive();
+    al::validateCollisionParts(mCollisionObj);
+    makeActorAlive();
+
+    al::tryGetArg(&mNum, initInfo, "Num");
+    al::startMtpAnimAndSetFrameAndStop(this, "Number", sead::Mathi::min(mNum - 1, 9));
+
+    bool isPlaySuccessSe = false;
+    al::tryGetArg(&isPlaySuccessSe, initInfo, "IsPlaySuccessSe");
+    if (isPlaySuccessSe)
+        mAudioUser = new al::SimpleAudioUser("SuccessSeObj", initInfo);
+}
+
+void KuriboTowerSwitch::initAfterPlacement() {
+    if (mMtxConnector)
+        al::attachMtxConnectorToCollision(mMtxConnector, this, false);
+}
+
+void KuriboTowerSwitch::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+
+    if (!_129)
+        _128 = true;
+    _129 = false;
+
+    if (mDisplayNum < 4)
+        mDisplayNum++;
+}
+
+bool KuriboTowerSwitch::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                                   al::HitSensor* self) {
+    if (rs::isMsgPlayerDisregardHomingAttack(message))
+        return true;
+
+    if (al::isNerve(this, &NrvKuriboTowerSwitch.On) ||
+        al::isNerve(this, &NrvKuriboTowerSwitch.OnWait) ||
+        al::isNerve(this, &NrvKuriboTowerSwitch.Disable)) {
+        return false;
+    }
+
+    if (rs::getNumKuriboTowerOn(message) < (u32)mNum) {
+        if (!al::isMsgPlayerFloorTouch(message))
+            return false;
+
+        if (3 < mDisplayNum && _128 && isReactionNerve()) {
+            _128 = false;
+            al::setNerve(this, &NrvKuriboTowerSwitch.ReactionLand);
+        }
+
+        _129 = true;
+        mDisplayNum = 0;
+        return true;
+    }
+
+    sead::Vector3f dir = al::getSensorPos(other) - al::getSensorPos(self);
+    sead::Vector3f up;
+    al::calcUpDir(&up, this);
+    al::verticalizeVec(&dir, up, dir);
+    if (dir.length() > 100.0f)
+        return false;
+
+    al::startHitReaction(this, "規定数乗っかった");
+    al::invalidateClipping(this);
+    al::setNerve(this, &NrvKuriboTowerSwitch.On);
+    return true;
+}
+
+bool KuriboTowerSwitch::isReactionNerve() const {
+    return al::isNerve(this, &NrvKuriboTowerSwitch.OffWait) ||
+           al::isNerve(this, &NrvKuriboTowerSwitch.ReactionLand);
+}
+
+void KuriboTowerSwitch::exeDisable() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(this, "OffWait");
+}
+
+void KuriboTowerSwitch::exeOffWait() {
+    if (al::isFirstStep(this))
+        al::tryStartActionIfNotPlaying(this, "OffWait");
+}
+
+void KuriboTowerSwitch::exeReactionLand() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "ReactionLand");
+
+    if (al::isActionEnd(this))
+        al::setNerve(this, &NrvKuriboTowerSwitch.OffWait);
+}
+
+void KuriboTowerSwitch::exeOn() {
+    if (al::isFirstStep(this)) {
+        al::invalidateHitSensors(this);
+        al::startAction(this, "On");
+        if (mAudioUser)
+            al::startSe(mAudioUser, "Riddle");
+    }
+
+    if (al::isActionEnd(this)) {
+        mCollisionObj->kill();
+        al::startHitReaction(this, "スイッチ押し込み終わり");
+        al::setNerve(this, &NrvKuriboTowerSwitch.OnWait);
+    }
+}
+
+void KuriboTowerSwitch::exeOnWait() {
+    if (al::isFirstStep(this)) {
+        al::tryOnStageSwitch(this, "SwitchTrampleOn");
+        al::startAction(this, "OnWait");
+        al::validateClipping(this);
+    }
+}

--- a/src/MapObj/KuriboTowerSwitch.h
+++ b/src/MapObj/KuriboTowerSwitch.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class CollisionObj;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+class SimpleAudioUser;
+}  // namespace al
+
+class KuriboTowerSwitch : public al::LiveActor {
+public:
+    KuriboTowerSwitch(const char* name);
+    void init(const al::ActorInitInfo& initInfo) override;
+    void initAfterPlacement() override;
+    void control() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    bool isReactionNerve() const;
+    void exeDisable();
+    void exeOffWait();
+    void exeReactionLand();
+    void exeOn();
+    void exeOnWait();
+
+private:
+    al::MtxConnector* mMtxConnector = nullptr;
+    s32 mNum = 10;
+    al::SimpleAudioUser* mAudioUser = nullptr;
+    al::CollisionObj* mCollisionObj = nullptr;
+    bool _128 = true;
+    bool _129 = false;
+    u32 mDisplayNum = 4;
+};
+
+static_assert(sizeof(KuriboTowerSwitch) == 0x130);


### PR DESCRIPTION
Needs names for 2 fields that I couldn't figure out exactly what they represent.

I'm a bit unclear on the type of `mNum`. It doesn't compile if I make it unsigned, but it clearly should be unsigned given the return type of `rs::getNumKuriboTowerOn`. I had to cast it to make the compiler stop complaining about a comparison between signed and unsigned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1273)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (a76cdfb - 5dd2154)

📈 **Matched code**: 15.18% (+0.02%, +2104 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +476 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::init(al::ActorInitInfo const&)` | +336 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::exeOn()` | +176 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::KuriboTowerSwitch(char const*)` | +168 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::KuriboTowerSwitch(char const*)` | +156 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `(anonymous namespace)::KuriboTowerSwitchNrvReactionLand::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::exeReactionLand()` | +88 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `(anonymous namespace)::KuriboTowerSwitchNrvOnWait::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::control()` | +84 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::exeOnWait()` | +84 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::isReactionNerve() const` | +72 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `(anonymous namespace)::KuriboTowerSwitchNrvOffWait::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `(anonymous namespace)::KuriboTowerSwitchNrvDisable::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::exeDisable()` | +60 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::exeOffWait()` | +60 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `KuriboTowerSwitch::initAfterPlacement()` | +28 | 0.00% | 100.00% |
| `MapObj/KuriboTowerSwitch` | `(anonymous namespace)::KuriboTowerSwitchNrvOn::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->