### PR TITLE
Library/Se/Project: Implement `SePlayParam`

### DIFF
--- a/lib/al/Library/Se/Project/SePlayParam.cpp
+++ b/lib/al/Library/Se/Project/SePlayParam.cpp
@@ -1,0 +1,28 @@
+#include "Library/Se/Project/SePlayParam.h"
+
+namespace al {
+
+SePlayParam::SePlayParam() {
+    reset();
+}
+
+void SePlayParam::reset() {
+    mType = SePlayParamType::Invalid;
+    mValue = 1.0f;
+    mValue2 = 0.0f;
+}
+
+void SePlayParam::set(SePlayParamType type, f32 value, f32 value2) {
+    mType = type;
+    mValue = value;
+    mValue2 = value2;
+}
+
+void SePlayParam::setMul(SePlayParamType type, f32 value, f32 value2) {
+    f32 mul = mValue * value;
+    mType = type;
+    mValue2 = value2;
+    mValue = mul;
+}
+
+}  // namespace al

--- a/lib/al/Library/Se/Project/SePlayParam.h
+++ b/lib/al/Library/Se/Project/SePlayParam.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+
+enum class SePlayParamType {
+    Invalid,
+    Volume,
+    Pitch,
+    SeqTempoRatio,
+    EffectSend,
+    SeqLocalVariable,
+    SeqGlobalVariable,
+    LpfFreq,
+    BiquadFilter,
+};
+
+class SePlayParam {
+public:
+    SePlayParam();
+
+    void reset();
+    void set(SePlayParamType type, f32 value, f32 value2);
+    void setMul(SePlayParamType type, f32 value, f32 value2);
+
+private:
+    SePlayParamType mType;
+    f32 mValue;
+    f32 mValue2;
+};
+
+static_assert(sizeof(SePlayParam) == 0xC);
+
+}  // namespace al


### PR DESCRIPTION
implements all of `SePlayParam.o` for #2034. ctor, `reset`, `set`, `setMul`, plus the header and cpp.

`al::SePlayParam` is a 12 byte SE param entry: `SePlayParamType mType` (0x0), `f32 mValue` (0x4, default 1.0f), `f32 mValue2` (0x8, default 0.0f). ctor and `reset` default to invalid/1.0/0.0, `set` overwrites all three, `setMul` swaps type + `mValue2` and multiplies `mValue`.

enum comes from the switch in `conveyParamListToHandle`, which maps each type to an `AcLSoundHandle` setter. that's what tells me `mValue` is the main operand and `mValue2` is the secondary index for the seq variable and biquad cases. invalid(0), volume(1), pitch(2), seqTempoRatio(3), effectSend(4), seqLocalVariable(5), seqGlobalVariable(6), lpfFreq(7), biquadFilter(8).

`setMul` needed an explicit temp float or the multiply wouldn't match. method/class names are from mangled symbols, field and enum names are inferred so flag anything off.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1318)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (ae6bf40 - 4f8b41d)

📈 **Matched code**: 15.32% (+0.00%, +72 bytes)

<details>
<summary>✅ 4 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Se/Project/SePlayParam` | `al::SePlayParam::setMul(al::SePlayParamType, float, float)` | +24 | 0.00% | 100.00% |
| `Library/Se/Project/SePlayParam` | `al::SePlayParam::SePlayParam()` | +16 | 0.00% | 100.00% |
| `Library/Se/Project/SePlayParam` | `al::SePlayParam::reset()` | +16 | 0.00% | 100.00% |
| `Library/Se/Project/SePlayParam` | `al::SePlayParam::set(al::SePlayParamType, float, float)` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->