### PR TITLE
Npc: Implement `SessionMusicianWarpAgent`

### DIFF
--- a/src/Npc/SessionMusicianWarpAgent.cpp
+++ b/src/Npc/SessionMusicianWarpAgent.cpp
@@ -1,0 +1,98 @@
+#include "Npc/SessionMusicianWarpAgent.h"
+
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementInfo.h"
+
+#include "MapObj/ChangeStageInfo.h"
+#include "MapObj/PlayerStartInfoHolder.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+#include "Util/DemoUtil.h"
+
+static void registerPlayerRestartPosNormal(const al::PlacementInfo& info, al::LiveActor* actor) {
+    al::PlacementInfo restartInfo = info;
+    al::getLinksInfo(&restartInfo, info, "PlayerRestartPosNormal");
+
+    rs::registerPlayerStartInfoToHolder(actor, restartInfo, nullptr, nullptr, nullptr, nullptr);
+}
+
+static void registerPlayerRestartPosTalk(const al::PlacementInfo& info, al::LiveActor* actor) {
+    al::PlacementInfo restartInfo = info;
+    al::getLinksInfo(&restartInfo, info, "PlayerRestartPosTalk");
+
+    rs::registerPlayerStartInfoToHolder(actor, restartInfo, nullptr, nullptr, nullptr, nullptr);
+}
+
+static ChangeStageInfo* createChangeStageNormal(const al::PlacementInfo& info,
+                                                al::LiveActor* actor) {
+    const char* stageName = nullptr;
+    if (!al::tryGetStringArg(&stageName, info, "ChangeStageName"))
+        return nullptr;
+
+    const char* stageId = nullptr;
+    if (!al::tryGetStringArg(&stageId, info, "ChangeStageIdNormal"))
+        return nullptr;
+
+    return rs::createChangeStageInfo(actor, stageId, stageName, false, -1,
+                                     ChangeStageInfo::SubScenarioType::NO_SUB_SCENARIO);
+}
+
+static ChangeStageInfo* createChangeStageTalk(const al::PlacementInfo& info, al::LiveActor* actor) {
+    const char* stageName = nullptr;
+    if (!al::tryGetStringArg(&stageName, info, "ChangeStageName"))
+        return nullptr;
+
+    const char* stageId = nullptr;
+    if (!al::tryGetStringArg(&stageId, info, "ChangeStageIdTalk"))
+        return nullptr;
+
+    return rs::createChangeStageInfo(actor, stageId, stageName, false, -1,
+                                     ChangeStageInfo::SubScenarioType::NO_SUB_SCENARIO);
+}
+
+SessionMusicianWarpAgent::SessionMusicianWarpAgent(al::LiveActor* actor,
+                                                   const al::ActorInitInfo& initInfo)
+    : mActor(actor) {
+    al::PlacementInfo info;
+    al::getLinksInfo(&info, initInfo, "WarpAgent");
+
+    mPlacementInfo = new al::PlacementInfo(info);
+
+    if (al::isExistLinkChild(info, "PlayerRestartPosNormal", 0))
+        registerPlayerRestartPosNormal(info, actor);
+
+    if (al::isExistLinkChild(info, "PlayerRestartPosTalk", 0))
+        registerPlayerRestartPosTalk(info, actor);
+
+    mChangeStageNormal = createChangeStageNormal(info, actor);
+    mChangeStageTalk = createChangeStageTalk(info, actor);
+
+    if (mChangeStageTalk)
+        mChangeStageTalk->setWipeType("地下工場");
+}
+
+static const char* getWarpTargetInfoName(SessionMusicianWarpAgent* self) {
+    if (GameDataFunction::getSessionEventProgress(self->getActor()) >
+        SessionEventProgress::Wait4thMusician)
+        return "PlayerRestartPosTalk";
+    return "PlayerRestartPosNormal";
+}
+
+bool SessionMusicianWarpAgent::tryGetWarpTargetInfo(al::PlacementInfo* targetInfo) {
+    return al::tryGetLinksInfo(targetInfo, *mPlacementInfo, getWarpTargetInfoName(this));
+}
+
+static inline const ChangeStageInfo* getNextStage(SessionMusicianWarpAgent* self) {
+    if (GameDataFunction::getSessionEventProgress(self->getActor()) >
+        SessionEventProgress::Wait4thMusician)
+        return self->getChangeStageTalk();
+
+    return self->getChangeStageNormal();
+}
+
+bool SessionMusicianWarpAgent::tryStartWarp() {
+    if (!mChangeStageNormal && !mChangeStageTalk)
+        return rs::requestStartDemoWarp(mActor);
+
+    return GameDataFunction::tryChangeNextStage(mActor, getNextStage(this));
+}

--- a/src/Npc/SessionMusicianWarpAgent.h
+++ b/src/Npc/SessionMusicianWarpAgent.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+class PlacementInfo;
+}  // namespace al
+
+class ChangeStageInfo;
+
+class SessionMusicianWarpAgent {
+public:
+    SessionMusicianWarpAgent(al::LiveActor* actor, const al::ActorInitInfo& initInfo);
+
+    bool tryGetWarpTargetInfo(al::PlacementInfo* targetInfo);
+    bool tryStartWarp();
+
+    al::LiveActor* getActor() const { return mActor; }
+
+    ChangeStageInfo* getChangeStageNormal() const { return mChangeStageNormal; }
+
+    ChangeStageInfo* getChangeStageTalk() const { return mChangeStageTalk; }
+
+private:
+    al::LiveActor* mActor;
+    al::PlacementInfo* mPlacementInfo = nullptr;
+    ChangeStageInfo* mChangeStageNormal = nullptr;
+    ChangeStageInfo* mChangeStageTalk = nullptr;
+};
+
+static_assert(sizeof(SessionMusicianWarpAgent) == 0x20);


### PR DESCRIPTION
Implements `SessionMusicianWarpAgent`

Huge thanks to @german77 who helped match some functions and figured out all the inline shenanigans.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1302)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (509d178 - af29322)

📈 **Matched code**: 15.29% (+0.01%, +824 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/SessionMusicianWarpAgent` | `SessionMusicianWarpAgent::SessionMusicianWarpAgent(al::LiveActor*, al::ActorInitInfo const&)` | +536 | 0.00% | 100.00% |
| `Npc/SessionMusicianWarpAgent` | `SessionMusicianWarpAgent::tryStartWarp()` | +176 | 0.00% | 100.00% |
| `Npc/SessionMusicianWarpAgent` | `SessionMusicianWarpAgent::tryGetWarpTargetInfo(al::PlacementInfo*)` | +112 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->