### PR TITLE
Project/Camera: Implement `SimpleCameraShooter`

### DIFF
--- a/lib/al/Project/Camera/SimpleCameraShooter.cpp
+++ b/lib/al/Project/Camera/SimpleCameraShooter.cpp
@@ -1,0 +1,120 @@
+#include "Project/Camera/SimpleCameraShooter.h"
+
+#include <gfx/seadCamera.h>
+#include <gfx/seadProjection.h>
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+#include "Library/Math/MathUtil.h"
+
+namespace al {
+
+SimpleCameraShooter::SimpleCameraShooter(const char* _name) {
+    mAspectRatio = 4.0f / 3.0f;
+}
+
+f32 SimpleCameraShooter::calcAspectRatioByScreenSize(s32 width, s32 height) {
+    mAspectRatio = (f32)width / (f32)height;
+    return mAspectRatio;
+}
+
+void SimpleCameraShooter::calcCameraPos(sead::Vector3f* cameraPos,
+                                        const IUseCollision* collision) const {
+    sead::Vector3f backDir = mBackDir;
+    f32 distance = mDistance;
+    if (collision) {
+        if (alCollisionUtil::checkStrikeSphereMove(collision, mHitInfos, 8, mPosition, 30.0f,
+                                                   distance * mBackDir, nullptr, nullptr))
+            distance *= mHitInfos[0]._0;
+    }
+
+    cameraPos->set(mPosition);
+    *cameraPos += backDir * distance;
+}
+
+void SimpleCameraShooter::calcFrontDir(sead::Vector3f* frontDir) const {
+    *frontDir = -mBackDir;
+}
+
+f32 SimpleCameraShooter::checkCollision(f32 distance, const IUseCollision* collision) const {
+    sead::Vector3f backDir = mBackDir;
+    if (alCollisionUtil::checkStrikeSphereMove(collision, mHitInfos, 8, mPosition, 30.0f,
+                                               backDir * distance, nullptr, nullptr))
+        distance *= mHitInfos[0]._0;
+    return distance;
+}
+
+void SimpleCameraShooter::applyCameraWithCollision(sead::LookAtCamera* camera,
+                                                   const IUseCollision* collision) const {
+    sead::Vector3f backDir = mBackDir;
+    f32 distance = mDistance;
+    if (collision)
+        distance = checkCollision(distance, collision);
+
+    sead::Vector3f cameraPos = mPosition;
+    cameraPos = backDir * distance + cameraPos;
+    camera->setPos(cameraPos);
+    camera->setAt(mPosition - backDir);
+    camera->setUp(mUpDir);
+    camera->normalizeUp();
+    camera->updateViewMatrix();
+}
+
+void SimpleCameraShooter::applyProjection(sead::PerspectiveProjection* projection) const {
+    projection->set(mNear, mFar, sead::Mathf::deg2rad(mFovyDegree), mAspectRatio);
+}
+
+void SimpleCameraShooter::lookAt(const sead::Vector3f& position) {
+    sead::Vector3f direction = position - mPosition;
+    if (tryNormalizeOrZero(&direction)) {
+        mBackDir = -direction;
+        applyLimitation();
+    }
+}
+
+void SimpleCameraShooter::applyLimitation() {
+    sead::Vector3f upperLimit = sead::Vector3f::ey;
+    sead::Vector3f lowerLimit = sead::Vector3f::ey;
+    rotateVectorDegree(&upperLimit, upperLimit, mSideDir, 110.0f);
+    rotateVectorDegree(&lowerLimit, lowerLimit, mSideDir, 70.0f);
+    tryNormalizeOrZero(&upperLimit);
+    tryNormalizeOrZero(&lowerLimit);
+
+    const sead::Vector3f* limit = nullptr;
+    f32 dot = upperLimit.dot(mBackDir);
+    if (dot < 0.0f) {
+        limit = &upperLimit;
+    } else {
+        dot = lowerLimit.dot(mBackDir);
+        if (dot < 0.0f)
+            limit = &lowerLimit;
+    }
+
+    if (limit) {
+        sead::Vector3f offset = *limit;
+        offset.multScalar(-dot);
+        mBackDir += offset;
+    }
+
+    tryNormalizeOrZero(&mBackDir);
+    if (isParallelDirection(mBackDir, sead::Vector3f::ey, 0.01f)) {
+        mUpDir = mBackDir.cross(mSideDir);
+        mSideDir = mUpDir.cross(mBackDir);
+    } else {
+        mSideDir = sead::Vector3f::ey.cross(mBackDir);
+        mUpDir = mBackDir.cross(mSideDir);
+    }
+    tryNormalizeOrZero(&mSideDir);
+    tryNormalizeOrZero(&mUpDir);
+}
+
+void SimpleCameraShooter::rotateYaw(f32 degree) {
+    rotateVectorDegree(&mBackDir, mBackDir, mUpDir, sead::Mathf::deg2rad(degree));
+    applyLimitation();
+}
+
+void SimpleCameraShooter::rotatePitch(f32 degree) {
+    rotateVectorDegree(&mBackDir, mBackDir, mSideDir, sead::Mathf::deg2rad(degree));
+    applyLimitation();
+}
+
+}  // namespace al

--- a/lib/al/Project/Camera/SimpleCameraShooter.h
+++ b/lib/al/Project/Camera/SimpleCameraShooter.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <math/seadVector.h>
+
+#include "Library/Collision/CollisionPartsKeeperUtil.h"
+
+namespace sead {
+class LookAtCamera;
+class PerspectiveProjection;
+}  // namespace sead
+
+namespace al {
+class IUseCollision;
+
+class SimpleCameraShooter {
+public:
+    SimpleCameraShooter(const char* _name);
+
+    f32 calcAspectRatioByScreenSize(s32 width, s32 height);
+    void calcCameraPos(sead::Vector3f* cameraPos, const IUseCollision* collision) const;
+    void calcFrontDir(sead::Vector3f* frontDir) const;
+    f32 checkCollision(f32 distance, const IUseCollision* collision) const;
+    void applyCameraWithCollision(sead::LookAtCamera* camera, const IUseCollision* collision) const;
+    void applyProjection(sead::PerspectiveProjection* projection) const;
+    void lookAt(const sead::Vector3f& position);
+    void applyLimitation();
+    void rotateYaw(f32 degree);
+    void rotatePitch(f32 degree);
+
+private:
+    sead::Vector3f mPosition = sead::Vector3f::zero;
+    sead::Vector3f mSideDir = sead::Vector3f::ex;
+    sead::Vector3f mUpDir = sead::Vector3f::ey;
+    sead::Vector3f mBackDir = sead::Vector3f::ez;
+    f32 mDistance = 100.0f;
+    f32 mFovyDegree = 45.0f;
+    f32 mNear = 100.0f;
+    f32 mFar = 1000000.0f;
+    f32 mAspectRatio = 1.0f;
+    u32 _44;
+    alCollisionUtil::SphereMoveHitInfo* mHitInfos = new alCollisionUtil::SphereMoveHitInfo[8];
+};
+
+static_assert(sizeof(SimpleCameraShooter) == 0x50);
+
+}  // namespace al


### PR DESCRIPTION
I'm pretty sure this class is unused

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1332)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (441aec9 - 437fd41)

📈 **Matched code**: 15.51% (+0.01%, +1800 bytes)

<details>
<summary>✅ 11 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::applyLimitation()` | +540 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::applyCameraWithCollision(sead::LookAtCamera*, al::IUseCollision const*) const` | +352 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::SimpleCameraShooter(char const*)` | +248 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::calcCameraPos(sead::Vector3<float>*, al::IUseCollision const*) const` | +200 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::checkCollision(float, al::IUseCollision const*) const` | +136 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::lookAt(sead::Vector3<float> const&)` | +120 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::rotateYaw(float)` | +60 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::rotatePitch(float)` | +60 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::calcFrontDir(sead::Vector3<float>*) const` | +36 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::applyProjection(sead::PerspectiveProjection*) const` | +28 | 0.00% | 100.00% |
| `Project/Camera/SimpleCameraShooter` | `al::SimpleCameraShooter::calcAspectRatioByScreenSize(int, int)` | +20 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->