### PR TITLE
Player: Implement `YoshiEgg`

### DIFF
--- a/src/MapObj/FukankunZoomCapMessage.h
+++ b/src/MapObj/FukankunZoomCapMessage.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <math/seadVector.h>
+#include <prim/seadSafeString.h>
+
+namespace al {
+struct ActorInitInfo;
+class LiveActor;
+}  // namespace al
+
+class FukankunZoomCapMessage {
+public:
+    FukankunZoomCapMessage(const al::LiveActor* actor);
+
+    void init(const al::ActorInitInfo& info, const char* capMessageName,
+              const char* fukankunZoomMessageName);
+    void initAfterPlacement();
+    void update();
+
+    const al::LiveActor* mActor;
+    s32 mFukankunZoomType;
+    s32 mCapMessageShowType;
+    s32 mFukankunZoomWatchTimeThreshold;
+    bool mIsDisableAfterEnding;
+    sead::Vector3f mFukankunZoomOffset;
+    const char* mFukankunZoomTargetJointName;
+    bool mIsDisabled;
+    sead::FixedSafeString<256>* mCapMessageName;
+    sead::FixedSafeString<256>* mFukankunZoomMessageName;
+    bool mIsCapMessageShown;
+};
+
+static_assert(sizeof(FukankunZoomCapMessage) == 0x50);

--- a/src/MapObj/FukankunZoomCapMessage.h
+++ b/src/MapObj/FukankunZoomCapMessage.h
@@ -18,6 +18,16 @@ public:
     void initAfterPlacement();
     void update();
 
+    void setFukankunZoomWatchTimeThreshold(s32 threshold) {
+        mFukankunZoomWatchTimeThreshold = threshold;
+    }
+
+    void resetZoomTypes() {
+        mFukankunZoomType = 0;
+        mCapMessageShowType = 0;
+    }
+
+private:
     const al::LiveActor* mActor;
     s32 mFukankunZoomType;
     s32 mCapMessageShowType;

--- a/src/Player/YoshiEgg.cpp
+++ b/src/Player/YoshiEgg.cpp
@@ -1,0 +1,125 @@
+#include "Player/YoshiEgg.h"
+
+#include "Library/LiveActor/ActorActionFunction.h"
+#include "Library/LiveActor/ActorClippingFunction.h"
+#include "Library/LiveActor/ActorInitUtil.h"
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+#include "Library/Nerve/NerveSetupUtil.h"
+#include "Library/Nerve/NerveUtil.h"
+#include "Library/Placement/PlacementFunction.h"
+
+#include "MapObj/FukankunZoomCapMessage.h"
+#include "MapObj/FukankunZoomTargetFunction.h"
+#include "Util/SensorMsgFunction.h"
+
+namespace {
+NERVE_IMPL(YoshiEgg, Wait);
+NERVE_IMPL(YoshiEgg, Appear);
+NERVE_IMPL(YoshiEgg, Break);
+
+NERVES_MAKE_STRUCT(YoshiEgg, Wait, Break);
+NERVES_MAKE_NOSTRUCT(YoshiEgg, Appear);
+}  // namespace
+
+YoshiEgg::YoshiEgg(const al::LiveActor* parent, const IUsePlayerCollision* playerCollision)
+    : al::LiveActor("卵"), mParent(parent), mPlayerCollision(playerCollision) {}
+
+void YoshiEgg::init(const al::ActorInitInfo& info) {
+    al::initChildActorWithArchiveNameNoPlacementInfo(this, info, "YoshiEgg", nullptr);
+    al::initNerve(this, &NrvYoshiEgg.Wait, 0);
+
+    if (!al::isPlaced(info)) {
+        makeActorDead();
+        return;
+    }
+
+    bool isFukankunZoomCapMessage = false;
+    if (al::tryGetArg(&isFukankunZoomCapMessage, info, "IsFukankunZoomCapMessage") &&
+        isFukankunZoomCapMessage) {
+        mFukankunZoomCapMessage = new FukankunZoomCapMessage(this);
+        mFukankunZoomCapMessage->init(info, "CapMessage", "FukankunZoomYoshiEgg");
+        FukankunZoomCapMessage* capMessage = mFukankunZoomCapMessage;
+        capMessage->mFukankunZoomWatchTimeThreshold =
+            FukankunZoomTargetFunction::getFukankunWatchCountDefault();
+        capMessage->mFukankunZoomType = 0;
+        capMessage->mCapMessageShowType = 0;
+    }
+
+    makeActorDead();
+}
+
+void YoshiEgg::initAfterPlacement() {
+    if (mFukankunZoomCapMessage)
+        mFukankunZoomCapMessage->initAfterPlacement();
+}
+
+void YoshiEgg::initPlacementEgg() {
+    al::copyPose(this, mParent);
+    appear();
+    al::setNerve(this, &NrvYoshiEgg.Wait);
+}
+
+void YoshiEgg::appearEgg() {
+    al::copyPose(this, mParent);
+    appear();
+    al::invalidateClipping(this);
+    al::setNerve(this, &Appear);
+}
+
+bool YoshiEgg::isEndAppear() const {
+    return !al::isNerve(this, &Appear);
+}
+
+bool YoshiEgg::isBreak() const {
+    return al::isNerve(this, &NrvYoshiEgg.Break);
+}
+
+void YoshiEgg::exeAppear() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Appear");
+
+    al::copyPose(this, mParent);
+    if (al::isActionEnd(this)) {
+        al::validateClipping(this);
+        al::setNerve(this, &NrvYoshiEgg.Wait);
+    }
+}
+
+void YoshiEgg::exeWait() {
+    al::tryStartActionIfNotPlaying(this, "Wait");
+    al::copyPose(this, mParent);
+    if (mFukankunZoomCapMessage)
+        mFukankunZoomCapMessage->update();
+}
+
+void YoshiEgg::exeBreak() {
+    if (al::isFirstStep(this))
+        al::startAction(this, "Break");
+
+    if (al::isActionEnd(this))
+        kill();
+}
+
+void YoshiEgg::attackSensor(al::HitSensor* self, al::HitSensor* other) {
+    if (!al::isSensorName(self, "Push") || YoshiEgg::isBreak())
+        return;
+
+    rs::sendMsgPushToPlayer(other, self);
+}
+
+bool YoshiEgg::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {
+    if (al::isSensorName(self, "Push"))
+        return al::isMsgPlayerDisregard(message);
+
+    if (!al::isMsgPlayerTrample(message) && !rs::isMsgPlayerAndCapObjHipDropReflectAll(message) &&
+        !rs::isMsgCapAttack(message) && !rs::isMsgThrowObjHitReflect(message) &&
+        !rs::isMsgTankBullet(message) && !rs::isMsgMotorcycleAttack(message))
+        return false;
+
+    if (!al::isNerve(this, &NrvYoshiEgg.Wait))
+        return false;
+
+    al::setNerve(this, &NrvYoshiEgg.Break);
+    return true;
+}

--- a/src/Player/YoshiEgg.cpp
+++ b/src/Player/YoshiEgg.cpp
@@ -101,10 +101,8 @@ void YoshiEgg::exeBreak() {
 }
 
 void YoshiEgg::attackSensor(al::HitSensor* self, al::HitSensor* other) {
-    if (!al::isSensorName(self, "Push") || YoshiEgg::isBreak())
-        return;
-
-    rs::sendMsgPushToPlayer(other, self);
+    if (al::isSensorName(self, "Push") && !isBreak())
+        rs::sendMsgPushToPlayer(other, self);
 }
 
 bool YoshiEgg::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al::HitSensor* self) {

--- a/src/Player/YoshiEgg.cpp
+++ b/src/Player/YoshiEgg.cpp
@@ -40,10 +40,9 @@ void YoshiEgg::init(const al::ActorInitInfo& info) {
         mFukankunZoomCapMessage = new FukankunZoomCapMessage(this);
         mFukankunZoomCapMessage->init(info, "CapMessage", "FukankunZoomYoshiEgg");
         FukankunZoomCapMessage* capMessage = mFukankunZoomCapMessage;
-        capMessage->mFukankunZoomWatchTimeThreshold =
-            FukankunZoomTargetFunction::getFukankunWatchCountDefault();
-        capMessage->mFukankunZoomType = 0;
-        capMessage->mCapMessageShowType = 0;
+        capMessage->setFukankunZoomWatchTimeThreshold(
+            FukankunZoomTargetFunction::getFukankunWatchCountDefault());
+        capMessage->resetZoomTypes();
     }
 
     makeActorDead();

--- a/src/Player/YoshiEgg.cpp
+++ b/src/Player/YoshiEgg.cpp
@@ -109,14 +109,13 @@ bool YoshiEgg::receiveMsg(const al::SensorMsg* message, al::HitSensor* other, al
     if (al::isSensorName(self, "Push"))
         return al::isMsgPlayerDisregard(message);
 
-    if (!al::isMsgPlayerTrample(message) && !rs::isMsgPlayerAndCapObjHipDropReflectAll(message) &&
-        !rs::isMsgCapAttack(message) && !rs::isMsgThrowObjHitReflect(message) &&
-        !rs::isMsgTankBullet(message) && !rs::isMsgMotorcycleAttack(message))
-        return false;
-
-    if (!al::isNerve(this, &NrvYoshiEgg.Wait))
-        return false;
-
-    al::setNerve(this, &NrvYoshiEgg.Break);
-    return true;
+    if (al::isMsgPlayerTrample(message) || rs::isMsgPlayerAndCapObjHipDropReflectAll(message) ||
+        rs::isMsgCapAttack(message) || rs::isMsgThrowObjHitReflect(message) ||
+        rs::isMsgTankBullet(message) || rs::isMsgMotorcycleAttack(message)) {
+        if (al::isNerve(this, &NrvYoshiEgg.Wait)) {
+            al::setNerve(this, &NrvYoshiEgg.Break);
+            return true;
+        }
+    }
+    return false;
 }

--- a/src/Player/YoshiEgg.h
+++ b/src/Player/YoshiEgg.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Library/LiveActor/LiveActor.h"
+
+namespace al {
+struct ActorInitInfo;
+class HitSensor;
+class SensorMsg;
+}  // namespace al
+
+class IUsePlayerCollision;
+class FukankunZoomCapMessage;
+
+class YoshiEgg : public al::LiveActor {
+public:
+    YoshiEgg(const al::LiveActor* parent, const IUsePlayerCollision* playerCollision);
+
+    void init(const al::ActorInitInfo& info) override;
+    void initAfterPlacement() override;
+    void attackSensor(al::HitSensor* self, al::HitSensor* other) override;
+    bool receiveMsg(const al::SensorMsg* message, al::HitSensor* other,
+                    al::HitSensor* self) override;
+
+    void initPlacementEgg();
+    void appearEgg();
+    bool isEndAppear() const;
+    bool isBreak() const;
+
+    void exeAppear();
+    void exeWait();
+    void exeBreak();
+
+private:
+    const al::LiveActor* mParent;
+    const IUsePlayerCollision* mPlayerCollision;
+    FukankunZoomCapMessage* mFukankunZoomCapMessage = nullptr;
+};
+
+static_assert(sizeof(YoshiEgg) == 0x120);


### PR DESCRIPTION
I heard something about the Yoshi saga?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1334)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (cf1c13f - 6851c63)

📈 **Matched code**: 15.52% (+0.01%, +1604 bytes)

<details>
<summary>✅ 16 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/YoshiEgg` | `YoshiEgg::init(al::ActorInitInfo const&)` | +244 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::receiveMsg(al::SensorMsg const*, al::HitSensor*, al::HitSensor*)` | +188 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::YoshiEgg(al::LiveActor const*, IUsePlayerCollision const*)` | +156 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::YoshiEgg(al::LiveActor const*, IUsePlayerCollision const*)` | +152 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::attackSensor(al::HitSensor*, al::HitSensor*)` | +112 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvAppear::execute(al::NerveKeeper*) const` | +112 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeAppear()` | +108 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvBreak::execute(al::NerveKeeper*) const` | +92 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeBreak()` | +88 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `(anonymous namespace)::YoshiEggNrvWait::execute(al::NerveKeeper*) const` | +76 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::appearEgg()` | +72 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::exeWait()` | +72 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::initPlacementEgg()` | +64 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::isEndAppear() const` | +36 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::initAfterPlacement()` | +16 | 0.00% | 100.00% |
| `Player/YoshiEgg` | `YoshiEgg::isBreak() const` | +16 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->