### PR TITLE
MapObj: Implement `BlockQuestion`

### DIFF
--- a/src/Item/RandomItemSelector.h
+++ b/src/Item/RandomItemSelector.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Scene/ISceneObj.h"
+
+#include "Util/ItemUtil.h"
+
+namespace al {
+class IUseSceneObjHolder;
+}
+
+class RandomItemSelector : public al::ISceneObj {
+public:
+    RandomItemSelector();
+    rs::ItemType::ValueType getRandomItemType();
+
+private:
+    char filler[0x10];
+};
+
+static_assert(sizeof(RandomItemSelector) == 0x18);
+
+namespace rs {
+void createRandomItemSelector(const al::IUseSceneObjHolder*);
+}

--- a/src/MapObj/BlockEmpty.h
+++ b/src/MapObj/BlockEmpty.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+}  // namespace al
+
+class BlockEmpty : public al::LiveActor {
+public:
+    BlockEmpty(const char*, const char*);
+    void init(const al::ActorInitInfo&) override;
+    void initAfterPlacement() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void setShadowDropLength(f32);
+    void startReaction();
+    void startReactionTransparent();
+    void exeWait();
+    void exeReaction();
+    void exeReactionTransparent();
+
+private:
+    char filler[0x28];
+};
+
+static_assert(sizeof(BlockEmpty) == 0x130);

--- a/src/MapObj/BlockQuestion.cpp
+++ b/src/MapObj/BlockQuestion.cpp
@@ -1,0 +1,213 @@
+#include "MapObj/BlockQuestion.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Collision/PartsConnectorUtil.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/LiveActor/LiveActorFunction.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Obj/PartsFunction.h"
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Stage/StageSwitchUtil.h"
+#include "Library/Thread/FunctorV0M.h"
+
+#include "Item/RandomItemSelector.h"
+#include "MapObj/BlockEmpty.h"
+#include "MapObj/BlockStateSingleItem.h"
+#include "MapObj/BlockStateTenCoin.h"
+#include "Util/SensorMsgFunction.h"
+#include "Util/ShadowUtil.h"
+
+namespace {
+NERVE_IMPL(BlockQuestion, Dead);
+NERVE_IMPL(BlockQuestion, TenCoin);
+NERVE_IMPL(BlockQuestion, SingleItem);
+
+NERVES_MAKE_STRUCT(BlockQuestion, TenCoin, SingleItem);
+NERVES_MAKE_NOSTRUCT(BlockQuestion, Dead);
+}  // namespace
+
+BlockQuestion::BlockQuestion(const char* name) : al::LiveActor(name) {}
+
+void BlockQuestion::init(const al::ActorInitInfo& initInfo) {
+    using BlockQuestionFunctor = al::FunctorV0M<BlockQuestion*, void (BlockQuestion::*)()>;
+
+    bool isPlayWaitSe = false;
+    const char* suffix = nullptr;
+    if (al::tryGetArg(&isPlayWaitSe, initInfo, "IsPlayWaitSe") && isPlayWaitSe)
+        suffix = "PlayWaitSe";
+    al::initMapPartsActor(this, initInfo, suffix);
+
+    mItemType = rs::getItemType(initInfo);
+    if (mItemType > rs::ItemType::ValueType::None)
+        rs::initItemByPlacementInfo(this, initInfo, false);
+
+    al::tryAddDisplayOffset(this, initInfo);
+    mShadowLength = rs::setShadowDropLength(this, initInfo, "本体");
+    al::expandClippingRadiusByShadowLength(this, &_134, mShadowLength);
+
+    if (mItemType == rs::ItemType::ValueType::Coin10) {
+        mBlockStateTenCoin = new BlockStateTenCoin(this, false);
+        al::initNerve(this, &NrvBlockQuestion.TenCoin, 1);
+        al::initNerveState(this, mBlockStateTenCoin, &NrvBlockQuestion.TenCoin, "10コイン");
+    } else {
+        mBlockStateSingleItem = new BlockStateSingleItem(this, mItemType, false);
+        al::initNerve(this, &NrvBlockQuestion.SingleItem, 1);
+        al::initNerveState(this, mBlockStateSingleItem, &NrvBlockQuestion.SingleItem, "アイテム");
+        if (mItemType == rs::ItemType::ValueType::Random)
+            rs::createRandomItemSelector(this);
+    }
+
+    mMtxConnector = al::tryCreateMtxConnector(this, initInfo);
+    if (mMtxConnector)
+        al::tryGetArg(&mIsConnectToCollisionBack, initInfo, "IsConnectToCollisionBack");
+
+    if (al::isEqualString(getName(), "都市ワールドホーム信号機004"))
+        mBlockEmpty = new BlockEmpty("空ブロック", "CityWorldHomeSignal005");
+    else
+        mBlockEmpty = new BlockEmpty("空ブロック", "BlockEmpty");
+    al::initCreateActorWithPlacementInfo(mBlockEmpty, initInfo);
+    mBlockEmpty->setShadowDropLength(mShadowLength);
+    mBlockEmpty->kill();
+
+    if (al::listenStageSwitchOnAppear(this,
+                                      BlockQuestionFunctor(this, &BlockQuestion::listenApeear))) {
+        makeActorDead();
+    } else {
+        makeActorAlive();
+    }
+
+    al::listenStageSwitchOnKill(this, BlockQuestionFunctor(this, &BlockQuestion::listenKill));
+}
+
+void BlockQuestion::listenApeear() {
+    appear();
+}
+
+void BlockQuestion::listenKill() {
+    if (!al::isDead(mBlockEmpty))
+        mBlockEmpty->kill();
+    else
+        kill();
+}
+
+void BlockQuestion::initAfterPlacement() {
+    if (!mMtxConnector)
+        return;
+
+    if (!mIsConnectToCollisionBack) {
+        al::attachMtxConnectorToCollision(mMtxConnector, this, 50.0f, 400.0f);
+        return;
+    }
+
+    sead::Vector3f front = {0.0f, 0.0f, 0.0f};
+    al::calcFrontDir(&front, this);
+    al::attachMtxConnectorToCollision(mMtxConnector, this, al::getTrans(this) + 50.0f * front,
+                                      -400.0f * front);
+}
+
+void BlockQuestion::appear() {
+    al::LiveActor::appear();
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+void BlockQuestion::control() {
+    if (mMtxConnector)
+        al::connectPoseQT(this, mMtxConnector);
+}
+
+bool BlockQuestion::receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                               al::HitSensor* self) {
+    if (rs::isMsgHammerBrosHammerEnemyAttack(message))
+        return false;
+
+    if (rs::isMsgBlockReaction3D(message)) {
+        if (al::isSensorMapObj(self) && al::isMsgPlayerSpinAttack(message))
+            return false;
+
+        const sead::Vector3f& otherPos = al::getSensorPos(other);
+        const sead::Vector3f& selfPos = al::getSensorPos(self);
+        if (al::isNerve(this, &NrvBlockQuestion.SingleItem) &&
+            mBlockStateSingleItem->isEnableAppearItem()) {
+            if (mItemType != rs::ItemType::ValueType::None)
+                mBlockStateSingleItem->setItemOffsetY(150.0f);
+
+            if (rs::isMsgCapAttack(message)) {
+                if ((otherPos - selfPos).length() > 150.0f)
+                    return false;
+                mBlockStateSingleItem->receiveMsg(message, other, self);
+                return false;
+            }
+
+            if (mBlockStateSingleItem->receiveMsg(message, other, self)) {
+                if (!rs::isMsgUpperPunchAll(message))
+                    rs::requestHitReactionToAttacker(message, self, other);
+                return true;
+            }
+        } else if (al::isNerve(this, &NrvBlockQuestion.TenCoin)) {
+            mBlockStateTenCoin->setItemOffsetY(150.0f);
+            if (rs::isMsgCapAttack(message) && (otherPos - selfPos).length() > 150.0f)
+                return false;
+
+            if (mBlockStateTenCoin->receiveMsg(message, other, self)) {
+                if (!rs::isMsgUpperPunchAll(message) &&
+                    !rs::isMsgCapAttackStayRollingCollide(message))
+                    rs::requestHitReactionToAttacker(message, self, other);
+                return true;
+            }
+        }
+    }
+
+    if (rs::isMsgTRexAttackCollideAll(message)) {
+        al::hideModelIfShow(this);
+        al::appearBreakModelRandomRotateY(al::getSubActor(this, "壊れモデル"));
+        al::invalidateHitSensors(this);
+        al::invalidateCollisionParts(this);
+        al::invalidateClipping(this);
+        if (al::isNerve(this, &NrvBlockQuestion.SingleItem)) {
+            mBlockStateSingleItem->autoGet(self);
+            kill();
+            return true;
+        }
+
+        if (al::isNerve(this, &NrvBlockQuestion.TenCoin))
+            mBlockStateTenCoin->autoGet(self);
+    }
+    return false;
+}
+
+void BlockQuestion::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (al::isSensorName(self, "BlockUpperPunch") &&
+        ((al::isNerve(this, &NrvBlockQuestion.SingleItem) && mBlockStateSingleItem->isReaction()) ||
+         (al::isNerve(this, &NrvBlockQuestion.TenCoin) && mBlockStateTenCoin->isReaction()))) {
+        al::sendMsgBlockUpperPunch(other, self, nullptr);
+    }
+}
+
+void BlockQuestion::exeSingleItem() {
+    if (al::updateNerveState(this)) {
+        mBlockEmpty->appear();
+        al::setNerve(this, &Dead);
+    }
+}
+
+void BlockQuestion::exeTenCoin() {
+    if (al::updateNerveState(this)) {
+        if (!al::isHideModel(this))
+            mBlockEmpty->appear();
+        al::setNerve(this, &Dead);
+    }
+}
+
+void BlockQuestion::exeDead() {
+    if (al::isFirstStep(this))
+        kill();
+}

--- a/src/MapObj/BlockQuestion.h
+++ b/src/MapObj/BlockQuestion.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "Util/ItemUtil.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class MtxConnector;
+class SensorMsg;
+}  // namespace al
+class BlockEmpty;
+class BlockStateSingleItem;
+class BlockStateTenCoin;
+
+class BlockQuestion : public al::LiveActor {
+public:
+    BlockQuestion(const char* name);
+    void init(const al::ActorInitInfo& initInfo) override;
+    void listenApeear();
+    void listenKill();
+    void initAfterPlacement() override;
+    void appear() override;
+    void control() override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    void exeSingleItem();
+    void exeTenCoin();
+    void exeDead();
+
+private:
+    rs::ItemType::ValueType mItemType = rs::ItemType::ValueType::None;
+    BlockStateTenCoin* mBlockStateTenCoin = nullptr;
+    BlockStateSingleItem* mBlockStateSingleItem = nullptr;
+    BlockEmpty* mBlockEmpty = nullptr;
+    al::MtxConnector* mMtxConnector = nullptr;
+    bool mIsConnectToCollisionBack = false;
+    sead::Vector3f _134 = sead::Vector3f::zero;
+    f32 mShadowLength = 0.0f;
+};
+
+static_assert(sizeof(BlockQuestion) == 0x148);

--- a/tools/check-format.py
+++ b/tools/check-format.py
@@ -487,7 +487,7 @@ def header_bool_getter_name_prefix(c, path):
 
 def source_no_raw_auto(c, path):
     for line in c.splitlines():
-        if "auto" in line and not "auto*" in line and not "auto&" in line and not " it " in line and "node " not in line and ".end()" not in line:
+        if "auto" in line and not "auto*" in line and not "auto&" in line and not " it " in line and "node " not in line and ".end()" not in line and "autoGet" not in line:
             FAIL("Raw use of auto isn't allowed! Please use auto* or auto& instead", line, path)
 
 def source_no_nerve_make(c, path):


### PR DESCRIPTION
Needed a change in `tools/check-format.py` so that it wouldn't complain about the calls to `BlockStateSingleItem::autoGet` and `BlockStateTenCoin::autoGet`. I checked in ghidra and this is the only named function with `auto`, so I just added `autoGet` as an exception.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1274)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (5fcb6d9 - 05e5686)

📈 **Matched code**: 15.20% (+0.02%, +2864 bytes)

<details>
<summary>✅ 19 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/BlockQuestion` | `BlockQuestion::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +732 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::init(al::ActorInitInfo const&)` | +672 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::initAfterPlacement()` | +224 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::BlockQuestion(char const*)` | +184 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::BlockQuestion(char const*)` | +172 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::attackSensor(al::HitSensor*, al::HitSensor*)` | +160 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `(anonymous namespace)::BlockQuestionNrvTenCoin::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::exeTenCoin()` | +88 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `(anonymous namespace)::BlockQuestionNrvSingleItem::execute(al::NerveKeeper*) const` | +80 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::exeSingleItem()` | +76 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `al::FunctorV0M<BlockQuestion*, void (BlockQuestion::*)()>::clone() const` | +76 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::listenKill()` | +68 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `(anonymous namespace)::BlockQuestionNrvDead::execute(al::NerveKeeper*) const` | +64 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::exeDead()` | +60 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::appear()` | +56 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `al::FunctorV0M<BlockQuestion*, void (BlockQuestion::*)()>::operator()() const` | +28 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::control()` | +16 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `BlockQuestion::listenApeear()` | +12 | 0.00% | 100.00% |
| `MapObj/BlockQuestion` | `al::FunctorV0M<BlockQuestion*, void (BlockQuestion::*)()>::~FunctorV0M()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->