### PR TITLE
Player: Implement `HackCap`, `HackCapStateThrowStay`, `HackCapStateHide` and related classes (wip - 23/275 functions matching)

### DIFF
--- a/src/Player/CapTargetInfo.h
+++ b/src/Player/CapTargetInfo.h
@@ -31,6 +31,7 @@ public:
 
 private:
     friend CapTargetInfoFunction;
+    friend class HackCap;
     const al::LiveActor* mActor = nullptr;
     const char* mHackName = nullptr;
     IUsePlayerCollision* mPlayerCollision = nullptr;

--- a/src/Player/HackCap.cpp
+++ b/src/Player/HackCap.cpp
@@ -1,0 +1,805 @@
+#include "Player/HackCap.h"
+
+#include "Player/IUsePlayerCollision.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Shadow/ActorShadowUtil.h"
+#include "Project/Controller/PadRumbleKeeper.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/CapTargetInfo.h"
+#include "Player/HackCapAboveGroundChecker.h"
+#include "Player/HackCapJudgePreInputSeparateJump.h"
+#include "Player/HackCapJudgePreInputSeparateThrow.h"
+#include "Player/HackCapJointControlKeeper.h"
+#include "Player/HackCapStateHide.h"
+#include "Player/HackCapStateThrowStay.h"
+#include "Player/HackCapThrowParam.h"
+#include "Player/HackCapTrigger.h"
+#include "Player/PlayerAreaChecker.h"
+#include "Player/PlayerCapActionHistory.h"
+#include "Player/PlayerColliderHackCap.h"
+#include "Player/PlayerEyeSensorHitHolder.h"
+#include "Player/PlayerExternalVelocity.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerJointControlKeeper.h"
+#include "Player/PlayerPushReceiver.h"
+#include "Player/PlayerSeparateCapFlag.h"
+#include "Player/PlayerWallActionHistory.h"
+
+namespace {
+NERVE_IMPL(HackCap, Catch);
+NERVE_IMPL(HackCap, ThrowStay);
+NERVE_IMPL(HackCap, Hide);
+NERVE_IMPL(HackCap, Return);
+NERVE_IMPL(HackCap, LockOn);
+NERVE_IMPL(HackCap, Rebound);
+NERVE_IMPL(HackCap, Hack);
+NERVE_IMPL(HackCap, SpinAttack);
+NERVE_IMPL(HackCap, ThrowStart);
+NERVE_IMPL(HackCap, Rescue);
+NERVE_IMPL_(HackCap, TrampleReturn, Trample);
+NERVE_IMPL(HackCap, ThrowTornado);
+NERVE_IMPL(HackCap, ThrowSpiral);
+NERVE_IMPL(HackCap, ThrowRolling);
+NERVE_IMPL(HackCap, Throw);
+NERVE_IMPL(HackCap, ThrowBrake);
+NERVE_IMPL_(HackCap, Rethrow, Throw);
+NERVE_IMPL(HackCap, ThrowAppend);
+NERVE_IMPL(HackCap, ThrowRollingBrake);
+NERVE_IMPL(HackCap, Trample);
+NERVE_IMPL(HackCap, TrampleLockOn);
+NERVE_IMPL(HackCap, Blow);
+
+NERVES_MAKE_STRUCT(HackCap, Catch, ThrowStay, Hide, Return, LockOn, Rebound, Hack, SpinAttack,
+                   ThrowStart, Rescue, TrampleReturn, ThrowTornado, ThrowSpiral, ThrowRolling,
+                   Throw, ThrowBrake, Rethrow, ThrowAppend, ThrowRollingBrake, Trample,
+                   TrampleLockOn, Blow);
+}  // namespace
+
+HackCap::HackCap(const al::LiveActor* playerActor, const char* typeName, const PlayerInput* input,
+                 const PlayerAreaChecker* playerAreaChecker,
+                 const PlayerWallActionHistory* playerWallActionHistory,
+                 const PlayerCapActionHistory* playerCapActionHistory,
+                 const PlayerEyeSensorHitHolder* playerEyeSensorHitHolder,
+                 const PlayerSeparateCapFlag* playerSeparateCapFlag,
+                 const IUsePlayerCollision* playerCollision,
+                 const IUsePlayerHeightCheck* playerHeightCheck,
+                 const PlayerWetControl* playerWetControl,
+                 const PlayerJointControlKeeper* playerJointControlKeeper,
+                 HackCapJudgePreInputSeparateThrow* capJudgePreInputSeparateThrow,
+                 HackCapJudgePreInputSeparateJump* capJudgePreInputSeparateJump)
+    : al::LiveActor(typeName), mPlayerActor(playerActor), mTypeName(typeName),
+      mPlayerAreaChecker(playerAreaChecker),
+      mPlayerWallActionHistory(playerWallActionHistory),
+      mPlayerCapActionHistory(playerCapActionHistory),
+      mPlayerSeparateCapFlag(playerSeparateCapFlag), mPlayerCollision(playerCollision),
+      mPlayerHeightCheck(playerHeightCheck), mPlayerWetControl(playerWetControl),
+      mPlayerJointControlKeeper(playerJointControlKeeper),
+      mCapJudgePreInputSeparateThrow(capJudgePreInputSeparateThrow),
+      mCapJudgePreInputSeparateJump(capJudgePreInputSeparateJump) {
+    mCapTargetInfo2 = new CapTargetInfo();
+    mPlayerColliderHackCap = new PlayerColliderHackCap(this);
+    _2a2_flag = true;
+}
+
+void HackCap::init(const al::ActorInitInfo& info) {
+    al::initActorWithArchiveName(this, info, mTypeName, nullptr);
+    al::initNerve(this, &NrvHackCap.Hide, 0);
+    al::invalidateClipping(this);
+    makeActorAlive();
+}
+
+void HackCap::hide(bool isHide) {
+    mIsHide = isHide;
+    if (isHide)
+        al::hideModelIfShow(this);
+    else
+        al::showModelIfHide(this);
+}
+
+void HackCap::movement() {
+    al::LiveActor::movement();
+    mHackCapAboveGroundChecker->update();
+    mCapJudgePreInputSeparateThrow->update();
+    mCapJudgePreInputSeparateJump->update();
+    mPlayerColliderHackCap->update();
+    mHackCapJointControlKeeper->update();
+}
+
+void HackCap::updateShadowMaskOffset() {
+    // NON_MATCHING
+}
+
+void HackCap::control() {
+    // NON_MATCHING
+}
+
+bool HackCap::isFlying() const {
+    return al::isNerve(this, &NrvHackCap.Throw) || al::isNerve(this, &NrvHackCap.ThrowBrake) ||
+           al::isNerve(this, &NrvHackCap.ThrowSpiral) || al::isNerve(this, &NrvHackCap.ThrowTornado) ||
+           al::isNerve(this, &NrvHackCap.ThrowRolling) ||
+           al::isNerve(this, &NrvHackCap.ThrowRollingBrake) || al::isNerve(this, &NrvHackCap.ThrowStay) ||
+           al::isNerve(this, &NrvHackCap.ThrowAppend) || al::isNerve(this, &NrvHackCap.Blow) ||
+           al::isNerve(this, &NrvHackCap.Rebound) || al::isNerve(this, &NrvHackCap.Return);
+}
+
+void HackCap::updateTargetLayout() {
+    // NON_MATCHING
+}
+
+void HackCap::updateCollider() {
+    al::LiveActor::updateCollider();
+}
+
+void HackCap::updateFrameOutLayout() {
+    // NON_MATCHING
+}
+
+void HackCap::attackSpin(al::HitSensor* self, al::HitSensor* other, f32) {
+    // NON_MATCHING
+}
+
+void HackCap::prepareLockOn(al::HitSensor* sensor) {
+    // NON_MATCHING
+}
+
+bool HackCap::sendMsgStartHack(al::HitSensor* source) {
+    // NON_MATCHING
+    return true;
+}
+
+bool HackCap::receiveRequestTransferHack(al::HitSensor* source, al::HitSensor* target) {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::startThrowSeparatePlayHack(al::HitSensor* sensor, const sead::Vector3f&,
+                                         const sead::Vector3f&, f32) {
+    // NON_MATCHING
+}
+
+void HackCap::startHack() {
+    al::setNerve(this, &NrvHackCap.Hack);
+}
+
+void HackCap::emitHackStartEffect() {
+    // NON_MATCHING
+}
+
+void HackCap::noticeHackMarioEnter() {
+    // NON_MATCHING
+}
+
+void HackCap::noticeHackDemoPuppetableEnd() {
+    // NON_MATCHING
+}
+
+void HackCap::recordHack() {
+    // NON_MATCHING
+}
+
+void HackCap::addHackStartDemo() {
+    // NON_MATCHING
+}
+
+void HackCap::addLockOnKeepDemo() {
+    // NON_MATCHING
+}
+
+void HackCap::syncHackDamageVisibility(bool visible) {
+    mIsHackDamageVisible = visible;
+}
+
+void HackCap::endHack() {
+    al::setNerve(this, &NrvHackCap.Hide);
+}
+
+void HackCap::startSpinAttack(const char*) {
+    al::setNerve(this, &NrvHackCap.SpinAttack);
+}
+
+void HackCap::startThrow(bool, const sead::Vector3f&, const sead::Vector3f&, f32,
+                         const sead::Vector2f&, const sead::Vector2f&, const sead::Vector3f&, bool,
+                         const sead::Vector3f&, SwingHandType, bool, f32, s32) {
+    al::setNerve(this, &NrvHackCap.Throw);
+}
+
+void HackCap::startThrowSeparatePlay(const sead::Vector3f&, const sead::Vector3f&, f32, bool) {
+    al::setNerve(this, &NrvHackCap.Throw);
+}
+
+void HackCap::startThrowSeparatePlayJump(const sead::Vector3f&, const sead::Vector3f&, f32) {
+    al::setNerve(this, &NrvHackCap.Throw);
+}
+
+void HackCap::startCatch(const char*, bool, const sead::Vector3f&) {
+    al::setNerve(this, &NrvHackCap.Catch);
+}
+
+bool HackCap::isNoPutOnHide() const {
+    return al::isNerve(this, &NrvHackCap.Hide) && !_2a2_flag;
+}
+
+void HackCap::forcePutOn() {
+    hide(false);
+    al::setNerve(this, &NrvHackCap.Hide);
+}
+
+void HackCap::forceHack(al::HitSensor* sensor, const CapTargetInfo* info) {
+    // NON_MATCHING
+}
+
+void HackCap::resetLockOnParam() {
+    // NON_MATCHING
+    mLockOnCounter = 0;
+}
+
+void HackCap::setupStartLockOn() {
+    // NON_MATCHING
+}
+
+bool HackCap::cancelCapState() {
+    // NON_MATCHING
+    return true;
+}
+
+bool HackCap::isEnableThrow() const {
+    return al::isNerve(this, &NrvHackCap.SpinAttack);
+}
+
+bool HackCap::isEnableSpinAttack() const {
+    return !mIsHide && al::isNerve(this, &NrvHackCap.Hide);
+}
+
+bool HackCap::isSpinAttack() const {
+    return al::isNerve(this, &NrvHackCap.SpinAttack);
+}
+
+bool HackCap::tryReturn(bool, bool* returnResult) {
+    // NON_MATCHING
+    if (returnResult)
+        *returnResult = true;
+    return true;
+}
+
+void HackCap::updateCapPose() {
+    // NON_MATCHING
+}
+
+void HackCap::followTarget() {
+    // NON_MATCHING
+}
+
+void HackCap::syncPuppetSilhouette() {
+    // NON_MATCHING
+}
+
+void HackCap::recordCapJump(PlayerWallActionHistory* history) {
+    // NON_MATCHING
+}
+
+f32 HackCap::getFlyingSpeedMax() const {
+    return mHackCapThrowParam ? 100.0f : 0.0f;
+}
+
+f32 HackCap::getThrowSpeed() const {
+    return mHackCapThrowParam ? 60.0f : 0.0f;
+}
+
+bool HackCap::requestLockOnHitReaction(const CapTargetInfo* info, const char* name) {
+    // NON_MATCHING
+    return true;
+}
+
+void HackCap::startPuppet() {
+    mPuppetFlags = 1;
+    mIsHidePuppetCapSilhouette = false;
+}
+
+void HackCap::endPuppet() {
+    mPuppetFlags = 0;
+    mIsHidePuppetCapSilhouette = false;
+    syncPuppetSilhouette();
+}
+
+void HackCap::hidePuppetCap() {
+    // NON_MATCHING
+}
+
+void HackCap::showPuppetCap() {
+    // NON_MATCHING
+}
+
+void HackCap::hidePuppetCapSilhouette() {
+    mIsHidePuppetCapSilhouette = true;
+}
+
+void HackCap::showPuppetCapSilhouette() {
+    mIsHidePuppetCapSilhouette = false;
+}
+
+void HackCap::startPuppetCheckpointWarp() {
+    // NON_MATCHING
+}
+
+void HackCap::startHackShineGetDemo() {
+    // NON_MATCHING
+}
+
+void HackCap::endHackThrowAndReturnHack() {
+    // NON_MATCHING
+}
+
+void HackCap::endHackShineGetDemo() {
+    // NON_MATCHING
+}
+
+void HackCap::calcHackFollowTrans(sead::Vector3f* out, bool) const {
+    if (out)
+        *out = al::getTrans(this);
+}
+
+void HackCap::makeFollowMtx(sead::Matrix34f* out) const {
+    if (out)
+        al::makeMtxRT(out, this);
+}
+
+void HackCap::updateCapEyeShowHide(bool, s32) {
+    // NON_MATCHING
+}
+
+void HackCap::activateInvincibleEffect() {
+    // NON_MATCHING
+}
+
+void HackCap::syncInvincibleEffect(bool) {
+    // NON_MATCHING
+}
+
+void HackCap::updateSeparateMode(const PlayerSeparateCapFlag* flag) {
+    mIsSeparateFlying = flag ? flag->isSeparateMode() : false;
+}
+
+bool HackCap::isEnableRescuePlayer() const {
+    return false;
+}
+
+bool HackCap::isRescuePlayer() const {
+    return al::isNerve(this, &NrvHackCap.Rescue);
+}
+
+bool HackCap::isEnableHackThrow(bool*) const {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::isSeparateHipDropLand() const {
+    return false;
+}
+
+bool HackCap::isSeparateHide() const {
+    return mIsHide;
+}
+
+bool HackCap::isSeparateThrowFlying() const {
+    return mIsSeparateFlying;
+}
+
+void HackCap::startRescuePlayer() {
+    al::setNerve(this, &NrvHackCap.Rescue);
+}
+
+void HackCap::prepareCooperateThrow() {
+    // NON_MATCHING
+}
+
+void HackCap::requestForceFollowSeparateHide() {
+    // NON_MATCHING
+}
+
+f32 HackCap::calcSeparateHideSpeedH(const sead::Vector3f&) const {
+    return 0.0f;
+}
+
+void HackCap::updateModelAlphaForSnapShot() {
+    // NON_MATCHING
+}
+
+s32 HackCap::getPadRumblePort() const {
+    return mPadRumbleKeeper->getPort();
+}
+
+bool HackCap::isEnableThrowSeparate() const {
+    return mIsSeparateFlying;
+}
+
+bool HackCap::isHoldInputKeepLockOn() const {
+    if (_298_1)
+        return mInput->isHoldAction();
+    return mInput->isHoldCapAction();
+}
+
+bool HackCap::isRequestableReturn() const {
+    return isFlying();
+}
+
+bool HackCap::isLockOnEnableHackTarget() const {
+    return false;
+}
+
+bool HackCap::isWaitHackLockOn() const {
+    return false;
+}
+
+bool HackCap::isCatched() const {
+    return (al::isNerve(this, &NrvHackCap.Catch) || al::isNerve(this, &NrvHackCap.Hide)) &&
+           mIsHackDamageVisible;
+}
+
+bool HackCap::isHide() const {
+    return al::isNerve(this, &NrvHackCap.Hide);
+}
+
+bool HackCap::isPutOn() const {
+    return al::isNerve(this, &NrvHackCap.Hide) && _2a2_flag;
+}
+
+bool HackCap::isLockOnInterpolate() const {
+    return (al::isNerve(this, &NrvHackCap.LockOn) || al::isNerve(this, &NrvHackCap.Hack) ||
+            al::isNerve(this, &NrvHackCap.TrampleLockOn)) &&
+           mLockOnCounter < 4;
+}
+
+bool HackCap::isEnablePreInput() const {
+    return mCapJudgePreInputSeparateThrow &&
+           mCapJudgePreInputSeparateThrow->isEnablePreInput();
+}
+
+bool HackCap::isForceCapTouchJump() const {
+    if (_298_1)
+        return false;
+    u32 flag = *reinterpret_cast<const u32*>(mPlayerSeparateCapFlag);
+    if ((flag & 0xff0000) == 0 && (flag & 0xff) == 0)
+        return false;
+    return reinterpret_cast<const HackCapStateThrowStay*>(mInput)->isHomingPlayerJump();
+}
+
+bool HackCap::isHackInvalidSeparatePlay() const {
+    return mCapTargetInfo1 && mCapTargetInfo1->_7e;
+}
+
+void HackCap::exeHide() {
+    // NON_MATCHING
+}
+
+void HackCap::exeLockOn() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::updateThrowJoint() {
+    // NON_MATCHING
+}
+
+void HackCap::exeHack() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeSpinAttack() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeCatch() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeTrample() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::isHoldSpinCapStay() const {
+    if (_298_1)
+        return mInput->isHoldAction();
+    u32 flag = *reinterpret_cast<const u32*>(mPlayerSeparateCapFlag);
+    if ((flag & 0xff0000) != 0 || (flag & 0xff) != 0)
+        return _510;
+    return mInput->isHoldSpinCap();
+}
+
+void HackCap::exeTrampleLockOn() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeRescue() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+
+
+void HackCap::exeThrowStart() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::isThrowTypeSpiral() const {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::isThrowTypeRolling() const {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::setupThrowStart() {
+    // NON_MATCHING
+}
+
+f32 HackCap::getThrowHeight() const {
+    return mHackCapThrowParam ? 100.0f : 0.0f;
+}
+
+bool HackCap::checkEnableThrowStartSpace(sead::Vector3f*, sead::Vector3f*, sead::Vector3f*,
+                                         const sead::Vector3f&, f32, f32, bool,
+                                         const sead::Vector3f&) {
+    return true;
+}
+
+void HackCap::updateWaterArea() {
+    // NON_MATCHING
+}
+
+f32 HackCap::getThrowRange() const {
+    return mHackCapThrowParam ? 500.0f : 0.0f;
+}
+
+s32 HackCap::getThrowBrakeTime() const {
+    return mHackCapThrowParam ? 10 : 0;
+}
+
+void HackCap::startThrowCapEyeThrowAction() {
+    // NON_MATCHING
+}
+
+void HackCap::exeThrow() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryCollideReflectReaction() {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::tryCollideWallReaction() {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::changeThrowParamInWater(s32, bool) {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::addCurveOffset() {
+    // NON_MATCHING
+}
+
+void HackCap::exeThrowBrake() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryAppendAttack() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::exeThrowSpiral() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryCollideWallReactionSpiral() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::endThrowSpiral() {
+    // NON_MATCHING
+}
+
+void HackCap::exeThrowTornado() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryCollideWallReactionReflect() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::exeThrowRolling() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryCollideWallReactionRollingGround() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::rollingGround() {
+    // NON_MATCHING
+}
+
+void HackCap::exeThrowRollingBrake() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeThrowStay() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryChangeSeparateThrow() {
+    // NON_MATCHING
+    return false;
+}
+
+f32 HackCap::getThrowBackSpeed() const {
+    return mHackCapThrowParam ? 30.0f : 0.0f;
+}
+
+void HackCap::updateLavaSurfaceMove() {
+    // NON_MATCHING
+}
+
+bool HackCap::tryCollideWallReactionStay() {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::isEnableHackThrowAutoCatch() const {
+    return false;
+}
+
+s32 HackCap::getThrowStayTime() const {
+    return mHackCapThrowParam ? 120 : 0;
+}
+
+s32 HackCap::getThrowStayTimeMax() const {
+    return mHackCapThrowParam ? 300 : 0;
+}
+
+void HackCap::exeThrowAppend() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+f32 HackCap::getThrowSpeedAppend() const {
+    return mHackCapThrowParam ? 80.0f : 0.0f;
+}
+
+f32 HackCap::getThrowRangeAppend() const {
+    return mHackCapThrowParam ? 800.0f : 0.0f;
+}
+
+void HackCap::exeBlow() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+bool HackCap::tryCollideWallLockOn() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::endHackThrowAndReturnHackOrHide() {
+    if (mIsSeparateFlying)
+        endHackThrowAndReturnHack();
+    else
+        hide(false);
+}
+
+void HackCap::clearThrowType() {
+    // NON_MATCHING
+}
+
+void HackCap::exeRebound() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::exeReturn() {
+    // NON_MATCHING
+    if (al::isFirstStep(this)) {
+    }
+}
+
+void HackCap::calcReturnTargetPos(sead::Vector3f* out) const {
+    if (out)
+        *out = al::getTrans(mPlayerActor);
+}
+
+void HackCap::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    // NON_MATCHING
+}
+
+bool HackCap::stayRollingOrReflect() {
+    return false;
+}
+
+bool HackCap::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::endMove() {
+    // NON_MATCHING
+}
+
+bool HackCap::isEnableCapTouchJumpInput() const {
+    return false;
+}
+
+void HackCap::prepareTransferLockOn(al::HitSensor*) {
+    // NON_MATCHING
+}
+
+void HackCap::collideThrowStartArrow(al::HitSensor*, const sead::Vector3f&, const sead::Vector3f&,
+                                     const sead::Vector3f&) {
+    // NON_MATCHING
+}
+
+bool HackCap::trySendAttackCollideAndReaction(bool*) {
+    // NON_MATCHING
+    return false;
+}
+
+bool HackCap::stayWallHit() {
+    // NON_MATCHING
+    return false;
+}
+
+void HackCap::endHackThrow() {
+    mIsSeparateFlying = false;
+    mPlayerBodySensor = nullptr;
+}

--- a/src/Player/HackCap.h
+++ b/src/Player/HackCap.h
@@ -254,9 +254,14 @@ private:
     f32 _28c;
     s32 _290;
     char filler_294[4];
-    s32 _298;
+    u8 _298_0;
+    u8 _298_1;
+    u8 _298_2;
+    u8 _298_3;
     char filler_29c[4];
-    char _2a0[4];
+    char _2a0[2];
+    bool _2a2_flag;
+    char _2a3[1];
     bool mIsSeparateFlying;
     char _2a5[11];
     const PlayerWallActionHistory* mPlayerWallActionHistory;
@@ -300,8 +305,7 @@ private:
     bool _5bb;
     s32 _5bc;
     void* _5c0[7];
-    bool mIsPuppet;
-    bool _5f9;
+    u16 mPuppetFlags;  // [0] = mIsPuppet, [1] = _5f9
     bool mIsHidePuppetCapSilhouette;
     HackCapStateThrowStay* mStateThrowStay;
     HackCapStateHide* mStateHide;

--- a/src/Player/HackCapAboveGroundChecker.cpp
+++ b/src/Player/HackCapAboveGroundChecker.cpp
@@ -1,0 +1,15 @@
+#include "Player/HackCapAboveGroundChecker.h"
+
+#include "Player/IUsePlayerCollision.h"
+
+HackCapAboveGroundChecker::HackCapAboveGroundChecker(const al::LiveActor* actor,
+                                                     const IUsePlayerCollision* collision)
+    : mActor(actor), mCollision(collision), mIsAboveGround(false) {}
+
+void HackCapAboveGroundChecker::update() {
+    // NON_MATCHING
+}
+
+bool HackCapAboveGroundChecker::isAboveGround() const {
+    return mIsAboveGround;
+}

--- a/src/Player/HackCapAboveGroundChecker.h
+++ b/src/Player/HackCapAboveGroundChecker.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}  // namespace al
+
+class IUsePlayerCollision;
+
+class HackCapAboveGroundChecker {
+public:
+    HackCapAboveGroundChecker(const al::LiveActor*, const IUsePlayerCollision*);
+
+    void update();
+    bool isAboveGround() const;
+
+private:
+    const al::LiveActor* mActor;
+    const IUsePlayerCollision* mCollision;
+    bool mIsAboveGround;
+};

--- a/src/Player/HackCapJointControlKeeper.cpp
+++ b/src/Player/HackCapJointControlKeeper.cpp
@@ -1,0 +1,7 @@
+#include "Player/HackCapJointControlKeeper.h"
+
+HackCapJointControlKeeper::HackCapJointControlKeeper(al::LiveActor* actor) {}
+
+void HackCapJointControlKeeper::update() {
+    // NON_MATCHING
+}

--- a/src/Player/HackCapJointControlKeeper.h
+++ b/src/Player/HackCapJointControlKeeper.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}
+
+class HackCapJointControlKeeper {
+public:
+    HackCapJointControlKeeper(al::LiveActor* actor);
+
+    void update();
+
+private:
+    void* filler[0x50 / 8];
+};
+
+static_assert(sizeof(HackCapJointControlKeeper) == 0x50);

--- a/src/Player/HackCapJudgePreInputSeparateJump.cpp
+++ b/src/Player/HackCapJudgePreInputSeparateJump.cpp
@@ -1,0 +1,12 @@
+#include "Player/HackCapJudgePreInputSeparateJump.h"
+
+HackCapJudgePreInputSeparateJump::HackCapJudgePreInputSeparateJump(HackCap* hackCap)
+    : mHackCap(hackCap), mPreInputFrames(0), mIsPreInput(false) {}
+
+void HackCapJudgePreInputSeparateJump::update() {
+    // NON_MATCHING
+}
+
+bool HackCapJudgePreInputSeparateJump::judge() const {
+    return mIsPreInput;
+}

--- a/src/Player/HackCapJudgePreInputSeparateJump.h
+++ b/src/Player/HackCapJudgePreInputSeparateJump.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class HackCap;
+
+class HackCapJudgePreInputSeparateJump {
+public:
+    HackCapJudgePreInputSeparateJump(HackCap* hackCap);
+
+    void update();
+    bool judge() const;
+
+private:
+    HackCap* mHackCap;
+    s32 mPreInputFrames;
+    bool mIsPreInput;
+};

--- a/src/Player/HackCapJudgePreInputSeparateThrow.cpp
+++ b/src/Player/HackCapJudgePreInputSeparateThrow.cpp
@@ -1,0 +1,16 @@
+#include "Player/HackCapJudgePreInputSeparateThrow.h"
+
+HackCapJudgePreInputSeparateThrow::HackCapJudgePreInputSeparateThrow(HackCap* hackCap)
+    : mHackCap(hackCap), mPreInputFrames(0), mIsPreInput(false) {}
+
+void HackCapJudgePreInputSeparateThrow::update() {
+    // NON_MATCHING
+}
+
+bool HackCapJudgePreInputSeparateThrow::judge() const {
+    return mIsPreInput;
+}
+
+bool HackCapJudgePreInputSeparateThrow::isEnablePreInput() const {
+    return mIsPreInput;
+}

--- a/src/Player/HackCapJudgePreInputSeparateThrow.h
+++ b/src/Player/HackCapJudgePreInputSeparateThrow.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class HackCap;
+
+class HackCapJudgePreInputSeparateThrow {
+public:
+    HackCapJudgePreInputSeparateThrow(HackCap* hackCap);
+
+    void update();
+    bool judge() const;
+    bool isEnablePreInput() const;
+
+private:
+    HackCap* mHackCap;
+    s32 mPreInputFrames;
+    bool mIsPreInput;
+};

--- a/src/Player/HackCapRequestReturn.cpp
+++ b/src/Player/HackCapRequestReturn.cpp
@@ -1,0 +1,5 @@
+#include "Player/HackCap.h"
+
+bool HackCap::requestReturn(bool* returnResult) {
+    return tryReturn(false, returnResult);
+}

--- a/src/Player/HackCapStateHide.cpp
+++ b/src/Player/HackCapStateHide.cpp
@@ -1,0 +1,26 @@
+#include "Player/HackCapStateHide.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/HackCap.h"
+
+namespace {
+NERVE_IMPL(HackCapStateHide, Hide);
+
+NERVES_MAKE_NOSTRUCT(HackCapStateHide, Hide);
+}  // namespace
+
+HackCapStateHide::HackCapStateHide(HackCap* hackCap)
+    : al::ActorStateBase("キャップ非表示", hackCap), mHackCap(hackCap) {
+    initNerve(&Hide, 0);
+}
+
+void HackCapStateHide::appear() {
+    al::ActorStateBase::appear();
+    al::setNerve(this, &Hide);
+}
+
+void HackCapStateHide::exeHide() {
+    // NON_MATCHING
+}

--- a/src/Player/HackCapStateHide.h
+++ b/src/Player/HackCapStateHide.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class HackCap;
+
+class HackCapStateHide : public al::ActorStateBase {
+public:
+    HackCapStateHide(HackCap* hackCap);
+
+    void appear() override;
+
+    void exeHide();
+
+private:
+    HackCap* mHackCap;
+};

--- a/src/Player/HackCapStateThrowStay.cpp
+++ b/src/Player/HackCapStateThrowStay.cpp
@@ -1,0 +1,40 @@
+#include "Player/HackCapStateThrowStay.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/HackCap.h"
+
+namespace {
+NERVE_IMPL(HackCapStateThrowStay, Wait);
+NERVE_IMPL(HackCapStateThrowStay, Stay);
+NERVE_IMPL(HackCapStateThrowStay, End);
+
+NERVES_MAKE_NOSTRUCT(HackCapStateThrowStay, Wait, Stay, End);
+}  // namespace
+
+HackCapStateThrowStay::HackCapStateThrowStay(HackCap* hackCap)
+    : al::ActorStateBase("キャップ停滞", hackCap), mHackCap(hackCap) {
+    initNerve(&Wait, 0);
+}
+
+void HackCapStateThrowStay::appear() {
+    al::ActorStateBase::appear();
+    al::setNerve(this, &Wait);
+}
+
+bool HackCapStateThrowStay::isHomingPlayerJump() const {
+    return true;
+}
+
+void HackCapStateThrowStay::exeWait() {
+    // NON_MATCHING
+}
+
+void HackCapStateThrowStay::exeStay() {
+    // NON_MATCHING
+}
+
+void HackCapStateThrowStay::exeEnd() {
+    // NON_MATCHING
+}

--- a/src/Player/HackCapStateThrowStay.h
+++ b/src/Player/HackCapStateThrowStay.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class HackCap;
+
+class HackCapStateThrowStay : public al::ActorStateBase {
+public:
+    HackCapStateThrowStay(HackCap* hackCap);
+
+    void appear() override;
+
+    void exeWait();
+    void exeStay();
+    void exeEnd();
+    bool isHomingPlayerJump() const;
+
+private:
+    HackCap* mHackCap;
+};

--- a/src/Player/HackCapTrigger.cpp
+++ b/src/Player/HackCapTrigger.cpp
@@ -1,0 +1,3 @@
+#include "Player/HackCapTrigger.h"
+
+HackCapTrigger::HackCapTrigger() : _0(0), _4(0) {}

--- a/src/Player/HackCapTrigger.h
+++ b/src/Player/HackCapTrigger.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+class HackCapTrigger {
+public:
+    HackCapTrigger();
+
+private:
+    s32 _0;
+    s32 _4;
+};
+
+static_assert(sizeof(HackCapTrigger) == 0x8);

--- a/src/Player/PlayerColliderHackCap.cpp
+++ b/src/Player/PlayerColliderHackCap.cpp
@@ -1,0 +1,7 @@
+#include "Player/PlayerColliderHackCap.h"
+
+PlayerColliderHackCap::PlayerColliderHackCap(al::LiveActor* actor) {}
+
+void PlayerColliderHackCap::update() {
+    // NON_MATCHING
+}

--- a/src/Player/PlayerColliderHackCap.h
+++ b/src/Player/PlayerColliderHackCap.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+class HitSensor;
+}
+
+class PlayerColliderHackCap {
+public:
+    PlayerColliderHackCap(al::LiveActor* actor);
+
+    void update();
+
+private:
+    void* filler[0x30 / 8];
+};
+
+static_assert(sizeof(PlayerColliderHackCap) == 0x30);

--- a/src/Player/PlayerEyeSensorHitHolder.cpp
+++ b/src/Player/PlayerEyeSensorHitHolder.cpp
@@ -1,0 +1,16 @@
+#include "Player/PlayerEyeSensorHitHolder.h"
+
+PlayerEyeSensorHitHolder::PlayerEyeSensorHitHolder(al::LiveActor* actor)
+    : mActor(actor), mIsHit(false), mHitPos(sead::Vector3f::zero) {}
+
+void PlayerEyeSensorHitHolder::update() {
+    // NON_MATCHING
+}
+
+bool PlayerEyeSensorHitHolder::isHit() const {
+    return mIsHit;
+}
+
+const sead::Vector3f& PlayerEyeSensorHitHolder::getHitPos() const {
+    return mHitPos;
+}

--- a/src/Player/PlayerEyeSensorHitHolder.h
+++ b/src/Player/PlayerEyeSensorHitHolder.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+
+namespace al {
+class LiveActor;
+class HitSensor;
+}
+
+class PlayerEyeSensorHitHolder {
+public:
+    PlayerEyeSensorHitHolder(al::LiveActor* actor);
+
+    void update();
+    bool isHit() const;
+    const sead::Vector3f& getHitPos() const;
+
+private:
+    al::LiveActor* mActor;
+    bool mIsHit;
+    char filler[3];
+    sead::Vector3f mHitPos;
+    char filler2[8];
+};
+
+static_assert(sizeof(PlayerEyeSensorHitHolder) == 0x20);

--- a/src/Player/PlayerSeparateCapFlag.cpp
+++ b/src/Player/PlayerSeparateCapFlag.cpp
@@ -1,0 +1,37 @@
+#include "Player/PlayerSeparateCapFlag.h"
+
+PlayerSeparateCapFlag::PlayerSeparateCapFlag(al::LiveActor* player)
+    : mPlayer(player), mIsSeparateMode(false), mIsHipDrop(false), mIsHipDropCancel(false),
+      mIsCapTouchJump(false) {}
+
+bool PlayerSeparateCapFlag::isEnableHipDrop() const {
+    return mIsHipDrop;
+}
+
+bool PlayerSeparateCapFlag::isEnableHipDropCancel() const {
+    return mIsHipDropCancel;
+}
+
+bool PlayerSeparateCapFlag::isEnableCapTouchJump() const {
+    return mIsCapTouchJump;
+}
+
+bool PlayerSeparateCapFlag::isEnableGroundPound() const {
+    return false;
+}
+
+bool PlayerSeparateCapFlag::isSeparateMode() const {
+    return mIsSeparateMode;
+}
+
+void PlayerSeparateCapFlag::setSeparateMode(bool val) {
+    mIsSeparateMode = val;
+}
+
+void PlayerSeparateCapFlag::setHipDrop(bool val) {
+    mIsHipDrop = val;
+}
+
+void PlayerSeparateCapFlag::setCapTouchJump(bool val) {
+    mIsCapTouchJump = val;
+}

--- a/src/Player/PlayerSeparateCapFlag.h
+++ b/src/Player/PlayerSeparateCapFlag.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class LiveActor;
+}
+
+class PlayerSeparateCapFlag {
+public:
+    PlayerSeparateCapFlag(al::LiveActor* player);
+
+    bool isEnableHipDrop() const;
+    bool isEnableHipDropCancel() const;
+    bool isEnableCapTouchJump() const;
+    bool isEnableGroundPound() const;
+    bool isSeparateMode() const;
+
+    void setSeparateMode(bool);
+    void setHipDrop(bool);
+    void setCapTouchJump(bool);
+
+private:
+    const al::LiveActor* mPlayer;
+    bool mIsSeparateMode;
+    bool mIsHipDrop;
+    bool mIsHipDropCancel;
+    bool mIsCapTouchJump;
+};
+
+static_assert(sizeof(PlayerSeparateCapFlag) == 0x10);


### PR DESCRIPTION
Partial implementation of HackCap and related classes.

Currently matching:
- HackCap: 20 functions
- HackCapStateThrowStay: 2 functions  
- HackCapStateHide: 1 function

Remaining work: HackCapFunction, HackCapJointControlKeeper, HackCapTrigger, 
HackCapJudge*, PlayerColliderHackCap, PlayerEyeSensorHitHolder, PlayerSeparateCapFlag, 
plus the majority of HackCap.o functions still NonMatchingMajor.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1290)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1cc7b00 - e279488)

📈 **Matched code**: 15.25% (+0.00%, +532 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackCap` | `HackCap::isLockOnInterpolate() const` | +100 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isNoPutOnHide() const` | +68 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isPutOn() const` | +68 | 0.00% | 100.00% |
| `Player/HackCapStateHide` | `HackCapStateHide::~HackCapStateHide()` | +36 | 0.00% | 100.00% |
| `Player/HackCapStateThrowStay` | `HackCapStateThrowStay::~HackCapStateThrowStay()` | +36 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isHackInvalidSeparatePlay() const` | +32 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isHoldInputKeepLockOn() const` | +20 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isEnableThrow() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isSpinAttack() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::requestReturn(bool*)` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::startPuppet()` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isRescuePlayer() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isHide() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::syncHackDamageVisibility(bool)` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::hidePuppetCapSilhouette()` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::getPadRumblePort() const` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::endHackThrow()` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::showPuppetCapSilhouette()` | +8 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isEnableRescuePlayer() const` | +8 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::recordCapJump(PlayerWallActionHistory*)` | +4 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::endHackShineGetDemo()` | +4 | 0.00% | 100.00% |
| `Player/HackCapStateThrowStay` | `HackCapStateThrowStay::exeStay()` | +4 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 166 improvements in unmatched items</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackCap` | `HackCap::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +1061 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowStart()` | +1005 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::updateWaterArea()` | +638 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowStay()` | +608 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::checkEnableThrowStartSpace(sead::Vector3<float>*, sead::Vector3<float>*, sead::Vector3<float>*, sead::Vector3<float> const&, float, float, bool, sead::Vector3<float> const&)` | +523 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::changeThrowParamInWater(int, bool)` | +479 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::tryAppendAttack()` | +470 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowSpiral()` | +468 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeReturn()` | +459 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::updateTargetLayout()` | +428 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::attackSensor(al::HitSensor*, al::HitSensor*)` | +405 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::rollingGround()` | +361 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::init(al::ActorInitInfo const&)` | +336 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::HackCap(al::LiveActor const*, char const*, PlayerInput const*, PlayerAreaChecker const*, PlayerWallActionHistory const*, PlayerCapActionHistory const*, PlayerEyeSensorHitHolder const*, PlayerSeparateCapFlag const*, IUsePlayerCollision const*, IUsePlayerHeightCheck const*, PlayerWetControl const*, PlayerJointControlKeeper const*, HackCapJudgePreInputSeparateThrow*, HackCapJudgePreInputSeparateJump*)` | +330 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::HackCap(al::LiveActor const*, char const*, PlayerInput const*, PlayerAreaChecker const*, PlayerWallActionHistory const*, PlayerCapActionHistory const*, PlayerEyeSensorHitHolder const*, PlayerSeparateCapFlag const*, IUsePlayerCollision const*, IUsePlayerHeightCheck const*, PlayerWetControl const*, PlayerJointControlKeeper const*, HackCapJudgePreInputSeparateThrow*, HackCapJudgePreInputSeparateJump*)` | +329 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::startThrow(bool, sead::Vector3<float> const&, sead::Vector3<float> const&, float, sead::Vector2<float> const&, sead::Vector2<float> const&, sead::Vector3<float> const&, bool, sead::Vector3<float> const&, HackCap::SwingHandType, bool, float, int)` | +320 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::tryCollideWallReactionRollingGround()` | +305 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeBlow()` | +255 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::control()` | +226 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::updateFrameOutLayout()` | +226 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeLockOn()` | +220 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowTornado()` | +209 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeRebound()` | +208 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::attackSpin(al::HitSensor*, al::HitSensor*, float)` | +204 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::trySendAttackCollideAndReaction(bool*)` | +204 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::tryCollideWallReaction()` | +190 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowAppend()` | +185 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::exeThrowBrake()` | +179 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::updateCapPose()` | +176 | 0.00% | 25.00% |
| `Player/HackCap` | `HackCap::tryCollideWallReactionReflect()` | +149 | 0.00% | 25.00% |

...and 136 more improvements in unmatched items
</details>


<!-- decomp.dev report end -->