### PR TITLE
System: Implement `WorldList`

### DIFF
--- a/src/System/WorldList.cpp
+++ b/src/System/WorldList.cpp
@@ -1,0 +1,342 @@
+#include "System/WorldList.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/Yaml/ByamlIter.h"
+
+template <>
+s32 sead::PtrArray<ShinePosInfo>::compareT(const ShinePosInfo* a, const ShinePosInfo* b) {
+    if (a->uniqueId < b->uniqueId)
+        return -1;
+    return a->uniqueId != b->uniqueId;
+}
+
+// NON_MATCHING: StrTreeMap::allocBuffer major issues https://decomp.me/scratch/znUi3
+WorldList::WorldList() {
+    al::ByamlIter worldListIter(al::tryGetBymlFromArcName("SystemData/WorldList", "WorldList"));
+
+    s32 worldCount = worldListIter.getSize();
+    mWorldList.allocBuffer(worldCount, nullptr);
+    for (s32 i = 0; i < worldCount; i++) {
+        al::ByamlIter worldIter;
+        const char* name = nullptr;
+        worldListIter.tryGetIterByIndex(&worldIter, i);
+
+        worldIter.tryGetStringByKey(&name, "Name");
+        const char* worldName = nullptr;
+        worldIter.tryGetStringByKey(&worldName, "WorldName");
+        s32 scenarioNum = 1;
+        worldIter.tryGetIntByKey(&scenarioNum, "ScenarioNum");
+        s32 clearMainScenarioNo = 1;
+        worldIter.tryGetIntByKey(&clearMainScenarioNo, "ClearMainScenario");
+        s32 afterEndingScenarioNo = 1;
+        worldIter.tryGetIntByKey(&afterEndingScenarioNo, "AfterEndingScenario");
+        s32 moonRockScenarioNo = 1;
+        worldIter.tryGetIntByKey(&moonRockScenarioNo, "MoonRockScenario");
+
+        WorldListEntry* entry = new WorldListEntry();
+        entry->mainStageName = name;
+        entry->worldDevelopName = worldName;
+        entry->worldScenarioNum = scenarioNum;
+        s32* scnum = new s32[scenarioNum];
+        entry->clearMainScenarioNo = clearMainScenarioNo;
+        entry->afterEndingScenarioNo = afterEndingScenarioNo;
+        entry->mainQuestIndexes = scnum;
+        entry->moonRockScenarioNo = moonRockScenarioNo;
+
+        al::ByamlIter questIter;
+        worldIter.tryGetIterByKey(&questIter, "MainQuestInfo");
+
+        for (s32 j = 0; j < scenarioNum; j++) {
+            s32 questIdx = -1;
+            questIter.tryGetIntByIndex(&questIdx, j);
+            entry->mainQuestIndexes[j] = questIdx;
+        }
+
+        mWorldList.pushBack(entry);
+    }
+
+    al::ByamlIter worldListDbIter(
+        al::tryGetBymlFromArcName("SystemData/WorldList", "WorldListFromDb"));
+    s32 worldDbCount = worldListDbIter.getSize();
+    for (s32 i = 0; i < worldDbCount; i++) {
+        al::ByamlIter worldIter;
+        worldListDbIter.tryGetIterByIndex(&worldIter, i);
+        al::ByamlIter stageListIter;
+        worldIter.tryGetIterByKey(&stageListIter, "StageList");
+
+        mWorldList[i]->stageList.allocBuffer(stageListIter.getSize(), nullptr);
+
+        for (s32 j = 0; j < stageListIter.getSize(); j++) {
+            al::ByamlIter stageIter;
+            stageListIter.tryGetIterByIndex(&stageIter, j);
+
+            const char* name = nullptr;
+            stageIter.tryGetStringByKey(&name, "name");
+
+            StageDBEntry* stageEntry = new StageDBEntry();
+            stageEntry->name.format("%s", name);
+
+            const char* category = nullptr;
+            if (stageIter.tryGetStringByKey(&category, "category")) {
+                stageEntry->category.format("%s", category);
+
+                if (al::isEqualString(stageEntry->category.cstr(), "MainStage"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "MainRouteStage"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "ExStage"))
+                    stageEntry->useScenarioNo = 1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "SmallStage"))
+                    stageEntry->useScenarioNo = 1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "PathwayStage"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "ShopStage"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "MoonExStage"))
+                    stageEntry->useScenarioNo = 1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "Demo"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "MoonFarSideExStage"))
+                    stageEntry->useScenarioNo = 2;
+                else if (al::isEqualString(stageEntry->category.cstr(), "BossRevenge"))
+                    stageEntry->useScenarioNo = 1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "MiniGame"))
+                    stageEntry->useScenarioNo = -1;
+                else if (al::isEqualString(stageEntry->category.cstr(), "Zone"))
+                    stageEntry->useScenarioNo = -1;
+            } else {
+                stageEntry->category.clear();
+                stageEntry->useScenarioNo = -1;
+            }
+
+            mWorldList[i]->stageList.pushBack(stageEntry);
+        }
+    }
+    {
+        al::ByamlIter worldListPosIter(
+            al::tryGetBymlFromArcName("SystemData/WorldList", "StagePosList"));
+        s32 posCount = worldListPosIter.getSize();
+
+        mStagePosList.allocBuffer(posCount, nullptr);
+
+        for (s32 i = 0; i < posCount; i++) {
+            al::ByamlIter entryIter;
+            const char* keyName = 0;
+            worldListPosIter.tryGetIterAndKeyNameByIndex(&entryIter, &keyName, i);
+
+            StagePosInfo* posInfo = new StagePosInfo();
+            // BUG: posList should be entryIter size
+            posInfo->posList.allocBuffer(worldCount, nullptr);
+            posInfo->mask = 0;
+
+            s32 size = entryIter.getSize();
+            for (s32 j = 0; j < size; j++) {
+                al::ByamlIter biter;
+                entryIter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j + 1).cstr());
+                sead::Vector3f trans = sead::Vector3f::zero;
+
+                if (biter.tryGetFloatByKey(&trans.x, "X"))
+                    posInfo->mask |= 1 << (j + 1);
+                biter.tryGetFloatByKey(&trans.y, "Y");
+                biter.tryGetFloatByKey(&trans.z, "Z");
+                posInfo->posList.emplaceBack(trans);
+            }
+
+            mStagePosList.insert(keyName, posInfo);
+        }
+    }
+    al::ByamlIter shinePosIter(al::tryGetBymlFromArcName("SystemData/ShineInfo", "ShinePosList"));
+    s32 shineCount = shinePosIter.getSize();
+    mShinePosList.allocBuffer(shineCount, nullptr);
+    for (s32 i = 0; i < shineCount; i++) {
+        al::ByamlIter iter;
+        shinePosIter.tryGetIterByIndex(&iter, i);
+
+        s32 uniqueId = -1;
+        iter.tryGetIntByKey(&uniqueId, "UniqueId");
+
+        ShinePosInfo* info = new ShinePosInfo();
+        info->uniqueId = uniqueId;
+        info->posList.allocBuffer(20, nullptr);
+        info->mask = 0;
+
+        al::ByamlIter biter;
+        for (s32 j = 1; j < 20; j++) {
+            if (iter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j).cstr())) {
+                sead::Vector3f trans = sead::Vector3f::zero;
+
+                if (biter.tryGetFloatByKey(&trans.x, "X")) {
+                    biter.tryGetFloatByKey(&trans.y, "Y");
+                    biter.tryGetFloatByKey(&trans.z, "Z");
+                    info->posList.emplaceBack(trans);
+                    info->mask |= 1 << j;
+                } else {
+                    info->posList.emplaceBack(sead::Vector3f::zero);
+                }
+            } else {
+                info->posList.emplaceBack(sead::Vector3f::zero);
+            }
+        }
+        mShinePosList.pushBack(info);
+    }
+    mShinePosList.sort();
+}
+
+s32 WorldList::getWorldNum() const {
+    return mWorldList.size();
+}
+
+s32 WorldList::getMainQuestMin(s32 worldId, s32 questId) const {
+    if (worldId < 0)
+        worldId = 0;
+    return mWorldList[worldId]->mainQuestIndexes[questId - 1];
+}
+
+const char* WorldList::getMainStageName(s32 worldId) const {
+    return mWorldList[worldId]->mainStageName;
+}
+
+s32 WorldList::tryFindWorldIndexByMainStageName(const char* mainStageName) const {
+    for (s32 i = 0; i < getWorldNum(); i++)
+        if (al::isEqualString(getMainStageName(i), mainStageName))
+            return i;
+
+    return -1;
+}
+
+s32 WorldList::tryFindWorldIndexByStageName(const char* stageName) const {
+    s32 worldIndex = tryFindWorldIndexByMainStageName(stageName);
+
+    if (worldIndex != -1)
+        return worldIndex;
+
+    for (s32 i = 0; i < getWorldNum(); i++) {
+        for (s32 j = 0; j < mWorldList[i]->stageList.size(); j++)
+            if (al::isEqualString(stageName, mWorldList[i]->stageList[j]->name.cstr()))
+                return i;
+    }
+
+    return -1;
+}
+
+s32 WorldList::tryFindWorldIndexByDevelopName(const char* developName) const {
+    for (s32 i = 0; i < getWorldNum(); i++)
+        if (al::isEqualString(getWorldDevelopName(i), developName))
+            return i;
+
+    return -1;
+}
+
+bool WorldList::isEqualClearMainScenarioNo(s32 worldId, s32 scenarioNo) const {
+    return mWorldList[worldId]->clearMainScenarioNo == scenarioNo;
+}
+
+s32 WorldList::getAfterEndingScenarioNo(s32 worldId) const {
+    return mWorldList[worldId]->afterEndingScenarioNo;
+}
+
+bool WorldList::isEqualAfterEndingScenarioNo(s32 worldId, s32 scenarioNo) const {
+    return getAfterEndingScenarioNo(worldId) == scenarioNo;
+}
+
+s32 WorldList::getMoonRockScenarioNo(s32 worldId) const {
+    return mWorldList[worldId]->moonRockScenarioNo;
+}
+
+bool WorldList::isEqualMoonRockScenarioNo(s32 worldId, s32 scenarioNo) const {
+    return getMoonRockScenarioNo(worldId) == scenarioNo;
+}
+
+const char* WorldList::getWorldDevelopName(s32 worldId) const {
+    if (worldId < 0)
+        worldId = 0;
+    return mWorldList[worldId]->worldDevelopName;
+}
+
+s32 WorldList::getWorldScenarioNum(s32 worldId) const {
+    return mWorldList[worldId]->worldScenarioNum;
+}
+
+s32 WorldList::findUseScenarioNo(const char* stageName) const {
+    if (al::isEqualString(stageName, "CurrentWorldHome"))
+        return -1;
+
+    s32 worldListSize = mWorldList.size();
+    for (s32 i = 0; i < worldListSize; i++) {
+        WorldListEntry* worldList = mWorldList[i];
+        s32 stageListSize = worldList->stageList.size();
+        for (s32 j = 0; j < stageListSize; j++)
+            if (al::isEqualString(worldList->stageList[j]->name.cstr(), stageName))
+                return worldList->stageList[j]->useScenarioNo;
+    }
+
+    return -1;
+}
+
+bool WorldList::checkNeedTreasureMessageStage(const char* stageName) const {
+    s32 worldListSize = mWorldList.size();
+    if (al::isEqualString(stageName, "ForestWorldWoodsStage") ||
+        al::isEqualString(stageName, "SnowWorldLobbyExStage"))
+        return false;
+
+    for (s32 i = 0; i < worldListSize; i++) {
+        WorldListEntry* world = mWorldList[i];
+        s32 stageListSize = world->stageList.size();
+        for (s32 j = 0; j < stageListSize; j++) {
+            if (!al::isEqualString(world->stageList[j]->name.cstr(), stageName))
+                continue;
+
+            const char* category = world->stageList[j]->category.cstr();
+            if (!al::isEqualString(category, "BossRevenge") &&
+                !al::isEqualString(category, "MainRouteStage") &&
+                !al::isEqualString(category, "MainStage") &&
+                !al::isEqualString(category, "ShopStage") &&
+                !al::isEqualString(category, "MiniGame") &&
+                !al::isEqualString(category, "SmallStage"))
+                return true;
+
+            return false;
+        }
+    }
+
+    return false;
+}
+
+bool WorldList::checkIsMainStage(const char* mainStageName) const {
+    return tryFindWorldIndexByMainStageName(mainStageName) != -1;
+}
+
+bool WorldList::tryFindTransOnMainStageByStageName(sead::Vector3f* outTrans, const char* stageName,
+                                                   s32 index) const {
+    sead::StrTreeMap<128, StagePosInfo*>::Node* posInfo = mStagePosList.find(stageName);
+
+    if (!posInfo)
+        return false;
+
+    outTrans->set(*posInfo->value()->posList[index - 1]);
+    return posInfo->value()->mask & (1 << index);
+}
+
+s32 WorldList::findHintByScenarioNo(s32 scenarioNo) const {
+    s32 size = mShinePosList.size();
+    for (s32 i = 0; i < size; i++)
+        if (mShinePosList[i]->uniqueId == scenarioNo)
+            return i;
+    return -1;
+}
+
+bool WorldList::tryFindHintTransByScenarioNo(sead::Vector3f* outTrans, s32 scenarioNo,
+                                             s32 index) const {
+    s32 hintId = findHintByScenarioNo(scenarioNo);
+    if (hintId == -1)
+        return false;
+
+    ShinePosInfo* posInfo = mShinePosList[hintId];
+
+    if ((1 << index & posInfo->mask) == 0)
+        return false;
+
+    outTrans->set(*posInfo->posList[index - 1]);
+    return true;
+}

--- a/src/System/WorldList.cpp
+++ b/src/System/WorldList.cpp
@@ -8,7 +8,9 @@ template <>
 s32 sead::PtrArray<ShinePosInfo>::compareT(const ShinePosInfo* a, const ShinePosInfo* b) {
     if (a->uniqueId < b->uniqueId)
         return -1;
-    return a->uniqueId != b->uniqueId;
+    if (a->uniqueId == b->uniqueId)
+        return 0;
+    return 1;
 }
 
 // NON_MATCHING: StrTreeMap::allocBuffer major issues https://decomp.me/scratch/znUi3
@@ -19,9 +21,9 @@ WorldList::WorldList() {
     mWorldList.allocBuffer(worldCount, nullptr);
     for (s32 i = 0; i < worldCount; i++) {
         al::ByamlIter worldIter;
-        const char* name = nullptr;
         worldListIter.tryGetIterByIndex(&worldIter, i);
 
+        const char* name = nullptr;
         worldIter.tryGetStringByKey(&name, "Name");
         const char* worldName = nullptr;
         worldIter.tryGetStringByKey(&worldName, "WorldName");
@@ -38,10 +40,9 @@ WorldList::WorldList() {
         entry->mainStageName = name;
         entry->worldDevelopName = worldName;
         entry->worldScenarioNum = scenarioNum;
-        s32* scnum = new s32[scenarioNum];
         entry->clearMainScenarioNo = clearMainScenarioNo;
         entry->afterEndingScenarioNo = afterEndingScenarioNo;
-        entry->mainQuestIndexes = scnum;
+        entry->mainQuestIndexes = new s32[scenarioNum];
         entry->moonRockScenarioNo = moonRockScenarioNo;
 
         al::ByamlIter questIter;
@@ -113,6 +114,8 @@ WorldList::WorldList() {
             mWorldList[i]->stageList.pushBack(stageEntry);
         }
     }
+    // BUG: missing or malformed entries in `StagePosList` or `ShinePosList`
+    // will cause all accesses to higher indices to desync/return garbage
     {
         al::ByamlIter worldListPosIter(
             al::tryGetBymlFromArcName("SystemData/WorldList", "StagePosList"));
@@ -122,7 +125,7 @@ WorldList::WorldList() {
 
         for (s32 i = 0; i < posCount; i++) {
             al::ByamlIter entryIter;
-            const char* keyName = 0;
+            const char* keyName = nullptr;
             worldListPosIter.tryGetIterAndKeyNameByIndex(&entryIter, &keyName, i);
 
             StagePosInfo* posInfo = new StagePosInfo();
@@ -131,13 +134,15 @@ WorldList::WorldList() {
             posInfo->mask = 0;
 
             s32 size = entryIter.getSize();
-            for (s32 j = 0; j < size; j++) {
+            for (s32 j = 1; j <= size; j++) {
                 al::ByamlIter biter;
-                entryIter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j + 1).cstr());
+                entryIter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j).cstr());
                 sead::Vector3f trans = sead::Vector3f::zero;
 
+                // NOTE: if x is missing but y or z are given, `tryFindTransOnMainStageByStageName`
+                // will set `*outTrans = {0.0f, y, z}` while returning `false`
                 if (biter.tryGetFloatByKey(&trans.x, "X"))
-                    posInfo->mask |= 1 << (j + 1);
+                    posInfo->mask |= 1 << j;
                 biter.tryGetFloatByKey(&trans.y, "Y");
                 biter.tryGetFloatByKey(&trans.z, "Z");
                 posInfo->posList.emplaceBack(trans);
@@ -163,20 +168,18 @@ WorldList::WorldList() {
 
         al::ByamlIter biter;
         for (s32 j = 1; j < 20; j++) {
-            if (iter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j).cstr())) {
-                sead::Vector3f trans = sead::Vector3f::zero;
-
-                if (biter.tryGetFloatByKey(&trans.x, "X")) {
-                    biter.tryGetFloatByKey(&trans.y, "Y");
-                    biter.tryGetFloatByKey(&trans.z, "Z");
-                    info->posList.emplaceBack(trans);
-                    info->mask |= 1 << j;
-                } else {
-                    info->posList.emplaceBack(sead::Vector3f::zero);
-                }
-            } else {
+            if (!iter.tryGetIterByKey(&biter, al::StringTmp<32>("%d", j).cstr())) {
                 info->posList.emplaceBack(sead::Vector3f::zero);
+                continue;
             }
+
+            sead::Vector3f trans = sead::Vector3f::zero;
+            if (biter.tryGetFloatByKey(&trans.x, "X")) {
+                biter.tryGetFloatByKey(&trans.y, "Y");
+                biter.tryGetFloatByKey(&trans.z, "Z");
+                info->mask |= 1 << j;
+            }
+            info->posList.emplaceBack(trans);
         }
         mShinePosList.pushBack(info);
     }
@@ -188,8 +191,7 @@ s32 WorldList::getWorldNum() const {
 }
 
 s32 WorldList::getMainQuestMin(s32 worldId, s32 questId) const {
-    if (worldId < 0)
-        worldId = 0;
+    worldId = sead::Mathi::clampMin(worldId, 0);
     return mWorldList[worldId]->mainQuestIndexes[questId - 1];
 }
 
@@ -249,9 +251,7 @@ bool WorldList::isEqualMoonRockScenarioNo(s32 worldId, s32 scenarioNo) const {
 }
 
 const char* WorldList::getWorldDevelopName(s32 worldId) const {
-    if (worldId < 0)
-        worldId = 0;
-    return mWorldList[worldId]->worldDevelopName;
+    return mWorldList[sead::Mathi::clampMin(worldId, 0)]->worldDevelopName;
 }
 
 s32 WorldList::getWorldScenarioNum(s32 worldId) const {
@@ -295,7 +295,6 @@ bool WorldList::checkNeedTreasureMessageStage(const char* stageName) const {
                 !al::isEqualString(category, "MiniGame") &&
                 !al::isEqualString(category, "SmallStage"))
                 return true;
-
             return false;
         }
     }

--- a/src/System/WorldList.h
+++ b/src/System/WorldList.h
@@ -1,56 +1,77 @@
 #pragma once
 
+#include <container/seadObjArray.h>
 #include <container/seadPtrArray.h>
 #include <container/seadStrTreeMap.h>
 #include <math/seadVector.h>
 #include <prim/seadSafeString.h>
 
-struct StagePosInfo {};
+struct StagePosInfo {
+    sead::ObjArray<sead::Vector3f> posList;
+    s32 mask = 0;
+};
+
+static_assert(sizeof(StagePosInfo) == 0x28);
+
+struct ShinePosInfo {
+    sead::ObjArray<sead::Vector3f> posList;
+    s32 uniqueId = 0;
+    s32 mask = 0;
+};
+
+static_assert(sizeof(ShinePosInfo) == 0x28);
 
 struct StageDBEntry {
-    sead::FixedSafeString<0x80> stageName;
-    sead::FixedSafeString<0x40> stageCategory;
-    s32 useScenario;
+    sead::FixedSafeString<0x80> name;
+    sead::FixedSafeString<0x40> category;
+    s32 useScenarioNo = 0;
 };
 
+static_assert(sizeof(StageDBEntry) == 0xf8);
+
 struct WorldListEntry {
-    const char* mainStageName;
-    const char* worldDevelopName;
-    s32 questInfoCount;
-    s32 clearMainScenario;
-    s32 endingScenario;
-    s32 moonRockScenario;
-    s32* mainQuestIndexes;
-    sead::PtrArray<StageDBEntry> stageNames;
+    const char* mainStageName = nullptr;
+    const char* worldDevelopName = nullptr;
+    s32 worldScenarioNum = 0;
+    s32 clearMainScenarioNo = 0;
+    s32 afterEndingScenarioNo = 0;
+    s32 moonRockScenarioNo = 0;
+    s32* mainQuestIndexes = 0;
+    sead::PtrArray<StageDBEntry> stageList;
 };
+
+static_assert(sizeof(WorldListEntry) == 0x38);
 
 class WorldList {
 public:
     WorldList();
 
     s32 getWorldNum() const;
-    s32 getMainQuestMin(s32, s32) const;
-    const char* getMainStageName(s32) const;
-    s32 tryFindWorldIndexByMainStageName(const char*) const;
-    s32 tryFindWorldIndexByStageName(const char*) const;
-    s32 tryFindWorldIndexByDevelopName(const char*) const;
-    bool isEqualClearMainScenarioNo(s32, s32) const;
-    s32 getAfterEndingScenarioNo(s32) const;
-    bool isEqualAfterEndingScenarioNo(s32, s32) const;
-    s32 getMoonRockScenarioNo(s32) const;
-    bool isEqualMoonRockScenarioNo(s32, s32) const;
-    const char* getWorldDevelopName(s32) const;
-    s32 getWorldScenarioNum(s32) const;
-    s32 findUseScenarioNo(const char*) const;
-    bool checkNeedTreasureMessageStage(const char*) const;
-    bool checkIsMainStage(const char*) const;
-    bool tryFindTransOnMainStageByStageName(sead::Vector3f*, const char*, s32) const;
-    bool tryFindHintTransByScenarioNo(sead::Vector3f*, s32, s32) const;
+    s32 getMainQuestMin(s32 worldId, s32 questId) const;
+    const char* getMainStageName(s32 worldId) const;
+    s32 tryFindWorldIndexByMainStageName(const char* mainStageName) const;
+    s32 tryFindWorldIndexByStageName(const char* stageName) const;
+    s32 tryFindWorldIndexByDevelopName(const char* developName) const;
+    bool isEqualClearMainScenarioNo(s32 worldId, s32 scenarioNo) const;
+    s32 getAfterEndingScenarioNo(s32 worldId) const;
+    bool isEqualAfterEndingScenarioNo(s32 worldId, s32 scenarioNo) const;
+    s32 getMoonRockScenarioNo(s32 worldId) const;
+    bool isEqualMoonRockScenarioNo(s32 worldId, s32 scenarioNo) const;
+    const char* getWorldDevelopName(s32 worldId) const;
+    s32 getWorldScenarioNum(s32 worldId) const;
+    s32 findUseScenarioNo(const char* stageName) const;
+    bool checkNeedTreasureMessageStage(const char* stageName) const;
+    bool checkIsMainStage(const char* mainStageName) const;
+    bool tryFindTransOnMainStageByStageName(sead::Vector3f* outTrans, const char* stageName,
+                                            s32 index) const;
+    bool tryFindHintTransByScenarioNo(sead::Vector3f* outTrans, s32 scenarioNo, s32 index) const;
 
 private:
+    s32 findHintByScenarioNo(s32 scenarioNo) const;
+
     sead::PtrArray<WorldListEntry> mWorldList;
     sead::StrTreeMap<128, StagePosInfo*> mStagePosList;
-    sead::PtrArrayImpl field_30;
+    sead::PtrArray<ShinePosInfo> mShinePosList;
 };
 
-static_assert(sizeof(WorldList) == 0x40, "WorldList Size");
+static_assert(sizeof(WorldList) == 0x40);


### PR DESCRIPTION
Initially implemented by @Fuzzy2319
Has major issues with WorldList ctor. Seems to be an issue with `StrTreeMap` implementation. https://decomp.me/scratch/znUi3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1299)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f19463 - 18424a4)

📈 **Matched code**: 15.38% (+0.02%, +2872 bytes)

<details>
<summary>✅ 22 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/WorldList` | `sead::StrTreeMap<128, StagePosInfo*>::insert(sead::SafeStringBase<char> const&, StagePosInfo* const&)` | +632 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::checkNeedTreasureMessageStage(char const*) const` | +484 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::tryFindTransOnMainStageByStageName(sead::Vector3<float>*, char const*, int) const` | +384 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::findUseScenarioNo(char const*) const` | +284 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::tryFindWorldIndexByStageName(char const*) const` | +280 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::tryFindHintTransByScenarioNo(sead::Vector3<float>*, int, int) const` | +184 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::checkIsMainStage(char const*) const` | +124 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::tryFindWorldIndexByMainStageName(char const*) const` | +120 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::tryFindWorldIndexByDevelopName(char const*) const` | +120 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getMainQuestMin(int, int) const` | +32 | 0.00% | 100.00% |
| `System/WorldList` | `sead::StrTreeMap<128, StagePosInfo*>::Node::erase_()` | +32 | 0.00% | 100.00% |
| `System/WorldList` | `sead::PtrArray<ShinePosInfo>::compareT(ShinePosInfo const*, ShinePosInfo const*)` | +24 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::isEqualClearMainScenarioNo(int, int) const` | +24 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::isEqualAfterEndingScenarioNo(int, int) const` | +24 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::isEqualMoonRockScenarioNo(int, int) const` | +24 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getWorldDevelopName(int) const` | +24 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getMainStageName(int) const` | +16 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getAfterEndingScenarioNo(int) const` | +16 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getMoonRockScenarioNo(int) const` | +16 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getWorldScenarioNum(int) const` | +16 | 0.00% | 100.00% |
| `System/WorldList` | `WorldList::getWorldNum() const` | +8 | 0.00% | 100.00% |
| `System/WorldList` | `sead::StrTreeMap<128, StagePosInfo*>::Node::~Node()` | +4 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/WorldList` | `WorldList::WorldList()` | +888 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->