### PR TITLE
Player: Implement `HackerJudgeNormalFall`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -114555,19 +114555,19 @@ Player/HackerJudgeNormalFall.o:
     label:
     - _ZN21HackerJudgeNormalFallC1EPKN2al9LiveActorEi
     - _ZN21HackerJudgeNormalFallC2EPKN2al9LiveActorEi
-    status: NotDecompiled
+    status: Matching
   - offset: 0x40eac4
     size: 8
     label: _ZN21HackerJudgeNormalFall5resetEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x40eacc
     size: 100
     label: _ZN21HackerJudgeNormalFall6updateEv
-    status: NotDecompiled
+    status: NonMatchingMinor
   - offset: 0x40eb30
     size: 16
     label: _ZNK21HackerJudgeNormalFall5judgeEv
-    status: NotDecompiled
+    status: Matching
 Player/HackerJudgeStartJump.o:
   '.text':
   - offset: 0x40eb40

--- a/src/Player/HackerJudgeNormalFall.cpp
+++ b/src/Player/HackerJudgeNormalFall.cpp
@@ -1,0 +1,30 @@
+#include "Player/HackerJudgeNormalFall.h"
+
+#include <math/seadMathCalcCommon.h>
+
+#include "Library/LiveActor/ActorCollisionFunction.h"
+
+#include "Util/PlayerCollisionUtil.h"
+
+HackerJudgeNormalFall::HackerJudgeNormalFall(const al::LiveActor* parent, s32 fallFrame)
+    : mActor(parent), mFallFrame(fallFrame) {}
+
+void HackerJudgeNormalFall::reset() {
+    mFramesNoCollideGround = 0;
+}
+
+// The original materializes the counter address separately in each collision branch.
+void HackerJudgeNormalFall::update() {
+    if (mPlayerCollision)
+        mFramesNoCollideGround = rs::isCollidedGround(mPlayerCollision) ?
+                                     0 :
+                                     sead::Mathi::clampMax(mFramesNoCollideGround + 1, mFallFrame);
+    else
+        mFramesNoCollideGround = al::isCollidedGround(mActor) ?
+                                     0 :
+                                     sead::Mathi::clampMax(mFramesNoCollideGround + 1, mFallFrame);
+}
+
+bool HackerJudgeNormalFall::judge() const {
+    return mFramesNoCollideGround >= mFallFrame;
+}

--- a/src/Player/HackerJudgeNormalFall.h
+++ b/src/Player/HackerJudgeNormalFall.h
@@ -14,7 +14,8 @@ class IUsePlayerCollision;
 
 class HackerJudgeNormalFall : public al::HioNode, public IJudge {
 public:
-    HackerJudgeNormalFall(const al::LiveActor* parent, s32 unk);
+    HackerJudgeNormalFall(const al::LiveActor* parent, s32 fallFrame);
+
     void reset() override;
     void update() override;
     bool judge() const override;
@@ -24,10 +25,10 @@ public:
     }
 
 private:
-    al::LiveActor* mActor;
-    s32 _10;
-    s32 _14;
-    IUsePlayerCollision* mPlayerCollision;
+    const al::LiveActor* mActor;
+    s32 mFallFrame;
+    s32 mFramesNoCollideGround = 0;
+    IUsePlayerCollision* mPlayerCollision = nullptr;
 };
 
 static_assert(sizeof(HackerJudgeNormalFall) == 0x20);


### PR DESCRIPTION
Implements `HackerJudgeNormalFall` to count consecutive frames without ground collision, reset the counter on ground contact, and report falling once the configured threshold is reached. Uses player collision when supplied, otherwise the actor's collision, and gives the previously unknown fields descriptive names.

The constructor, `reset()`, and `judge()` match the original binary. `update()` is marked `NonMatchingMinor`: it compiles to 92 bytes instead of 100 because the counter is stored using a direct offset rather than a separately computed address in each collision branch, with corresponding register allocation differences.

Validation: `ninja -C build`, full `tools/check` with these statuses, clang-format, custom style checks for the changed files, and `git diff --check` pass. The three matching functions also pass individual matching and placement checks.

Closes MonsterDruide1/OdysseyDecompTracker#1159.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1359)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (71e64e1 - 0bc56a6)

📈 **Matched code**: 15.58% (+0.00%, +52 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackerJudgeNormalFall` | `HackerJudgeNormalFall::HackerJudgeNormalFall(al::LiveActor const*, int)` | +28 | 0.00% | 100.00% |
| `Player/HackerJudgeNormalFall` | `HackerJudgeNormalFall::judge() const` | +16 | 0.00% | 100.00% |
| `Player/HackerJudgeNormalFall` | `HackerJudgeNormalFall::reset()` | +8 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackerJudgeNormalFall` | `HackerJudgeNormalFall::update()` | +75 | 0.00% | 75.00% |

</details>


<!-- decomp.dev report end -->