### PR TITLE
Library/LiveActor: Fix symbol of `setAllAnimFrameRate`

### DIFF
--- a/lib/al/Library/LiveActor/ActorAnimFunction.h
+++ b/lib/al/Library/LiveActor/ActorAnimFunction.h
@@ -63,7 +63,7 @@ inline void createMat(const LiveActor* actor, s32 programType) {
 // All
 
 void setAllAnimFrame(LiveActor* actor, f32 frame);
-void setAllAnimFrameRate(LiveActor* f32);
+void setAllAnimFrameRate(LiveActor* actor, f32 frameRate);
 
 // Skl
 


### PR DESCRIPTION
`f32` is not a good name for a parameter. This one was missing a comma, but let's add the proper names, while we're at it.

Found and reported by @mcanterogomez

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1356)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (833f614 - d4fa269)

No changes

<!-- decomp.dev report end -->