### PR TITLE
Player: Implement `WhipTargetInfo`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -129704,27 +129704,27 @@ Player/WhipTargetInfo.o:
     label:
     - _ZN14WhipTargetInfoC1Ev
     - _ZN14WhipTargetInfoC2Ev
-    status: NotDecompiled
+    status: Matching
   - offset: 0x493eb0
     size: 8
     label: _ZN14WhipTargetInfo14initWhipTargetEPN2al9HitSensorEPKN4sead7Vector3IfEE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x493eb8
     size: 8
     label: _ZN14WhipTargetInfo5clearEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x493ec0
     size: 16
     label: _ZNK14WhipTargetInfo7isValidEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x493ed0
     size: 44
     label: _ZN14WhipTargetInfo15calcTargetUpDirEPN4sead7Vector3IfEE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x493efc
     size: 24
     label: _ZNK14WhipTargetInfo8getTransEv
-    status: NotDecompiled
+    status: Matching
 Player/Yoshi.o:
   '.text':
   - offset: 0x493f14

--- a/src/Player/WhipTargetInfo.cpp
+++ b/src/Player/WhipTargetInfo.cpp
@@ -1,0 +1,30 @@
+#include "Player/WhipTargetInfo.h"
+
+#include "Library/LiveActor/ActorPoseUtil.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+
+WhipTargetInfo::WhipTargetInfo() = default;
+
+void WhipTargetInfo::initWhipTarget(al::HitSensor* sensor, const sead::Vector3f* trans) {
+    mTrans = trans;
+    mSensor = sensor;
+}
+
+void WhipTargetInfo::clear() {
+    mTrans = nullptr;
+    mSensor = nullptr;
+}
+
+bool WhipTargetInfo::isValid() const {
+    return mSensor != nullptr;
+}
+
+void WhipTargetInfo::calcTargetUpDir(sead::Vector3f* upDir) {
+    al::calcUpDir(upDir, al::getSensorHost(mSensor));
+}
+
+const sead::Vector3f& WhipTargetInfo::getTrans() const {
+    if (mTrans)
+        return *mTrans;
+    return al::getSensorPos(mSensor);
+}

--- a/src/Player/WhipTargetInfo.h
+++ b/src/Player/WhipTargetInfo.h
@@ -15,4 +15,10 @@ public:
     bool isValid() const;
     void calcTargetUpDir(sead::Vector3f* upDir);
     const sead::Vector3f& getTrans() const;
+
+private:
+    const sead::Vector3f* mTrans = nullptr;
+    al::HitSensor* mSensor = nullptr;
 };
+
+static_assert(sizeof(WhipTargetInfo) == 0x10);


### PR DESCRIPTION
Implements all six functions in `Player/WhipTargetInfo.o`, including target initialization, clearing, validity checks, the target actor's up direction, and position lookup with a sensor-position fallback. Adds the two-pointer member layout and a `0x10` size assertion, and marks all six functions `Matching` in `data/file_list.yml`.

Validation: `ninja -C build` and the full `tools/check` pass. All six functions pass individual binary matching and placement checks. Both C++ files pass clang-format and repository style checks; `git diff --check` passes.

Closes MonsterDruide1/OdysseyDecompTracker#1324.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1354)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1b31730 - 944d184)

📈 **Matched code**: 15.58% (+0.00%, +108 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/WhipTargetInfo` | `WhipTargetInfo::calcTargetUpDir(sead::Vector3<float>*)` | +44 | 0.00% | 100.00% |
| `Player/WhipTargetInfo` | `WhipTargetInfo::getTrans() const` | +24 | 0.00% | 100.00% |
| `Player/WhipTargetInfo` | `WhipTargetInfo::isValid() const` | +16 | 0.00% | 100.00% |
| `Player/WhipTargetInfo` | `WhipTargetInfo::WhipTargetInfo()` | +8 | 0.00% | 100.00% |
| `Player/WhipTargetInfo` | `WhipTargetInfo::initWhipTarget(al::HitSensor*, sead::Vector3<float> const*)` | +8 | 0.00% | 100.00% |
| `Player/WhipTargetInfo` | `WhipTargetInfo::clear()` | +8 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->