### PR TITLE
Library/Controller: Implement `PadGyroAddon`

### DIFF
--- a/lib/al/Library/Controller/PadGyroAddon.cpp
+++ b/lib/al/Library/Controller/PadGyroAddon.cpp
@@ -1,0 +1,29 @@
+#include "Library/Controller/PadGyroAddon.h"
+
+#include <controller/nin/seadNinJoyNpadDevice.h>
+#include <controller/seadControllerMgr.h>
+
+#include "Library/Controller/NpadController.h"
+
+namespace al {
+PadGyroAddon::PadGyroAddon(sead::Controller* controller, s32 index)
+    : sead::ControllerAddon(controller), mIndex(index) {
+    mId = sead::ControllerDefine::AddonId::cAddon_Gyro;
+}
+
+bool PadGyroAddon::calc() {
+    mIsStatusOk = tryUpdateGyroStatus();
+    return false;
+}
+
+void PadGyroAddon::getPose(sead::Vector3f* outSide, sead::Vector3f* outUp,
+                           sead::Vector3f* outFront) const {
+    if (outSide)
+        outSide->set(mSide);
+    if (outUp)
+        outUp->set(mUp);
+    if (outFront)
+        outFront->set(mFront);
+}
+
+}  // namespace al

--- a/lib/al/Library/Controller/PadGyroAddon.h
+++ b/lib/al/Library/Controller/PadGyroAddon.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <basis/seadTypes.h>
+#include <controller/seadControllerAddon.h>
+#include <math/seadVector.h>
+
+namespace al {
+class PadGyroAddon : public sead::ControllerAddon {
+    SEAD_RTTI_OVERRIDE(PadGyroAddon, ControllerAddon)
+public:
+    PadGyroAddon(sead::Controller* controller, s32 index);
+
+    bool calc() override;
+
+    bool tryUpdateGyroStatus();
+    void getPose(sead::Vector3f* outSide, sead::Vector3f* outUp, sead::Vector3f* outFront) const;
+
+private:
+    bool mIsStatusOk = false;
+    sead::Vector3f mSide = sead::Vector3f::ex;
+    sead::Vector3f mUp = sead::Vector3f::ey;
+    sead::Vector3f mFront = sead::Vector3f::ez;
+    sead::Vector3f mAngularVelocity = {0.0f, 0.0f, 0.0f};
+    sead::Vector3f mAngle = {0.0f, 0.0f, 0.0f};
+    s64 mPrevSamplingNumber = 0;
+    s32 mSampleCount = 0;
+    s32 mIndex;
+};
+
+static_assert(sizeof(PadGyroAddon) == 0x78);
+}  // namespace al


### PR DESCRIPTION
Required for `GameFrameworkNx::createControllerMgr` to match properly. I had this one for a while but I cant manage to match `tryUpdateGyroStatus`. Since a proper header is needed I made this PR to at least match what I have.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1341)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (5eb179e - 44a51e1)

📈 **Matched code**: 15.52% (+0.00%, +532 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::checkDerivedRuntimeTypeInfo(sead::RuntimeTypeInfo::Interface const*) const` | +204 | 0.00% | 100.00% |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::PadGyroAddon(sead::Controller*, int)` | +124 | 0.00% | 100.00% |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::getRuntimeTypeInfo() const` | +92 | 0.00% | 100.00% |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::getPose(sead::Vector3<float>*, sead::Vector3<float>*, sead::Vector3<float>*) const` | +64 | 0.00% | 100.00% |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::calc()` | +44 | 0.00% | 100.00% |
| `Library/Controller/PadGyroAddon` | `al::PadGyroAddon::~PadGyroAddon()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->