### PR TITLE
Util: Implement `MoonRockUtil`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -155001,23 +155001,23 @@ Util/MoonRockUtil.o:
   - offset: 0x556b90
     size: 64
     label: _ZN2rs38isEnableShowDemoAfterOpenMoonRockFirstEPKN2al9LiveActorE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x556bd0
     size: 64
     label: _ZN2rs23isFirstDemoOpenMoonRockEPKN2al9LiveActorE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x556c10
     size: 104
     label: _ZN2rs32isEnableShowDemoMoonRockMapWorldEPKN2al9LiveActorE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x556c78
     size: 60
     label: _ZN2rs30showDemoAfterOpenMoonRockFirstEPKN2al9LiveActorE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x556cb4
     size: 100
     label: _ZN2rs24showDemoMoonRockMapWorldEPKN2al9LiveActorE
-    status: NotDecompiled
+    status: Matching
 Util/MoviePlayer.o:
   '.text':
   - offset: 0x556d18

--- a/src/Util/MoonRockUtil.cpp
+++ b/src/Util/MoonRockUtil.cpp
@@ -1,0 +1,38 @@
+#include "Util/MoonRockUtil.h"
+
+#include "Library/LiveActor/LiveActor.h"
+
+#include "System/GameDataFile.h"
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolder.h"
+#include "System/GameDataHolderAccessor.h"
+#include "System/MoonRockData.h"
+
+namespace rs {
+bool isEnableShowDemoAfterOpenMoonRockFirst(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    return accessor->getGameDataFile()->getMoonRockData()->isEnableShowDemoAfterOpenMoonRockFirst();
+}
+
+bool isFirstDemoOpenMoonRock(const al::LiveActor* actor) {
+    return isEnableShowDemoAfterOpenMoonRockFirst(actor);
+}
+
+bool isEnableShowDemoMoonRockMapWorld(const al::LiveActor* actor) {
+    MoonRockData* moonRockData =
+        GameDataHolderAccessor(actor)->getGameDataFile()->getMoonRockData();
+    return moonRockData->isEnableShowDemoMoonRockMapWorld(
+        GameDataFunction::getCurrentWorldIdNoDevelop(actor));
+}
+
+void showDemoAfterOpenMoonRockFirst(const al::LiveActor* actor) {
+    GameDataHolderAccessor accessor(actor);
+    accessor->getGameDataFile()->getMoonRockData()->showDemoAfterOpenMoonRockFirst();
+}
+
+void showDemoMoonRockMapWorld(const al::LiveActor* actor) {
+    MoonRockData* moonRockData =
+        GameDataHolderAccessor(actor)->getGameDataFile()->getMoonRockData();
+    moonRockData->showDemoMoonRockMapWorld(GameDataFunction::getCurrentWorldIdNoDevelop(actor));
+}
+}  // namespace rs


### PR DESCRIPTION
Implements all five functions in `Util/MoonRockUtil.o` using the existing game-data and Moon Rock helpers, and marks them as matching.

Validation: all five functions match the original binary (392 bytes), including placement checks. The full build, `tools/check`, and formatting checks pass.

Closes MonsterDruide1/OdysseyDecompTracker#1519

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1361)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (71e64e1 - e56dea6)

📈 **Matched code**: 15.58% (+0.00%, +392 bytes)

<details>
<summary>✅ 5 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Util/MoonRockUtil` | `rs::isEnableShowDemoMoonRockMapWorld(al::LiveActor const*)` | +104 | 0.00% | 100.00% |
| `Util/MoonRockUtil` | `rs::showDemoMoonRockMapWorld(al::LiveActor const*)` | +100 | 0.00% | 100.00% |
| `Util/MoonRockUtil` | `rs::isEnableShowDemoAfterOpenMoonRockFirst(al::LiveActor const*)` | +64 | 0.00% | 100.00% |
| `Util/MoonRockUtil` | `rs::isFirstDemoOpenMoonRock(al::LiveActor const*)` | +64 | 0.00% | 100.00% |
| `Util/MoonRockUtil` | `rs::showDemoAfterOpenMoonRockFirst(al::LiveActor const*)` | +60 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->