### PR TITLE
Player: Implement `CollisionShapeInfo{Arrow,Sphere,Disk}` bounding accessors

### DIFF
--- a/src/Player/CollisionShapeInfo.cpp
+++ b/src/Player/CollisionShapeInfo.cpp
@@ -2,3 +2,75 @@
 
 CollisionShapeInfoBase::CollisionShapeInfoBase(CollisionShapeId id, const char* name)
     : mId(id), mName(name) {}
+
+const sead::Vector3f& CollisionShapeInfoArrow::getBoundingCenter() const {
+    return mBoundingCenter;
+}
+
+const sead::Vector3f& CollisionShapeInfoArrow::getBoundingCenterWorld() const {
+    return mBoundingCenterWorld;
+}
+
+f32 CollisionShapeInfoArrow::getBoundingRadius() const {
+    return mBoundingRadius;
+}
+
+f32 CollisionShapeInfoArrow::getBoundingRadiusWorld() const {
+    return mBoundingRadiusWorld;
+}
+
+f32 CollisionShapeInfoArrow::getCheckStepRange() const {
+    return mBoundingRadius;
+}
+
+f32 CollisionShapeInfoArrow::getCheckStepRangeWorld() const {
+    return mBoundingRadiusWorld;
+}
+
+const sead::Vector3f& CollisionShapeInfoSphere::getBoundingCenter() const {
+    return mBoundingCenter;
+}
+
+const sead::Vector3f& CollisionShapeInfoSphere::getBoundingCenterWorld() const {
+    return mBoundingCenterWorld;
+}
+
+f32 CollisionShapeInfoSphere::getBoundingRadius() const {
+    return mBoundingRadius;
+}
+
+f32 CollisionShapeInfoSphere::getBoundingRadiusWorld() const {
+    return mBoundingRadiusWorld;
+}
+
+f32 CollisionShapeInfoSphere::getCheckStepRange() const {
+    return mBoundingRadius;
+}
+
+f32 CollisionShapeInfoSphere::getCheckStepRangeWorld() const {
+    return mBoundingRadiusWorld;
+}
+
+const sead::Vector3f& CollisionShapeInfoDisk::getBoundingCenter() const {
+    return mBoundingCenter;
+}
+
+const sead::Vector3f& CollisionShapeInfoDisk::getBoundingCenterWorld() const {
+    return mBoundingCenterWorld;
+}
+
+f32 CollisionShapeInfoDisk::getBoundingRadius() const {
+    return mBoundingRadius;
+}
+
+f32 CollisionShapeInfoDisk::getBoundingRadiusWorld() const {
+    return mBoundingRadiusWorld;
+}
+
+f32 CollisionShapeInfoDisk::getCheckStepRange() const {
+    return mCheckStepRange;
+}
+
+f32 CollisionShapeInfoDisk::getCheckStepRangeWorld() const {
+    return mCheckStepRangeWorld;
+}

--- a/src/Player/CollisionShapeInfo.h
+++ b/src/Player/CollisionShapeInfo.h
@@ -57,7 +57,12 @@ public:
     void calcRelativeShapeInfo(const sead::Matrix34f&) override;
 
 private:
-    void* _18[20];
+    u8 _18[0x1c - 0x18];
+    sead::Vector3f mBoundingCenter;
+    f32 mBoundingRadius;
+    sead::Vector3f mBoundingCenterWorld;
+    f32 mBoundingRadiusWorld;
+    u8 _3c[0xb8 - 0x3c];
 };
 
 static_assert(sizeof(CollisionShapeInfoArrow) == 0xb8);
@@ -88,7 +93,11 @@ public:
     void set48(f32 value) { _48 = value; }
 
 private:
-    void* _18[5];
+    f32 mBoundingRadius;
+    sead::Vector3f mBoundingCenter;
+    sead::Vector3f mBoundingCenterWorld;
+    f32 mBoundingRadiusWorld;
+    u8 _38[0x40 - 0x38];
     s32 _40;
     bool mIsSupportGround;
     f32 _48;
@@ -126,7 +135,15 @@ public:
     void setIgnoreGround() { mIsIgnoreGround = true; }
 
 private:
-    void* _18[13];
+    f32 mBoundingRadius;
+    f32 mBoundingRadiusWorld;
+    f32 mCheckStepRange;
+    f32 mCheckStepRangeWorld;
+    u8 _28[0x30 - 0x28];
+    sead::Vector3f mBoundingCenter;
+    u8 _3c[0x50 - 0x3c];
+    sead::Vector3f mBoundingCenterWorld;
+    u8 _5c[0x80 - 0x5c];
     bool mIsSupportGround;
     f32 _84;
     f32 _88;


### PR DESCRIPTION
Reverses the member layout touched by the 18 bounding-shape / check-step accessors across the three `CollisionShapeInfo` subclasses (remaining bytes kept as padding; `sizeof` `static_assert`s preserved) and implements them. All 18 verified byte-matching via `tools/check`.

Naming note: for `Arrow` and `Sphere`, `getCheckStepRange` reads the **same** field as `getBoundingRadius`; `Disk` stores them separately. Field names follow the primary accessor — happy to adjust to project conventions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1314)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ae6bf40 - 7a9d73a)

📈 **Matched code**: 15.32% (+0.00%, +144 bytes)

<details>
<summary>✅ 18 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getBoundingCenter() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getBoundingCenterWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getBoundingRadius() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getBoundingRadiusWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getCheckStepRange() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoArrow::getCheckStepRangeWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getBoundingCenter() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getBoundingCenterWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getBoundingRadius() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getBoundingRadiusWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getCheckStepRange() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoSphere::getCheckStepRangeWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getBoundingCenter() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getBoundingCenterWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getBoundingRadius() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getBoundingRadiusWorld() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getCheckStepRange() const` | +8 | 0.00% | 100.00% |
| `Player/CollisionShapeInfo` | `CollisionShapeInfoDisk::getCheckStepRangeWorld() const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->