### PR TITLE
Boss/BombTail: Implement `BombTailBomb`/`BombTailCap` pre-battle handlers and `BombTailTail` updates

### DIFF
--- a/src/Boss/BombTail/BombTailBomb.cpp
+++ b/src/Boss/BombTail/BombTailBomb.cpp
@@ -1,0 +1,3 @@
+#include "Boss/BombTail/BombTailBomb.h"
+
+void BombTailBomb::exeBeforeBattleStart() {}

--- a/src/Boss/BombTail/BombTailBomb.h
+++ b/src/Boss/BombTail/BombTailBomb.h
@@ -1,0 +1,61 @@
+#pragma once
+
+#include <math/seadMatrix.h>
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BombTailDamage;
+
+class BombTailBomb : public al::LiveActor {
+public:
+    BombTailBomb(const char* name, const al::LiveActor* parent_actor);
+    void init(const al::ActorInitInfo& info) override;
+    bool tryStartFollow(const char* action_name);
+    void kill() override;
+    void calcAnim() override;
+    bool isChanceBomb() const;
+    void changeAtOnGround(const sead::Vector3f* position);
+    void startWaitForDemo(BombTailDamage* damage, const sead::Matrix34f* matrix);
+    void startBattle();
+    void setTailThrowTargetPos(const sead::Vector3f& position);
+    void startAppear(BombTailDamage* damage, const sead::Matrix34f* matrix);
+    void startPrepareAttackChance(BombTailDamage* damage, const sead::Matrix34f* matrix);
+    void startPopUp(const sead::Vector3f& position, const sead::Vector3f& velocity,
+                    BombTailDamage* damage, s32 delay);
+    void startExplosion(bool is_chance);
+    bool isReflect() const;
+    bool isReflectChance() const;
+    bool isLandChance() const;
+    bool isExplosioned() const;
+    void calcThrowChancePos(sead::Vector3f* position, f32 rate);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void startAttackChanceSign(bool is_first, bool is_last);
+    void startAttackStart(al::LiveActor* actor);
+    void startThrow(f32 speed);
+    void invalidateFollowForChanceReflect();
+    void syncReflectChance();
+    void tryChanceEnd();
+    void exeBeforeBattleStart();
+    void exeAppear();
+    void exeAppearChance();
+    void exeFollowWait();
+    void exeThrowPopup();
+    void exeBound();
+    void exeLand();
+    void exeLandChance();
+    void exeThrow();
+    void exeReflect();
+    void exeReflectCorrect();
+    void exeExplosionSign();
+    void exeBlowDown();
+    void exeExplosion();
+    void validateFollowForChanceReflect();
+
+private:
+    char filler[0xe8];
+};
+
+static_assert(sizeof(BombTailBomb) == 0x1f0);

--- a/src/Boss/BombTail/BombTailCap.cpp
+++ b/src/Boss/BombTail/BombTailCap.cpp
@@ -1,0 +1,3 @@
+#include "Boss/BombTail/BombTailCap.h"
+
+void BombTailCap::exeBeforeBattleStart() {}

--- a/src/Boss/BombTail/BombTailCap.h
+++ b/src/Boss/BombTail/BombTailCap.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+class BombTailCap : public al::LiveActor {
+public:
+    BombTailCap(al::LiveActor* parent_actor);
+    void initCap(al::LiveActor* parent_actor, const al::ActorInitInfo& info);
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void appear() override;
+    void disappear();
+    void startBattle();
+    void startPanicEnd();
+    void startResetAttack();
+    void endResetAttack();
+    void startReaction();
+    void startReactionWithoutAnim(const al::SensorMsg* message, al::HitSensor* other,
+                                  al::HitSensor* self);
+    void exeAppearPanicEnd();
+    void exeBeforeBattleStart();
+    void exeWait();
+    void exeBlowDown();
+    void exeDisappear();
+    void exeReaction();
+    void exeResetAttackState();
+
+private:
+    char filler[0x58];
+};
+
+static_assert(sizeof(BombTailCap) == 0x160);

--- a/src/Boss/BombTail/BombTailTail.cpp
+++ b/src/Boss/BombTail/BombTailTail.cpp
@@ -1,0 +1,7 @@
+#include "Boss/BombTail/BombTailTail.h"
+
+void BombTailTailJointCalulator::calcBounce(const sead::Matrix34f* matrix, float value) {
+    calcTailBombThrowOld(matrix);
+}
+
+void BombTailTail::startResetAttack() {}

--- a/src/Boss/BombTail/BombTailTail.cpp
+++ b/src/Boss/BombTail/BombTailTail.cpp
@@ -1,6 +1,6 @@
 #include "Boss/BombTail/BombTailTail.h"
 
-void BombTailTailJointCalulator::calcBounce(const sead::Matrix34f* matrix, float value) {
+void BombTailTailJointCalulator::calcBounce(const sead::Matrix34f* matrix, f32 value) {
     calcTailBombThrowOld(matrix);
 }
 

--- a/src/Boss/BombTail/BombTailTail.h
+++ b/src/Boss/BombTail/BombTailTail.h
@@ -25,7 +25,7 @@ public:
     BombTailTailJointCalulator(al::LiveActor* actor, const al::LiveActor* parent_actor);
     void calcTailBombThrow(const sead::Matrix34f* matrix, s32 index, f32 rate);
     void calcTailBombThrowOld(const sead::Matrix34f* matrix);
-    void calcBounce(const sead::Matrix34f* matrix, float value);
+    void calcBounce(const sead::Matrix34f* matrix, f32 value);
     void calcReturn();
     void calcBombFollowMtx(sead::Matrix34f* matrix, f32 rate);
     void validateControl();

--- a/src/Boss/BombTail/BombTailTail.h
+++ b/src/Boss/BombTail/BombTailTail.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadMatrix.h>
+
+#include "Library/Joint/JointControllerBase.h"
+#include "Library/LiveActor/LiveActor.h"
+
+class BombTailBomb;
+
+class BombTailTailJointController : public al::JointControllerBase {
+public:
+    BombTailTailJointController(const sead::Matrix34f* matrix, const bool* is_control, f32 rate);
+    void calcJointCallback(s32 joint_index, sead::Matrix34f* matrix) override;
+    const char* getCtrlTypeName() const override;
+
+private:
+    char filler[0x48];
+};
+
+static_assert(sizeof(BombTailTailJointController) == 0x70);
+
+class BombTailTailJointCalulator {
+public:
+    BombTailTailJointCalulator(al::LiveActor* actor, const al::LiveActor* parent_actor);
+    void calcTailBombThrow(const sead::Matrix34f* matrix, s32 index, f32 rate);
+    void calcTailBombThrowOld(const sead::Matrix34f* matrix);
+    void calcBounce(const sead::Matrix34f* matrix, float value);
+    void calcReturn();
+    void calcBombFollowMtx(sead::Matrix34f* matrix, f32 rate);
+    void validateControl();
+    void controlTailVisAnim();
+    void resetSampleFromAnim();
+
+private:
+    char filler[0x58];
+};
+
+static_assert(sizeof(BombTailTailJointCalulator) == 0x58);
+
+class BombTailTail : public al::LiveActor {
+public:
+    BombTailTail();
+    void initTail(const al::ActorInitInfo& info, al::LiveActor* parent_actor, const char* suffix,
+                  s32 index);
+    void calcAnim() override;
+    void updateDepthShadowMap();
+    void endClipped() override;
+    void control() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+    void startBattle();
+    void endBattle();
+    void reset();
+    void startThrow(BombTailBomb* bomb);
+    void endThrow(bool is_attack_end);
+    bool tryStartBounce();
+    void updateBounce(const sead::Matrix34f& matrix, f32 rate);
+    void hitBounce();
+    void startResetAttack();
+    void onAnimDynamics();
+    void offAnimDynamics();
+    const sead::Matrix34f* getControlTopJointMtx() const;
+    f32 calcTailLength() const;
+    void exeBeforeBattleStart();
+    void exeFollow();
+    void exeThrow();
+    void exeReturn();
+    void exeBounce();
+    void exeReflect();
+
+private:
+    char filler[0xc8];
+};
+
+static_assert(sizeof(BombTailTail) == 0x1d0);

--- a/src/Boss/BombTail/BombTailTailPartsModelUpdater.cpp
+++ b/src/Boss/BombTail/BombTailTailPartsModelUpdater.cpp
@@ -1,0 +1,9 @@
+#include "Boss/BombTail/BombTailTailPartsModelUpdater.h"
+
+void BombTailTailPartsModelUpdater::preCalcAnim() {
+    updatePose();
+}
+
+void BombTailTailPartsModelUpdater::postEndClipped() {
+    updatePose();
+}

--- a/src/Boss/BombTail/BombTailTailPartsModelUpdater.h
+++ b/src/Boss/BombTail/BombTailTailPartsModelUpdater.h
@@ -1,0 +1,26 @@
+#pragma once
+
+namespace al {
+class HitSensor;
+class LiveActor;
+class SensorMsg;
+}  // namespace al
+
+class BombTailTailPartsModelUpdater {
+public:
+    BombTailTailPartsModelUpdater();
+    void initPartsFixFileNoRegister(al::LiveActor* actor, al::LiveActor* parent_actor,
+                                    const char* suffix, const char* archive_name);
+    void preCalcAnim();
+    void updatePose();
+    void postEndClipped();
+    void attackSensor(al::HitSensor* self, al::HitSensor* other);
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self);
+    void offSyncAppearAndHide();
+    void onSyncAppearAndHide();
+
+private:
+    char filler[0x48];
+};
+
+static_assert(sizeof(BombTailTailPartsModelUpdater) == 0x48);


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1284)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (abe7639 - 7afe831)

📈 **Matched code**: 15.18% (+0.00%, +24 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Boss/BombTail/BombTailBomb` | `BombTailBomb::exeBeforeBattleStart()` | +4 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailCap` | `BombTailCap::exeBeforeBattleStart()` | +4 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailTail` | `BombTailTailJointCalulator::calcBounce(sead::Matrix34<float> const*, float)` | +4 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailTail` | `BombTailTail::startResetAttack()` | +4 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailTailPartsModelUpdater` | `BombTailTailPartsModelUpdater::preCalcAnim()` | +4 | 0.00% | 100.00% |
| `Boss/BombTail/BombTailTailPartsModelUpdater` | `BombTailTailPartsModelUpdater::postEndClipped()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->