### PR TITLE
Library/Camera: Remove `normalizeUp` from `LookAtCamera`

### DIFF
--- a/lib/al/Library/Camera/CameraPoser.cpp
+++ b/lib/al/Library/Camera/CameraPoser.cpp
@@ -369,7 +369,6 @@ void CameraPoser::makeLookAtCameraPrev(sead::LookAtCamera* camera) const {
     camera->setPos(mEye);
     camera->setAt(mAt);
     camera->setUp(mUp);
-    camera->normalizeUp();
 
     if (mVerticalAbsorber && !mPoserFlag->isOffVerticalAbsorb)
         mVerticalAbsorber->makeLookAtCamera(camera);

--- a/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
+++ b/lib/al/Library/Play/Camera/CameraVerticalAbsorber.cpp
@@ -100,7 +100,6 @@ void CameraVerticalAbsorber::update() {
     mLookAtCamera.setPos(mCameraPoser->getEye());
     mLookAtCamera.setAt(mCameraPoser->getAt());
     mLookAtCamera.setUp(mCameraPoser->getUp());
-    mLookAtCamera.normalizeUp();
 
     makeLookAtCamera(&mLookAtCamera);
     mLookAtCamera.updateViewMatrix();


### PR DESCRIPTION
A slight temporary regression. normalizeUp is called every time setUp is called and is required for some functions to match in https://github.com/open-ead/sead/pull/213

Currently the sead PR breaks compilation in SMO and I want to fully pass the check since that PR is quite big and is important to verify that no unwanted regressions are introduced. Once 213 is merged the functions will be matching again.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1337)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (b64cbfb - 896b3e5)

📉 **Matched code**: 15.49% (-0.01%, -1392 bytes)

<details open>
<summary>🥀 2 broken matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Play/Camera/CameraVerticalAbsorber` | `al::CameraVerticalAbsorber::update()` | -642 | 100.00% | 25.00% |
| `Library/Camera/CameraPoser` | `al::CameraPoser::makeLookAtCameraPrev(sead::LookAtCamera*) const` | -402 | 100.00% | 25.00% |

</details>


<!-- decomp.dev report end -->