### PR TITLE
Player: Implement `HackerJudgeStartRun`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -114597,20 +114597,20 @@ Player/HackerJudgeStartRun.o:
     label:
     - _ZN19HackerJudgeStartRunC1EPKN2al9LiveActorEPP14IUsePlayerHack
     - _ZN19HackerJudgeStartRunC2EPKN2al9LiveActorEPP14IUsePlayerHack
-    status: NotDecompiled
+    status: Matching
   - offset: 0x40ebc8
     size: 140
     label: _ZNK19HackerJudgeStartRun5judgeEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x40ec54
     size: 4
     label: _ZN19HackerJudgeStartRun5resetEv
-    status: NotDecompiled
+    status: Matching
     lazy: true
   - offset: 0x40ec58
     size: 4
     label: _ZN19HackerJudgeStartRun6updateEv
-    status: NotDecompiled
+    status: Matching
     lazy: true
 Player/HackerStateBase.o:
   '.text':

--- a/src/Player/HackerJudgeStartRun.cpp
+++ b/src/Player/HackerJudgeStartRun.cpp
@@ -1,0 +1,24 @@
+#include "Player/HackerJudgeStartRun.h"
+
+#include "Library/LiveActor/ActorCollisionFunction.h"
+
+#include "Player/PlayerCounterForceRun.h"
+#include "Util/PlayerCollisionUtil.h"
+#include "Util/PlayerHackInputFunction.h"
+
+HackerJudgeStartRun::HackerJudgeStartRun(const al::LiveActor* parent, IUsePlayerHack** hacker)
+    : HackerJudge(hacker), mParent(parent) {}
+
+bool HackerJudgeStartRun::judge() const {
+    if (!(mPlayerCollision ? rs::isCollidedGround(mPlayerCollision) :
+                             al::isCollidedGround(mParent)))
+        return false;
+    if (rs::isOnHackMoveStick(*getHacker()))
+        return true;
+    if (mCounterForceRun && mCounterForceRun->isForceRun())
+        return true;
+    if (mPlayerCollision && mAutoRunSpeedThreshold > 0.0f &&
+        rs::isAutoRunOnGroundSkateCode(mParent, mPlayerCollision, mAutoRunSpeedThreshold))
+        return true;
+    return false;
+}

--- a/src/Player/HackerJudgeStartRun.h
+++ b/src/Player/HackerJudgeStartRun.h
@@ -10,12 +10,16 @@ class LiveActor;
 
 class IUsePlayerCollision;
 class IUsePlayerHack;
+class PlayerCounterForceRun;
 
 class HackerJudgeStartRun : public HackerJudge {
 public:
-    HackerJudgeStartRun(const al::LiveActor*, IUsePlayerHack**);
-    void reset() override;
-    void update() override;
+    HackerJudgeStartRun(const al::LiveActor* parent, IUsePlayerHack** hacker);
+
+    void reset() override {}
+
+    void update() override {}
+
     bool judge() const override;
 
     void setPlayerCollision(IUsePlayerCollision* playerCollision) {
@@ -23,10 +27,10 @@ public:
     }
 
 private:
-    al::LiveActor* mParent;
-    s32 _18;
-    IUsePlayerCollision* mPlayerCollision;
-    f32 _28;
+    const al::LiveActor* mParent;
+    const PlayerCounterForceRun* mCounterForceRun = nullptr;
+    IUsePlayerCollision* mPlayerCollision = nullptr;
+    f32 mAutoRunSpeedThreshold = 0.0f;
 };
 
 static_assert(sizeof(HackerJudgeStartRun) == 0x30);


### PR DESCRIPTION
Implements `HackerJudgeStartRun` using the existing ground-collision, hack movement-input, force-run, and auto-run helpers. Corrects the force-run field to a `PlayerCounterForceRun` pointer and names the auto-run speed threshold. The empty `reset()` and `update()` functions are defined inline in the header with their `lazy` flags preserved.

All four functions match the original binary and are marked `Matching` in `data/file_list.yml` (216 bytes total).

Validation: `ninja -C build`, full `tools/check`, individual matching and placement checks for all four functions, clang-format, custom style checks for the changed files, and `git diff --check` pass.

Closes MonsterDruide1/OdysseyDecompTracker#1161.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1360)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (71e64e1 - 0343131)

📈 **Matched code**: 15.58% (+0.00%, +216 bytes)

<details>
<summary>✅ 4 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Player/HackerJudgeStartRun` | `HackerJudgeStartRun::judge() const` | +140 | 0.00% | 100.00% |
| `Player/HackerJudgeStartRun` | `HackerJudgeStartRun::HackerJudgeStartRun(al::LiveActor const*, IUsePlayerHack**)` | +68 | 0.00% | 100.00% |
| `Player/HackerJudgeStartRun` | `HackerJudgeStartRun::reset()` | +4 | 0.00% | 100.00% |
| `Player/HackerJudgeStartRun` | `HackerJudgeStartRun::update()` | +4 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->