### PR TITLE
Util: Implement `SwitchUtil`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -170303,11 +170303,11 @@ Util/SwitchUtil.o:
   - offset: 0x5bfa18
     size: 92
     label: _ZN2rs18isOnSwitchLinkSaveEPKN2al9LiveActorERKNS0_13ActorInitInfoE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x5bfa74
     size: 12
     label: _ZN2rs12isSaveSwitchERKN2al13ActorInitInfoE
-    status: NotDecompiled
+    status: Matching
 Util/TextureUtil.o:
   '.text':
   - offset: 0x5bfa80

--- a/src/Util/SwitchUtil.cpp
+++ b/src/Util/SwitchUtil.cpp
@@ -1,0 +1,20 @@
+#include "Util/SwitchUtil.h"
+
+#include "Library/Placement/PlacementFunction.h"
+#include "Library/Placement/PlacementId.h"
+#include "Library/Placement/PlacementInfo.h"
+
+namespace rs {
+bool isOnSwitchLinkSave(const al::LiveActor* actor, const al::ActorInitInfo& actorInitInfo) {
+    al::PlacementInfo placementInfo;
+    if (al::tryGetLinksInfo(&placementInfo, actorInitInfo, "NoDelete_SwitchSave")) {
+        al::PlacementId placementId;
+        al::getPlacementId(&placementId, placementInfo);
+    }
+    return false;
+}
+
+bool isSaveSwitch(const al::ActorInitInfo& actorInitInfo) {
+    return al::isObjectNameSubStr(actorInitInfo, "Save");
+}
+}  // namespace rs


### PR DESCRIPTION
Implements both functions in `Util/SwitchUtil.o`. `isOnSwitchLinkSave()` preserves the original behavior: it looks up `NoDelete_SwitchSave`, reads its placement ID when present, and returns `false`. `isSaveSwitch()` checks whether the object name contains `Save`. Both functions match the original assembly and are marked `Matching` in `data/file_list.yml`.

Validation: `ninja -C build` and the full `tools/check` pass. Both functions pass individual binary matching and placement checks; clang-format, repository style checks for the new source file, and `git diff --check` pass.

Closes MonsterDruide1/OdysseyDecompTracker#1544.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1355)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (1b31730 - b4b5940)

📈 **Matched code**: 15.58% (+0.00%, +104 bytes)

<details>
<summary>✅ 2 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/SwitchUtil` | `rs::isOnSwitchLinkSave(al::LiveActor const*, al::ActorInitInfo const&)` | +92 | 0.00% | 100.00% |
| `Util/SwitchUtil` | `rs::isSaveSwitch(al::ActorInitInfo const&)` | +12 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->