### PR TITLE
Event: Implement `EventFlowNodeAmiiboTouchLayout`

### DIFF
--- a/src/Event/EventFlowNodeAmiiboTouchLayout.cpp
+++ b/src/Event/EventFlowNodeAmiiboTouchLayout.cpp
@@ -1,0 +1,164 @@
+#include "Library/Event/EventFlowFunction.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Nfp/NfpFunction.h"
+#include "Library/Nfp/NfpTypes.h"
+
+#include "Amiibo/AmiiboNpcDirector.h"
+#include "Event/EventFlowNodeAmiiboTouchLayout.h"
+#include "Layout/AmiiboNpcLayout.h"
+#include "Util/AmiiboUtil.h"
+#include "Util/NpcEventFlowUtil.h"
+#include "Util/StageInputFunction.h"
+
+namespace {
+NERVE_IMPL(EventFlowNodeAmiiboTouchLayout, RequestAppearLayout);
+NERVE_IMPL(EventFlowNodeAmiiboTouchLayout, WaitTouchTrigger);
+NERVE_IMPL(EventFlowNodeAmiiboTouchLayout, WaitTouchAmiibo);
+NERVE_IMPL(EventFlowNodeAmiiboTouchLayout, IconEnd);
+NERVE_IMPL(EventFlowNodeAmiiboTouchLayout, WaitEndLayout);
+
+NERVES_MAKE_NOSTRUCT(EventFlowNodeAmiiboTouchLayout, RequestAppearLayout);
+NERVES_MAKE_STRUCT(EventFlowNodeAmiiboTouchLayout, WaitTouchTrigger, WaitTouchAmiibo, IconEnd,
+                   WaitEndLayout);
+}  // namespace
+
+EventFlowNodeAmiiboTouchLayout::EventFlowNodeAmiiboTouchLayout(const char* name)
+    : al::EventFlowNode(name) {}
+
+void EventFlowNodeAmiiboTouchLayout::init(const al::EventFlowNodeInitInfo& info) {
+    al::initEventFlowNode(this, info);
+    al::initEventQuery(this, info);
+    initNerve(&RequestAppearLayout, 0);
+}
+
+void EventFlowNodeAmiiboTouchLayout::start() {
+    al::EventFlowNode::start();
+    al::setNerve(this, &RequestAppearLayout);
+    if (rs::isOpenWaitNpcDemoEventTalkMessage(getActor()))
+        rs::startCloseNpcDemoEventTalkMessage(getActor());
+}
+
+s32 EventFlowNodeAmiiboTouchLayout::getNextId() const {
+    return al::getCaseEventNextId(this, mCaseEventIdx);
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeRequestAppearLayout() {
+    if (AmiiboFunction::requestAppearAmiiboLayout(getActor()))
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchTrigger);
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeWaitTouchTrigger() {
+    if (rs::isHoldAmiiboMode(getActor())) {
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchAmiibo);
+        return;
+    }
+
+    tryCancel();
+}
+
+bool EventFlowNodeAmiiboTouchLayout::tryCancel() {
+    al::LiveActor* actor = getActor();
+
+    if (rs::isTriggerUiCancel(actor)) {
+        mCaseEventIdx = 4;
+        AmiiboFunction::requestEndAmiiboLayout(actor);
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+        return true;
+    }
+
+    return false;
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeCountHold() {
+    if (!rs::isHoldAmiiboMode(getActor())) {
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchTrigger);
+        return;
+    }
+
+    if (!tryCancel() && al::isGreaterEqualStep(this, 8))
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchAmiibo);
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeWaitTouchAmiibo() {
+    al::LiveActor* actor = getActor();
+
+    if (rs::isTriggerUiCancel(actor)) {
+        mCaseEventIdx = 4;
+        AmiiboFunction::requestEndAmiiboLayout(actor);
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+        return;
+    }
+
+    if (!rs::isHoldAmiiboMode(actor)) {
+        AmiiboFunction::getAmiiboTouchLayout(actor)->endTouch();
+        AmiiboFunction::stopNfpTouch(actor);
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.IconEnd);
+        return;
+    }
+
+    if (al::isFirstStep(this))
+        AmiiboFunction::startNfpTouch(actor);
+
+    if (al::isLessStep(this, 10) && AmiiboFunction::isNfpErrorHandled(actor)) {
+        AmiiboFunction::stopNfpTouch(actor);
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchTrigger);
+        return;
+    }
+
+    if (al::isStep(this, 10))
+        AmiiboFunction::getAmiiboTouchLayout(actor)->startTouch();
+
+    touch(AmiiboFunction::tryGetTriggerTouchNfpInfo(getActor()));
+}
+
+void EventFlowNodeAmiiboTouchLayout::touch(const al::NfpInfo* nfpInfo) {
+    if (!nfpInfo)
+        return;
+
+    al::LiveActor* actor = getActor();
+
+    if (AmiiboFunction::isSearchAmiibo(actor, *nfpInfo))
+        mCaseEventIdx = 3;
+    else if (rs::isEnableUseStageSceneAmiibo(*nfpInfo))
+        mCaseEventIdx = 0;
+    else if (rs::isExistAmiiboMstxtData(this, *nfpInfo))
+        mCaseEventIdx = 1;
+    else
+        mCaseEventIdx = 2;
+
+    AmiiboFunction::stopNfpTouch(actor);
+    AmiiboFunction::requestDecideAmiiboLayout(actor);
+
+    al::NfpCharacterId characterId = {};
+    al::tryGetCharacterId(&characterId, *nfpInfo);
+
+    s32 numberingId = 0;
+    al::tryGetNumberingId(&numberingId, *nfpInfo);
+
+    s32 id = rs::createCharacterIdS32(characterId);
+    AmiiboFunction::setTouchAmiiboName(actor, id, numberingId);
+    AmiiboFunction::trySetAmiiboCostumeName(actor, id);
+
+    al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeIconEnd() {
+    al::LiveActor* actor = getActor();
+
+    if (rs::isTriggerUiCancel(actor)) {
+        mCaseEventIdx = 4;
+        AmiiboFunction::requestEndAmiiboLayout(actor);
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+        return;
+    }
+
+    if (AmiiboFunction::getAmiiboTouchLayout(actor)->isIconEndActionEnd())
+        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchTrigger);
+}
+
+void EventFlowNodeAmiiboTouchLayout::exeWaitEndLayout() {
+    if (AmiiboFunction::isEndAmiiboLayout(getActor()))
+        end();
+}

--- a/src/Event/EventFlowNodeAmiiboTouchLayout.cpp
+++ b/src/Event/EventFlowNodeAmiiboTouchLayout.cpp
@@ -1,3 +1,5 @@
+#include "Event/EventFlowNodeAmiiboTouchLayout.h"
+
 #include "Library/Event/EventFlowFunction.h"
 #include "Library/LiveActor/LiveActor.h"
 #include "Library/Nerve/NerveSetupUtil.h"
@@ -6,7 +8,6 @@
 #include "Library/Nfp/NfpTypes.h"
 
 #include "Amiibo/AmiiboNpcDirector.h"
-#include "Event/EventFlowNodeAmiiboTouchLayout.h"
 #include "Layout/AmiiboNpcLayout.h"
 #include "Util/AmiiboUtil.h"
 #include "Util/NpcEventFlowUtil.h"
@@ -84,12 +85,8 @@ void EventFlowNodeAmiiboTouchLayout::exeCountHold() {
 void EventFlowNodeAmiiboTouchLayout::exeWaitTouchAmiibo() {
     al::LiveActor* actor = getActor();
 
-    if (rs::isTriggerUiCancel(actor)) {
-        mCaseEventIdx = 4;
-        AmiiboFunction::requestEndAmiiboLayout(actor);
-        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+    if (tryCancel())
         return;
-    }
 
     if (!rs::isHoldAmiiboMode(actor)) {
         AmiiboFunction::getAmiiboTouchLayout(actor)->endTouch();
@@ -147,12 +144,8 @@ void EventFlowNodeAmiiboTouchLayout::touch(const al::NfpInfo* nfpInfo) {
 void EventFlowNodeAmiiboTouchLayout::exeIconEnd() {
     al::LiveActor* actor = getActor();
 
-    if (rs::isTriggerUiCancel(actor)) {
-        mCaseEventIdx = 4;
-        AmiiboFunction::requestEndAmiiboLayout(actor);
-        al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitEndLayout);
+    if (tryCancel())
         return;
-    }
 
     if (AmiiboFunction::getAmiiboTouchLayout(actor)->isIconEndActionEnd())
         al::setNerve(this, &NrvEventFlowNodeAmiiboTouchLayout.WaitTouchTrigger);

--- a/src/Event/EventFlowNodeAmiiboTouchLayout.h
+++ b/src/Event/EventFlowNodeAmiiboTouchLayout.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/Event/EventFlowNode.h"
+
+namespace al {
+struct NfpInfo;
+}
+
+class EventFlowNodeAmiiboTouchLayout : public al::EventFlowNode {
+public:
+    EventFlowNodeAmiiboTouchLayout(const char* name);
+
+    void init(const al::EventFlowNodeInitInfo& info) override;
+    void start() override;
+    s32 getNextId() const override;
+
+    bool tryCancel();
+    void touch(const al::NfpInfo* nfpInfo);
+
+    void exeRequestAppearLayout();
+    void exeWaitTouchTrigger();
+    void exeCountHold();
+    void exeWaitTouchAmiibo();
+    void exeIconEnd();
+    void exeWaitEndLayout();
+
+private:
+    s32 mCaseEventIdx = 4;
+};

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -63,7 +63,7 @@ void initEventCameraObject(al::EventFlowExecutor* executor, const al::ActorInitI
 void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* executor,
                                         const al::ActorInitInfo& initInfo, const char*);
 void initEventCameraTalk(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
-                         const char*, float);
+                         const char*, f32);
 void initEventCameraTalk2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
                           const char*);
 void initEventCameraLookBoard(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
@@ -71,19 +71,19 @@ void initEventCameraLookBoard(al::EventFlowExecutor* executor, const al::ActorIn
 void initEventCameraAnim(al::EventFlowExecutor* executor, const al::LiveActor* actor,
                          const al::ActorInitInfo& initInfo, const char*);
 void initEventCameraFixActor(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
-                             const char*, const al::LiveActor* actor, const sead::Vector3f*, float,
-                             float, float);
+                             const char*, const al::LiveActor* actor, const sead::Vector3f*, f32,
+                             f32, f32);
 void initEventCameraFixActor2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
-                              const char*, const al::LiveActor* actor, const sead::Vector3f*, float,
-                              float, float, bool);
+                              const char*, const al::LiveActor* actor, const sead::Vector3f*, f32,
+                              f32, f32, bool);
 void initEventCameraFixActorAutoAroundFront(al::EventFlowExecutor* executor,
                                             const al::ActorInitInfo& initInfo, const char*,
-                                            const al::LiveActor* actor, const sead::Vector3f*,
-                                            float, float, float, bool);
+                                            const al::LiveActor* actor, const sead::Vector3f*, f32,
+                                            f32, f32, bool);
 void initEventCameraFixActorAutoAroundFront2(al::EventFlowExecutor* executor,
                                              const al::ActorInitInfo& initInfo, const char*,
-                                             const al::LiveActor* actor, const sead::Vector3f*,
-                                             float, float, float);
+                                             const al::LiveActor* actor, const sead::Vector3f*, f32,
+                                             f32, f32);
 bool isDefinedEventCamera(const al::EventFlowExecutor* executor, const char*);
 void initEventActionNameConverter(al::EventFlowExecutor* executor,
                                   const al::IEventFlowActionNameConverter*);
@@ -94,7 +94,7 @@ void checkMatchPatternCurrentCostume(bool*, bool*, const al::LiveActor* actor, c
 bool checkMatchPatternCurrentCostumePair(const al::LiveActor* actor, const char*);
 bool isSuccessNpcEventBalloonMessage(const al::LiveActor* actor);
 bool isPlayingNpcEventBalloonMessageVoice(const al::LiveActor* actor);
-void requestNpcEventBalloonMessage(al::EventFlowNode*, const char16_t*,
+void requestNpcEventBalloonMessage(al::EventFlowNode*, const char16*,
                                    const NpcEventBalloonRequestInfo&);
 void requestNpcEventTalkBalloonMessage(al::EventFlowNode*, const char*,
                                        const NpcEventBalloonRequestInfo&);
@@ -136,9 +136,9 @@ bool tryShowDemoPlayerIfRequested(al::LiveActor* actor, al::EventFlowExecutor*);
 bool tryStartDemoPlayerActionIfRequested(al::LiveActor* actor, al::EventFlowExecutor*);
 void swapEventCharacterName(al::EventFlowExecutor* executor, const sead::WBufferedSafeString*);
 void resetEventCharacterName(al::EventFlowExecutor*);
-void startOpenNpcDemoEventTalkMessage(al::EventFlowNode*, const char16_t*);
-void startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode*, const char16_t*);
-void startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode*, const char16_t*, int);
+void startOpenNpcDemoEventTalkMessage(al::EventFlowNode*, const char16*);
+void startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode*, const char16*);
+void startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode*, const char16*, s32);
 void startCloseNpcDemoEventTalkMessage(al::LiveActor* actor);
 bool isOpenWaitNpcDemoEventTalkMessage(const al::LiveActor* actor);
 bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor* actor);
@@ -147,8 +147,8 @@ bool isCloseNpcDemoEventTalkMessage(const al::LiveActor* actor);
 const char* getEventTalkWindowMessageStyle(const al::EventFlowNode*);
 bool isCloseEventWipeFadeBlack(const al::EventFlowNode*);
 bool isOpenEventWipeFadeBlack(const al::EventFlowNode*);
-void requestCloseEventWipeFadeBlack(al::EventFlowNode*, int);
-void requestOpenEventWipeFadeBlack(al::EventFlowNode*, int);
+void requestCloseEventWipeFadeBlack(al::EventFlowNode*, s32);
+void requestOpenEventWipeFadeBlack(al::EventFlowNode*, s32);
 void calcPlayerWatchTrans(sead::Vector3f*, const al::LiveActor* actor, const TalkNpcParam*);
 bool isPlayerInWater(const al::EventFlowNode*);
 bool isNpcScareTiming(const al::EventFlowExecutor*);
@@ -159,10 +159,10 @@ sead::Vector3f* getNpcLookPos(const al::EventFlowExecutor*);
 bool isExistTrafficAreaDirector(const al::LiveActor* actor);
 bool tryPermitEnterTrafficNpcAndSyncDrawClipping(al::LiveActor* actor);
 bool tryPermitEnterTrafficCar(const al::LiveActor* actor, const sead::Vector3f&);
-void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, int doorIndex);
-void requestSwitchTalkNpcEventVolleyBall(al::LiveActor* actor, int);
-void requestSwitchTalkNpcEventJumpingRope(al::LiveActor* actor, int);
-void requestSwitchTalkNpcEventRadicon(al::LiveActor* actor, int);
+void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
+void requestSwitchTalkNpcEventVolleyBall(al::LiveActor* actor, s32);
+void requestSwitchTalkNpcEventJumpingRope(al::LiveActor* actor, s32);
+void requestSwitchTalkNpcEventRadicon(al::LiveActor* actor, s32);
 bool isEventAfterDoorSnow1(const al::EventFlowNode*);
 bool isEventAfterDoorSnow2(const al::EventFlowNode*);
 bool isEventAfterDoorSnow3(const al::EventFlowNode*);
@@ -177,7 +177,7 @@ void requestEventGetAchievement(al::LiveActor* actor, const char*);
 bool checkEndSceneExecuteAndResetRequest(al::EventFlowNode*);
 bool checkEndSceneExecuteAndResetRequest(al::LiveActor* actor);
 bool isExecuteSceneEvent(const al::LiveActor* actor);
-bool checkTriggerDecideWithRequestIcon(al::LiveActor* actor, const sead::Vector3f&, float);
+bool checkTriggerDecideWithRequestIcon(al::LiveActor* actor, const sead::Vector3f&, f32);
 void skipEventDemo(al::EventFlowExecutor*);
 }  // namespace rs
 

--- a/src/Util/NpcEventFlowUtil.h
+++ b/src/Util/NpcEventFlowUtil.h
@@ -2,32 +2,186 @@
 
 #include <basis/seadTypes.h>
 #include <math/seadVector.h>
+#include <prim/seadSafeString.h>
 
 namespace al {
 struct ActorInitInfo;
 class EventFlowExecutor;
 class LiveActor;
 class MessageTagDataHolder;
+class EventFlowMovement;
+class IEventFlowActionNameConverter;
+class IEventFlowQueryJudge;
+class EventFlowNode;
+struct EventFlowChoiceInfo;
+class EventFlowEventData;
 }  // namespace al
 
+class TalkNpcParam;
+struct NpcEventBalloonRequestInfo;
+class Shine;
+struct TalkNpcActionAnimInfo;
+
 namespace rs {
-al::EventFlowExecutor* initEventFlow(al::LiveActor*, const al::ActorInitInfo&, const char*,
-                                     const char*);
-al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor*, const al::ActorInitInfo&, const char*,
-                                           const char*, const char*);
-bool isDefinedEventCamera(const al::EventFlowExecutor*, const char*);
-bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
-void startEventFlow(al::EventFlowExecutor*, const char*);
+al::EventFlowExecutor* initEventFlow(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                     const char*, const char*);
+al::EventFlowExecutor* initEventFlowForRunAwayNpc(al::LiveActor* actor,
+                                                  const al::ActorInitInfo& initInfo, const char*,
+                                                  const char*);
+al::EventFlowExecutor* initEventFlowForSystem(al::LiveActor* actor,
+                                              const al::ActorInitInfo& initInfo, const char*,
+                                              const char*, const char*);
+al::EventFlowExecutor* initEventFlowSuffix(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                           const char*, const char*, const char*);
+al::EventFlowExecutor* initEventFlowFromPlacementInfo(al::LiveActor* actor,
+                                                      const al::ActorInitInfo& initInfo,
+                                                      const char*);
+al::EventFlowExecutor* initCommonEventFlow(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                                           const char*);
+al::EventFlowExecutor* createCommonEventFlowFromPlacementInfo(al::LiveActor* actor,
+                                                              const al::ActorInitInfo& initInfo);
+void initEventCharacterName(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                            const char*);
+void makeEventCharacterName(sead::WBufferedSafeString*, const al::ActorInitInfo& initInfo,
+                            const char*);
+void initEventParam(al::EventFlowExecutor* executor, const TalkNpcParam*, const char*);
+bool tryInitItemKeeperByEvent(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
+                              const al::EventFlowExecutor*);
+void startEventFlow(al::EventFlowExecutor* executor, const char*);
 bool updateEventFlow(al::EventFlowExecutor*);
-void initEventMessageTagDataHolder(al::EventFlowExecutor*, const al::MessageTagDataHolder*);
-void initEventCameraObject(al::EventFlowExecutor* flowExecutor, const al::ActorInitInfo& initInfo,
+void stopEventFlow(al::EventFlowExecutor*);
+void restartEventFlow(al::EventFlowExecutor*);
+void initEventMovementRail(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo);
+void initEventMovement(al::EventFlowExecutor* executor, al::EventFlowMovement*,
+                       const al::ActorInitInfo& initInfo);
+void initEventMovementTurnSeparate(al::EventFlowExecutor* executor,
+                                   const al::ActorInitInfo& initInfo);
+void initEventMovementWait(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo);
+void initEventMovementWander(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo);
+void initEventCameraObject(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
                            const char* name);
-void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* flowExecutor,
-                                        const al::ActorInitInfo& initInfo, const char* name);
-bool isSuccessNpcEventBalloonMessage(const al::LiveActor*);
-void setEventBalloonFilterOnlyMiniGame(const al::LiveActor*);
-void resetEventBalloonFilter(const al::LiveActor*);
-void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, s32 doorIndex);
-void requestSwitchTalkNpcEventVolleyBall(al::LiveActor*, s32);
-bool checkTriggerDecideWithRequestIcon(al::LiveActor*, const sead::Vector3f&, f32);
+void initEventCameraObjectAfterKeepPose(al::EventFlowExecutor* executor,
+                                        const al::ActorInitInfo& initInfo, const char*);
+void initEventCameraTalk(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                         const char*, float);
+void initEventCameraTalk2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                          const char*);
+void initEventCameraLookBoard(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                              const sead::Vector3f&, const char*);
+void initEventCameraAnim(al::EventFlowExecutor* executor, const al::LiveActor* actor,
+                         const al::ActorInitInfo& initInfo, const char*);
+void initEventCameraFixActor(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                             const char*, const al::LiveActor* actor, const sead::Vector3f*, float,
+                             float, float);
+void initEventCameraFixActor2(al::EventFlowExecutor* executor, const al::ActorInitInfo& initInfo,
+                              const char*, const al::LiveActor* actor, const sead::Vector3f*, float,
+                              float, float, bool);
+void initEventCameraFixActorAutoAroundFront(al::EventFlowExecutor* executor,
+                                            const al::ActorInitInfo& initInfo, const char*,
+                                            const al::LiveActor* actor, const sead::Vector3f*,
+                                            float, float, float, bool);
+void initEventCameraFixActorAutoAroundFront2(al::EventFlowExecutor* executor,
+                                             const al::ActorInitInfo& initInfo, const char*,
+                                             const al::LiveActor* actor, const sead::Vector3f*,
+                                             float, float, float);
+bool isDefinedEventCamera(const al::EventFlowExecutor* executor, const char*);
+void initEventActionNameConverter(al::EventFlowExecutor* executor,
+                                  const al::IEventFlowActionNameConverter*);
+void initEventQueryJudge(al::EventFlowExecutor* executor, const al::IEventFlowQueryJudge*);
+void initEventMessageTagDataHolder(al::EventFlowExecutor* executor,
+                                   const al::MessageTagDataHolder*);
+void checkMatchPatternCurrentCostume(bool*, bool*, const al::LiveActor* actor, const char*);
+bool checkMatchPatternCurrentCostumePair(const al::LiveActor* actor, const char*);
+bool isSuccessNpcEventBalloonMessage(const al::LiveActor* actor);
+bool isPlayingNpcEventBalloonMessageVoice(const al::LiveActor* actor);
+void requestNpcEventBalloonMessage(al::EventFlowNode*, const char16_t*,
+                                   const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessage(al::EventFlowNode*, const char*,
+                                       const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageEntranceCamera(al::EventFlowNode*, const char*,
+                                                     const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageWithEnableButtonA(al::EventFlowNode*, const char*,
+                                                        const NpcEventBalloonRequestInfo&);
+void requestNpcEventTalkBalloonMessageWithDisableButtonA(al::EventFlowNode*, const char*,
+                                                         const NpcEventBalloonRequestInfo&);
+void requestNpcEventActionBalloonMessage(al::LiveActor* actor, bool,
+                                         const NpcEventBalloonRequestInfo&);
+void setEventBalloonFilterOnlyMiniGame(const al::LiveActor* actor);
+void resetEventBalloonFilter(const al::LiveActor* actor);
+void startChoiceEvent(al::EventFlowNode*, al::EventFlowChoiceInfo*);
+bool isSuccessLockEventTalkDemo(const al::EventFlowNode*);
+bool tryLockStartEventTalkDemo(al::EventFlowNode*);
+bool tryLockStartEventTalkDemoWithoutBalloon(al::EventFlowNode*);
+bool tryStartEventTalkDemo(al::EventFlowNode*);
+bool tryStartEventTalkOnlyRequesterDemo(al::EventFlowNode*);
+bool tryStartEventTalkKeepHackDemo(al::EventFlowNode*);
+bool tryStartEventTalkUseCoinDemo(al::EventFlowNode*);
+bool tryStartEventNormalDemo(al::EventFlowNode*);
+bool tryStartEventKeepBindDemo(al::LiveActor* actor);
+bool tryStartEventCutSceneDemo(al::LiveActor* actor);
+bool tryStartEventCutSceneKeepHackDemo(al::LiveActor* actor);
+bool tryStartEventCutSceneTalkOnlyRequesterDemo(al::LiveActor* actor);
+void endEventCutSceneDemo(al::LiveActor* actor);
+void endEventCutSceneTalkOnlyRequeterDemo(al::LiveActor* actor);
+void endEventCutSceneDemoBySkip(al::LiveActor* actor);
+void endEventCutSceneDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor* actor);
+void endEventCutSceneTalkOnlyRequeterDemoOrTryEndEventCutSceneDemoBySkip(al::LiveActor* actor);
+void requestEndEventDemo(al::LiveActor* actor);
+void requestEndEventDemo(al::EventFlowNode*);
+bool isActiveEventDemo(const al::EventFlowNode*);
+bool isActiveEventDemo(const al::LiveActor* actor);
+bool isEqualEventDemoStartActor(const al::LiveActor* actor);
+bool tryHideDemoPlayerIfRequested(al::LiveActor* actor, al::EventFlowExecutor*);
+bool tryShowDemoPlayerIfRequested(al::LiveActor* actor, al::EventFlowExecutor*);
+bool tryStartDemoPlayerActionIfRequested(al::LiveActor* actor, al::EventFlowExecutor*);
+void swapEventCharacterName(al::EventFlowExecutor* executor, const sead::WBufferedSafeString*);
+void resetEventCharacterName(al::EventFlowExecutor*);
+void startOpenNpcDemoEventTalkMessage(al::EventFlowNode*, const char16_t*);
+void startOpenNpcDemoEventTalkMessageWithButtonA(al::EventFlowNode*, const char16_t*);
+void startOpenNpcDemoEventSystemMessageWithButtonA(al::EventFlowNode*, const char16_t*, int);
+void startCloseNpcDemoEventTalkMessage(al::LiveActor* actor);
+bool isOpenWaitNpcDemoEventTalkMessage(const al::LiveActor* actor);
+bool isPlayingTextPaneAnimEventTalkMessage(const al::LiveActor* actor);
+bool isEndNpcDemoEventTalkMessage(const al::EventFlowNode*);
+bool isCloseNpcDemoEventTalkMessage(const al::LiveActor* actor);
+const char* getEventTalkWindowMessageStyle(const al::EventFlowNode*);
+bool isCloseEventWipeFadeBlack(const al::EventFlowNode*);
+bool isOpenEventWipeFadeBlack(const al::EventFlowNode*);
+void requestCloseEventWipeFadeBlack(al::EventFlowNode*, int);
+void requestOpenEventWipeFadeBlack(al::EventFlowNode*, int);
+void calcPlayerWatchTrans(sead::Vector3f*, const al::LiveActor* actor, const TalkNpcParam*);
+bool isPlayerInWater(const al::EventFlowNode*);
+bool isNpcScareTiming(const al::EventFlowExecutor*);
+bool isExistNpcLookPos(const al::LiveActor* actor);
+bool isExistNpcLookPos(const al::EventFlowExecutor*);
+sead::Vector3f* getNpcLookPos(const al::LiveActor* actor);
+sead::Vector3f* getNpcLookPos(const al::EventFlowExecutor*);
+bool isExistTrafficAreaDirector(const al::LiveActor* actor);
+bool tryPermitEnterTrafficNpcAndSyncDrawClipping(al::LiveActor* actor);
+bool tryPermitEnterTrafficCar(const al::LiveActor* actor, const sead::Vector3f&);
+void requestSwitchTalkNpcEventAfterDoorSnow(al::LiveActor* actor, int doorIndex);
+void requestSwitchTalkNpcEventVolleyBall(al::LiveActor* actor, int);
+void requestSwitchTalkNpcEventJumpingRope(al::LiveActor* actor, int);
+void requestSwitchTalkNpcEventRadicon(al::LiveActor* actor, int);
+bool isEventAfterDoorSnow1(const al::EventFlowNode*);
+bool isEventAfterDoorSnow2(const al::EventFlowNode*);
+bool isEventAfterDoorSnow3(const al::EventFlowNode*);
+bool isEventAfterDoorSnow4(const al::EventFlowNode*);
+const char* tryGetTalkNpcVolleyBallEntryName(const al::LiveActor* actor);
+const char* tryGetTalkNpcJumpingRopeEntryName(const al::LiveActor* actor);
+const char* tryGetTalkNpcRadiconEntryName(const al::LiveActor* actor);
+void requestEventGetShineDirect(al::EventFlowNode*, Shine*);
+void requestEventOpenBgmList(al::EventFlowNode*);
+void requestEventOpenShineList(al::LiveActor* actor);
+void requestEventGetAchievement(al::LiveActor* actor, const char*);
+bool checkEndSceneExecuteAndResetRequest(al::EventFlowNode*);
+bool checkEndSceneExecuteAndResetRequest(al::LiveActor* actor);
+bool isExecuteSceneEvent(const al::LiveActor* actor);
+bool checkTriggerDecideWithRequestIcon(al::LiveActor* actor, const sead::Vector3f&, float);
+void skipEventDemo(al::EventFlowExecutor*);
 }  // namespace rs
+
+namespace TalkNpcFunction {
+bool receiveEventChangeWaitAction(TalkNpcActionAnimInfo*, const al::EventFlowEventData*,
+                                  const TalkNpcParam*);
+}


### PR DESCRIPTION
also completed the header of NpcEventFlowUtil.h (i'm not convinced that the last two functions are in this file, probably in the next one since they're to do with sensors and not event flow)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1311)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (844570d - 3ceaf76)

📈 **Matched code**: 15.31% (+0.02%, +1980 bytes)

<details>
<summary>✅ 17 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeWaitTouchAmiibo()` | +296 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::touch(al::NfpInfo const*)` | +256 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeCountHold()` | +180 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `(anonymous namespace)::EventFlowNodeAmiiboTouchLayoutNrvWaitTouchTrigger::execute(al::NerveKeeper*) const` | +156 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeWaitTouchTrigger()` | +144 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `(anonymous namespace)::EventFlowNodeAmiiboTouchLayoutNrvIconEnd::execute(al::NerveKeeper*) const` | +144 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeIconEnd()` | +132 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::tryCancel()` | +104 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `(anonymous namespace)::EventFlowNodeAmiiboTouchLayoutNrvRequestAppearLayout::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `(anonymous namespace)::EventFlowNodeAmiiboTouchLayoutNrvWaitEndLayout::execute(al::NerveKeeper*) const` | +88 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::start()` | +80 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeRequestAppearLayout()` | +76 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::exeWaitEndLayout()` | +76 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::EventFlowNodeAmiiboTouchLayout(char const*)` | +68 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::init(al::EventFlowNodeInitInfo const&)` | +64 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `(anonymous namespace)::EventFlowNodeAmiiboTouchLayoutNrvWaitTouchAmiibo::execute(al::NerveKeeper*) const` | +20 | 0.00% | 100.00% |
| `Event/EventFlowNodeAmiiboTouchLayout` | `EventFlowNodeAmiiboTouchLayout::getNextId() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->