### PR TITLE
Npc: Implement `SessionMusicianBgmCtrlObj`

### DIFF
--- a/src/Npc/SessionMusicianBgmController.h
+++ b/src/Npc/SessionMusicianBgmController.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Nerve/NerveExecutor.h"
+
+namespace al {
+struct ActorInitInfo;
+class AudioGeneralPurposeAreaChecker;
+class BgmBeatCounter;
+class ISceneObj;
+class LiveActor;
+}  // namespace al
+
+class SessionMusicianBgmController : public al::NerveExecutor {
+public:
+    SessionMusicianBgmController(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                 bool forceFullBand);
+    ~SessionMusicianBgmController() override = default;
+
+    void exeWait();
+    void exeInArea();
+    void exeOutArea();
+
+    bool tryStartBgmSituation();
+
+private:
+    al::LiveActor* mActor;
+    al::AudioGeneralPurposeAreaChecker* mAudioChecker;
+    const char* mPrevBgmName = nullptr;
+    bool mIsFullBandPerformance = false;
+    al::BgmBeatCounter* mBeatCounter = nullptr;
+    al::ISceneObj* mSceneObj = nullptr;
+};
+
+static_assert(sizeof(SessionMusicianBgmController) == 0x40);

--- a/src/Npc/SessionMusicianBgmCtrlObj.cpp
+++ b/src/Npc/SessionMusicianBgmCtrlObj.cpp
@@ -1,0 +1,23 @@
+#include "Npc/SessionMusicianBgmCtrlObj.h"
+
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorInitInfo.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveExecutor.h"
+
+#include "Npc/SessionMusicianBgmController.h"
+
+SessionBgmCtrlObj::SessionBgmCtrlObj(const char* name) : al::LiveActor(name) {}
+
+void SessionBgmCtrlObj::init(const al::ActorInitInfo& initInfo) {
+    al::initActorSceneInfo(this, initInfo);
+    al::initExecutorMapObjMovement(this, initInfo);
+    al::initActorSeKeeperWithout3D(this, initInfo, "SessionMusicianManager");
+
+    mBgmController = new SessionMusicianBgmController(this, initInfo, true);
+    makeActorAlive();
+}
+
+void SessionBgmCtrlObj::control() {
+    mBgmController->updateNerve();
+}

--- a/src/Npc/SessionMusicianBgmCtrlObj.h
+++ b/src/Npc/SessionMusicianBgmCtrlObj.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveExecutor.h"
+
+#include "Npc/SessionMusicianBgmController.h"
+
+namespace al {
+struct ActorInitInfo;
+}  // namespace al
+
+class SessionBgmCtrlObj : public al::LiveActor {
+public:
+    SessionBgmCtrlObj(const char* name);
+
+    void init(const al::ActorInitInfo& initInfo) override;
+    void control() override;
+
+private:
+    SessionMusicianBgmController* mBgmController = nullptr;
+};
+
+static_assert(sizeof(SessionBgmCtrlObj) == 0x110);

--- a/src/Scene/ProjectActorFactory.cpp
+++ b/src/Scene/ProjectActorFactory.cpp
@@ -145,6 +145,7 @@
 #include "Npc/FlyObject.h"
 #include "Npc/KuriboGirl.h"
 #include "Npc/RaceAudienceNpc.h"
+#include "Npc/SessionMusicianBgmCtrlObj.h"
 #include "Npc/VocalMike.h"
 #include "Npc/VolleyballNpc.h"
 #include "Npc/WorldTravelingNpc.h"
@@ -556,7 +557,7 @@ const al::NameToCreator<al::ActorCreatorFunction> sProjectActorFactoryEntries[] 
     {"SePlayObjWithSave", nullptr},
     {"SePlayRail", nullptr},
     {"SequentialSwitch", nullptr},
-    {"SessionBgmCtrlObj", nullptr},
+    {"SessionBgmCtrlObj", al::createActorFunction<SessionBgmCtrlObj>},
     {"SessionMayorNpc", nullptr},
     {"SessionMusicianNpc", nullptr},
     {"Shibaken", nullptr},


### PR DESCRIPTION
Implements `SessionMusicianBgmCtrlObj`.

The file object is called `SessionMusicianBgmCtrlObj` but the class is seemingly mistakenly named `SessionBgmCtrlObj`.

This commit also contains `SessionMusicianBgmController.h`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1309)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (844570d - c2d2468)

📈 **Matched code**: 15.30% (+0.00%, +440 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/SessionMusicianBgmCtrlObj` | `SessionBgmCtrlObj::SessionBgmCtrlObj(char const*)` | +136 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `SessionBgmCtrlObj::SessionBgmCtrlObj(char const*)` | +124 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `SessionBgmCtrlObj::init(al::ActorInitInfo const&)` | +120 | 0.00% | 100.00% |
| `Scene/ProjectActorFactory` | `al::LiveActor* al::createActorFunction<SessionBgmCtrlObj>(char const*)` | +52 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `SessionBgmCtrlObj::control()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->