### PR TITLE
Util: Implement small functions of `PlayerCollisionUtil`

### DIFF
--- a/lib/al/Library/Collision/CollisionPartsKeeperUtil.h
+++ b/lib/al/Library/Collision/CollisionPartsKeeperUtil.h
@@ -42,7 +42,7 @@ bool isWallCode(const Triangle&, const char*);
 bool isCameraCode(const Triangle&, const char*);
 bool isCollisionCode(const Triangle&, const char*, const char*);
 bool isMaterialCode(const HitInfo*, const char*);
-bool isFloorCode(const Triangle&, const char*);
+bool isFloorCode(const HitInfo*, const char*);
 bool isWallCode(const HitInfo*, const char*);
 bool isCameraCode(const HitInfo*, const char*);
 bool isCollisionCode(const HitInfo*, const char*, const char*);

--- a/src/Util/PlayerCollisionUtil.cpp
+++ b/src/Util/PlayerCollisionUtil.cpp
@@ -1,0 +1,29 @@
+#include "Util/PlayerCollisionUtil.h"
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+
+#include "Player/IUsePlayerHeightCheck.h"
+
+namespace rs {
+
+bool isCollisionCodePress(const al::HitInfo& hitInfo) {
+    return al::isFloorCode(&hitInfo, "Press");
+}
+
+bool isCollisionCodeGrabCeil(const al::HitInfo& hitInfo) {
+    return al::isFloorCode(&hitInfo, "GrabCeil");
+}
+
+const char* getRippleGenerateMaterialFlower() {
+    return "FlowerForest";
+}
+
+bool isAboveGround(const IUsePlayerHeightCheck* playerHeightCheck) {
+    return playerHeightCheck->isAboveGround();
+}
+
+f32 getGroundHeight(const IUsePlayerHeightCheck* playerHeightCheck) {
+    return playerHeightCheck->getGroundHeight();
+}
+
+}  // namespace rs


### PR DESCRIPTION
Adds `PlayerCollisionUtil.cpp` with 5 functions, all verified byte-matching via `tools/check`:
- `isCollisionCodePress` / `isCollisionCodeGrabCeil` → `al::isFloorCode(&hitInfo, code)`
- `getRippleGenerateMaterialFlower` → `"FlowerForest"`
- `isAboveGround` / `getGroundHeight` → `IUsePlayerHeightCheck` virtual dispatch

Also fixes a typo in `CollisionPartsKeeperUtil.h`: the `HitInfo*` overload group declared `isFloorCode(const Triangle&)` (dup of the Triangle group) instead of `isFloorCode(const HitInfo*)` — the missing overload the above functions call.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1317)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ae6bf40 - 771e728)

📈 **Matched code**: 15.32% (+0.00%, +60 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/PlayerCollisionUtil` | `rs::isCollisionCodePress(al::HitInfo const&)` | +12 | 0.00% | 100.00% |
| `Util/PlayerCollisionUtil` | `rs::isCollisionCodeGrabCeil(al::HitInfo const&)` | +12 | 0.00% | 100.00% |
| `Util/PlayerCollisionUtil` | `rs::getRippleGenerateMaterialFlower()` | +12 | 0.00% | 100.00% |
| `Util/PlayerCollisionUtil` | `rs::isAboveGround(IUsePlayerHeightCheck const*)` | +12 | 0.00% | 100.00% |
| `Util/PlayerCollisionUtil` | `rs::getGroundHeight(IUsePlayerHeightCheck const*)` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->