### PR TITLE
README: update link to guide on dumping ROM from console

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Additionally, you'll also need:
 
    Next, you'll need to acquire the **original 1.0 `main` NSO executable**.
 
-    * To dump it from a Switch,
-      follow [the instructions on the wiki](https://zeldamods.org/wiki/Help:Dumping_games#Dumping_binaries_.28executable_files.29).
-    * You do not need to dump the entire game (RomFS + ExeFS + DLC). Just dumping the 1.0 ExeFS is sufficient.
+    * To dump it from a Nintendo Switch,
+      follow [the instructions on the wiki](https://smo.wiki/Guide:Dumping_and_extracting_your_ROM).
+    * This guide explains how to dump and extract the entire game's ROM. For this project, dumping the ExeFS of 1.0 is sufficient, but having the RomFS files may also be helpful for cross-referencing strings or names.
 
 3. If you are using Nix, run `nix run '.#setup' [path to the NSO]`. For all others, run `tools/setup.py [path to the NSO]`
     * This will:


### PR DESCRIPTION
As noted by `@pokeyjojo` on Discord, our `README.md` features a link to an outdated guide on how to dump the game's files.

Let's change it to a rather new guide on the SMO wiki. It only explains how to dump the entire game's ROM, not just the ExeFS partition, but having the RomFS around as well has always proven to be helpful for me as well, so ... why not advise it to dump *everything* in the setup guide, so users don't have to go back and dump the other parts at some point as well?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1335)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b64cbfb - bdd6046)

No changes

<!-- decomp.dev report end -->