### PR TITLE
Amiibo: Implement `HelpAmiiboDirector`

### DIFF
--- a/src/Amiibo/HelpAmiiboDirector.cpp
+++ b/src/Amiibo/HelpAmiiboDirector.cpp
@@ -1,0 +1,292 @@
+#include "Amiibo/HelpAmiiboDirector.h"
+
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Layout/LayoutActionFunction.h"
+#include "Library/Layout/LayoutActor.h"
+#include "Library/Layout/LayoutActorUtil.h"
+#include "Library/Layout/LayoutInitInfo.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveKeeper.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Play/Layout/SimpleLayoutAppearWaitEnd.h"
+#include "Library/Player/PlayerHolder.h"
+#include "Library/Player/PlayerUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Amiibo/HelpAmiiboCoinCollect.h"
+#include "Amiibo/HelpAmiiboCountUpCoin.h"
+#include "Amiibo/HelpAmiiboExecutor.h"
+#include "Amiibo/HelpAmiiboLifeMaxUpItem.h"
+#include "Amiibo/HelpAmiiboPlayerInvincible.h"
+#include "Scene/SceneObjFactory.h"
+#include "System/GameDataFunction.h"
+#include "System/ProjectNfpDirector.h"
+#include "Util/PlayerUtil.h"
+#include "Util/StageInputFunction.h"
+
+namespace {
+NERVE_IMPL(HelpAmiiboDirector, Wait);
+NERVE_IMPL(HelpAmiiboDirector, CountHold);
+NERVE_IMPL(HelpAmiiboDirector, Active);
+NERVE_IMPL(HelpAmiiboDirector, IconClose);
+
+NERVES_MAKE_STRUCT(HelpAmiiboDirector, Wait, CountHold, Active, IconClose);
+}  // namespace
+
+HelpAmiiboDirector::HelpAmiiboDirector() {}
+
+void HelpAmiiboDirector::init(ProjectNfpDirector* projectNfpDirector,
+                              const al::PlayerHolder* playerHolder,
+                              al::AudioDirector* audioDirector,
+                              const al::LayoutInitInfo& initInfo) {
+    mProjectNfpDirector = projectNfpDirector;
+    mPlayerHolder = playerHolder;
+    mAudioKeeper =
+        alAudioKeeperFunction::createAudioKeeper(audioDirector, "HelpAmiiboDirector", nullptr);
+
+    mNerveKeeper = new al::NerveKeeper(this, &NrvHelpAmiiboDirector.Wait, 0);
+    mSimpleLayout =
+        new al::SimpleLayoutAppearWaitEnd("amiiboアイコン", "AmiiboMode", initInfo, nullptr, false);
+    mLayoutActor = new al::LayoutActor("amiiboアイコン[アイコンパーツ]");
+    al::initLayoutPartsActor(mLayoutActor, mSimpleLayout, initInfo, "ParAmiiboIcon", nullptr);
+}
+
+void HelpAmiiboDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+    mCoinCollect = new HelpAmiiboCoinCollect(this, actor);
+
+    mTouchEntries.allocBuffer(4, nullptr);
+    mTouchEntries.pushBack(new HelpAmiiboPlayerInvincible(this, actor));
+    mTouchEntries.pushBack(new HelpAmiiboLifeMaxUpItem(this, actor));
+    mTouchEntries.pushBack(mCoinCollect);
+    mTouchEntries.pushBack(new HelpAmiiboCountUpCoin(this, actor));
+
+    mTouchEntries[0]->initAfterPlacement(initInfo);
+    mTouchEntries[1]->initAfterPlacement(initInfo);
+    mTouchEntries[2]->initAfterPlacement(initInfo);
+    mTouchEntries[3]->initAfterPlacement(initInfo);
+}
+
+static bool isTriggerTouchAmiibo(HelpAmiiboType type,
+                                 const sead::PtrArray<HelpAmiiboExecutor>& touchEntries) {
+    volatile HelpAmiiboType volatileType = type;
+
+    s32 entryCount = touchEntries.size();
+    for (s32 i = 0; i < entryCount; i++)
+        if (touchEntries[i]->getType() == volatileType && touchEntries[i]->isTouched())
+            return true;
+
+    return false;
+}
+
+bool HelpAmiiboDirector::isTriggerTouchAmiiboMario() const {
+    return isTriggerTouchAmiibo(HelpAmiiboType::Mario, mTouchEntries);
+}
+
+bool HelpAmiiboDirector::isTriggerTouchAmiiboPeach() const {
+    return isTriggerTouchAmiibo(HelpAmiiboType::Peach, mTouchEntries);
+}
+
+bool HelpAmiiboDirector::isTriggerTouchAmiiboKoopa() const {
+    return isTriggerTouchAmiibo(HelpAmiiboType::Koopa, mTouchEntries);
+}
+
+bool HelpAmiiboDirector::isTriggerTouchAmiiboYoshi() const {
+    return isTriggerTouchAmiibo(HelpAmiiboType::Yoshi, mTouchEntries);
+}
+
+bool HelpAmiiboDirector::isTriggerTouchAmiiboAll() const {
+    return isTriggerTouchAmiiboMario() || isTriggerTouchAmiiboPeach() ||
+           isTriggerTouchAmiiboKoopa() || isTriggerTouchAmiiboYoshi();
+}
+
+void HelpAmiiboDirector::execute() {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+    if (rs::isPlayerEnablePeachAmiibo(actor))
+        mIsTouchAmiibo = true;
+
+    mNerveKeeper->update();
+    if (al::isActionPlaying(mLayoutActor, "Reject", nullptr)) {
+        if (al::isActionEnd(mLayoutActor, nullptr))
+            al::startAction(mLayoutActor, "Wait", nullptr);
+    }
+
+    s32 entries = mTouchEntries.size();
+    for (s32 i = 0; i < entries; i++)
+        mTouchEntries[i]->tryExecute();
+}
+
+void HelpAmiiboDirector::reset() {
+    mSimpleLayout->end();
+    mProjectNfpDirector->stop();
+    al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
+}
+
+bool HelpAmiiboDirector::isHelpAmiiboMode() const {
+    if (al::isNerve(this, &NrvHelpAmiiboDirector.CountHold))
+        return true;
+    return al::isNerve(this, &NrvHelpAmiiboDirector.Active);
+}
+
+void HelpAmiiboDirector::appearCoinCollectEffect() {
+    mCoinCollect->appearEffect();
+}
+
+void HelpAmiiboDirector::killCoinCollectEffect() {
+    mCoinCollect->killEffect();
+}
+
+static bool isNotExecutable(const al::PlayerHolder* mPlayerHolder) {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+
+    return GameDataFunction::isRaceStartYukimaru(actor) || rs::isSeparatePlay(actor);
+}
+
+bool HelpAmiiboDirector::tryExecute(const al::NfpInfo* nfpInfo) {
+    if (isNotExecutable(mPlayerHolder))
+        return false;
+
+    if (!mIsTouchAmiibo) {
+        al::startSe(this, "Invalid");
+        return false;
+    }
+
+    s32 entries = mTouchEntries.size();
+    for (s32 i = 0; i < entries; i++) {
+        if (mTouchEntries[i]->isTriggerTouch(*nfpInfo) && mTouchEntries[i]->isEnableUse() &&
+            mTouchEntries[i]->tryTouch(*nfpInfo)) {
+            mTouchEntries[i]->tryExecute();
+            al::startSe(this, "TouchAmiibo");
+            al::startHitReaction(mSimpleLayout, "タッチ", nullptr);
+            mIsTouchAmiibo = false;
+            return true;
+        }
+    }
+
+    al::startSe(this, "Invalid");
+    al::startAction(mLayoutActor, "Reject", nullptr);
+    return false;
+}
+
+void HelpAmiiboDirector::exeWait() {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+    if (rs::isPlayerHackFukankun(actor))
+        return;
+
+    if (rs::isTriggerAmiiboMode(actor))
+        al::setNerve(this, &NrvHelpAmiiboDirector.CountHold);
+}
+
+void HelpAmiiboDirector::exeCountHold() {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+
+    if (!rs::isHoldAmiiboMode(actor))
+        al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
+    else if (al::isGreaterEqualStep(this, 8))
+        al::setNerve(this, &NrvHelpAmiiboDirector.Active);
+}
+
+void HelpAmiiboDirector::exeActive() {
+    al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
+    if (al::isFirstStep(this))
+        mProjectNfpDirector->start();
+
+    if (!rs::isHoldAmiiboMode(actor)) {
+        mProjectNfpDirector->stop();
+        al::setNerve(this, &NrvHelpAmiiboDirector.IconClose);
+        return;
+    }
+
+    if (al::isLessStep(this, 10) && mProjectNfpDirector->isNfpErrorHandled()) {
+        mProjectNfpDirector->stop();
+        al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
+        al::startAction(mLayoutActor, "Hide", nullptr);
+        return;
+    }
+
+    if (al::isStep(this, 10)) {
+        mSimpleLayout->appear();
+        al::startAction(mLayoutActor, "Appear", nullptr);
+    }
+
+    if (al::isActionPlaying(mLayoutActor, "Appear", nullptr)) {
+        if (al::isActionEnd(mLayoutActor, nullptr))
+            al::startAction(mLayoutActor, "Wait", nullptr);
+    }
+
+    al::NfpInfo* nfpInfo = mProjectNfpDirector->tryGetTriggerTouchNfpInfo();
+    if (nfpInfo && tryExecute(nfpInfo)) {
+        mProjectNfpDirector->stop();
+        al::setNerve(this, &NrvHelpAmiiboDirector.IconClose);
+    }
+}
+
+void HelpAmiiboDirector::exeIconClose() {
+    if (al::isFirstStep(this))
+        al::startAction(mLayoutActor, "End", nullptr);
+    if (al::isActionEnd(mLayoutActor, nullptr) || al::isDead(mSimpleLayout)) {
+        mSimpleLayout->kill();
+        al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
+    }
+}
+
+namespace AmiiboFunction {
+
+void tryCreateHelpAmiiboDirector(const al::IUseSceneObjHolder* objHolder) {
+    al::createSceneObj(objHolder, SceneObjID_HelpAmiiboDirector);
+}
+
+bool isTriggerTouchAmiiboMario(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (!director)
+        return false;
+    return director->isTriggerTouchAmiiboMario();
+}
+
+bool isTriggerTouchAmiiboPeach(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (!director)
+        return false;
+    return director->isTriggerTouchAmiiboPeach();
+}
+
+bool isTriggerTouchAmiiboKoopa(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (!director)
+        return false;
+    return director->isTriggerTouchAmiiboKoopa();
+}
+
+bool isTriggerTouchAmiiboAll(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (!director)
+        return false;
+    return director->isTriggerTouchAmiiboAll();
+}
+
+}  // namespace AmiiboFunction
+
+namespace rs {
+
+void resetHelpAmiiboState(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (director)
+        director->reset();
+}
+
+bool isHelpAmiiboMode(const al::IUseSceneObjHolder* objHolder) {
+    HelpAmiiboDirector* director = al::tryGetSceneObj<HelpAmiiboDirector>(objHolder);
+
+    if (!director)
+        return false;
+    return director->isHelpAmiiboMode();
+}
+
+}  // namespace rs

--- a/src/Amiibo/HelpAmiiboDirector.cpp
+++ b/src/Amiibo/HelpAmiiboDirector.cpp
@@ -35,7 +35,7 @@ NERVE_IMPL(HelpAmiiboDirector, IconClose);
 NERVES_MAKE_STRUCT(HelpAmiiboDirector, Wait, CountHold, Active, IconClose);
 }  // namespace
 
-HelpAmiiboDirector::HelpAmiiboDirector() {}
+HelpAmiiboDirector::HelpAmiiboDirector() = default;
 
 void HelpAmiiboDirector::init(ProjectNfpDirector* projectNfpDirector,
                               const al::PlayerHolder* playerHolder,
@@ -47,10 +47,10 @@ void HelpAmiiboDirector::init(ProjectNfpDirector* projectNfpDirector,
         alAudioKeeperFunction::createAudioKeeper(audioDirector, "HelpAmiiboDirector", nullptr);
 
     mNerveKeeper = new al::NerveKeeper(this, &NrvHelpAmiiboDirector.Wait, 0);
-    mSimpleLayout =
+    mAmiiboIcon =
         new al::SimpleLayoutAppearWaitEnd("amiiboアイコン", "AmiiboMode", initInfo, nullptr, false);
-    mLayoutActor = new al::LayoutActor("amiiboアイコン[アイコンパーツ]");
-    al::initLayoutPartsActor(mLayoutActor, mSimpleLayout, initInfo, "ParAmiiboIcon", nullptr);
+    mAmmiiboIconParts = new al::LayoutActor("amiiboアイコン[アイコンパーツ]");
+    al::initLayoutPartsActor(mAmmiiboIconParts, mAmiiboIcon, initInfo, "ParAmiiboIcon", nullptr);
 }
 
 void HelpAmiiboDirector::initAfterPlacementSceneObj(const al::ActorInitInfo& initInfo) {
@@ -105,12 +105,12 @@ bool HelpAmiiboDirector::isTriggerTouchAmiiboAll() const {
 void HelpAmiiboDirector::execute() {
     al::LiveActor* actor = al::getPlayerActor(mPlayerHolder, 0);
     if (rs::isPlayerEnablePeachAmiibo(actor))
-        mIsTouchAmiibo = true;
+        mIsEnableAmiibo = true;
 
     mNerveKeeper->update();
-    if (al::isActionPlaying(mLayoutActor, "Reject", nullptr)) {
-        if (al::isActionEnd(mLayoutActor, nullptr))
-            al::startAction(mLayoutActor, "Wait", nullptr);
+    if (al::isActionPlaying(mAmmiiboIconParts, "Reject", nullptr)) {
+        if (al::isActionEnd(mAmmiiboIconParts, nullptr))
+            al::startAction(mAmmiiboIconParts, "Wait", nullptr);
     }
 
     s32 entries = mTouchEntries.size();
@@ -119,15 +119,14 @@ void HelpAmiiboDirector::execute() {
 }
 
 void HelpAmiiboDirector::reset() {
-    mSimpleLayout->end();
+    mAmiiboIcon->end();
     mProjectNfpDirector->stop();
     al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
 }
 
 bool HelpAmiiboDirector::isHelpAmiiboMode() const {
-    if (al::isNerve(this, &NrvHelpAmiiboDirector.CountHold))
-        return true;
-    return al::isNerve(this, &NrvHelpAmiiboDirector.Active);
+    return al::isNerve(this, &NrvHelpAmiiboDirector.CountHold) ||
+           al::isNerve(this, &NrvHelpAmiiboDirector.Active);
 }
 
 void HelpAmiiboDirector::appearCoinCollectEffect() {
@@ -148,7 +147,7 @@ bool HelpAmiiboDirector::tryExecute(const al::NfpInfo* nfpInfo) {
     if (isNotExecutable(mPlayerHolder))
         return false;
 
-    if (!mIsTouchAmiibo) {
+    if (!mIsEnableAmiibo) {
         al::startSe(this, "Invalid");
         return false;
     }
@@ -159,14 +158,14 @@ bool HelpAmiiboDirector::tryExecute(const al::NfpInfo* nfpInfo) {
             mTouchEntries[i]->tryTouch(*nfpInfo)) {
             mTouchEntries[i]->tryExecute();
             al::startSe(this, "TouchAmiibo");
-            al::startHitReaction(mSimpleLayout, "タッチ", nullptr);
-            mIsTouchAmiibo = false;
+            al::startHitReaction(mAmiiboIcon, "タッチ", nullptr);
+            mIsEnableAmiibo = false;
             return true;
         }
     }
 
     al::startSe(this, "Invalid");
-    al::startAction(mLayoutActor, "Reject", nullptr);
+    al::startAction(mAmmiiboIconParts, "Reject", nullptr);
     return false;
 }
 
@@ -202,18 +201,18 @@ void HelpAmiiboDirector::exeActive() {
     if (al::isLessStep(this, 10) && mProjectNfpDirector->isNfpErrorHandled()) {
         mProjectNfpDirector->stop();
         al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
-        al::startAction(mLayoutActor, "Hide", nullptr);
+        al::startAction(mAmmiiboIconParts, "Hide", nullptr);
         return;
     }
 
     if (al::isStep(this, 10)) {
-        mSimpleLayout->appear();
-        al::startAction(mLayoutActor, "Appear", nullptr);
+        mAmiiboIcon->appear();
+        al::startAction(mAmmiiboIconParts, "Appear", nullptr);
     }
 
-    if (al::isActionPlaying(mLayoutActor, "Appear", nullptr)) {
-        if (al::isActionEnd(mLayoutActor, nullptr))
-            al::startAction(mLayoutActor, "Wait", nullptr);
+    if (al::isActionPlaying(mAmmiiboIconParts, "Appear", nullptr)) {
+        if (al::isActionEnd(mAmmiiboIconParts, nullptr))
+            al::startAction(mAmmiiboIconParts, "Wait", nullptr);
     }
 
     al::NfpInfo* nfpInfo = mProjectNfpDirector->tryGetTriggerTouchNfpInfo();
@@ -225,9 +224,9 @@ void HelpAmiiboDirector::exeActive() {
 
 void HelpAmiiboDirector::exeIconClose() {
     if (al::isFirstStep(this))
-        al::startAction(mLayoutActor, "End", nullptr);
-    if (al::isActionEnd(mLayoutActor, nullptr) || al::isDead(mSimpleLayout)) {
-        mSimpleLayout->kill();
+        al::startAction(mAmmiiboIconParts, "End", nullptr);
+    if (al::isActionEnd(mAmmiiboIconParts, nullptr) || al::isDead(mAmiiboIcon)) {
+        mAmiiboIcon->kill();
         al::setNerve(this, &NrvHelpAmiiboDirector.Wait);
     }
 }
@@ -235,7 +234,7 @@ void HelpAmiiboDirector::exeIconClose() {
 namespace AmiiboFunction {
 
 void tryCreateHelpAmiiboDirector(const al::IUseSceneObjHolder* objHolder) {
-    al::createSceneObj(objHolder, SceneObjID_HelpAmiiboDirector);
+    al::createSceneObj<HelpAmiiboDirector>(objHolder);
 }
 
 bool isTriggerTouchAmiiboMario(const al::IUseSceneObjHolder* objHolder) {

--- a/src/Amiibo/HelpAmiiboDirector.h
+++ b/src/Amiibo/HelpAmiiboDirector.h
@@ -69,9 +69,9 @@ private:
     sead::PtrArray<HelpAmiiboExecutor> mTouchEntries;
 
     al::NerveKeeper* mNerveKeeper = nullptr;
-    al::SimpleLayoutAppearWaitEnd* mSimpleLayout = nullptr;
-    al::LayoutActor* mLayoutActor = nullptr;
-    bool mIsTouchAmiibo = true;
+    al::SimpleLayoutAppearWaitEnd* mAmiiboIcon = nullptr;
+    al::LayoutActor* mAmmiiboIconParts = nullptr;
+    bool mIsEnableAmiibo = true;
     HelpAmiiboCoinCollect* mCoinCollect = nullptr;
 };
 

--- a/src/Amiibo/HelpAmiiboDirector.h
+++ b/src/Amiibo/HelpAmiiboDirector.h
@@ -7,6 +7,8 @@
 #include "Library/Nerve/IUseNerve.h"
 #include "Library/Scene/ISceneObj.h"
 
+#include "Scene/SceneObjFactory.h"
+
 namespace al {
 struct NfpInfo;
 
@@ -30,6 +32,8 @@ class HelpAmiiboDirector : public al::IUseHioNode,
                            public al::IUseAudioKeeper,
                            public al::IUseNerve {
 public:
+    static constexpr s32 sSceneObjId = SceneObjID_HelpAmiiboDirector;
+
     HelpAmiiboDirector();
     void init(ProjectNfpDirector* projectNfpDirector, const al::PlayerHolder* playerHolder,
               al::AudioDirector* audioDirector, const al::LayoutInitInfo& initInfo);
@@ -47,14 +51,16 @@ public:
     void killCoinCollectEffect();
     bool tryExecute(const al::NfpInfo* nfpInfo);
 
-    const char* getSceneObjName() const override;
-    al::AudioKeeper* getAudioKeeper() const override;
-    al::NerveKeeper* getNerveKeeper() const override;
-
     void exeWait();
     void exeCountHold();
     void exeActive();
     void exeIconClose();
+
+    const char* getSceneObjName() const override { return "アイテム出現用amiiboディレクター"; }
+
+    al::AudioKeeper* getAudioKeeper() const override { return mAudioKeeper; }
+
+    al::NerveKeeper* getNerveKeeper() const override { return mNerveKeeper; }
 
 private:
     ProjectNfpDirector* mProjectNfpDirector = nullptr;
@@ -65,7 +71,7 @@ private:
     al::NerveKeeper* mNerveKeeper = nullptr;
     al::SimpleLayoutAppearWaitEnd* mSimpleLayout = nullptr;
     al::LayoutActor* mLayoutActor = nullptr;
-    bool _58 = true;
+    bool mIsTouchAmiibo = true;
     HelpAmiiboCoinCollect* mCoinCollect = nullptr;
 };
 

--- a/src/Amiibo/HelpAmiiboExecutor.h
+++ b/src/Amiibo/HelpAmiiboExecutor.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <basis/seadTypes.h>
+#include <prim/seadEnum.h>
 
 #include "Library/HostIO/HioNode.h"
 
@@ -12,13 +13,13 @@ struct ActorInitInfo;
 
 class HelpAmiiboDirector;
 
-enum class HelpAmiiboType : s64 {
-    Mario = 0,
-    Peach = 1,
-    Koopa = 2,
-    Yoshi = 3,
-    All = 4,
-};
+SEAD_ENUM(HelpAmiiboType,
+    Mario,
+    Peach,
+    Koopa,
+    Yoshi,
+    All,
+)
 
 class HelpAmiiboExecutor : public al::IUseHioNode {
 public:
@@ -36,9 +37,9 @@ public:
     bool tryTouch(const al::NfpInfo& nfpInfo);
     void tryExecute();
 
-    bool isTouched() const { return mIsTouched; }
-
     HelpAmiiboDirector* getDirector() const { return mHelpAmiiboDirector; }
+
+    bool isTouched() const { return mIsTouched; }
 
     al::LiveActor* getActor() const { return mHelpAmiiboActor; }
 


### PR DESCRIPTION
This is a very old implementation.  `isTriggerTouchAmiiboMario` was very hard to match at the end I managed to get a solid match with volatile + sead enum which also got rid of the weird s64 enum we had earlier.

The rest of the class was tricky but nothing out of the ordinary.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1300)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0de3c75 - 1733a2d)

📈 **Matched code**: 15.40% (+0.04%, +4496 bytes)

<details>
<summary>✅ 35 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::tryExecute(al::NfpInfo const*)` | +460 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::initAfterPlacementSceneObj(al::ActorInitInfo const&)` | +440 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::exeActive()` | +432 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isTriggerTouchAmiiboAll() const` | +428 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::execute()` | +236 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::init(ProjectNfpDirector*, al::PlayerHolder const*, al::AudioDirector*, al::LayoutInitInfo const&)` | +208 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `(anonymous namespace)::HelpAmiiboDirectorNrvIconClose::execute(al::NerveKeeper*) const` | +168 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::exeIconClose()` | +156 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `AmiiboFunction::isTriggerTouchAmiiboMario(al::IUseSceneObjHolder const*)` | +152 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `AmiiboFunction::isTriggerTouchAmiiboPeach(al::IUseSceneObjHolder const*)` | +152 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `AmiiboFunction::isTriggerTouchAmiiboKoopa(al::IUseSceneObjHolder const*)` | +152 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isTriggerTouchAmiiboMario() const` | +140 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isTriggerTouchAmiiboPeach() const` | +140 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isTriggerTouchAmiiboKoopa() const` | +140 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isTriggerTouchAmiiboYoshi() const` | +140 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `(anonymous namespace)::HelpAmiiboDirectorNrvCountHold::execute(al::NerveKeeper*) const` | +132 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::exeCountHold()` | +120 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `(anonymous namespace)::HelpAmiiboDirectorNrvWait::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::exeWait()` | +100 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `rs::isHelpAmiiboMode(al::IUseSceneObjHolder const*)` | +88 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `rs::resetHelpAmiiboState(al::IUseSceneObjHolder const*)` | +80 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::isHelpAmiiboMode() const` | +76 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::HelpAmiiboDirector()` | +60 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::reset()` | +56 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `AmiiboFunction::isTriggerTouchAmiiboAll(al::IUseSceneObjHolder const*)` | +36 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `(anonymous namespace)::HelpAmiiboDirectorNrvActive::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::getSceneObjName() const` | +12 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::appearCoinCollectEffect()` | +8 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `HelpAmiiboDirector::killCoinCollectEffect()` | +8 | 0.00% | 100.00% |
| `Amiibo/HelpAmiiboDirector` | `AmiiboFunction::tryCreateHelpAmiiboDirector(al::IUseSceneObjHolder const*)` | +8 | 0.00% | 100.00% |

...and 5 more new matches
</details>


<!-- decomp.dev report end -->