### PR TITLE
workflow: Add custom commit names to renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -17,5 +17,22 @@
       "datasourceTemplate": "github-releases",
       "depNameTemplate": "MonsterDruide1/OdysseyDecompToolsCache"
     }
-  ]
+  ],
+  "semanticCommits": "disabled",
+  "packageRules": [
+    {
+      "matchManagers": ["git-submodules"],
+      "commitMessage": "{{{depName}}}: Update to {{{newDigestShort}}}"
+    },
+    {
+      "matchManagers": ["github-actions"],
+      "commitMessage": "workflow: Update {{{depName}}} to {{{newVersion}}}"
+    },
+    {
+      "matchManagers": ["custom.regex"],
+      "matchDepNames": ["MonsterDruide1/OdysseyDecompToolsCache"],
+      "commitMessage": "tools: Update binary cache to {{{newVersion}}}"
+    }
+  ],
+  "configMigration": true
 }


### PR DESCRIPTION
Adds three different "handlers" for custom commit messages on Reviewable PRs, that follow our usual convention:
- submodules/libaries: `lib/sead: Update to abcdef`
- GitHub actions: `workflow: Update myaction to v1.2.3`
- binary tools ache: `tools: Update binary cache to v1.2.3`

There's no way to test this, let's just hope this works.
On other changes, I disabled `semanticCommits` (`chore(deps): [...]`), although that's probably useless now, and enabled Renovate migrating its own config if something changes on their side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1342)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (6cea24b - 4e738bc)

No changes

<!-- decomp.dev report end -->