### PR TITLE
Audio: Implement `CollectBgmPlayer::prepare`, `SePlayObjWithSave::init`, and `ShopBgmPlayer::movement`

### DIFF
--- a/lib/al/Library/Obj/SePlayObj.h
+++ b/lib/al/Library/Obj/SePlayObj.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+class SePlayObj : public LiveActor {
+public:
+    SePlayObj(const char* name);
+    void init(const ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void makeActorAlive() override;
+    void kill() override;
+    void movement() override;
+    void waitSwitch();
+    void startPlaying();
+    bool isPlaying();
+    void exeWaitSwitch();
+    void exePlay();
+    bool tryPlayStart();
+    void exePlayRepeat();
+
+private:
+    char filler[0x98];
+};
+
+static_assert(sizeof(SePlayObj) == 0x1a0);
+}  // namespace al

--- a/src/Audio/CollectBgmPlayer.cpp
+++ b/src/Audio/CollectBgmPlayer.cpp
@@ -1,0 +1,3 @@
+#include "Audio/CollectBgmPlayer.h"
+
+void CollectBgmPlayer::prepare() {}

--- a/src/Audio/CollectBgmPlayer.h
+++ b/src/Audio/CollectBgmPlayer.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/ISceneObj.h"
+
+namespace al {
+class IUseAudioKeeper;
+}
+
+class CollectBgmPlayer : public al::HioNode, public al::ISceneObj {
+public:
+    CollectBgmPlayer();
+    void init(const al::IUseAudioKeeper* audio_keeper);
+    void prepare();
+    void start(const char* name, const char* situation_name);
+    void stop(s32 fade_frames);
+    void isPlaying(const char* name, const char* situation_name) const;
+
+private:
+    char filler[0x18];
+};
+
+static_assert(sizeof(CollectBgmPlayer) == 0x20);

--- a/src/Audio/SePlayObjWithSave.cpp
+++ b/src/Audio/SePlayObjWithSave.cpp
@@ -1,0 +1,5 @@
+#include "Audio/SePlayObjWithSave.h"
+
+void SePlayObjWithSave::init(const al::ActorInitInfo& info) {
+    al::SePlayObj::init(info);
+}

--- a/src/Audio/SePlayObjWithSave.h
+++ b/src/Audio/SePlayObjWithSave.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "Library/Obj/SePlayObj.h"
+
+class SePlayObjWithSave : public al::SePlayObj {
+public:
+    SePlayObjWithSave(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+};
+
+static_assert(sizeof(SePlayObjWithSave) == 0x1a0);

--- a/src/Audio/ShopBgmPlayer.cpp
+++ b/src/Audio/ShopBgmPlayer.cpp
@@ -1,0 +1,5 @@
+#include "Audio/ShopBgmPlayer.h"
+
+void ShopBgmPlayer::movement() {
+    al::LiveActor::movement();
+}

--- a/src/Audio/ShopBgmPlayer.h
+++ b/src/Audio/ShopBgmPlayer.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class ShopBgmPlayer : public al::LiveActor {
+public:
+    ShopBgmPlayer(const char* name);
+    void init(const al::ActorInitInfo& info) override;
+    void makeActorAlive() override;
+    void movement() override;
+    void exeWaitOnSwitch();
+    void exePlay();
+
+private:
+    char filler[0x10];
+};
+
+static_assert(sizeof(ShopBgmPlayer) == 0x118);


### PR DESCRIPTION
Implements the following matching audio functions:

* CollectBgmPlayer::prepare()
* SePlayObjWithSave::init(...)
* ShopBgmPlayer::movement()

Validation:

* python tools/build.py ✅
* tools/check ✅
* individual tools/check -mw for each function ✅
* git diff --check ✅

No unrelated files were modified.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1283)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (8d9f865 - 30709b1)

📈 **Matched code**: 15.18% (+0.00%, +12 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Audio/CollectBgmPlayer` | `CollectBgmPlayer::prepare()` | +4 | 0.00% | 100.00% |
| `Audio/SePlayObjWithSave` | `SePlayObjWithSave::init(al::ActorInitInfo const&)` | +4 | 0.00% | 100.00% |
| `Audio/ShopBgmPlayer` | `ShopBgmPlayer::movement()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->