### PR TITLE
Project/SaveData: Document bug for reading nonexistant files

### DIFF
--- a/lib/al/Project/SaveData/SaveDataSequenceRead.cpp
+++ b/lib/al/Project/SaveData/SaveDataSequenceRead.cpp
@@ -28,9 +28,16 @@ s32 SaveDataSequenceRead::threadFunc(const char* fileName) {
     u32 readSize = 0;
     s32 result = read(&fileDevice, fileName, &readSize);
 
+    // BUG: should be checking for result != 0
     if (result == 0)
         return result;
 
+    // NOTE: mBuffer contains uninitialized or stale data, as read() definitely failed
+    // this means that `isSaveDataCorrupted` never runs on existing save files
+    // as `mBuffer` contains stale data for files after the first one, this check might pass
+    // because `version` is a constant (remains correct and in-place) and the `bufferSize` check
+    // has a bug that skips checksum verification if the sizes do not match
+    // => state of mIsCorrupted is undefined, but unused, so this bug has no further effect
     if (isSaveDataCorrupted(mBuffer, mVersion, readSize)) {
         mIsCorrupted = true;
         return -1;
@@ -52,7 +59,7 @@ s32 SaveDataSequenceRead::read(sead::FileDevice* fileDevice, const char* fileNam
         return fileDevice->getLastRawError();
 
     if (!fileDevice->tryRead(readSize, &fileHandle, mBuffer, mBufferSize))
-        return 1;  // BUG: N's mistake here. This should be -1
+        return 1;
 
     fileDevice->tryClose(&fileHandle);
     return fileDevice->getLastRawError();


### PR DESCRIPTION
Another bug in this file we didn't document before: N messed up the `!= 0` check for error codes, so the `isSaveDataCorrupted` check is executed on invalid or stale data. A secondary, known bug even leads to `mIsCorrupted` not detecting something going wrong here. Sadly, this has no further effect on the game, as this check result is not used anywhere (passed through two getters and before going unused).

Also, removed one `BUG:` note there - returning `1` as failure code is totally fine. Standard error codes here are positive, for example `514` for `PathNotFound`, so `1` is good.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1326)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0de3c75 - a55a507)

No changes

<!-- decomp.dev report end -->