### PR TITLE
workflow: Check for duplicate filenames in workflow

### DIFF
--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -25,10 +25,18 @@ jobs:
         allow-unsafe-pr-checkout: true
     - name: Check for W-state functions
       run: |
-        if grep -q "status: Wip" "data/odyssey_functions.csv"; then
+        if grep -q "status: Wip" "data/file_list.yml"; then
           echo "Function list should not contain WIP-functions!"
           echo "Found the following lines:"
-          grep "status: Wip" "data/odyssey_functions.csv"
+          grep "status: Wip" "data/file_list.yml"
+          exit 1
+        fi
+    - name: Check duplicate file names
+      run: |
+        if cat data/file_list.yml | grep -v '^ ' | sort | uniq -d; then
+          echo "Function list should not contain duplicate filenames!"
+          echo "Found the following duplicates:"
+          cat data/file_list.yml | grep -v '^ ' | sort | uniq
           exit 1
         fi
     - name: Set up dependencies

--- a/.github/workflows/compile-check.yml
+++ b/.github/workflows/compile-check.yml
@@ -33,10 +33,11 @@ jobs:
         fi
     - name: Check duplicate file names
       run: |
-        if cat data/file_list.yml | grep -v '^ ' | sort | uniq -d; then
+        duplicates=$(grep -v '^ ' data/file_list.yml | sort | uniq -d)
+        if [ -n "$duplicates" ]; then
           echo "Function list should not contain duplicate filenames!"
           echo "Found the following duplicates:"
-          cat data/file_list.yml | grep -v '^ ' | sort | uniq
+          printf "%s\n" "$duplicates"
           exit 1
         fi
     - name: Set up dependencies


### PR DESCRIPTION
Some tools malfunction when filenames are used multiple times, saving only the last occurrence of the file instead of merging them together. The simplest solution for now is declaring that "the spec" requires all filenames to be unique, and add a new workflow to enforce this.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1320)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (f51e9fa - 27730a4)

**Total code**: 12511924 bytes (+2500 bytes)
**Total functions**: 74171 (+20)

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/FixMapPartsAppearKillAsync` | `FixMapPartsAppearKillAsync::init(al::ActorInitInfo const&)` | +69 | 0.00% | 75.00% |

</details>


<!-- decomp.dev report end -->