### PR TITLE
Project/Fluid: Implement `FluidSurfaceHolder` and add `OceanWave` header

### DIFF
--- a/lib/al/Library/Play/Graphics/OceanWave.h
+++ b/lib/al/Library/Play/Graphics/OceanWave.h
@@ -77,6 +77,7 @@ public:
     void setFieldScale(f32) override;
     const char* getTypeName() const override;
 
+private:
     GraphicsSystemInfo* mGfxSysInfo;
     OceanWaveTexture* mWaveTexture;
     FluidSimulateWave* mFluidSimulateWave;

--- a/lib/al/Library/Play/Graphics/OceanWave.h
+++ b/lib/al/Library/Play/Graphics/OceanWave.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <gfx/seadColor.h>
+
+#include "Library/Fluid/IUseFluidSurface.h"
+#include "Library/HostIO/HioNode.h"
+#include "Library/Play/Graphics/PartsGraphics.h"
+
+namespace al {
+
+class GraphicsSystemInfo;
+class ExecuteDirector;
+class OceanWaveTexture;
+class FluidSimulateWave;
+class OrthoDepthTexture;
+class ApertureMesh;
+class UniformBlock;
+class EffectKeeper;
+class FogParam;
+class YFogParam;
+class ShaderProgram;
+class VastGridMesh;
+
+class OceanWave : public PartsGraphics, public IUseFluidSurface, public HioNode {
+public:
+    OceanWave(GraphicsSystemInfo*, ExecuteDirector*);
+    virtual ~OceanWave();
+
+    void init();
+    void addRipple(const sead::Vector3f&, f32, f32);
+    void calcWindDir(sead::Vector2f* windDir) const;
+    void drawMesh(const GraphicsRenderInfo&, const RenderVariables*, bool, bool) const;
+    void initRippleGaussian(s32);
+
+    void setApertureCameraHeightLodLen(f32);
+    void setApertureDisplacementScaleBase(f32);
+    void setApertureIsDoubleLod(bool);
+    void setApertureLayerNum(s32);
+    void setApertureLodOffset(s32);
+    void setApertureMinGridDivLevel(s32);
+    void setAperturePatchLength(f32);
+    void setApertureQuadLayerLevel(s32);
+    void setCloudSeaParameter();
+    void setGridMeshParam(f32, f32, f32, f32, s32);
+    void setHeight(f32 height);
+    void setOceanTextureCoefSmallL(f32);
+    void setOceanTextureInitParam(f32, f32, f32, f32, f32);
+    void setOceanTextureParam(f32, f32, f32);
+    void setOceanTextureTexLenScale(f32);
+
+    bool tryCalcDepthRate(f32*, const sead::Vector3f&) const;
+    bool tryCalcHeightDepthAdd(f32*, const sead::Vector3f&) const;
+    bool tryCalcRippleHeight(f32*, const sead::Vector3f&) const;
+    bool tryCalcWaveDisplacement(sead::Vector3f*, const sead::Vector3f&) const;
+    bool tryCalcWaveHeight(f32*, const sead::Vector3f&) const;
+
+    void updateRippleCenterPos(const sead::Vector3f&);
+
+    void finalize() override;
+    void update(const GraphicsUpdateInfo&) override;
+    void calcGpu(const GraphicsCalcGpuInfo&) override;
+    void drawGBufferAfterSky(const GraphicsRenderInfo&) const override;
+    void drawForward(const GraphicsRenderInfo&, const RenderVariables&) const override;
+    void drawDeferred(const GraphicsRenderInfo&) const override;
+    void drawIndirect(const GraphicsRenderInfo&, const RenderVariables&) const override;
+    const char* getName() const override;
+
+    bool calcIsInArea(const sead::Vector3f&) const override;
+    void calcPos(sead::Vector3f*, const sead::Vector3f&) const override;
+    void calcPosFlat(sead::Vector3f*, const sead::Vector3f&) const override;
+    void calcDisplacementPos(sead::Vector3f*, const sead::Vector3f&) const override;
+    void calcNormal(sead::Vector3f*, const sead::Vector3f&) const override;
+    bool tryAddRipple(const sead::Vector3f&, f32, f32) override;
+    bool tryAddRippleWithRange(const sead::Vector3f&, f32, f32, f32, f32) override;
+    bool tryAddQuadRipple(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&,
+                          const sead::Vector3f&, f32) override;
+    void setFieldScale(f32) override;
+    const char* getTypeName() const override;
+
+    GraphicsSystemInfo* mGfxSysInfo;
+    OceanWaveTexture* mWaveTexture;
+    FluidSimulateWave* mFluidSimulateWave;
+    OrthoDepthTexture* mDepthTex;
+    OrthoDepthTexture* mBeachDepthTex;
+    OrthoDepthTexture* mHeightDepthTex;
+    OrthoDepthTexture* mAoDepthTex;
+    ExecuteDirector* mExecuteDirector;
+    VastGridMesh* mVastGridMesh;
+    ApertureMesh* mApertureMesh;
+    s32 _80;
+    s32 _84;
+    s32 _88;
+    f32 _8c;
+    f32 _90;
+    f32 mTimeScale;
+    f32 _98;
+    f32 _9c;
+    UniformBlock* mUBOOceanParam;
+    s32 mTranslucentType;
+    f32 mRefractEta;
+    f32 mRefractRate;
+    f32 mRoughness;
+    f32 mMetalness;
+    f32 mScatterScale;
+    sead::Color4f mBaseColor;
+    sead::Color4f mRefractColor;
+    f32 mPhaseK;
+    f32 mPhaseBackK;
+    f32 mPhaseRate;
+    f32 mF0;
+    f32 mHighFreqNormalUVScale;
+    f32 mHighFreqNormalScale;
+    f32 _f8;
+    sead::Color4f mColorDamp;
+    f32 mLinearDepthScale;
+    bool _110;
+    bool mIsOffSnapshotMode;
+    sead::Vector3f _114;
+    f32 mWaveHeightScale;
+    f32 mRippleNormalScale;
+    f32 _128;
+    f32 _12c;
+    f32 _130;
+    f32 _134;
+    f32 mRippleHeightClamp;
+    bool _13c;
+    EffectKeeper* _140;
+    const char* _148;
+    f32 mCameraFar;
+    f32 _154;
+    f32 mDepthRateMin;
+    bool _15c;
+    f32 mHeightCheckDist;
+    f32 mFarFlatDistNear;
+    f32 mFarFlatDistFar;
+    f32 mFarFlatDistNrmNear;
+    f32 mFarFlatDistNrmFar;
+    f32 mFarFlatDistHighNrmNear;
+    f32 mFarFlatDistHighNrmFar;
+    f32 mFarNrmMinRate;
+    f32 mFarRoughness;
+    f32 _184;
+    FogParam* mFogParam;
+    YFogParam* mYFogParam;
+    sead::Vector3f _198;
+    f32 _1a4;
+    f32 _1a8;
+    f32 _1ac;
+    f32 mShoreDepthGradScale;
+    f32 mShoreRippleGradScale;
+    f32 mShoreColorScale;
+    bool _1bc;
+    f32 mCloudBacklightIntensity;
+    f32 mCloudTransparencyDistance;
+    bool mIsEnableRippleAlpha;
+    f32 mNoiseTexCrdScale;
+    sead::Vector3f _1d0;
+    sead::Vector3f mNoiseTexCrdAdd;
+    bool mIsEnableNoiseTex;
+    s32 _1ec;
+    sead::Vector4f mBubbleParam;   // these two should be separated into their
+    sead::Vector4f mBubbleParam2;  // individual params when figured out
+    sead::Color4f mBubbleColor;
+    f32 _220;
+    sead::Vector3f _224;
+    sead::Vector3f _230;
+    f32 _23c;
+    f32 _240;
+    f32 _244;
+    f32 _248;
+    f32 _24c;
+    f32 _250;
+    s32 _254;
+    f32 _258;
+    f32 _25c;
+    bool _260;
+    f32 mSphereCurveTonePower;
+    f32 mSphereCurveSlope;
+    f32 mSphereCurvePeakPos;
+    f32 mSphereCurvePeakPower;
+    f32 mSphereCurvePeakIntensity;
+    f32 mSphereCurveFrontK;
+    f32 mSphereCurveBackK;
+    f32 mSphereCurveFrontBackRate;
+    bool mIsEnableSphereCurve;
+    bool mIsEnableShadow;
+    bool mIsEnableAoShadow;
+    sead::Color4f mAoShadowColor;
+    bool _298;
+    bool mIsDisableShore;
+    bool mIsRipple;
+    bool _29b;
+    u8 mDepthFetchType;
+    s32 _2a0;
+    bool _2a4;
+    bool _2a5;
+    bool _2a6;
+    ShaderProgram* mShaderRenderOcean;
+    ShaderProgram* mShaderRenderCloudSea;
+    f32 mHeight;
+    const char* mTypeName;
+    bool _2c8;
+};
+
+static_assert(sizeof(OceanWave) == 0x2d0);
+
+}  // namespace al

--- a/lib/al/Project/Fluid/FluidSurfaceHolder.cpp
+++ b/lib/al/Project/Fluid/FluidSurfaceHolder.cpp
@@ -1,0 +1,151 @@
+#include "Project/Fluid/FluidSurfaceHolder.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Fluid/IUseFluidSurface.h"
+
+namespace al {
+
+FluidSurfaceHolder::FluidSurfaceHolder() {
+    mSurfaces.allocBuffer(40, nullptr);
+}
+
+void FluidSurfaceHolder::registerFluidSurface(IUseFluidSurface* fluidSurface) {
+    mSurfaces.pushBack(fluidSurface);
+}
+
+void FluidSurfaceHolder::setWaterRippleFieldScale(f32 fieldScale) {
+    mRippleFieldScale = fieldScale;
+    for (s32 i = 0; i < mSurfaces.size(); i++)
+        mSurfaces[i]->setFieldScale(mRippleFieldScale);
+}
+
+bool FluidSurfaceHolder::calcIsInFluid(const sead::Vector3f& trans, const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    return true;
+}
+
+// NON_MATCHING: https://decomp.me/scratch/YGKVO
+IUseFluidSurface* FluidSurfaceHolder::tryFindFluidSurface(const sead::Vector3f& trans,
+                                                          const char* type) {
+    IUseFluidSurface* out = nullptr;
+
+    if (isEqualString(type, "Anything")) {
+        f32 minDist = 100000.0f;
+        for (s32 i = 0; i < mSurfaces.size(); i++) {
+            if (!mSurfaces[i]->calcIsInArea(trans))
+                continue;
+
+            sead::Vector3f posFlat = {0.0f, 0.0f, 0.0f};
+            mSurfaces[i]->calcPosFlat(&posFlat, trans);
+
+            f32 dist = (posFlat - trans).length();
+            if (dist < minDist) {
+                minDist = dist;
+                out = mSurfaces[i];
+            }
+        }
+    } else {
+        f32 minDist = 100000.0f;
+        for (s32 i = 0; i < mSurfaces.size(); i++) {
+            if (!isEqualSubString(mSurfaces[i]->getTypeName(), type))
+                continue;
+
+            if (!mSurfaces[i]->calcIsInArea(trans))
+                continue;
+
+            sead::Vector3f posFlat = {0.0f, 0.0f, 0.0f};
+            mSurfaces[i]->calcPosFlat(&posFlat, trans);
+
+            f32 dist = (posFlat - trans).length();
+            if (dist < minDist) {
+                minDist = dist;
+                out = mSurfaces[i];
+            }
+        }
+    }
+
+    return out;
+}
+
+bool FluidSurfaceHolder::tryCalcFluidPos(sead::Vector3f* fluidPos, const sead::Vector3f& trans,
+                                         const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    mCurSurfaceIn->calcPos(fluidPos, trans);
+    return true;
+}
+
+bool FluidSurfaceHolder::tryCalcFluidPosFlat(sead::Vector3f* fluidPosFlat,
+                                             const sead::Vector3f& trans, const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    mCurSurfaceIn->calcPosFlat(fluidPosFlat, trans);
+    return true;
+}
+
+bool FluidSurfaceHolder::tryCalcFluidDisplacement(sead::Vector3f* fluidDisplacement,
+                                                  const sead::Vector3f& trans, const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    mCurSurfaceIn->calcDisplacementPos(fluidDisplacement, trans);
+    return true;
+}
+
+bool FluidSurfaceHolder::tryCalcFluidNormal(sead::Vector3f* fluidNormal,
+                                            const sead::Vector3f& trans, const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    mCurSurfaceIn->calcNormal(fluidNormal, trans);
+    return true;
+}
+
+bool FluidSurfaceHolder::tryAddRipple(const sead::Vector3f& trans, f32 a, f32 b, const char* type) {
+    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
+    if (!surface)
+        return false;
+
+    mCurSurfaceIn = surface;
+    return mCurSurfaceIn->tryAddRipple(trans, a, b);
+}
+
+bool FluidSurfaceHolder::tryAddRippleAll(const sead::Vector3f& trans, f32 a, f32 b) {
+    bool out = false;
+    for (s32 i = 0; i < mSurfaces.size(); i++)
+        out |= mSurfaces[i]->tryAddRipple(trans, a, b);
+    return out;
+}
+
+bool FluidSurfaceHolder::tryAddRippleAllWithRange(const sead::Vector3f& trans, f32 a, f32 b, f32 c,
+                                                  f32 d) {
+    bool out = false;
+    for (s32 i = 0; i < mSurfaces.size(); i++)
+        out |= mSurfaces[i]->tryAddRippleWithRange(trans, a, b, c, d);
+    return out;
+}
+
+bool FluidSurfaceHolder::tryAddQuadRippleAll(const sead::Vector3f& a, const sead::Vector3f& b,
+                                             const sead::Vector3f& c, const sead::Vector3f& d,
+                                             f32 e) {
+    bool out = false;
+    for (s32 i = 0; i < mSurfaces.size(); i++)
+        out |= mSurfaces[i]->tryAddQuadRipple(a, b, c, d, e);
+    return out;
+}
+
+}  // namespace al

--- a/lib/al/Project/Fluid/FluidSurfaceHolder.cpp
+++ b/lib/al/Project/Fluid/FluidSurfaceHolder.cpp
@@ -73,54 +73,44 @@ IUseFluidSurface* FluidSurfaceHolder::tryFindFluidSurface(const sead::Vector3f& 
 
 bool FluidSurfaceHolder::tryCalcFluidPos(sead::Vector3f* fluidPos, const sead::Vector3f& trans,
                                          const char* type) {
-    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
-    if (!surface)
+    if (!calcIsInFluid(trans, type))
         return false;
 
-    mCurSurfaceIn = surface;
     mCurSurfaceIn->calcPos(fluidPos, trans);
     return true;
 }
 
 bool FluidSurfaceHolder::tryCalcFluidPosFlat(sead::Vector3f* fluidPosFlat,
                                              const sead::Vector3f& trans, const char* type) {
-    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
-    if (!surface)
+    if (!calcIsInFluid(trans, type))
         return false;
 
-    mCurSurfaceIn = surface;
     mCurSurfaceIn->calcPosFlat(fluidPosFlat, trans);
     return true;
 }
 
 bool FluidSurfaceHolder::tryCalcFluidDisplacement(sead::Vector3f* fluidDisplacement,
                                                   const sead::Vector3f& trans, const char* type) {
-    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
-    if (!surface)
+    if (!calcIsInFluid(trans, type))
         return false;
 
-    mCurSurfaceIn = surface;
     mCurSurfaceIn->calcDisplacementPos(fluidDisplacement, trans);
     return true;
 }
 
 bool FluidSurfaceHolder::tryCalcFluidNormal(sead::Vector3f* fluidNormal,
                                             const sead::Vector3f& trans, const char* type) {
-    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
-    if (!surface)
+    if (!calcIsInFluid(trans, type))
         return false;
 
-    mCurSurfaceIn = surface;
     mCurSurfaceIn->calcNormal(fluidNormal, trans);
     return true;
 }
 
 bool FluidSurfaceHolder::tryAddRipple(const sead::Vector3f& trans, f32 a, f32 b, const char* type) {
-    IUseFluidSurface* surface = tryFindFluidSurface(trans, type);
-    if (!surface)
+    if (!calcIsInFluid(trans, type))
         return false;
 
-    mCurSurfaceIn = surface;
     return mCurSurfaceIn->tryAddRipple(trans, a, b);
 }
 

--- a/lib/al/Project/Fluid/FluidSurfaceHolder.h
+++ b/lib/al/Project/Fluid/FluidSurfaceHolder.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <container/seadPtrArray.h>
+#include <math/seadVector.h>
+
+namespace al {
+
+class IUseFluidSurface;
+
+class FluidSurfaceHolder {
+public:
+    FluidSurfaceHolder();
+
+    void registerFluidSurface(IUseFluidSurface* fluidSurface);
+    void setWaterRippleFieldScale(f32 fieldScale);
+    bool calcIsInFluid(const sead::Vector3f& trans, const char* type);
+    IUseFluidSurface* tryFindFluidSurface(const sead::Vector3f& trans, const char* type);
+    bool tryCalcFluidPos(sead::Vector3f* fluidPos, const sead::Vector3f& trans, const char* type);
+    bool tryCalcFluidPosFlat(sead::Vector3f* fluidPosFlat, const sead::Vector3f& trans,
+                             const char* type);
+    bool tryCalcFluidDisplacement(sead::Vector3f* fluidDisplacement, const sead::Vector3f& trans,
+                                  const char* type);
+    bool tryCalcFluidNormal(sead::Vector3f* fluidNormal, const sead::Vector3f& trans,
+                            const char* type);
+    bool tryAddRipple(const sead::Vector3f& trans, f32, f32, const char* type);
+    bool tryAddRippleAll(const sead::Vector3f& trans, f32, f32);
+    bool tryAddRippleAllWithRange(const sead::Vector3f& trans, f32, f32, f32, f32);
+    bool tryAddQuadRippleAll(const sead::Vector3f&, const sead::Vector3f&, const sead::Vector3f&,
+                             const sead::Vector3f&, f32);
+
+private:
+    sead::PtrArray<IUseFluidSurface> mSurfaces;
+    IUseFluidSurface* mCurSurfaceIn = nullptr;
+    f32 mRippleFieldScale = 1.0f;
+};
+
+static_assert(sizeof(FluidSurfaceHolder) == 0x20);
+
+}  // namespace al

--- a/lib/al/Project/Fluid/FluidSurfaceHolder.h
+++ b/lib/al/Project/Fluid/FluidSurfaceHolder.h
@@ -22,6 +22,7 @@ public:
                                   const char* type);
     bool tryCalcFluidNormal(sead::Vector3f* fluidNormal, const sead::Vector3f& trans,
                             const char* type);
+    // TODO: add parameter names for all four functions below
     bool tryAddRipple(const sead::Vector3f& trans, f32, f32, const char* type);
     bool tryAddRippleAll(const sead::Vector3f& trans, f32, f32);
     bool tryAddRippleAllWithRange(const sead::Vector3f& trans, f32, f32, f32, f32);


### PR DESCRIPTION
FluidSurfaceHolder::tryFindFluidSurface is non-matching: https://decomp.me/scratch/YGKVO

hope it's fine that i put the OceanWave header in this PR

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1310)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1ce9676 - b465397)

📈 **Matched code**: 15.30% (+0.01%, +1164 bytes)

<details>
<summary>✅ 12 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryAddQuadRippleAll(sead::Vector3<float> const&, sead::Vector3<float> const&, sead::Vector3<float> const&, sead::Vector3<float> const&, float)` | +172 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryAddRippleAllWithRange(sead::Vector3<float> const&, float, float, float, float)` | +164 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryAddRippleAll(sead::Vector3<float> const&, float, float)` | +140 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::setWaterRippleFieldScale(float)` | +120 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryAddRipple(sead::Vector3<float> const&, float, float, char const*)` | +96 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryCalcFluidPos(sead::Vector3<float>*, sead::Vector3<float> const&, char const*)` | +88 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryCalcFluidPosFlat(sead::Vector3<float>*, sead::Vector3<float> const&, char const*)` | +88 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryCalcFluidDisplacement(sead::Vector3<float>*, sead::Vector3<float> const&, char const*)` | +88 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryCalcFluidNormal(sead::Vector3<float>*, sead::Vector3<float> const&, char const*)` | +88 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::registerFluidSurface(al::IUseFluidSurface*)` | +44 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::calcIsInFluid(sead::Vector3<float> const&, char const*)` | +44 | 0.00% | 100.00% |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::FluidSurfaceHolder()` | +32 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Fluid/FluidSurfaceHolder` | `al::FluidSurfaceHolder::tryFindFluidSurface(sead::Vector3<float> const&, char const*)` | +141 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->