### PR TITLE
MapObj: Implement `TouchTargetInfo`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -89236,27 +89236,27 @@ MapObj/TouchTargetInfo.o:
     label:
     - _ZN15TouchTargetInfoC1Ev
     - _ZN15TouchTargetInfoC2Ev
-    status: NotDecompiled
+    status: Matching
   - offset: 0x33a134
     size: 152
     label: _ZN15TouchTargetInfo15setInfoBySensorEPKN2al9HitSensorERKN4sead7Vector3IfEES8_
-    status: NotDecompiled
+    status: Matching
   - offset: 0x33a1cc
     size: 28
     label: _ZN15TouchTargetInfo5resetEv
-    status: NotDecompiled
+    status: Matching
   - offset: 0x33a1e8
     size: 88
     label: _ZN15TouchTargetInfo18setInfoByConnectorEPKN2al12MtxConnectorERKN4sead7Vector3IfEES8_b
-    status: NotDecompiled
+    status: Matching
   - offset: 0x33a240
     size: 76
     label: _ZN15TouchTargetInfo18setInfoByPosAndNrmERKN4sead7Vector3IfEES4_
-    status: NotDecompiled
+    status: Matching
   - offset: 0x33a28c
     size: 228
     label: _ZNK15TouchTargetInfo20calcCurrentPosAndNrmEPN4sead7Vector3IfEES3_
-    status: NotDecompiled
+    status: Matching
 MapObj/TouchTargetKeeper.o:
   '.text':
   - offset: 0x33a370

--- a/src/MapObj/TouchTargetInfo.cpp
+++ b/src/MapObj/TouchTargetInfo.cpp
@@ -1,0 +1,70 @@
+#include "MapObj/TouchTargetInfo.h"
+
+#include "Library/Collision/PartsMtxConnector.h"
+#include "Library/LiveActor/ActorSensorUtil.h"
+
+TouchTargetInfo::TouchTargetInfo() {
+    reset();
+}
+
+void TouchTargetInfo::setInfoBySensor(const al::HitSensor* sensor, const sead::Vector3f& offset,
+                                      const sead::Vector3f& normal) {
+    reset();
+    mType = Type::Sensor;
+    mIsKeepTarget = true;
+    mSensor = sensor;
+    mSensorOffset = offset;
+    mPos.setAdd(al::getSensorPos(sensor), mSensorOffset);
+    mNormal.set(normal);
+}
+
+void TouchTargetInfo::reset() {
+    mType = Type::PosAndNrm;
+    mIsKeepTarget = false;
+    mSensor = nullptr;
+    mConnector = nullptr;
+    mSensorOffset.set(0.0f, 0.0f, 0.0f);
+    mPos.set(0.0f, 0.0f, 0.0f);
+    mNormal.set(0.0f, 0.0f, 0.0f);
+}
+
+void TouchTargetInfo::setInfoByConnector(const al::MtxConnector* connector,
+                                         const sead::Vector3f& pos, const sead::Vector3f& normal,
+                                         bool isKeepTarget) {
+    reset();
+    mType = Type::Connector;
+    mIsKeepTarget = isKeepTarget;
+    mConnector = connector;
+    mPos = pos;
+    mNormal = normal;
+}
+
+void TouchTargetInfo::setInfoByPosAndNrm(const sead::Vector3f& pos, const sead::Vector3f& normal) {
+    reset();
+    mType = Type::PosAndNrm;
+    mPos = pos;
+    mNormal = normal;
+}
+
+void TouchTargetInfo::calcCurrentPosAndNrm(sead::Vector3f* pos, sead::Vector3f* normal) const {
+    switch (mType) {
+    case Type::PosAndNrm:
+        if (pos)
+            pos->set(mPos);
+        if (normal)
+            normal->set(mNormal);
+        break;
+    case Type::Sensor:
+        if (pos)
+            pos->setAdd(al::getSensorPos(mSensor), mSensorOffset);
+        if (normal)
+            normal->set(mNormal);
+        break;
+    case Type::Connector:
+        if (pos)
+            mConnector->multTrans(pos, mPos);
+        if (normal)
+            mConnector->multVec(normal, mNormal);
+        break;
+    }
+}

--- a/src/MapObj/TouchTargetInfo.h
+++ b/src/MapObj/TouchTargetInfo.h
@@ -9,8 +9,30 @@ class MtxConnector;
 
 class TouchTargetInfo {
 public:
-    void setInfoBySensor(const al::HitSensor*, const sead::Vector3f&, const sead::Vector3f&);
-    void setInfoByConnector(const al::MtxConnector*, const sead::Vector3f&, const sead::Vector3f&,
-                            bool);
-    void setInfoByPosAndNrm(const sead::Vector3f&, const sead::Vector3f&);
+    TouchTargetInfo();
+
+    void setInfoBySensor(const al::HitSensor* sensor, const sead::Vector3f& offset,
+                         const sead::Vector3f& normal);
+    void reset();
+    void setInfoByConnector(const al::MtxConnector* connector, const sead::Vector3f& pos,
+                            const sead::Vector3f& normal, bool isKeepTarget);
+    void setInfoByPosAndNrm(const sead::Vector3f& pos, const sead::Vector3f& normal);
+    void calcCurrentPosAndNrm(sead::Vector3f* pos, sead::Vector3f* normal) const;
+
+private:
+    enum class Type {
+        PosAndNrm,
+        Sensor,
+        Connector,
+    };
+
+    Type mType;
+    bool mIsKeepTarget;
+    const al::HitSensor* mSensor;
+    const al::MtxConnector* mConnector;
+    sead::Vector3f mSensorOffset;
+    sead::Vector3f mPos;
+    sead::Vector3f mNormal;
 };
+
+static_assert(sizeof(TouchTargetInfo) == 0x40);


### PR DESCRIPTION
Implements all six functions in `MapObj/TouchTargetInfo.o` and restores the class layout for sensor, connector, and position/normal targets. Uses the existing sensor, matrix connector, and vector helpers, and names the target-retention flag `mIsKeepTarget` based on its use in `TouchTargetKeeper::update()`.

Validation: all six functions (600 bytes) pass binary matching and placement checks. The full build, `tools/check`, and formatting checks pass.

Closes MonsterDruide1/OdysseyDecompTracker#902

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1362)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (0c397c5 - f2c36ec)

📈 **Matched code**: 15.60% (+0.00%, +600 bytes)

<details>
<summary>✅ 6 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::calcCurrentPosAndNrm(sead::Vector3<float>*, sead::Vector3<float>*) const` | +228 | 0.00% | 100.00% |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::setInfoBySensor(al::HitSensor const*, sead::Vector3<float> const&, sead::Vector3<float> const&)` | +152 | 0.00% | 100.00% |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::setInfoByConnector(al::MtxConnector const*, sead::Vector3<float> const&, sead::Vector3<float> const&, bool)` | +88 | 0.00% | 100.00% |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::setInfoByPosAndNrm(sead::Vector3<float> const&, sead::Vector3<float> const&)` | +76 | 0.00% | 100.00% |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::TouchTargetInfo()` | +28 | 0.00% | 100.00% |
| `MapObj/TouchTargetInfo` | `TouchTargetInfo::reset()` | +28 | 0.00% | 100.00% |

</details>


<!-- decomp.dev report end -->