### PR TITLE
workflow: add code blocks to custom renovate commit names

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,16 +22,16 @@
   "packageRules": [
     {
       "matchManagers": ["git-submodules"],
-      "commitMessage": "{{{depName}}}: Update to {{{newDigestShort}}}"
+      "commitMessage": "{{{depName}}}: Update to `{{{newDigestShort}}}`"
     },
     {
       "matchManagers": ["github-actions"],
-      "commitMessage": "workflow: Update {{{depName}}} to {{{newVersion}}}"
+      "commitMessage": "workflow: Update `{{{depName}}}` to `{{{newVersion}}}`"
     },
     {
       "matchManagers": ["custom.regex"],
       "matchDepNames": ["MonsterDruide1/OdysseyDecompToolsCache"],
-      "commitMessage": "tools: Update binary cache to {{{newVersion}}}"
+      "commitMessage": "tools: Update binary cache to `{{{newVersion}}}`"
     }
   ],
   "configMigration": true


### PR DESCRIPTION
Follow-up to #1342, where I forgot to add the backticks for making code blocks in the names.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1350)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (430f414 - 10d7142)

No changes

<!-- decomp.dev report end -->