### PR TITLE
Item: Implement `RandomItemSelector`

### DIFF
--- a/data/file_list.yml
+++ b/data/file_list.yml
@@ -49699,19 +49699,19 @@ Item/RandomItemSelector.o:
     label:
     - _ZN18RandomItemSelectorC1Ev
     - _ZN18RandomItemSelectorC2Ev
-    status: NotDecompiled
+    status: Matching
   - offset: 0x1ccf60
     size: 136
     label: _ZN18RandomItemSelector17getRandomItemTypeEPKN2al18IUseSceneObjHolderE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x1ccfe8
     size: 8
     label: _ZN2rs24createRandomItemSelectorEPKN2al18IUseSceneObjHolderE
-    status: NotDecompiled
+    status: Matching
   - offset: 0x1ccff0
     size: 4
     label: _ZN18RandomItemSelectorD0Ev
-    status: NotDecompiled
+    status: Matching
     lazy: true
 Item/Shine.o:
   '.text':

--- a/src/Item/RandomItemSelector.cpp
+++ b/src/Item/RandomItemSelector.cpp
@@ -1,0 +1,60 @@
+#include "Item/RandomItemSelector.h"
+
+#include "Library/Base/StringUtil.h"
+#include "Library/Math/MathUtil.h"
+#include "Library/Resource/ResourceFunction.h"
+#include "Library/Scene/SceneObjUtil.h"
+#include "Library/Yaml/ByamlIter.h"
+
+#include "System/GameDataFunction.h"
+#include "System/GameDataHolderAccessor.h"
+
+RandomItemSelector::RandomItemSelector() {
+    const char* itemName;
+    al::Resource* resource = al::findOrCreateResource("SystemData/ItemList", nullptr);
+    al::ByamlIter iter(al::findResourceYaml(resource, "RandomItemList", nullptr));
+    mItemLists = new ItemList[6];
+    for (s32 i = 0; i < 6; i++) {
+        al::ByamlIter listIter;
+        iter.tryGetIterByKey(&listIter, al::StringTmp<64>("Diff%d", i).cstr());
+        s32 listSize = listIter.getSize();
+        mItemLists[i].itemCount = listSize;
+        mItemLists[i].itemTypes = new rs::ItemType::ValueType[listSize];
+        rs::ItemType::ValueType* itemTypes = mItemLists[i].itemTypes;
+        s32 itemCount = listIter.getSize();
+        for (s32 j = 0; j < itemCount; j++) {
+            listIter.tryGetStringByIndex(&itemName, j);
+            if (al::isEqualString(itemName, "Coin"))
+                itemTypes[j] = rs::ItemType::Coin;
+            else if (al::isEqualString(itemName, "LifeUpItem"))
+                itemTypes[j] = rs::ItemType::LifeUpItem;
+        }
+    }
+    mItemIndex = al::getRandom(100);
+}
+
+rs::ItemType::ValueType RandomItemSelector::getRandomItemType(const al::IUseSceneObjHolder* user) {
+    s32 hitPoint;
+    {
+        GameDataHolderAccessor accessor(user);
+        hitPoint = GameDataFunction::getPlayerHitPoint(accessor);
+    }
+    s32 maxHitPoint;
+    {
+        GameDataHolderAccessor accessor(user);
+        maxHitPoint = GameDataFunction::getPlayerHitPointMaxCurrent(accessor);
+    }
+    s32 missingHitPoint = maxHitPoint - hitPoint;
+    if (missingHitPoint == 0)
+        return rs::ItemType::Coin;
+
+    const ItemList& list = mItemLists[missingHitPoint];
+    s32 itemCount = list.itemCount;
+    return list.itemTypes[mItemIndex++ % itemCount];
+}
+
+namespace rs {
+RandomItemSelector* createRandomItemSelector(const al::IUseSceneObjHolder* user) {
+    return al::createSceneObj<RandomItemSelector>(user);
+}
+}  // namespace rs

--- a/src/Item/RandomItemSelector.h
+++ b/src/Item/RandomItemSelector.h
@@ -14,14 +14,20 @@ public:
     static constexpr s32 sSceneObjId = SceneObjID_RandomItemSelector;
 
     RandomItemSelector();
-    rs::ItemType::ValueType getRandomItemType(const al::IUseSceneObjHolder*);
+    rs::ItemType::ValueType getRandomItemType(const al::IUseSceneObjHolder* user);
 
 private:
-    char filler[0x10];
+    struct ItemList {
+        s32 itemCount = 0;
+        rs::ItemType::ValueType* itemTypes = nullptr;
+    };
+
+    ItemList* mItemLists = nullptr;
+    s32 mItemIndex = 0;
 };
 
 static_assert(sizeof(RandomItemSelector) == 0x18);
 
 namespace rs {
-void createRandomItemSelector(const al::IUseSceneObjHolder*);
-}
+RandomItemSelector* createRandomItemSelector(const al::IUseSceneObjHolder* user);
+}  // namespace rs

--- a/src/Scene/SceneObjFactory.cpp
+++ b/src/Scene/SceneObjFactory.cpp
@@ -8,6 +8,7 @@
 #include "Amiibo/HelpAmiiboDirector.h"
 #include "Item/CoinCollectHolder.h"
 #include "Item/CoinCollectWatcher.h"
+#include "Item/RandomItemSelector.h"
 #include "Layout/KidsModeLayoutAccessor.h"
 #include "MapObj/RhyhtmInfoWatcher.h"
 #include "MapObj/RouteGuideDirector.h"
@@ -79,7 +80,7 @@ static al::ISceneObj* sceneObjCreator(s32 id) {
         return nullptr;
 
     case SceneObjID_RandomItemSelector:
-        return nullptr;
+        return new RandomItemSelector();
 
     case SceneObjID_ReactionObjectActionIndexHolder:
         return nullptr;


### PR DESCRIPTION
Implements `RandomItemSelector`: loads the six item lists by missing HP, returns a coin at full HP, and cycles through the selected list from a randomized starting index. Restores the class layout and connects creation to the scene-object factory.

Validation: the full build, clang-format 18, custom lint, and `tools/check` pass. Following the review refactoring, the constructor and `getRandomItemType()` have minor binary differences and are marked `NonMatchingMinor`; the creation function and destructor remain matching. The changes preserve behavior.

Closes MonsterDruide1/OdysseyDecompTracker#465

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/MonsterDruide1/OdysseyDecomp/1363)
<!-- Reviewable:end -->

---

<!-- decomp.dev report start -->
### Report for 1.0 (3ae121d - 4dffd27)

📈 **Matched code**: 15.69% (+0.00%, +148 bytes)

<details>
<summary>✅ 3 new matches</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/RandomItemSelector` | `RandomItemSelector::getRandomItemType(al::IUseSceneObjHolder const*)` | +136 | 0.00% | 100.00% |
| `Item/RandomItemSelector` | `rs::createRandomItemSelector(al::IUseSceneObjHolder const*)` | +8 | 0.00% | 100.00% |
| `Item/RandomItemSelector` | `RandomItemSelector::~RandomItemSelector()` | +4 | 0.00% | 100.00% |

</details>

<details>
<summary>📈 1 improvement in an unmatched item</summary>

| Unit | Item | Bytes | Before | After |
| - | - | - | - | - |
| `Item/RandomItemSelector` | `RandomItemSelector::RandomItemSelector()` | +369 | 0.00% | 75.00% |

</details>


<!-- decomp.dev report end -->