### PR TITLE
System: Implement `TempSaveData`

### DIFF
--- a/src/Item/ShineInfo.h
+++ b/src/Item/ShineInfo.h
@@ -8,7 +8,7 @@ class LiveActor;
 struct ActorInitInfo;
 }  // namespace al
 class QuestInfo;
-class UniqObjInfo;
+struct UniqObjInfo;
 
 struct ShineData {
     char stageName[128];

--- a/src/System/FixedHeapArray.h
+++ b/src/System/FixedHeapArray.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+// NOTE: no bounds check done for any operations
+template <typename T, s32 Size>
+class FixedHeapArray {
+public:
+    void alloc() { mPtr = new T[Size]; }
+
+    s32 size() const { return Size; }
+
+    T& operator[](s32 index) { return mPtr[index]; }
+
+    const T& operator[](s32 index) const { return mPtr[index]; }
+
+    T* begin() const { return mPtr; }
+
+    T* end() const { return mPtr + Size; }
+
+private:
+    T* mPtr = nullptr;
+};

--- a/src/System/GameDataFile.h
+++ b/src/System/GameDataFile.h
@@ -9,6 +9,7 @@
 
 #include "Npc/SessionEventProgress.h"
 #include "Npc/SessionMusicianType.h"
+#include "System/FixedHeapArray.h"
 #include "System/UniqObjInfo.h"
 #include "Util/ScenePrepoFunction.h"
 
@@ -166,26 +167,6 @@ public:
     };
 
     static_assert(sizeof(CheckpointInfo) == 0x148);
-
-    // NOTE: no bounds check done for any operations
-    template <typename T, s32 Size>
-    class FixedHeapArray {
-    public:
-        void alloc() { mPtr = new T[Size]; }
-
-        s32 size() const { return Size; }
-
-        T& operator[](s32 index) { return mPtr[index]; }
-
-        const T& operator[](s32 index) const { return mPtr[index]; }
-
-        T* begin() const { return mPtr; }
-
-        T* end() const { return mPtr + Size; }
-
-    private:
-        T* mPtr = nullptr;
-    };
 
     enum class CountType { Value_0, Value_1, Value_2 };
 

--- a/src/System/GameDataHolder.h
+++ b/src/System/GameDataHolder.h
@@ -36,7 +36,7 @@ class SaveDataAccessSequence;
 class TemporaryScenarioCameraHolder;
 class TempSaveData;
 class TimeBalloonSequenceInfo;
-class UniqObjInfo;
+struct UniqObjInfo;
 class WorldList;
 
 struct HackObjInfo {

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -1,0 +1,148 @@
+#include "System/TempSaveData.h"
+
+#include "Library/Placement/PlacementId.h"
+
+#include "System/UniqObjInfo.h"
+
+TempSaveData::TempSaveData() {
+    mWordObjects = new UniqObjInfo[64];
+    mMiniGameObjects = new UniqObjInfo[64];
+    mScenarioObjects = new UniqObjInfo[64];
+    mWorldValues.allocBuffer(64, nullptr);
+}
+
+void TempSaveData::init() {
+    for (s32 i = 0; i < 64; i++) {
+        mWordObjects[i].clear();
+        mMiniGameObjects[i].clear();
+        mScenarioObjects[i].clear();
+        // BUG: Clearing multiple times the hashed values
+        mWorldValues.clear();
+    }
+}
+
+void TempSaveData::initForScenario() {
+    for (s32 i = 0; i < 64; i++)
+        mScenarioObjects[i].clear();
+}
+
+void TempSaveData::resetMiniGame() {
+    for (s32 i = 0; i < 64; i++)
+        mMiniGameObjects[i].clear();
+}
+
+inline s32 getUniqObjId(const UniqObjInfo* objInfo, const al::PlacementId* placementId,
+                        const char* stageName) {
+    al::StringTmp<128> str;
+    placementId->makeString(&str);
+
+    s32 id = -1;
+    for (s32 i = 0; i < 64; i++) {
+        if (!objInfo[i].getStageName().isEmpty() &&
+            al::isEqualString(objInfo[i].getStageName().cstr(), stageName) &&
+            al::isEqualString(objInfo[i].getObjId(), str)) {
+            id = i;
+            break;
+        }
+    }
+    return id;
+}
+
+void deleteUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
+                   const char* stageName) {
+    s32 id = getUniqObjId(objInfo, placementId, stageName);
+    if (id == -1)
+        return;
+
+    objInfo[id].getStageName()->clear();
+    objInfo[id].getObjId()->clear();
+}
+
+void TempSaveData::setInfo(s32 worldIndex, s32 unknown) {
+    mWorldIndex = worldIndex;
+    _1c = unknown;
+}
+
+void TempSaveData::writeInWorld(const al::PlacementId* placementId, const char* stageName) {
+    UniqObjInfo* objInfo = mWordObjects;
+    s32 id = getUniqObjId(objInfo, placementId, stageName);
+    if (id != -1)
+        return;
+
+    for (s32 i = 0; i < 64; i++) {
+        if (objInfo[i].getStageName()->isEmpty()) {
+            placementId->makeString(objInfo[i].getObjId());
+            objInfo[i].getStageName()->format("%s", stageName);
+            break;
+        }
+    }
+}
+
+void TempSaveData::deleteInWorld(const al::PlacementId* placementId, const char* stageName) {
+    deleteUniqObj(mWordObjects, placementId, stageName);
+}
+
+bool TempSaveData::isOnInWorld(const al::PlacementId* placementId, const char* stageName) const {
+    return getUniqObjId(mWordObjects, placementId, stageName) != -1;
+}
+
+void TempSaveData::writeInWorldResetMiniGame(const al::PlacementId* placementId,
+                                             const char* stageName) {
+    UniqObjInfo* objInfo = mMiniGameObjects;
+    s32 id = getUniqObjId(objInfo, placementId, stageName);
+    if (id != -1)
+        return;
+
+    for (s32 i = 0; i < 64; i++) {
+        if (objInfo[i].getStageName()->isEmpty()) {
+            placementId->makeString(objInfo[i].getObjId());
+            objInfo[i].getStageName()->format("%s", stageName);
+            break;
+        }
+    }
+}
+
+void TempSaveData::deleteInWorldResetMiniGame(const al::PlacementId* placementId,
+                                              const char* stageName) {
+    deleteUniqObj(mMiniGameObjects, placementId, stageName);
+}
+
+bool TempSaveData::isOnInWorldResetMiniGame(const al::PlacementId* placementId,
+                                            const char* stageName) const {
+    return getUniqObjId(mMiniGameObjects, placementId, stageName) != -1;
+}
+
+void TempSaveData::writeInScenario(const al::PlacementId* placementId, const char* stageName) {
+    UniqObjInfo* objInfo = mScenarioObjects;
+    s32 id = getUniqObjId(objInfo, placementId, stageName);
+    if (id != -1)
+        return;
+
+    for (s32 i = 0; i < 64; i++) {
+        if (objInfo[i].getStageName()->isEmpty()) {
+            placementId->makeString(objInfo[i].getObjId());
+            objInfo[i].getStageName()->format("%s", stageName);
+            break;
+        }
+    }
+}
+
+bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char* stageName) const {
+    return getUniqObjId(mScenarioObjects, placementId, stageName) != -1;
+}
+
+// NON_MATCHING: Wrong loading order https://decomp.me/scratch/OCYs2
+void TempSaveData::writeHashInWorld(const char* hash, bool value) {
+    auto* node = mWorldValues.find(hash);
+    if (node) {
+        node->value() = value;
+        return;
+    }
+
+    mWorldValues.insert(hash, value);
+}
+
+bool TempSaveData::findHashValueInWorld(const char* hash) const {
+    auto* node = mWorldValues.find(hash);
+    return node && node->value();
+}

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -32,13 +32,14 @@ void TempSaveData::resetMiniGame() {
         mMiniGameObjects[i].clear();
 }
 
-static ALWAYS_INLINE s32 getUniqObjId(const UniqObjInfo* objInfo,
-                                      const al::PlacementId* placementId, const char* stageName) {
+static ALWAYS_INLINE s32
+getUniqObjId(const FixedHeapArray<UniqObjInfo, TempSaveData::maxObjEntries> objInfo,
+             const al::PlacementId* placementId, const char* stageName) {
     al::StringTmp<128> str;
     placementId->makeString(&str);
 
     s32 id = -1;
-    for (s32 i = 0; i < TempSaveData::maxObjEntries; i++) {
+    for (s32 i = 0; i < objInfo.size(); i++) {
         if (!objInfo[i].stageName.isEmpty() &&
             al::isEqualString(objInfo[i].stageName.cstr(), stageName) &&
             al::isEqualString(objInfo[i].objId, str)) {
@@ -49,13 +50,14 @@ static ALWAYS_INLINE s32 getUniqObjId(const UniqObjInfo* objInfo,
     return id;
 }
 
-static ALWAYS_INLINE void writeUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
-                                       const char* stageName) {
+static ALWAYS_INLINE void
+writeUniqObj(FixedHeapArray<UniqObjInfo, TempSaveData::maxObjEntries> objInfo,
+             const al::PlacementId* placementId, const char* stageName) {
     s32 id = getUniqObjId(objInfo, placementId, stageName);
     if (id != -1)
         return;
 
-    for (s32 i = 0; i < TempSaveData::maxObjEntries; i++) {
+    for (s32 i = 0; i < objInfo.size(); i++) {
         if (objInfo[i].stageName.isEmpty()) {
             placementId->makeString(&objInfo[i].objId);
             objInfo[i].stageName.format("%s", stageName);
@@ -64,8 +66,8 @@ static ALWAYS_INLINE void writeUniqObj(UniqObjInfo* objInfo, const al::Placement
     }
 }
 
-void deleteUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
-                   const char* stageName) {
+void deleteUniqObj(FixedHeapArray<UniqObjInfo, TempSaveData::maxObjEntries> objInfo,
+                   const al::PlacementId* placementId, const char* stageName) {
     s32 id = getUniqObjId(objInfo, placementId, stageName);
     if (id == -1)
         return;
@@ -80,38 +82,38 @@ void TempSaveData::setInfo(s32 worldIndex, s32 scenarioIndex) {
 }
 
 void TempSaveData::writeInWorld(const al::PlacementId* placementId, const char* stageName) {
-    writeUniqObj(mWorldObjects.begin(), placementId, stageName);
+    writeUniqObj(mWorldObjects, placementId, stageName);
 }
 
 void TempSaveData::deleteInWorld(const al::PlacementId* placementId, const char* stageName) {
-    deleteUniqObj(mWorldObjects.begin(), placementId, stageName);
+    deleteUniqObj(mWorldObjects, placementId, stageName);
 }
 
 bool TempSaveData::isOnInWorld(const al::PlacementId* placementId, const char* stageName) const {
-    return getUniqObjId(mWorldObjects.begin(), placementId, stageName) != -1;
+    return getUniqObjId(mWorldObjects, placementId, stageName) != -1;
 }
 
 void TempSaveData::writeInWorldResetMiniGame(const al::PlacementId* placementId,
                                              const char* stageName) {
-    writeUniqObj(mMiniGameObjects.begin(), placementId, stageName);
+    writeUniqObj(mMiniGameObjects, placementId, stageName);
 }
 
 void TempSaveData::deleteInWorldResetMiniGame(const al::PlacementId* placementId,
                                               const char* stageName) {
-    deleteUniqObj(mMiniGameObjects.begin(), placementId, stageName);
+    deleteUniqObj(mMiniGameObjects, placementId, stageName);
 }
 
 bool TempSaveData::isOnInWorldResetMiniGame(const al::PlacementId* placementId,
                                             const char* stageName) const {
-    return getUniqObjId(mMiniGameObjects.begin(), placementId, stageName) != -1;
+    return getUniqObjId(mMiniGameObjects, placementId, stageName) != -1;
 }
 
 void TempSaveData::writeInScenario(const al::PlacementId* placementId, const char* stageName) {
-    writeUniqObj(mScenarioObjects.begin(), placementId, stageName);
+    writeUniqObj(mScenarioObjects, placementId, stageName);
 }
 
 bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char* stageName) const {
-    return getUniqObjId(mScenarioObjects.begin(), placementId, stageName) != -1;
+    return getUniqObjId(mScenarioObjects, placementId, stageName) != -1;
 }
 
 void TempSaveData::writeHashInWorld(const char* hash, bool value) {

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -9,11 +9,11 @@ TempSaveData::TempSaveData() {
     mWorldObjects.alloc();
     mMiniGameObjects.alloc();
     mScenarioObjects.alloc();
-    mWorldValues.allocBuffer(64, nullptr);
+    mWorldValues.allocBuffer(maxObjEntries, nullptr);
 }
 
 void TempSaveData::init() {
-    for (s32 i = 0; i < 64; i++) {
+    for (s32 i = 0; i < maxObjEntries; i++) {
         mWorldObjects[i].clear();
         mMiniGameObjects[i].clear();
         mScenarioObjects[i].clear();
@@ -23,12 +23,12 @@ void TempSaveData::init() {
 }
 
 void TempSaveData::initForScenario() {
-    for (s32 i = 0; i < 64; i++)
+    for (s32 i = 0; i < mScenarioObjects.size(); i++)
         mScenarioObjects[i].clear();
 }
 
 void TempSaveData::resetMiniGame() {
-    for (s32 i = 0; i < 64; i++)
+    for (s32 i = 0; i < mMiniGameObjects.size(); i++)
         mMiniGameObjects[i].clear();
 }
 
@@ -38,7 +38,7 @@ static ALWAYS_INLINE s32 getUniqObjId(const UniqObjInfo* objInfo,
     placementId->makeString(&str);
 
     s32 id = -1;
-    for (s32 i = 0; i < 64; i++) {
+    for (s32 i = 0; i < TempSaveData::maxObjEntries; i++) {
         if (!objInfo[i].stageName.isEmpty() &&
             al::isEqualString(objInfo[i].stageName.cstr(), stageName) &&
             al::isEqualString(objInfo[i].objId, str)) {
@@ -55,7 +55,7 @@ static ALWAYS_INLINE void writeUniqObj(UniqObjInfo* objInfo, const al::Placement
     if (id != -1)
         return;
 
-    for (s32 i = 0; i < 64; i++) {
+    for (s32 i = 0; i < TempSaveData::maxObjEntries; i++) {
         if (objInfo[i].stageName.isEmpty()) {
             placementId->makeString(&objInfo[i].objId);
             objInfo[i].stageName.format("%s", stageName);

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -115,15 +115,8 @@ bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char
 }
 
 void TempSaveData::writeHashInWorld(const char* hash, bool value) {
-    // TODO: Replace this with StrTreeMap::put
-    {
-        sead::SafeString str(hash);
-        auto* node = mWorldValues.find(str);
-        if (node) {
-            node->value() = value;
-            return;
-        }
-    }
+    if (mWorldValues.put(hash, value))
+        return;
 
     mWorldValues.insert(hash, value);
 }

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -114,12 +114,15 @@ bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char
     return getUniqObjId(mScenarioObjects.begin(), placementId, stageName) != -1;
 }
 
-// NON_MATCHING: Wrong loading order https://decomp.me/scratch/OCYs2
 void TempSaveData::writeHashInWorld(const char* hash, bool value) {
-    auto* node = mWorldValues.find(hash);
-    if (node) {
-        node->value() = value;
-        return;
+    // TODO: Replace this with StrTreeMap::put
+    {
+        sead::SafeString str(hash);
+        auto* node = mWorldValues.find(str);
+        if (node) {
+            node->value() = value;
+            return;
+        }
     }
 
     mWorldValues.insert(hash, value);

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -115,7 +115,7 @@ bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char
 }
 
 void TempSaveData::writeHashInWorld(const char* hash, bool value) {
-    if (mWorldValues.put(hash, value))
+    if (mWorldValues.replace(hash, value))
         return;
 
     mWorldValues.insert(hash, value);

--- a/src/System/TempSaveData.cpp
+++ b/src/System/TempSaveData.cpp
@@ -1,22 +1,23 @@
 #include "System/TempSaveData.h"
 
+#include "Library/Base/Macros.h"
 #include "Library/Placement/PlacementId.h"
 
 #include "System/UniqObjInfo.h"
 
 TempSaveData::TempSaveData() {
-    mWordObjects = new UniqObjInfo[64];
-    mMiniGameObjects = new UniqObjInfo[64];
-    mScenarioObjects = new UniqObjInfo[64];
+    mWorldObjects.alloc();
+    mMiniGameObjects.alloc();
+    mScenarioObjects.alloc();
     mWorldValues.allocBuffer(64, nullptr);
 }
 
 void TempSaveData::init() {
     for (s32 i = 0; i < 64; i++) {
-        mWordObjects[i].clear();
+        mWorldObjects[i].clear();
         mMiniGameObjects[i].clear();
         mScenarioObjects[i].clear();
-        // BUG: Clearing multiple times the hashed values
+        // NOTE: Clearing multiple times the hashed values
         mWorldValues.clear();
     }
 }
@@ -31,21 +32,36 @@ void TempSaveData::resetMiniGame() {
         mMiniGameObjects[i].clear();
 }
 
-inline s32 getUniqObjId(const UniqObjInfo* objInfo, const al::PlacementId* placementId,
-                        const char* stageName) {
+static ALWAYS_INLINE s32 getUniqObjId(const UniqObjInfo* objInfo,
+                                      const al::PlacementId* placementId, const char* stageName) {
     al::StringTmp<128> str;
     placementId->makeString(&str);
 
     s32 id = -1;
     for (s32 i = 0; i < 64; i++) {
-        if (!objInfo[i].getStageName().isEmpty() &&
-            al::isEqualString(objInfo[i].getStageName().cstr(), stageName) &&
-            al::isEqualString(objInfo[i].getObjId(), str)) {
+        if (!objInfo[i].stageName.isEmpty() &&
+            al::isEqualString(objInfo[i].stageName.cstr(), stageName) &&
+            al::isEqualString(objInfo[i].objId, str)) {
             id = i;
             break;
         }
     }
     return id;
+}
+
+static ALWAYS_INLINE void writeUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
+                                       const char* stageName) {
+    s32 id = getUniqObjId(objInfo, placementId, stageName);
+    if (id != -1)
+        return;
+
+    for (s32 i = 0; i < 64; i++) {
+        if (objInfo[i].stageName.isEmpty()) {
+            placementId->makeString(&objInfo[i].objId);
+            objInfo[i].stageName.format("%s", stageName);
+            break;
+        }
+    }
 }
 
 void deleteUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
@@ -54,81 +70,48 @@ void deleteUniqObj(UniqObjInfo* objInfo, const al::PlacementId* placementId,
     if (id == -1)
         return;
 
-    objInfo[id].getStageName()->clear();
-    objInfo[id].getObjId()->clear();
+    objInfo[id].stageName.clear();
+    objInfo[id].objId.clear();
 }
 
-void TempSaveData::setInfo(s32 worldIndex, s32 unknown) {
+void TempSaveData::setInfo(s32 worldIndex, s32 scenarioIndex) {
     mWorldIndex = worldIndex;
-    _1c = unknown;
+    mScenarioIndex = scenarioIndex;
 }
 
 void TempSaveData::writeInWorld(const al::PlacementId* placementId, const char* stageName) {
-    UniqObjInfo* objInfo = mWordObjects;
-    s32 id = getUniqObjId(objInfo, placementId, stageName);
-    if (id != -1)
-        return;
-
-    for (s32 i = 0; i < 64; i++) {
-        if (objInfo[i].getStageName()->isEmpty()) {
-            placementId->makeString(objInfo[i].getObjId());
-            objInfo[i].getStageName()->format("%s", stageName);
-            break;
-        }
-    }
+    writeUniqObj(mWorldObjects.begin(), placementId, stageName);
 }
 
 void TempSaveData::deleteInWorld(const al::PlacementId* placementId, const char* stageName) {
-    deleteUniqObj(mWordObjects, placementId, stageName);
+    deleteUniqObj(mWorldObjects.begin(), placementId, stageName);
 }
 
 bool TempSaveData::isOnInWorld(const al::PlacementId* placementId, const char* stageName) const {
-    return getUniqObjId(mWordObjects, placementId, stageName) != -1;
+    return getUniqObjId(mWorldObjects.begin(), placementId, stageName) != -1;
 }
 
 void TempSaveData::writeInWorldResetMiniGame(const al::PlacementId* placementId,
                                              const char* stageName) {
-    UniqObjInfo* objInfo = mMiniGameObjects;
-    s32 id = getUniqObjId(objInfo, placementId, stageName);
-    if (id != -1)
-        return;
-
-    for (s32 i = 0; i < 64; i++) {
-        if (objInfo[i].getStageName()->isEmpty()) {
-            placementId->makeString(objInfo[i].getObjId());
-            objInfo[i].getStageName()->format("%s", stageName);
-            break;
-        }
-    }
+    writeUniqObj(mMiniGameObjects.begin(), placementId, stageName);
 }
 
 void TempSaveData::deleteInWorldResetMiniGame(const al::PlacementId* placementId,
                                               const char* stageName) {
-    deleteUniqObj(mMiniGameObjects, placementId, stageName);
+    deleteUniqObj(mMiniGameObjects.begin(), placementId, stageName);
 }
 
 bool TempSaveData::isOnInWorldResetMiniGame(const al::PlacementId* placementId,
                                             const char* stageName) const {
-    return getUniqObjId(mMiniGameObjects, placementId, stageName) != -1;
+    return getUniqObjId(mMiniGameObjects.begin(), placementId, stageName) != -1;
 }
 
 void TempSaveData::writeInScenario(const al::PlacementId* placementId, const char* stageName) {
-    UniqObjInfo* objInfo = mScenarioObjects;
-    s32 id = getUniqObjId(objInfo, placementId, stageName);
-    if (id != -1)
-        return;
-
-    for (s32 i = 0; i < 64; i++) {
-        if (objInfo[i].getStageName()->isEmpty()) {
-            placementId->makeString(objInfo[i].getObjId());
-            objInfo[i].getStageName()->format("%s", stageName);
-            break;
-        }
-    }
+    writeUniqObj(mScenarioObjects.begin(), placementId, stageName);
 }
 
 bool TempSaveData::isOnInScenario(const al::PlacementId* placementId, const char* stageName) const {
-    return getUniqObjId(mScenarioObjects, placementId, stageName) != -1;
+    return getUniqObjId(mScenarioObjects.begin(), placementId, stageName) != -1;
 }
 
 // NON_MATCHING: Wrong loading order https://decomp.me/scratch/OCYs2

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -32,10 +32,12 @@ public:
 
     s32 getWorldIndex() const { return mWorldIndex; }
 
+    static const s32 maxObjEntries = 64;
+
 private:
-    FixedHeapArray<UniqObjInfo, 64> mWorldObjects;
-    FixedHeapArray<UniqObjInfo, 64> mMiniGameObjects;
-    FixedHeapArray<UniqObjInfo, 64> mScenarioObjects;
+    FixedHeapArray<UniqObjInfo, maxObjEntries> mWorldObjects;
+    FixedHeapArray<UniqObjInfo, maxObjEntries> mMiniGameObjects;
+    FixedHeapArray<UniqObjInfo, maxObjEntries> mScenarioObjects;
     s32 mWorldIndex = -1;
     s32 mScenarioIndex = -1;
     sead::StrTreeMap<32, bool> mWorldValues;

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -32,7 +32,7 @@ public:
 
     s32 getWorldIndex() const { return mWorldIndex; }
 
-    static const s32 maxObjEntries = 64;
+    static constexpr s32 maxObjEntries = 64;
 
 private:
     FixedHeapArray<UniqObjInfo, maxObjEntries> mWorldObjects;

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -1,10 +1,13 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <container/seadStrTreeMap.h>
 
 namespace al {
 class PlacementId;
 }  // namespace al
+
+class UniqObjInfo;
 
 class TempSaveData {
 public:
@@ -13,24 +16,27 @@ public:
     void init();
     void initForScenario();
     void resetMiniGame();
-    void setInfo(s32, s32);
-    void writeInWorld(const al::PlacementId*, const char*);
-    void deleteInWorld(const al::PlacementId*, const char*);
-    bool isOnInWorld(const al::PlacementId*, const char*) const;
-    void writeInWorldResetMiniGame(const al::PlacementId*, const char*);
-    void deleteInWorldResetMiniGame(const al::PlacementId*, const char*);
-    bool isOnInWorldResetMiniGame(const al::PlacementId*, const char*) const;
-    void writeInScenario(const al::PlacementId*, const char*);
-    bool isOnInScenario(const al::PlacementId*, const char*) const;
-    void writeHashInWorld(const char*, bool);
-    bool findHashValueInWorld(const char*) const;
+    void setInfo(s32 worldIndex, s32 unknown);
+    void writeInWorld(const al::PlacementId* placementId, const char* stageName);
+    void deleteInWorld(const al::PlacementId* placementId, const char* stageName);
+    bool isOnInWorld(const al::PlacementId* placementId, const char* stageName) const;
+    void writeInWorldResetMiniGame(const al::PlacementId* placementId, const char* stageName);
+    void deleteInWorldResetMiniGame(const al::PlacementId* placementId, const char* stageName);
+    bool isOnInWorldResetMiniGame(const al::PlacementId* placementId, const char* stageName) const;
+    void writeInScenario(const al::PlacementId* placementId, const char* stageName);
+    bool isOnInScenario(const al::PlacementId* placementId, const char* stageName) const;
+    void writeHashInWorld(const char* hash, bool value);
+    bool findHashValueInWorld(const char* hash) const;
 
     s32 getWorldIndex() const { return mWorldIndex; }
 
 private:
-    char filler[0x18];
-    s32 mWorldIndex;
-    char filler_1c[0x24];
+    UniqObjInfo* mWordObjects = nullptr;
+    UniqObjInfo* mMiniGameObjects = nullptr;
+    UniqObjInfo* mScenarioObjects = nullptr;
+    s32 mWorldIndex = -1;
+    s32 _1c = -1;
+    sead::StrTreeMap<32, bool> mWorldValues;
 };
 
 static_assert(sizeof(TempSaveData) == 0x40);

--- a/src/System/TempSaveData.h
+++ b/src/System/TempSaveData.h
@@ -3,11 +3,13 @@
 #include <basis/seadTypes.h>
 #include <container/seadStrTreeMap.h>
 
+#include "System/FixedHeapArray.h"
+
 namespace al {
 class PlacementId;
 }  // namespace al
 
-class UniqObjInfo;
+struct UniqObjInfo;
 
 class TempSaveData {
 public:
@@ -16,7 +18,7 @@ public:
     void init();
     void initForScenario();
     void resetMiniGame();
-    void setInfo(s32 worldIndex, s32 unknown);
+    void setInfo(s32 worldIndex, s32 scenarioIndex);
     void writeInWorld(const al::PlacementId* placementId, const char* stageName);
     void deleteInWorld(const al::PlacementId* placementId, const char* stageName);
     bool isOnInWorld(const al::PlacementId* placementId, const char* stageName) const;
@@ -31,11 +33,11 @@ public:
     s32 getWorldIndex() const { return mWorldIndex; }
 
 private:
-    UniqObjInfo* mWordObjects = nullptr;
-    UniqObjInfo* mMiniGameObjects = nullptr;
-    UniqObjInfo* mScenarioObjects = nullptr;
+    FixedHeapArray<UniqObjInfo, 64> mWorldObjects;
+    FixedHeapArray<UniqObjInfo, 64> mMiniGameObjects;
+    FixedHeapArray<UniqObjInfo, 64> mScenarioObjects;
     s32 mWorldIndex = -1;
-    s32 _1c = -1;
+    s32 mScenarioIndex = -1;
     sead::StrTreeMap<32, bool> mWorldValues;
 };
 

--- a/src/System/UniqObjInfo.cpp
+++ b/src/System/UniqObjInfo.cpp
@@ -5,8 +5,8 @@
 #include "Library/Placement/PlacementId.h"
 
 void UniqObjInfo::set(const char* stage_name, const char* obj_id) {
-    mStageName.format("%s", stage_name);
-    mObjId.format("%s", obj_id);
+    stageName.format("%s", stage_name);
+    objId.format("%s", obj_id);
 }
 
 void UniqObjInfo::set(const sead::BufferedSafeString& stage_name,
@@ -21,17 +21,17 @@ void UniqObjInfo::set(const char* stage_name, const al::PlacementInfo* placement
 }
 
 void UniqObjInfo::clear() {
-    mStageName.clear();
-    mObjId.clear();
+    stageName.clear();
+    objId.clear();
 }
 
 bool UniqObjInfo::isEmpty() const {
-    return mStageName.isEmpty();
+    return stageName.isEmpty();
 }
 
 bool UniqObjInfo::isEqual(const char* stage_name, const char* obj_id) const {
-    return al::isEqualString(stage_name, mStageName.cstr()) &&
-           al::isEqualString(obj_id, mObjId.cstr());
+    return al::isEqualString(stage_name, stageName.cstr()) &&
+           al::isEqualString(obj_id, objId.cstr());
 }
 
 bool UniqObjInfo::isEqual(const sead::BufferedSafeString& stage_name,
@@ -40,15 +40,15 @@ bool UniqObjInfo::isEqual(const sead::BufferedSafeString& stage_name,
 }
 
 bool UniqObjInfo::isEqual(const UniqObjInfo& other) const {
-    return isEqual(other.mStageName, other.mObjId);
+    return isEqual(other.stageName, other.objId);
 }
 
 void UniqObjInfo::print() const {}
 
 void UniqObjInfo::fillDummyData() {
     clear();
-    for (s32 i = 0; i < mStageName.getBufferSize(); i++)
-        mStageName.append(al::getRandom(1));
-    for (s32 i = 0; i < mObjId.getBufferSize(); i++)
-        mObjId.append(al::getRandom(1));
+    for (s32 i = 0; i < stageName.getBufferSize(); i++)
+        stageName.append(al::getRandom(1));
+    for (s32 i = 0; i < objId.getBufferSize(); i++)
+        objId.append(al::getRandom(1));
 }

--- a/src/System/UniqObjInfo.h
+++ b/src/System/UniqObjInfo.h
@@ -20,9 +20,13 @@ public:
     void print() const;
     void fillDummyData();
 
-    const char* getStageName() const { return mStageName.cstr(); }
+    sead::FixedSafeString<128>* getStageName() { return &mStageName; }
 
-    const char* getObjId() const { return mObjId.cstr(); }
+    const sead::FixedSafeString<128>& getStageName() const { return mStageName; }
+
+    sead::FixedSafeString<128>* getObjId() { return &mObjId; }
+
+    const sead::FixedSafeString<128>& getObjId() const { return mObjId; }
 
 private:
     sead::FixedSafeString<128> mStageName;

--- a/src/System/UniqObjInfo.h
+++ b/src/System/UniqObjInfo.h
@@ -6,8 +6,7 @@ namespace al {
 class PlacementInfo;
 }
 
-class UniqObjInfo {
-public:
+struct UniqObjInfo {
     void set(const char* stage_name, const char* obj_id);
     void set(const sead::BufferedSafeString& stage_name, const sead::BufferedSafeString& obj_id);
     void set(const char* stage_name, const al::PlacementInfo* placement_info);
@@ -20,17 +19,8 @@ public:
     void print() const;
     void fillDummyData();
 
-    sead::FixedSafeString<128>* getStageName() { return &mStageName; }
-
-    const sead::FixedSafeString<128>& getStageName() const { return mStageName; }
-
-    sead::FixedSafeString<128>* getObjId() { return &mObjId; }
-
-    const sead::FixedSafeString<128>& getObjId() const { return mObjId; }
-
-private:
-    sead::FixedSafeString<128> mStageName;
-    sead::FixedSafeString<128> mObjId;
+    sead::FixedSafeString<128> stageName;
+    sead::FixedSafeString<128> objId;
 };
 
 static_assert(sizeof(UniqObjInfo) == 0x130);


### PR DESCRIPTION
I'm attempting to find the correct implementation for `StrTreeMap::allocBuffer` this did not trigger the issue I was looking for. 

TempSaveData seems to store a list obj bool values and stage objects. `writeHashInWorld `is not matching https://decomp.me/scratch/OCYs2

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1298)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0de3c75 - c92df4d)

📈 **Matched code**: 15.40% (+0.04%, +4736 bytes)

<details>
<summary>✅ 23 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/TempSaveData` | `TempSaveData::TempSaveData()` | +696 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::StrTreeMap<32, bool>::insert(sead::SafeStringBase<char> const&, bool const&)` | +636 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::writeInWorld(al::PlacementId const*, char const*)` | +364 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::writeInWorldResetMiniGame(al::PlacementId const*, char const*)` | +364 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::writeInScenario(al::PlacementId const*, char const*)` | +364 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::writeHashInWorld(char const*, bool)` | +348 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::findHashValueInWorld(char const*) const` | +304 | 0.00% | 100.00% |
| `System/TempSaveData` | `deleteUniqObj(FixedHeapArray<UniqObjInfo, 64>, al::PlacementId const*, char const*)` | +256 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::isOnInWorld(al::PlacementId const*, char const*) const` | +256 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::isOnInWorldResetMiniGame(al::PlacementId const*, char const*) const` | +256 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::isOnInScenario(al::PlacementId const*, char const*) const` | +256 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::init()` | +168 | 0.00% | 100.00% |
| `System/TempSaveData` | `void sead::TreeMapImpl<sead::SafeStringBase<char> >::forEach<sead::Delegate1<sead::StrTreeMap<32, bool>, sead::TreeMapNode<sead::SafeStringBase<char> >*> >(sead::TreeMapNode<sead::SafeStringBase<char> >*, sead::Delegate1<sead::StrTreeMap<32, bool>, sead::TreeMapNode<sead::SafeStringBase<char> >*> const&)` | +116 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::Delegate1<sead::StrTreeMap<32, bool>, sead::TreeMapNode<sead::SafeStringBase<char> >*>::clone(sead::Heap*) const` | +92 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::initForScenario()` | +68 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::resetMiniGame()` | +68 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::Delegate1<sead::StrTreeMap<32, bool>, sead::TreeMapNode<sead::SafeStringBase<char> >*>::invoke(sead::TreeMapNode<sead::SafeStringBase<char> >*)` | +48 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::StrTreeMap<32, bool>::Node::erase_()` | +32 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::StrTreeMap<32, bool>::eraseNodeForClear_(sead::TreeMapNode<sead::SafeStringBase<char> >*)` | +16 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::setInfo(int, int)` | +8 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::deleteInWorld(al::PlacementId const*, char const*)` | +8 | 0.00% | 100.00% |
| `System/TempSaveData` | `TempSaveData::deleteInWorldResetMiniGame(al::PlacementId const*, char const*)` | +8 | 0.00% | 100.00% |
| `System/TempSaveData` | `sead::StrTreeMap<32, bool>::Node::~Node()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->