### PR TITLE
MapObj: implement PropellerRotateCtrl

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -80217,19 +80217,19 @@ MapObj/PropellerRotateCtrl.o:
     label:
     - _ZN19PropellerRotateCtrlC1EPN2al9LiveActorERK19PropellerRotateInfo
     - _ZN19PropellerRotateCtrlC2EPN2al9LiveActorERK19PropellerRotateInfo
-    status: NotDecompiled
+    status: Matching
   - offset: 0x2e845c
     size: 56
     label: _ZN19PropellerRotateCtrl6updateEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x2e8494
     size: 232
     label: _ZN19PropellerRotateCtrl17calcJointCallbackEiPN4sead8Matrix34IfEE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x2e857c
     size: 12
     label: _ZNK19PropellerRotateCtrl15getCtrlTypeNameEv
-    status: NotDecompiled
+    status: Matching
     lazy: true
 MapObj/PulseSwitch.o:
   '.text':

--- a/src/MapObj/PropellerRotateCtrl.cpp
+++ b/src/MapObj/PropellerRotateCtrl.cpp
@@ -1,0 +1,36 @@
+#include "MapObj/PropellerRotateCtrl.h"
+
+#include "Library/Joint/JointControllerKeeper.h"
+#include "Library/LiveActor/ActorModelFunction.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Math/MatrixUtil.h"
+
+PropellerRotateCtrl::PropellerRotateCtrl(al::LiveActor* actor, const PropellerRotateInfo& info)
+    : al::JointControllerBase(16), mRotateInfo(&info) {
+    appendJointId(al::getJointIndex(actor, info.mJointName));
+    al::registerJointController(actor, this);
+}
+
+void PropellerRotateCtrl::update() {
+    mRotateFrame =
+        al::modi(mRotateFrame + mRotateInfo->mRotatePeriod + 1, mRotateInfo->mRotatePeriod);
+}
+
+void PropellerRotateCtrl::calcJointCallback(s32 jointIndex, sead::Matrix34f* mtx) {
+    if (mRotateFrame < 1)
+        return;
+
+    s32 axis = mRotateInfo->mRotateAxis % 3;
+    f32 direction = mRotateInfo->mRotateDirection;
+    if (axis == 0) {
+        direction *= al::normalize(mRotateFrame, 0, mRotateInfo->mRotatePeriod);
+        al::rotateMtxXDirDegree(mtx, *mtx, direction * 360.0f);
+    } else if (axis == 1)
+        al::rotateMtxYDirDegree(
+            mtx, *mtx,
+            direction * al::normalize(mRotateFrame, 0, mRotateInfo->mRotatePeriod) * 360.0f);
+    else
+        al::rotateMtxZDirDegree(
+            mtx, *mtx,
+            direction * al::normalize(mRotateFrame, 0, mRotateInfo->mRotatePeriod) * 360.0f);
+}

--- a/src/MapObj/PropellerRotateCtrl.h
+++ b/src/MapObj/PropellerRotateCtrl.h
@@ -6,7 +6,15 @@ namespace al {
 class LiveActor;
 }
 
-class PropellerRotateInfo;
+class PropellerRotateInfo {
+public:
+    const char* mJointName;
+    s32 mRotateAxis;
+    s32 mRotateDirection;
+    s32 mRotatePeriod;
+};
+
+static_assert(sizeof(PropellerRotateInfo) == 0x18);
 
 class PropellerRotateCtrl : public al::JointControllerBase {
 public:
@@ -14,7 +22,8 @@ public:
 
     void update();
     void calcJointCallback(s32 jointIndex, sead::Matrix34f* mtx) override;
-    const char* getCtrlTypeName() const override;
+
+    const char* getCtrlTypeName() const override { return "プロペラ回転制御"; }
 
 private:
     const PropellerRotateInfo* mRotateInfo = nullptr;


### PR DESCRIPTION
Implements all four functions in `MapObj/PropellerRotateCtrl.o` and defines the `PropellerRotateInfo` layout with a size assertion. The constructor, `update()`, `calcJointCallback()`, and `getCtrlTypeName()` all match the original assembly and are marked `Matching` in `data/file_list.yml`.

Validation: build passes; each function passes `tools/check`; the full `tools/check` passes; clang-format, repository style checks for both changed C++ files, and `git diff --check` pass.

Closes MonsterDruide1/OdysseyDecompTracker#799.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1352)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1b31730 - 40c582b)

📈 **Matched code**: 15.58% (+0.00%, +408 bytes)

<details>
<summary>✅ 4 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/PropellerRotateCtrl` | `PropellerRotateCtrl::calcJointCallback(int, sead::Matrix34<float>*)` | +232 | 0.00% | 100.00% |
| `MapObj/PropellerRotateCtrl` | `PropellerRotateCtrl::PropellerRotateCtrl(al::LiveActor*, PropellerRotateInfo const&)` | +108 | 0.00% | 100.00% |
| `MapObj/PropellerRotateCtrl` | `PropellerRotateCtrl::update()` | +56 | 0.00% | 100.00% |
| `MapObj/PropellerRotateCtrl` | `PropellerRotateCtrl::getCtrlTypeName() const` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->