### PR TITLE
Player: Implement `HackCap` matching functions 20/30 matching/nodecompiled

### DIFF
--- a/src/Player/CapTargetInfo.h
+++ b/src/Player/CapTargetInfo.h
@@ -31,6 +31,7 @@ public:
 
 private:
     friend CapTargetInfoFunction;
+    friend class HackCap;
     const al::LiveActor* mActor = nullptr;
     const char* mHackName = nullptr;
     IUsePlayerCollision* mPlayerCollision = nullptr;

--- a/src/Player/HackCap.cpp
+++ b/src/Player/HackCap.cpp
@@ -1,0 +1,101 @@
+#include "Player/HackCap.h"
+
+#include "Player/IUsePlayerCollision.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorCollisionFunction.h"
+#include "Library/LiveActor/ActorFlagFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/LiveActor/ActorMovementFunction.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorFunction.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Shadow/ActorShadowUtil.h"
+#include "Project/Controller/PadRumbleKeeper.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/CapTargetInfo.h"
+#include "Player/HackCapThrowParam.h"
+#include "Player/PlayerAreaChecker.h"
+#include "Player/PlayerCapActionHistory.h"
+#include "Player/PlayerExternalVelocity.h"
+#include "Player/PlayerInput.h"
+#include "Player/PlayerJointControlKeeper.h"
+#include "Player/PlayerPushReceiver.h"
+#include "Player/PlayerWallActionHistory.h"
+
+namespace {
+NERVE_IMPL(HackCap, Catch);
+NERVE_IMPL(HackCap, ThrowStay);
+NERVE_IMPL(HackCap, Hide);
+NERVE_IMPL(HackCap, Return);
+NERVE_IMPL(HackCap, LockOn);
+NERVE_IMPL(HackCap, Rebound);
+NERVE_IMPL(HackCap, Hack);
+NERVE_IMPL(HackCap, SpinAttack);
+NERVE_IMPL(HackCap, ThrowStart);
+NERVE_IMPL(HackCap, Rescue);
+NERVE_IMPL_(HackCap, TrampleReturn, Trample);
+NERVE_IMPL(HackCap, ThrowTornado);
+NERVE_IMPL(HackCap, ThrowSpiral);
+NERVE_IMPL(HackCap, ThrowRolling);
+NERVE_IMPL(HackCap, Throw);
+NERVE_IMPL(HackCap, ThrowBrake);
+NERVE_IMPL_(HackCap, Rethrow, Throw);
+NERVE_IMPL(HackCap, ThrowAppend);
+NERVE_IMPL(HackCap, ThrowRollingBrake);
+NERVE_IMPL(HackCap, Trample);
+NERVE_IMPL(HackCap, TrampleLockOn);
+NERVE_IMPL(HackCap, Blow);
+
+NERVES_MAKE_STRUCT(HackCap, Catch, ThrowStay, Hide, Return, LockOn, Rebound, Hack, SpinAttack,
+                   ThrowStart, Rescue, TrampleReturn, ThrowTornado, ThrowSpiral, ThrowRolling,
+                   Throw, ThrowBrake, Rethrow, ThrowAppend, ThrowRollingBrake, Trample,
+                   TrampleLockOn, Blow);
+}  // namespace
+
+void HackCap::syncHackDamageVisibility(bool visible) {
+    mIsHackDamageVisible = visible;
+}
+
+
+bool HackCap::isSpinAttack() const {
+    return al::isNerve(this, &NrvHackCap.SpinAttack);
+}
+
+void HackCap::recordCapJump(PlayerWallActionHistory* history) {
+    // NON_MATCHING
+}
+
+void HackCap::startPuppet() {
+    mPuppetFlags = 1;
+    mIsHidePuppetCapSilhouette = false;
+}
+
+void HackCap::hidePuppetCapSilhouette() {
+    mIsHidePuppetCapSilhouette = true;
+}
+
+void HackCap::showPuppetCapSilhouette() {
+    mIsHidePuppetCapSilhouette = false;
+}
+
+void HackCap::endHackShineGetDemo() {
+    // NON_MATCHING
+}
+
+s32 HackCap::getPadRumblePort() const {
+    return mPadRumbleKeeper->getPort();
+}
+
+bool HackCap::isHackInvalidSeparatePlay() const {
+    return mCapTargetInfo1 && mCapTargetInfo1->_7e;
+}
+
+void HackCap::endHackThrow() {
+    al::setNerve(this, &NrvHackCap.Catch);
+}

--- a/src/Player/HackCap.h
+++ b/src/Player/HackCap.h
@@ -254,9 +254,14 @@ private:
     f32 _28c;
     s32 _290;
     char filler_294[4];
-    s32 _298;
+    u8 _298_0;
+    u8 _298_1;
+    u8 _298_2;
+    u8 _298_3;
     char filler_29c[4];
-    char _2a0[4];
+    char _2a0[2];
+    bool _2a2_flag;
+    char _2a3[1];
     bool mIsSeparateFlying;
     char _2a5[11];
     const PlayerWallActionHistory* mPlayerWallActionHistory;
@@ -300,8 +305,7 @@ private:
     bool _5bb;
     s32 _5bc;
     void* _5c0[7];
-    bool mIsPuppet;
-    bool _5f9;
+    u16 mPuppetFlags;  // [0] = mIsPuppet, [1] = _5f9
     bool mIsHidePuppetCapSilhouette;
     HackCapStateThrowStay* mStateThrowStay;
     HackCapStateHide* mStateHide;

--- a/src/Player/HackCapRequestReturn.cpp
+++ b/src/Player/HackCapRequestReturn.cpp
@@ -1,0 +1,5 @@
+#include "Player/HackCap.h"
+
+bool HackCap::requestReturn(bool* returnResult) {
+    return tryReturn(false, returnResult);
+}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1292)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1cc7b00 - d668008)

📈 **Matched code**: 15.25% (+0.00%, +148 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackCap` | `HackCap::isHackInvalidSeparatePlay() const` | +32 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isSpinAttack() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::requestReturn(bool*)` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::startPuppet()` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::isRescuePlayer() const` | +16 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::syncHackDamageVisibility(bool)` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::hidePuppetCapSilhouette()` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::getPadRumblePort() const` | +12 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::showPuppetCapSilhouette()` | +8 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::recordCapJump(PlayerWallActionHistory*)` | +4 | 0.00% | 100.00% |
| `Player/HackCap` | `HackCap::endHackShineGetDemo()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->