### PR TITLE
Util: Implement `YoshiUtil`

### DIFF
--- a/src/Player/YoshiTongue.h
+++ b/src/Player/YoshiTongue.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class IUsePlayerCollision;
+class PlayerWallActionHistory;
+class PlayerEyeSensorHitHolder;
+class PlayerConst;
+class IUsePlayerHack;
+class IUsePlayerCollision;
+
+class YoshiTongue : public al::LiveActor {
+public:
+    YoshiTongue(const al::LiveActor*, const al::LiveActor*, const IUsePlayerCollision*,
+                const PlayerWallActionHistory*, const PlayerEyeSensorHitHolder*, const PlayerConst*,
+                IUsePlayerHack**, const char*);
+
+    void init(const al::ActorInitInfo& info) override;
+    void updateCollider() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void updateEatBindActor();
+    void calcAnim() override;
+    void startAttack(const sead::Vector3f&, const sead::Vector3f&);
+    void startShrink();
+    void endShrink();
+    void eatFinish();
+    void endHack();
+    bool isEnableStartAttack() const;
+    bool isEnableLookAtTip() const;
+    bool isEnableShrinkStart() const;
+    bool isEnableEatFinish() const;
+    bool isExistEatBind() const;
+    bool isShrinkMove() const;
+    bool isConnectWall() const;
+    bool isConnectGround() const;
+    void calcYoshiFaceDir(sead::Vector3f*) const;
+    void calcTongueTipPos(sead::Vector3f*) const;
+    bool tryCalcTonguePullForce(f32*, sead::Vector3f*) const;
+    bool tryCalcTonguePullDistance(sead::Vector3f*) const;
+    bool tryCalcTongueConnect(const al::CollisionParts**, sead::Vector3f*, sead::Vector3f*,
+                              sead::Vector3f*, sead::Vector3f*) const;
+    f32 getShrinkRestRange() const;
+    void adjustShrinkRestRange(f32);
+    void exeStretch();
+    f32 getTongueParamSpeed() const;
+    f32 getTongueParamRange() const;
+    bool reactionCollideWall();
+    bool reactionCollideGround();
+
+    void returnOrEatHide();
+    void exeStay();
+    void exeHit();
+    void exeClingWall();
+    void exeClingGround();
+    void exeShrink();
+    void exeReturn();
+
+    void exeEat();
+    void exeHide();
+    bool isEnableStayClingGround() const;
+
+private:
+    char filler[0x110];
+};
+
+static_assert(sizeof(YoshiTongue) == 0x218);

--- a/src/Util/YoshiUtil.cpp
+++ b/src/Util/YoshiUtil.cpp
@@ -1,0 +1,56 @@
+#include "Util/YoshiUtil.h"
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/Collision/PartsInterpolator.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Nature/WaterSurfaceFinder.h"
+
+#include "Player/PlayerConst.h"
+#include "Player/YoshiTongue.h"
+
+namespace rs {
+bool isSensorTypeYoshiEnableSendPush(const al::HitSensor* sensor) {
+    return al::isSensorNpc(sensor);
+}
+
+bool isSensorTypeYoshiMsgReceivable(const al::HitSensor* sensor) {
+    return al::isSensorNpc(sensor);
+}
+
+bool isInPuddleHeight(const al::WaterSurfaceFinder* surfaceFinder, const PlayerConst* playerConst) {
+    return surfaceFinder->isFoundSurface() &&
+           surfaceFinder->getDistance() < playerConst->getSwimCenterOffset();
+}
+
+bool tryCalcTonguePullPose(sead::Quatf* pose, const al::LiveActor* actor,
+                           const YoshiTongue* yoshiTongue) {
+    sead::Vector3f pullDistance = {0.0f, 0.0f, 0.0f};
+    if (yoshiTongue->tryCalcTonguePullDistance(&pullDistance)) {
+        sead::Vector3f pullDir = {0.0f, 0.0f, 0.0f};
+        if (al::tryNormalizeOrZero(&pullDir, pullDistance)) {
+            sead::Vector3f upDir = {0.0f, 0.0f, 0.0f};
+            al::calcUpDir(&upDir, actor);
+            if (al::isParallelDirection(upDir, pullDir, 0.01f)) {
+                al::calcFrontDir(&upDir, actor);
+                upDir.negate();
+            }
+
+            al::makeQuatFrontUp(pose, pullDir, upDir);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool findClingGroundPos(sead::Vector3f* groundPos, const al::LiveActor* actor,
+                        const sead::Vector3f& pos, f32 height) {
+    const sead::Vector3f& gravity = al::getGravity(actor);
+    al::TriangleFilterGroundOnly filter(gravity);
+
+    return alCollisionUtil::getHitPosOnArrow(actor, groundPos, pos, gravity * height, nullptr,
+                                             &filter);
+}
+}  // namespace rs


### PR DESCRIPTION
In honor to the downfall of `YoshiUtil` I decided to do this implementation.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1329)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0f19463 - 6a07a07)

📈 **Matched code**: 15.36% (+0.00%, +460 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/YoshiUtil` | `rs::tryCalcTonguePullPose(sead::Quat<float>*, al::LiveActor const*, YoshiTongue const*)` | +216 | 0.00% | 100.00% |
| `Util/YoshiUtil` | `rs::findClingGroundPos(sead::Vector3<float>*, al::LiveActor const*, sead::Vector3<float> const&, float)` | +160 | 0.00% | 100.00% |
| `Util/YoshiUtil` | `rs::isInPuddleHeight(al::WaterSurfaceFinder const*, PlayerConst const*)` | +76 | 0.00% | 100.00% |
| `Util/YoshiUtil` | `rs::isSensorTypeYoshiEnableSendPush(al::HitSensor const*)` | +4 | 0.00% | 100.00% |
| `Util/YoshiUtil` | `rs::isSensorTypeYoshiMsgReceivable(al::HitSensor const*)` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->