### PR TITLE
System: match 39 trivial GameDataFile accessors

### DIFF
--- a/src/System/GameDataFile.cpp
+++ b/src/System/GameDataFile.cpp
@@ -293,3 +293,157 @@ void GameDataFile::enableHintById(s32 shineIndex) {
     if (shineIndex >= 0)
         mHintList[shineIndex].isDisabled = false;
 }
+
+void GameDataFile::resetTempData() {}
+
+s64 GameDataFile::getPlayTimeTotal() const {
+    return mPlayTimeTotal;
+}
+
+void GameDataFile::resetSaveDataIdForPrepoForWrite() {
+    mSaveDataIdForPrepoForWrite = mSaveDataIdForPrepo;
+}
+
+PlayerHitPointData* GameDataFile::getPlayerHitPointData() const {
+    return mPlayerHitPointData;
+}
+
+bool GameDataFile::isUseMissRestartInfo() const {
+    return mIsUseMissRestartInfo;
+}
+
+bool GameDataFile::isPayShineAllInAllWorld() const {
+    return mIsPayShineAllInAllWorld;
+}
+
+s32 GameDataFile::getKeyNum() const {
+    return mKeyNum;
+}
+
+s32 GameDataFile::getCoinCollectGotNum(s32 world_id) const {
+    return mCoinCollectGotNum[world_id];
+}
+
+bool GameDataFile::isPayCoinToSphinx() const {
+    return mIsPayCoinToSphinx;
+}
+
+bool GameDataFile::isStartWorldTravelingPeach() const {
+    return mIsStartWorldTravelingPeach;
+}
+
+void GameDataFile::startWorldTravelingPeach() {
+    mIsStartWorldTravelingPeach = true;
+}
+
+s32 GameDataFile::getPlayerJumpCount() const {
+    return mPlayerJumpCount;
+}
+
+s32 GameDataFile::getPlayerThrowCapCount() const {
+    return mPlayerThrowCapCount;
+}
+
+s32 GameDataFile::getCheckpointNumMaxInWorld() const {
+    return 16;
+}
+
+void GameDataFile::startYukimaruRace() {
+    mRaceType = RaceType_Yukimaru;
+}
+
+void GameDataFile::startYukimaruRaceTutorial() {
+    mRaceType = RaceType_YukimaruTutorial;
+}
+
+void GameDataFile::startRaceManRace() {
+    mRaceType = RaceType_Flag;
+}
+
+void GameDataFile::unlockHint() {
+    unlockHintImpl(HintStatus_UnlockByNpc);
+}
+
+void GameDataFile::unlockHintAmiibo() {
+    unlockHintImpl(HintStatus_UnlockByAmiibo);
+}
+
+bool GameDataFile::isUnlockAchievementShineName() const {
+    return mIsUnlockAchievement;
+}
+
+void GameDataFile::winRace() {
+    mRaceResult = RaceResult_Win;
+}
+
+s32 GameDataFile::getMiniGameNumMax() const {
+    return 4;
+}
+
+bool GameDataFile::isExistTimeBalloonNpc() const {
+    return mIsExistTimeBalloonNpc;
+}
+
+const sead::Vector3f& GameDataFile::getTimeBalloonNpcTrans() const {
+    return mTimeBalloonNpcTrans;
+}
+
+bool GameDataFile::isExistPoetter() const {
+    return mIsExistPoetter;
+}
+
+const sead::Vector3f& GameDataFile::getPoetterTrans() const {
+    return mPoetterTrans;
+}
+
+bool GameDataFile::isAlreadyShowExplainCheckpointFlag() const {
+    return mIsShowExplainCheckpointFlag;
+}
+
+s32 GameDataFile::getShopNpcIconNumMax() const {
+    return 4;
+}
+
+s32 GameDataFile::getScenarioNoPlacement() const {
+    return mScenarioNoPlacement;
+}
+
+bool GameDataFile::isFlagOnTalkMessageInfo(s32 index) const {
+    return mFlagTalkMessage[index];
+}
+
+bool GameDataFile::isTalkKakku() const {
+    return mIsTalkKakku;
+}
+
+void GameDataFile::talkKakku() {
+    mIsTalkKakku = true;
+}
+
+bool GameDataFile::isTalkWorldTravelingPeach() const {
+    return mIsTalkWorldTravelingPeach;
+}
+
+void GameDataFile::talkWorldTravelingPeach() {
+    mIsTalkWorldTravelingPeach = true;
+}
+
+bool GameDataFile::isTalkCollectBgmNpc() const {
+    return mIsTalkCollectBgmNpc;
+}
+
+void GameDataFile::talkCollectBgmNpc() {
+    mIsTalkCollectBgmNpc = true;
+}
+
+s32 GameDataFile::getTokimekiMayorNpcFavorabilityRating() const {
+    return mTokimekiMayorNpcFavorabilityRating;
+}
+
+void GameDataFile::setTokimekiMayorNpcFavorabilityRating(s32 rating) {
+    mTokimekiMayorNpcFavorabilityRating = rating;
+}
+
+bool GameDataFile::isFirstNetwork() const {
+    return mIsFirstNetwork;
+}


### PR DESCRIPTION
Decompiles 39 trivial accessors in `GameDataFile`, all verified byte-matching via `tools/check`:

- Member getters (`getKeyNum`, `getPlayTimeTotal`, `getPlayerJumpCount`, `getPlayerHitPointData`, …)
- Bool-flag checks (`isPayCoinToSphinx`, `isTalkKakku`, `isFirstNetwork`, `isUseMissRestartInfo`, …) and their setters (`talkKakku`, `startWorldTravelingPeach`, …)
- Race/hint state setters (`startYukimaruRace`→`mRaceType`, `winRace`→`mRaceResult`, `unlockHint`/`unlockHintAmiibo`→`unlockHintImpl`)
- Array-indexed getters (`getCoinCollectGotNum`, `isFlagOnTalkMessageInfo`)
- Constant-return maxima (`getCheckpointNumMaxInWorld`, `getMiniGameNumMax`, `getShopNpcIconNumMax`)

Members were already named in the header, so no layout changes. Left `changeWipeType`/`setActivateHome`/`noFirstNetwork` (forward to not-yet-decompiled callees) and `getCollectedBgmMaxNum` (ambiguous offset) for later.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1315)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ae6bf40 - 98ba11f)

📈 **Matched code**: 15.32% (+0.00%, +352 bytes)

<details>
<summary>✅ 39 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `System/GameDataFile` | `GameDataFile::resetSaveDataIdForPrepoForWrite()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getCoinCollectGotNum(int) const` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::startWorldTravelingPeach()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::startYukimaruRace()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::startYukimaruRaceTutorial()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::startRaceManRace()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::winRace()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isFlagOnTalkMessageInfo(int) const` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::talkKakku()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::talkWorldTravelingPeach()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::talkCollectBgmNpc()` | +12 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getPlayTimeTotal() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getPlayerHitPointData() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isUseMissRestartInfo() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isPayShineAllInAllWorld() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getKeyNum() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isPayCoinToSphinx() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isStartWorldTravelingPeach() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getPlayerJumpCount() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getPlayerThrowCapCount() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getCheckpointNumMaxInWorld() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::unlockHint()` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::unlockHintAmiibo()` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isUnlockAchievementShineName() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getMiniGameNumMax() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isExistTimeBalloonNpc() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getTimeBalloonNpcTrans() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isExistPoetter() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::getPoetterTrans() const` | +8 | 0.00% | 100.00% |
| `System/GameDataFile` | `GameDataFile::isAlreadyShowExplainCheckpointFlag() const` | +8 | 0.00% | 100.00% |

...and 9 more new matches
</details>


<!-- decomp.dev report end -->