### PR TITLE
Npc: Implement `SessionMusicianBgmController`

### DIFF
--- a/lib/al/Library/Audio/System/AudioKeeper.h
+++ b/lib/al/Library/Audio/System/AudioKeeper.h
@@ -3,16 +3,21 @@
 #include <math/seadMatrix.h>
 #include <math/seadVector.h>
 
+#include "Library/Area/AreaObj.h"
+#include "Library/Area/IUseAreaObj.h"
 #include "Library/HostIO/HioNode.h"
 
 namespace al {
+
 class AudioDirector;
 class ModelKeeper;
 class CameraDirector;
+class AreaObjDirector;
 class AudioEventController;
 class AudioEffectController;
 class AudioRequestKeeperSyncedBgm;
 class AudioMic;
+class PlayerHolder;
 class SeKeeper;
 class BgmKeeper;
 
@@ -24,6 +29,7 @@ public:
     void initSeKeeper(const AudioDirector*, const char*, const sead::Vector3f*,
                       const sead::Matrix34f*, const ModelKeeper*, CameraDirector*);
     void initBgmKeeper(const AudioDirector*, const char*);
+
     void validate();
     void invalidate();
     void startClipped();
@@ -31,19 +37,19 @@ public:
     void appear();
     void kill();
 
-    AudioEventController* getAudioEventController() const { return mAudioEventController; };
+    AudioEventController* getAudioEventController() const { return mAudioEventController; }
 
-    AudioEffectController* getAudioEffectController() const { return mAudioEffectController; };
+    AudioEffectController* getAudioEffectController() const { return mAudioEffectController; }
 
     AudioRequestKeeperSyncedBgm* getAudioRequestKeeperSyncedBgm() const {
         return mAudioRequestKeeperSyncedBgm;
-    };
+    }
 
-    SeKeeper* getSeKeeper() const { return mSeKeeper; };
+    SeKeeper* getSeKeeper() const { return mSeKeeper; }
 
-    BgmKeeper* getBgmKeeper() const { return mBgmKeeper; };
+    BgmKeeper* getBgmKeeper() const { return mBgmKeeper; }
 
-    AudioMic* getAudioMic() const { return mAudioMic; };
+    AudioMic* getAudioMic() const { return mAudioMic; }
 
 private:
     AudioEventController* mAudioEventController;
@@ -55,6 +61,60 @@ private:
 };
 
 static_assert(sizeof(AudioKeeper) == 0x38);
+
+class AudioGeneralPurposeAreaChecker : public HioNode, public IUseAreaObj {
+public:
+    AudioGeneralPurposeAreaChecker(const char* areaName);
+
+    void init(AreaObjDirector* areaObjDirector);
+
+    void reset();
+    void update();
+
+    bool tryFindAreaObjPlayerOne(AreaObj**) const;
+
+    bool isInArea() const;
+    bool isInvaridByOneTime() const;
+
+    void setPlayerHolder(const PlayerHolder* playerHolder);
+
+    s32 getIntArgInCurArea(const char*) const;
+    f32 getFloatArgInCurArea(const char*) const;
+    bool getBoolArgInCurArea(const char*) const;
+
+    const char* getStringArgInCurArea(const char*) const;
+    const char* getStringArgInCurAreaWithAreaCheck(const char*) const;
+
+    s32 getIntArgInPastArea(const char*) const;
+    const char* getStringArgInPastArea(const char*) const;
+
+    bool tryGetIntArgInCurArea(s32*, const char*) const;
+    bool tryGetStringArgInCurArea(const char**, const char*) const;
+
+    AreaObjDirector* getAreaObjDirector() const override { return mAreaObjDirector; }
+
+    bool isEnteredArea() const { return mIsEnteredArea; }
+
+    bool isExitedArea() const { return mIsExitedArea; }
+
+private:
+    const char* mAreaName;
+
+    const AreaObj* mCurArea = nullptr;
+    const AreaObj* mPrevArea = nullptr;
+
+    u8* unk = nullptr;  // Unused? Also (seemingly) unused in RedCarpet.
+
+    AreaObjDirector* mAreaObjDirector = nullptr;
+    const PlayerHolder* mPlayerHolder = nullptr;
+
+    bool mIsEnteredArea = false;
+    bool mIsExitedArea = false;
+    bool mIsAreaChanged = false;
+    bool mIsCurAreaActive = false;
+};
+
+static_assert(sizeof(AudioGeneralPurposeAreaChecker) == 0x40);
 
 }  // namespace al
 

--- a/src/Audio/CollectBgmPlayer.h
+++ b/src/Audio/CollectBgmPlayer.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+#include "Library/HostIO/HioNode.h"
+#include "Library/Scene/ISceneObj.h"
+
+#include "Scene/SceneObjFactory.h"
+
+namespace al {
+class IUseAudioKeeper;
+}  // namespace al
+
+class CollectBgmPlayer : public al::HioNode, public al::ISceneObj {
+public:
+    static constexpr s32 sSceneObjId = SceneObjID_CollectBgmPlayer;
+
+    CollectBgmPlayer();
+
+    void init(const al::IUseAudioKeeper*);
+
+    void prepare();
+    void start(const char* bgmName, const char* bgmSituation);
+    void stop(s32);
+
+    bool isPlaying(const char*, const char*) const;
+
+private:
+    const al::IUseAudioKeeper* mAudioKeeper = nullptr;
+    const char* mCurBgmName = nullptr;
+    const char* mCurBgmSituation = nullptr;
+};
+
+static_assert(sizeof(CollectBgmPlayer) == 0x20);

--- a/src/Npc/SessionMusicianBgmController.cpp
+++ b/src/Npc/SessionMusicianBgmController.cpp
@@ -1,0 +1,214 @@
+#include "Npc/SessionMusicianBgmController.h"
+
+#include "Library/Audio/System/AudioKeeper.h"
+#include "Library/Base/StringUtil.h"
+#include "Library/Bgm/BgmBeatCounter.h"
+#include "Library/Bgm/BgmLineFunction.h"
+#include "Library/LiveActor/ActorInitFunction.h"
+#include "Library/LiveActor/ActorSceneInfo.h"
+#include "Library/LiveActor/LiveActor.h"
+#include "Library/Nerve/NerveExecutor.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Se/SeFunction.h"
+
+#include "Audio/CollectBgmPlayer.h"
+#include "Npc/SessionMusicianLocalFunction.h"
+
+namespace {
+NERVE_HOST_TYPE_IMPL(SessionMusicianBgmController, Wait);
+NERVE_HOST_TYPE_IMPL(SessionMusicianBgmController, InArea);
+NERVE_HOST_TYPE_IMPL(SessionMusicianBgmController, OutArea);
+
+NERVES_MAKE_NOSTRUCT(HostType, Wait, InArea, OutArea);
+}  // namespace
+
+SessionMusicianBgmController::SessionMusicianBgmController(al::LiveActor* actor,
+                                                           const al::ActorInitInfo& initInfo,
+                                                           bool forceFullBand)
+    : al::NerveExecutor("セッションBGM制御"), mActor(actor) {
+    initNerve(&Wait, 0);
+    al::initActorBgmKeeper(mActor, initInfo, nullptr);
+    mAudioChecker = new al::AudioGeneralPurposeAreaChecker("SessionBgmChangeArea");
+    mAudioChecker->init(mActor->getAreaObjDirector());
+    mAudioChecker->setPlayerHolder(mActor->getSceneInfo()->playerHolder);
+
+    bool isSessionFullMember = SessionMusicianLocalFunction::isSessionFullMember(mActor);
+    if (forceFullBand)
+        mIsFullBandPerformance = forceFullBand;
+    else
+        mIsFullBandPerformance = isSessionFullMember;
+
+    if (mIsFullBandPerformance)
+        al::replaceBgmPlayInfoResourceName(mActor, "WorldMain", "StmRsBgmCityScenario04");
+
+    mBeatCounter = new al::BgmBeatCounter(mActor, -0.17f);
+
+    mCollectBgmPlayer = al::getSceneObj<CollectBgmPlayer>(mActor);
+}
+
+static void endInstrumentPlayback(al::LiveActor* actor, bool playAllInstrumentsFlag,
+                                  bool stopSituationFlag) {
+    if (playAllInstrumentsFlag) {
+        al::endBgmSituation(actor, "PlayEtcInst", false);
+        SessionMusicianLocalFunction::endPlayingTheDs(actor);
+        SessionMusicianLocalFunction::endPlayingTheBa(actor);
+        SessionMusicianLocalFunction::endPlayingTheGt(actor);
+        SessionMusicianLocalFunction::endPlayingTheTp(actor);
+        return;
+    }
+
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 0))
+        SessionMusicianLocalFunction::endPlayingTheDs(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 1))
+        SessionMusicianLocalFunction::endPlayingTheBa(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 2))
+        SessionMusicianLocalFunction::endPlayingTheGt(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 3))
+        SessionMusicianLocalFunction::endPlayingTheTp(actor);
+
+    if (stopSituationFlag)
+        al::endBgmSituation(actor, "StopPlayingEtcInst", false);
+}
+
+static void startInstrumentPlayback(al::LiveActor* actor, bool playAllInstrumentsFlag,
+                                    bool stopSituationFlag) {
+    if (playAllInstrumentsFlag) {
+        al::startBgmSituation(actor, "PlayEtcInst", false, true);
+        SessionMusicianLocalFunction::startPlayingTheDs(actor);
+        SessionMusicianLocalFunction::startPlayingTheBa(actor);
+        SessionMusicianLocalFunction::startPlayingTheGt(actor);
+        SessionMusicianLocalFunction::startPlayingTheTp(actor);
+        return;
+    }
+
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 0))
+        SessionMusicianLocalFunction::startPlayingTheDs(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 1))
+        SessionMusicianLocalFunction::startPlayingTheBa(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 2))
+        SessionMusicianLocalFunction::startPlayingTheGt(actor);
+    if (SessionMusicianLocalFunction::isSubscribed(actor, 3))
+        SessionMusicianLocalFunction::startPlayingTheTp(actor);
+
+    if (stopSituationFlag)
+        al::startBgmSituation(actor, "StopPlayingEtcInst", false, true);
+}
+
+void SessionMusicianBgmController::exeWait() {
+    tryStartBgmSituation();
+    mAudioChecker->update();
+    mBeatCounter->update();
+    if (mAudioChecker->isEnteredArea())
+        al::setNerve(this, &InArea);
+}
+
+bool SessionMusicianBgmController::tryStartBgmSituation() {
+    if (mIsFullBandPerformance)
+        return false;
+
+    const char* bgmName = al::getCurPlayingBgmPlayName(mActor);
+    if (!(bgmName != nullptr && al::isEqualString("WorldMain", bgmName)) ||
+        (mPrevBgmName != nullptr && al::isEqualString("WorldMain", mPrevBgmName))) {
+        mPrevBgmName = bgmName;
+        return false;
+    }
+    startInstrumentPlayback(mActor, false, false);
+    mPrevBgmName = bgmName;
+    return true;
+}
+
+void SessionMusicianBgmController::exeInArea() {
+    mAudioChecker->update();
+    mBeatCounter->update();
+
+    if (al::isFirstStep(this)) {
+        al::stopAllBgm(mActor, -1);
+        mPrevBgmName = nullptr;
+
+        if (!mIsFullBandPerformance && SessionMusicianLocalFunction::isSessionFullMember(mActor)) {
+            al::replaceBgmPlayInfoResourceName(mActor, "WorldMain", "StmRsBgmCityScenario04");
+            mIsFullBandPerformance = true;
+        }
+
+        al::LiveActor* actor = mActor;
+        bool isFullBand = mIsFullBandPerformance;
+        al::startBgm(actor, "LiveTest", -1, 0);
+        startInstrumentPlayback(actor, isFullBand, true);
+    }
+
+    s32 musicianCount =
+        mIsFullBandPerformance ? 4 : SessionMusicianLocalFunction::getMemberMusicianNum(mActor);
+
+    switch (musicianCount) {
+    case 0:
+        al::holdSe(mActor, "Empty");
+        break;
+    case 1:
+        al::holdSe(mActor, "MusicianOne");
+        break;
+    case 2:
+        al::holdSe(mActor, "MusiciansTwo");
+        break;
+    case 3:
+        al::holdSe(mActor, "MusiciansThree");
+        break;
+    case 4:
+        al::holdSe(mActor, "MusiciansFull");
+        break;
+    }
+
+    if (mBeatCounter->isTriggerBeat(2, 1)) {
+        switch (musicianCount) {
+        case 1:
+            al::startSe(mActor, "ClapS");
+            break;
+        case 2:
+            al::startSe(mActor, "ClapM");
+            break;
+        case 3:
+            al::startSe(mActor, "ClapL");
+            break;
+        case 4:
+            al::startSe(mActor, "ClapL");
+            break;
+        }
+    } else if (mBeatCounter->isTriggerBeat(2, 0)) {
+        switch (musicianCount) {
+        case 1:
+            al::startSe(mActor, "ClapSOffBeat");
+            break;
+        case 2:
+            al::startSe(mActor, "ClapMOffBeat");
+            break;
+        case 3:
+            al::startSe(mActor, "ClapLOffBeat");
+            break;
+        case 4:
+            al::startSe(mActor, "ClapLOffBeat");
+            break;
+        }
+    }
+
+    if (mAudioChecker->isExitedArea())
+        al::setNerve(this, &OutArea);
+}
+
+void SessionMusicianBgmController::exeOutArea() {
+    mAudioChecker->update();
+    mBeatCounter->update();
+    if (al::isFirstStep(this)) {
+        auto* actor = mActor;
+        bool isFullBandPerformance = mIsFullBandPerformance;
+        al::stopBgm(mActor, "LiveTest", -1);
+        endInstrumentPlayback(actor, isFullBandPerformance, true);
+    }
+
+    tryStartBgmSituation();
+
+    if (mAudioChecker->isEnteredArea()) {
+        endInstrumentPlayback(mActor, mIsFullBandPerformance, false);
+        al::setNerve(this, &InArea);
+    }
+}

--- a/src/Npc/SessionMusicianBgmController.h
+++ b/src/Npc/SessionMusicianBgmController.h
@@ -11,6 +11,8 @@ class ISceneObj;
 class LiveActor;
 }  // namespace al
 
+class CollectBgmPlayer;
+
 class SessionMusicianBgmController : public al::NerveExecutor {
 public:
     SessionMusicianBgmController(al::LiveActor* actor, const al::ActorInitInfo& initInfo,
@@ -25,11 +27,11 @@ public:
 
 private:
     al::LiveActor* mActor;
-    al::AudioGeneralPurposeAreaChecker* mAudioChecker;
+    al::AudioGeneralPurposeAreaChecker* mAudioChecker = nullptr;
     const char* mPrevBgmName = nullptr;
     bool mIsFullBandPerformance = false;
     al::BgmBeatCounter* mBeatCounter = nullptr;
-    al::ISceneObj* mSceneObj = nullptr;
+    CollectBgmPlayer* mCollectBgmPlayer = nullptr;
 };
 
 static_assert(sizeof(SessionMusicianBgmController) == 0x40);

--- a/src/Npc/SessionMusicianLocalFunction.h
+++ b/src/Npc/SessionMusicianLocalFunction.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <math/seadQuat.h>
+#include <math/seadVector.h>
+
+#include "Npc/SessionMusicianType.h"
+
+namespace al {
+class LiveActor;
+class PlacementInfo;
+class IUseSceneObjHolder;
+}  // namespace al
+class SessionMayorNpc;
+class SessionMusicianNpc;
+class SessionMusicianManager;
+
+namespace SessionMusicianLocalFunction {
+SessionMusicianType getMusicianType(const al::LiveActor* actor);
+bool isMusicianType(const al::LiveActor* actor, SessionMusicianType type);
+bool isSubscribed(const al::LiveActor* actor, SessionMusicianType type);
+bool isAlreadySessionMember(const SessionMusicianNpc* npc);
+void entryMusicianToManager(SessionMusicianNpc* musician);
+s32 getMemberMusicianNum(const al::LiveActor* actor);
+bool isSessionFullMember(const al::LiveActor* actor);
+
+void startPlayingTheBa(const al::LiveActor* actor);
+void startPlayingTheDs(const al::LiveActor* actor);
+void startPlayingTheGt(const al::LiveActor* actor);
+void startPlayingTheTp(const al::LiveActor* actor);
+
+void endPlayingTheBa(const al::LiveActor* actor);
+void endPlayingTheDs(const al::LiveActor* actor);
+void endPlayingTheGt(const al::LiveActor* actor);
+void endPlayingTheTp(const al::LiveActor* actor);
+
+void tryCreateSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+SessionMusicianManager* getSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+bool isExistSessionMusicianManager(const al::IUseSceneObjHolder* holder);
+bool tryStartWarpToSessionMayor(const al::IUseSceneObjHolder* holder, al::PlacementInfo* info);
+void entrySessionMayorToManager(SessionMayorNpc* mayor);
+
+bool isJoinedSessionMusician(const al::IUseSceneObjHolder* holder);
+bool tryAddJoinedSessionMusicianDemoActor(const al::IUseSceneObjHolder* holder);
+SessionMusicianNpc* tryGetJoinedSessionMusicanActor(const al::IUseSceneObjHolder* holder);
+bool tryGetSessionMoonGetDemoPlayerPos(sead::Vector3f* pos, const al::IUseSceneObjHolder* holder);
+bool tryGetSessionMoonGetDemoPlayerPose(sead::Quatf* pose, const al::IUseSceneObjHolder* holder);
+bool trySetJoinedSessionMusicianTransformForMoonGetDemo(const al::IUseSceneObjHolder* holder);
+
+void addDemoAllMusicians(const al::IUseSceneObjHolder* holder);
+}  // namespace SessionMusicianLocalFunction


### PR DESCRIPTION
Implements `SessionMusicianBgmController` and prerequisite headers.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1321)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f19463 - e1d7d3f)

📈 **Matched code**: 15.38% (+0.02%, +2488 bytes)

<details>
<summary>✅ 10 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Npc/SessionMusicianBgmController` | `SessionMusicianBgmController::exeInArea()` | +992 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `SessionMusicianBgmController::SessionMusicianBgmController(al::LiveActor*, al::ActorInitInfo const&, bool)` | +344 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `SessionMusicianBgmController::exeOutArea()` | +284 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `startInstrumentPlayback(al::LiveActor*, bool, bool)` | +248 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `endInstrumentPlayback(al::LiveActor*, bool, bool)` | +240 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `SessionMusicianBgmController::exeWait()` | +180 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmController` | `SessionMusicianBgmController::tryStartBgmSituation()` | +148 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `SessionMusicianBgmController::~SessionMusicianBgmController()` | +36 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `(anonymous namespace)::HostTypeNrvInArea::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |
| `Npc/SessionMusicianBgmCtrlObj` | `(anonymous namespace)::HostTypeNrvOutArea::execute(al::NerveKeeper*) const` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->