### PR TITLE
Player: Implement HackCapStateHide destructor (1/13)

### DIFF
--- a/src/Player/HackCapStateHide.cpp
+++ b/src/Player/HackCapStateHide.cpp
@@ -1,0 +1,26 @@
+#include "Player/HackCapStateHide.h"
+
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+
+#include "Player/HackCap.h"
+
+namespace {
+NERVE_IMPL(HackCapStateHide, Hide);
+
+NERVES_MAKE_NOSTRUCT(HackCapStateHide, Hide);
+}  // namespace
+
+HackCapStateHide::HackCapStateHide(HackCap* hackCap)
+    : al::ActorStateBase("隠れ", hackCap), mHackCap(hackCap) {
+    initNerve(&Hide, 0);
+}
+
+void HackCapStateHide::appear() {
+    al::ActorStateBase::appear();
+    al::setNerve(this, &Hide);
+}
+
+void HackCapStateHide::exeHide() {
+    // NON_MATCHING
+}

--- a/src/Player/HackCapStateHide.h
+++ b/src/Player/HackCapStateHide.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Library/Nerve/NerveStateBase.h"
+
+namespace al {
+class LiveActor;
+}
+
+class HackCap;
+
+class HackCapStateHide : public al::ActorStateBase {
+public:
+    HackCapStateHide(HackCap* hackCap);
+
+    void appear() override;
+
+    void exeHide();
+
+private:
+    HackCap* mHackCap;
+};


### PR DESCRIPTION
Implements the matching destructor for the `HackCapStateHide` class.

**Matching functions implemented:**
- `HackCapStateHide::~HackCapStateHide()`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1297)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1cc7b00 - 3c9ff61)

📈 **Matched code**: 15.25% (+0.00%, +36 bytes)

<details>
<summary>✅ 1 new match</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackCapStateHide` | `HackCapStateHide::~HackCapStateHide()` | +36 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->