### PR TITLE
Library/Model: Implement `SkyParam`

### DIFF
--- a/lib/al/Library/Model/SkyDirector.cpp
+++ b/lib/al/Library/Model/SkyDirector.cpp
@@ -21,11 +21,11 @@ SkyParam::SkyParam() {
 }
 
 bool SkyParam::isEqual(const IUseRequestParam& other) const {
-    const SkyParam* param = static_cast<const SkyParam*>(&other);
+    const SkyParam& param = static_cast<const SkyParam&>(other);
 
-    return isNear(getRotate(), param->getRotate()) &&
-           isEqualString(getSkyName(), param->getSkyName()) &&
-           isNear(getStarIntensity(), param->getStarIntensity());
+    return isNear(getRotate(), param.getRotate()) &&
+           isEqualString(getSkyName(), param.getSkyName()) &&
+           isNear(getStarIntensity(), param.getStarIntensity());
 }
 
 const sead::Vector3f& SkyParam::getRotate() const {

--- a/lib/al/Library/Model/SkyDirector.cpp
+++ b/lib/al/Library/Model/SkyDirector.cpp
@@ -1,0 +1,43 @@
+#include "Library/Model/SkyDirector.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Yaml/ParameterBase.h"
+
+namespace al {
+
+// NON-MATCHING: Stack mismatch https://decomp.me/scratch/uG8AT
+SkyParam::SkyParam() {
+    mParameterObj = new ParameterObj();
+
+    mSkyName = new ParameterString64(StringTmp<64>("RSGraphicTestSkyBlue"), mParameterObj, "Name",
+                                     "空のモデル名", "", true);
+
+    mRotate = new ParameterV3f({0.0f, 0.0f, 0.0f}, mParameterObj, "Rotate", "回転",
+                               "Min=-360.0f, Max=360.0f", true);
+
+    mStarIntensity = new ParameterF32(0.0f, mParameterObj, "StarIntensity", "星の明るさ",
+                                      "Min=0.0f, Max=100.0f", true);
+}
+
+bool SkyParam::isEqual(const IUseRequestParam& other) const {
+    const SkyParam* param = static_cast<const SkyParam*>(&other);
+
+    return isNear(getRotate(), param->getRotate()) &&
+           isEqualString(getSkyName(), param->getSkyName()) &&
+           isNear(getStarIntensity(), param->getStarIntensity());
+}
+
+const sead::Vector3f& SkyParam::getRotate() const {
+    return mRotate->getValue();
+}
+
+const char* SkyParam::getSkyName() const {
+    return mSkyName->getValue().cstr();
+}
+
+f32 SkyParam::getStarIntensity() const {
+    return mStarIntensity->getValue();
+}
+
+}  // namespace al

--- a/lib/al/Library/Model/SkyDirector.h
+++ b/lib/al/Library/Model/SkyDirector.h
@@ -2,13 +2,45 @@
 
 #include <basis/seadTypes.h>
 #include <container/seadPtrArray.h>
+#include <math/seadVector.h>
 #include <prim/seadSafeString.h>
+
+#include "Project/Base/ParamRequestInterp.h"
 
 namespace al {
 struct ActorInitInfo;
 class SkyParam;
 class Sky;
 class ParamRequestInterp;
+class ParameterObj;
+class ParameterString64;
+class ParameterV3f;
+class ParameterF32;
+
+class SkyParam : public IUseRequestParam {
+public:
+    SkyParam();
+
+    const char* getParamName() const override { return "空"; }
+
+    ParameterObj* getParamObj() override { return mParameterObj; }
+
+    const ParameterObj* getParamObj() const override { return mParameterObj; }
+
+    bool isEqual(const IUseRequestParam& other) const override;
+
+    const sead::Vector3f& getRotate() const;
+    const char* getSkyName() const;
+    f32 getStarIntensity() const;
+
+private:
+    ParameterObj* mParameterObj;
+    ParameterString64* mSkyName;
+    ParameterV3f* mRotate;
+    ParameterF32* mStarIntensity;
+};
+
+static_assert(sizeof(SkyParam) == 0x28);
 
 class SkyDirector {
 public:

--- a/lib/al/Library/Yaml/ParameterBase.h
+++ b/lib/al/Library/Yaml/ParameterBase.h
@@ -45,6 +45,10 @@ SEAD_ENUM(YamlParamType,
                         ParameterObj* obj, bool e)                                                 \
             : Parameter(value, name, label, meta, obj, e) {}                                       \
                                                                                                    \
+        Parameter##Name(Type const& value, ParameterObj* obj, const sead::SafeString& name,        \
+                        const sead::SafeString& label, const sead::SafeString& meta, bool e)       \
+            : Parameter(value, name, label, meta, obj, e) {}                                       \
+                                                                                                   \
         Parameter##Name(Type const& value, const sead::SafeString& name,                           \
                         const sead::SafeString& label, const sead::SafeString& meta,               \
                         ParameterList* list, bool e)                                               \

--- a/lib/al/Project/Base/ParamRequestInterp.cpp
+++ b/lib/al/Project/Base/ParamRequestInterp.cpp
@@ -1,0 +1,29 @@
+#include "Project/Base/ParamRequestInterp.h"
+
+#include "Library/Yaml/ParameterBase.h"
+
+namespace al {
+
+bool IUseRequestParam::isEqual(const IUseRequestParam& requestParam) const {
+    if (!getParamObj())
+        return false;
+
+    return getParamObj()->isEqual(*requestParam.getParamObj());
+}
+
+void IUseRequestParam::copy(const IUseRequestParam& requestParam) {
+    if (!getParamObj())
+        return;
+
+    getParamObj()->copy(*requestParam.getParamObj());
+}
+
+void IUseRequestParam::copyInterp(const IUseRequestParam& requestParamStart,
+                                  const IUseRequestParam& requestParamEnd, f32 rate) {
+    if (!getParamObj())
+        return;
+
+    getParamObj()->copyLerp(*requestParamStart.getParamObj(), *requestParamEnd.getParamObj(), rate);
+}
+
+}  // namespace al

--- a/lib/al/Project/Base/ParamRequestInterp.h
+++ b/lib/al/Project/Base/ParamRequestInterp.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+
+namespace al {
+class ParameterObj;
+
+class IUseRequestParam {
+public:
+    virtual const char* getParamName() const = 0;
+    virtual ParameterObj* getParamObj() = 0;
+    virtual const ParameterObj* getParamObj() const = 0;
+    virtual bool isEqual(const IUseRequestParam& requestParam) const;
+    virtual void copy(const IUseRequestParam& requestParam);
+    virtual void copyInterp(const IUseRequestParam& requestParamStart,
+                            const IUseRequestParam& requestParamEnd, f32 rate);
+};
+
+static_assert(sizeof(IUseRequestParam) == 0x8);
+
+}  // namespace al

--- a/lib/al/Project/Base/ParamRequestInterp.h
+++ b/lib/al/Project/Base/ParamRequestInterp.h
@@ -2,10 +2,12 @@
 
 #include <basis/seadTypes.h>
 
+#include "Library/HostIO/HioNode.h"
+
 namespace al {
 class ParameterObj;
 
-class IUseRequestParam {
+class IUseRequestParam : public HioNode {
 public:
     virtual const char* getParamName() const = 0;
     virtual ParameterObj* getParamObj() = 0;


### PR DESCRIPTION
A bunch of free symbols. But sadly I couldn't fix ParameterXXX ctor for this class.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1336)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (5eb179e - 70cd384)

📈 **Matched code**: 15.53% (+0.01%, +1288 bytes)

<details>
<summary>✅ 25 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::Parameter(sead::FixedSafeString<64> const&, sead::SafeStringBase<char> const&, sead::SafeStringBase<char> const&, sead::SafeStringBase<char> const&, al::ParameterObj*, bool)` | +516 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::isEqual(al::IUseRequestParam const&) const` | +188 | 0.00% | 100.00% |
| `Project/Base/ParamRequestInterp` | `al::IUseRequestParam::copyInterp(al::IUseRequestParam const&, al::IUseRequestParam const&, float)` | +164 | 0.00% | 100.00% |
| `Project/Base/ParamRequestInterp` | `al::IUseRequestParam::isEqual(al::IUseRequestParam const&) const` | +104 | 0.00% | 100.00% |
| `Project/Base/ParamRequestInterp` | `al::IUseRequestParam::copy(al::IUseRequestParam const&)` | +104 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getSkyName() const` | +48 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getRotate() const` | +12 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getStarIntensity() const` | +12 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getParamName() const` | +12 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::ParameterV3f::getParamTypeStr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::ParameterV3f::getParamType() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::Vector3<float> >::ptr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::Vector3<float> >::ptr()` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::Vector3<float> >::size() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::Vector3<float> >::getParamTypeStr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::Vector3<float> >::getParamType() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::ParameterString64::getParamTypeStr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::ParameterString64::getParamType() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::ptr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::ptr()` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::size() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::getParamTypeStr() const` | +8 | 0.00% | 100.00% |
| `Library/Fluid/RippleCtrl` | `al::Parameter<sead::FixedSafeString<64> >::getParamType() const` | +8 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getParamObj()` | +8 | 0.00% | 100.00% |
| `Library/Model/SkyDirector` | `al::SkyParam::getParamObj() const` | +8 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Model/SkyDirector` | `al::SkyParam::SkyParam()` | +184 | 0.00% | 25.00% |

</details>


<!-- decomp.dev report end -->