### PR TITLE
Player: Implement HackCapStateThrowStay matching functions (2/37)

### DIFF
--- a/src/Player/HackCapStateThrowStay.cpp
+++ b/src/Player/HackCapStateThrowStay.cpp
@@ -1,0 +1,40 @@
+#include "Player/HackCapStateThrowStay.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/HackCap.h"
+
+namespace {
+NERVE_IMPL(HackCapStateThrowStay, Wait);
+NERVE_IMPL(HackCapStateThrowStay, Stay);
+NERVE_IMPL(HackCapStateThrowStay, End);
+
+NERVES_MAKE_NOSTRUCT(HackCapStateThrowStay, Wait, Stay, End);
+}  // namespace
+
+HackCapStateThrowStay::HackCapStateThrowStay(HackCap* hackCap)
+    : al::ActorStateBase("投げ中待機", hackCap), mHackCap(hackCap) {
+    initNerve(&Wait, 0);
+}
+
+void HackCapStateThrowStay::appear() {
+    al::ActorStateBase::appear();
+    al::setNerve(this, &Wait);
+}
+
+bool HackCapStateThrowStay::isHomingPlayerJump() const {
+    return true;
+}
+
+void HackCapStateThrowStay::exeWait() {
+    // NON_MATCHING
+}
+
+void HackCapStateThrowStay::exeStay() {
+    // NON_MATCHING
+}
+
+void HackCapStateThrowStay::exeEnd() {
+    // NON_MATCHING
+}

--- a/src/Player/HackCapStateThrowStay.h
+++ b/src/Player/HackCapStateThrowStay.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class HackCap;
+
+class HackCapStateThrowStay : public al::ActorStateBase {
+public:
+    HackCapStateThrowStay(HackCap* hackCap);
+
+    void appear() override;
+
+    void exeWait();
+    void exeStay();
+    void exeEnd();
+    bool isHomingPlayerJump() const;
+
+private:
+    HackCap* mHackCap;
+};


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1296)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1cc7b00 - fe6a274)

📈 **Matched code**: 15.25% (+0.00%, +40 bytes)

<details>
<summary>✅ 2 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackCapStateThrowStay` | `HackCapStateThrowStay::~HackCapStateThrowStay()` | +36 | 0.00% | 100.00% |
| `Player/HackCapStateThrowStay` | `HackCapStateThrowStay::exeStay()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->