### PR TITLE
deps: Remove `libtinfo.so.5`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -16,11 +16,4 @@ RUN pip install --break-system-packages capstone colorama cxxfilt pyelftools pyt
 # install dependencies for code environment
 RUN apt update && apt install -y clangd clang-format llvm
 
-# install (outdated) libtinfo5, required for old clang version
-RUN if [ "$(uname -m)" = "x86_64" ]; then \
-        curl -o libtinfo5_6.3-2_amd64.deb http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && \
-        dpkg -i libtinfo5_6.3-2_amd64.deb && \
-        rm -f libtinfo5_6.3-2_amd64.deb; \
-    fi
-
 ENTRYPOINT ["bash"]

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -33,7 +33,6 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt update && sudo apt install -y python3-pip ninja-build cmake ccache xdelta3 clang libssl-dev python-is-python3 curl
-        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v6
       with:

--- a/.github/workflows/test-compile.yml
+++ b/.github/workflows/test-compile.yml
@@ -13,7 +13,6 @@ jobs:
     - name: Set up dependencies
       run: |
         sudo apt update && sudo apt install -y ninja-build cmake ccache clang curl
-        wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
     - name: Set up python
       uses: actions/setup-python@v6
       with:

--- a/README.md
+++ b/README.md
@@ -64,18 +64,8 @@ All other systems have to manually install the required packages and programs. W
 Ubuntu users can install those dependencies by running:
 
 ```shell
-sudo apt install python3 ninja-build cmake ccache libssl-dev libncurses5 llvm
+sudo apt install python3 ninja-build cmake ccache libssl-dev llvm
 ```
-
-If you are running Ubuntu 23.10 or later, the `libncurses5` package won't be available anymore. You can install it from
-the archive using:
-
-```shell
-wget http://archive.ubuntu.com/ubuntu/pool/universe/n/ncurses/libtinfo5_6.3-2_amd64.deb && sudo dpkg -i libtinfo5_6.3-2_amd64.deb && rm -f libtinfo5_6.3-2_amd64.deb
-```
-
-For other systems, please check for the corresponding `libncurses5` backport, for
-example [ncurses5-compat-libs](https://aur.archlinux.org/packages/ncurses5-compat-libs) for Arch-based distributions.
 
 Additionally, you'll also need:
 


### PR DESCRIPTION
This dependency was only required by `llvm-objdump`, historically pulled in from [nx-decomp-tools-binaries](https://github.com/open-ead/nx-decomp-tools-binaries). However, we changed to our own binary cache a while ago and decided that `llvm-objdump` should just be globally installed by the user, so this binary went unused.

Either way, `nx-decomp-tools-binaries` recently updated their binaries to LLVM 22 instead of 18, which removes the dependency on `libtinfo5`. Therefore, we can also remove it from our workflows and guides.
https://github.com/open-ead/nx-decomp-tools-binaries/pull/4

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1278)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b0d461e - cd4bdce)

No changes

<!-- decomp.dev report end -->